### PR TITLE
feat: add FritzBox event log parser with DOCSIS error detection

### DIFF
--- a/app/fritzbox.py
+++ b/app/fritzbox.py
@@ -1,8 +1,9 @@
-"""FritzBox authentication and DOCSIS data retrieval."""
+"""FritzBox authentication and DOCSIS data retrieval + event log parsing."""
 
 import hashlib
 import json
 import logging
+import re
 import xml.etree.ElementTree as ET
 
 import requests
@@ -128,3 +129,165 @@ def get_connection_info(url: str, sid: str) -> dict:
     except Exception as e:
         log.warning("Failed to get connection info: %s", e)
         return {}
+
+
+# ── DOCSIS Event Log Constants ──
+
+# Known DOCSIS event codes and their meaning
+DOCSIS_EVENT_CODES = {
+    "T1": "Ranging Request not acknowledged",
+    "T2": "No Ranging Response from CMTS",
+    "T3": "No Ranging Response (timeout)",
+    "T4": "Registration failed (timeout)",
+    "T5": "No Upstream Channel Descriptor",
+    "T6": "Registration aborted",
+}
+
+# Regex patterns for FritzBox event log entries related to DOCSIS
+_DOCSIS_EVENT_PATTERNS = [
+    re.compile(r"(T[1-6])\s*(?:Timeout|timeout|Timer)", re.IGNORECASE),
+    re.compile(r"(Ranging\s+(?:Request|Abort|Timeout))", re.IGNORECASE),
+    re.compile(r"(SYNC\s+(?:Timeout|Loss))", re.IGNORECASE),
+    re.compile(r"(No\s+(?:Ranging\s+Response|UCD|MDD))", re.IGNORECASE),
+    re.compile(r"(Registration\s+(?:Rejected|Failed|Abort))", re.IGNORECASE),
+    re.compile(r"(Cable\s+Modem\s+(?:Reset|Reboot|Restart))", re.IGNORECASE),
+    re.compile(r"(DHCP\s+(?:RENEW|NAK|failed))", re.IGNORECASE),
+    re.compile(r"(DS\s+Channel\s+(?:Lock|Lost))", re.IGNORECASE),
+    re.compile(r"(US\s+Channel\s+(?:Lock|Lost))", re.IGNORECASE),
+    # FritzBox-specific German patterns
+    re.compile(r"(Zeitüberschreitung)", re.IGNORECASE),
+    re.compile(r"(DSL-Synchronisierung)", re.IGNORECASE),
+    re.compile(r"(Kabelmodem)", re.IGNORECASE),
+    re.compile(r"(Verbindung\s+(?:getrennt|unterbrochen|fehlgeschlagen))", re.IGNORECASE),
+]
+
+
+def get_event_log(url: str, sid: str, max_entries: int = 200) -> list[dict]:
+    """Fetch and parse the FritzBox event log, filtering for DOCSIS events.
+
+    Returns list of dicts with:
+        timestamp: str (ISO format or raw)
+        message: str (event text)
+        category: str (docsis_error, connection, info)
+        docsis_code: str | None (T1-T6 if detected)
+    """
+    try:
+        # Try system log page
+        r = requests.post(
+            f"{url}/data.lua",
+            data={
+                "xhr": 1,
+                "sid": sid,
+                "lang": "de",
+                "page": "log",
+                "xhrId": "all",
+                "no_sidrenew": "",
+                "filter": "all",
+            },
+            timeout=15,
+        )
+        r.raise_for_status()
+        data = r.json().get("data", {})
+        log_entries = data.get("log", [])
+
+        if not log_entries:
+            # Fallback: try query.lua
+            r2 = requests.post(
+                f"{url}/query.lua",
+                data={
+                    "sid": sid,
+                    "command": "BoxInfoLog",
+                    "count": str(max_entries),
+                },
+                timeout=15,
+            )
+            r2.raise_for_status()
+            log_entries = r2.json() if r2.text.strip().startswith("[") else []
+
+        return _parse_event_log(log_entries, max_entries)
+
+    except Exception as e:
+        log.warning("Failed to fetch event log: %s", e)
+        return []
+
+
+def _parse_event_log(entries: list, max_entries: int) -> list[dict]:
+    """Parse raw event log entries and filter for DOCSIS-relevant events."""
+    results = []
+
+    for entry in entries[:max_entries]:
+        # FritzBox log format varies: could be list of [date, time, message, category]
+        # or dict with "date", "time", "msg" keys
+        if isinstance(entry, list) and len(entry) >= 3:
+            date_str = entry[0]
+            time_str = entry[1]
+            message = entry[2]
+            raw_category = entry[3] if len(entry) > 3 else ""
+        elif isinstance(entry, dict):
+            date_str = entry.get("date", "")
+            time_str = entry.get("time", "")
+            message = entry.get("msg", entry.get("message", ""))
+            raw_category = entry.get("category", entry.get("group", ""))
+        else:
+            continue
+
+        if not message:
+            continue
+
+        # Check if this is a DOCSIS-relevant event
+        category = _classify_event(message)
+        if not category:
+            continue
+
+        # Extract DOCSIS error code if present
+        docsis_code = None
+        for code in DOCSIS_EVENT_CODES:
+            if code in message:
+                docsis_code = code
+                break
+
+        # Build timestamp
+        timestamp = f"{date_str} {time_str}".strip()
+        # Try to normalize to ISO format
+        timestamp = _normalize_timestamp(timestamp)
+
+        results.append({
+            "timestamp": timestamp,
+            "message": message.strip(),
+            "category": category,
+            "docsis_code": docsis_code,
+        })
+
+    return results
+
+
+def _classify_event(message: str) -> str | None:
+    """Classify an event log message. Returns category or None if not DOCSIS-related."""
+    message_lower = message.lower()
+
+    # DOCSIS error patterns
+    for pattern in _DOCSIS_EVENT_PATTERNS:
+        if pattern.search(message):
+            return "docsis_error"
+
+    # Connection events
+    connection_keywords = [
+        "internet", "verbindung", "connection", "online", "offline",
+        "kabel", "cable", "docsis", "dsl",
+    ]
+    if any(kw in message_lower for kw in connection_keywords):
+        return "connection"
+
+    return None
+
+
+def _normalize_timestamp(ts: str) -> str:
+    """Try to normalize a Fritz timestamp to ISO format."""
+    # Common FritzBox format: "01.02.2026 14:30:00"
+    match = re.match(r"(\d{2})\.(\d{2})\.(\d{4})\s+(\d{2}:\d{2}(?::\d{2})?)", ts)
+    if match:
+        day, month, year, time_part = match.groups()
+        if ":" in time_part and time_part.count(":") == 1:
+            time_part += ":00"
+        return f"{year}-{month}-{day}T{time_part}"
+    return ts

--- a/tests/test_fritzbox_eventlog.py
+++ b/tests/test_fritzbox_eventlog.py
@@ -1,0 +1,166 @@
+"""Tests for FritzBox event log parser."""
+
+import pytest
+from app.fritzbox import (
+    _parse_event_log, _classify_event, _normalize_timestamp,
+    DOCSIS_EVENT_CODES, _DOCSIS_EVENT_PATTERNS,
+)
+
+
+# ── _normalize_timestamp ──
+
+class TestNormalizeTimestamp:
+    def test_german_date_format(self):
+        result = _normalize_timestamp("15.01.2026 14:30:00")
+        assert result == "2026-01-15T14:30:00"
+
+    def test_german_date_no_seconds(self):
+        result = _normalize_timestamp("01.02.2026 08:15")
+        assert result == "2026-02-01T08:15:00"
+
+    def test_already_iso(self):
+        result = _normalize_timestamp("2026-01-15T14:30:00")
+        assert result == "2026-01-15T14:30:00"
+
+    def test_unparseable(self):
+        result = _normalize_timestamp("garbage")
+        assert result == "garbage"
+
+
+# ── _classify_event ──
+
+class TestClassifyEvent:
+    def test_t3_timeout(self):
+        assert _classify_event("T3 Timeout detected") == "docsis_error"
+
+    def test_ranging_request(self):
+        assert _classify_event("Ranging Request not acknowledged") == "docsis_error"
+
+    def test_sync_loss(self):
+        assert _classify_event("SYNC Loss on channel 3") == "docsis_error"
+
+    def test_registration_failed(self):
+        assert _classify_event("Registration Failed") == "docsis_error"
+
+    def test_cable_modem_reset(self):
+        assert _classify_event("Cable Modem Reboot") == "docsis_error"
+
+    def test_dhcp_failed(self):
+        assert _classify_event("DHCP NAK received") == "docsis_error"
+
+    def test_ds_channel_lost(self):
+        assert _classify_event("DS Channel Lost") == "docsis_error"
+
+    def test_us_channel_lock(self):
+        assert _classify_event("US Channel Lock") == "docsis_error"
+
+    # German patterns
+    def test_zeitueberschreitung(self):
+        assert _classify_event("Zeitüberschreitung bei Registrierung") == "docsis_error"
+
+    def test_dsl_synchronisierung(self):
+        assert _classify_event("DSL-Synchronisierung gestartet") == "docsis_error"
+
+    def test_kabelmodem(self):
+        assert _classify_event("Kabelmodem Neustart") == "docsis_error"
+
+    def test_verbindung_getrennt(self):
+        assert _classify_event("Verbindung getrennt") == "docsis_error"
+
+    # Connection events (not DOCSIS error but still captured)
+    def test_internet_connection(self):
+        assert _classify_event("Internet connection established") == "connection"
+
+    def test_cable_keyword(self):
+        assert _classify_event("cable modem status") == "connection"
+
+    def test_online_keyword(self):
+        assert _classify_event("System online since 2026-01-15") == "connection"
+
+    # Non-matching events
+    def test_irrelevant_event(self):
+        assert _classify_event("WLAN device connected") is None
+
+    def test_empty_string(self):
+        assert _classify_event("") is None
+
+
+# ── _parse_event_log ──
+
+class TestParseEventLog:
+    def test_list_format_entries(self):
+        """FritzBox returns log as list of [date, time, message, category]."""
+        entries = [
+            ["15.01.2026", "14:30:00", "T3 Timeout", "system"],
+            ["15.01.2026", "14:31:00", "Internet connection established", "internet"],
+            ["15.01.2026", "14:32:00", "WLAN device connected", "wlan"],  # should be filtered
+        ]
+        result = _parse_event_log(entries, max_entries=100)
+        assert len(result) == 2  # T3 and Internet, not WLAN
+        assert result[0]["docsis_code"] == "T3"
+        assert result[0]["category"] == "docsis_error"
+        assert result[1]["category"] == "connection"
+
+    def test_dict_format_entries(self):
+        """Some FritzBox APIs return dicts."""
+        entries = [
+            {"date": "15.01.2026", "time": "10:00:00", "msg": "T4 Timeout", "group": "system"},
+        ]
+        result = _parse_event_log(entries, max_entries=100)
+        assert len(result) == 1
+        assert result[0]["docsis_code"] == "T4"
+
+    def test_max_entries_limit(self):
+        entries = [
+            ["15.01.2026", f"10:{i:02d}:00", "T3 Timeout", "system"]
+            for i in range(50)
+        ]
+        result = _parse_event_log(entries, max_entries=10)
+        assert len(result) <= 10
+
+    def test_empty_message_skipped(self):
+        entries = [["15.01.2026", "10:00:00", "", "system"]]
+        result = _parse_event_log(entries, max_entries=100)
+        assert result == []
+
+    def test_timestamp_normalized(self):
+        entries = [
+            ["15.01.2026", "14:30:00", "T3 Timeout", "system"],
+        ]
+        result = _parse_event_log(entries, max_entries=100)
+        assert result[0]["timestamp"] == "2026-01-15T14:30:00"
+
+    def test_all_docsis_codes_detected(self):
+        """Each T1-T6 code should be detected."""
+        for code in DOCSIS_EVENT_CODES:
+            entries = [
+                ["01.01.2026", "00:00:00", f"{code} Timeout something", "system"],
+            ]
+            result = _parse_event_log(entries, max_entries=100)
+            assert len(result) >= 1
+            assert result[0]["docsis_code"] == code
+
+    def test_non_docsis_entry_filtered(self):
+        entries = [
+            ["01.01.2026", "00:00:00", "Firmware update available", "update"],
+        ]
+        result = _parse_event_log(entries, max_entries=100)
+        assert result == []
+
+    def test_invalid_entry_format(self):
+        """Non-list, non-dict entries should be skipped."""
+        entries = ["just a string", 42, None]
+        result = _parse_event_log(entries, max_entries=100)
+        assert result == []
+
+
+# ── DOCSIS_EVENT_CODES ──
+
+class TestDocsisEventCodes:
+    def test_all_t_codes_present(self):
+        for code in ["T1", "T2", "T3", "T4", "T5", "T6"]:
+            assert code in DOCSIS_EVENT_CODES
+            assert isinstance(DOCSIS_EVENT_CODES[code], str)
+
+    def test_t3_description(self):
+        assert "Ranging" in DOCSIS_EVENT_CODES["T3"] or "timeout" in DOCSIS_EVENT_CODES["T3"].lower()


### PR DESCRIPTION
- Add DOCSIS_EVENT_CODES dict (T1-T6) with descriptions
- Add 13 regex patterns for EN/DE DOCSIS event detection
- Add get_event_log() to fetch and parse FritzBox system log
- Add _parse_event_log() supporting list and dict entry formats
- Add _classify_event() for docsis_error/connection categorization
- Add _normalize_timestamp() for German date format conversion
- Add 21 tests covering all event log parsing functions