### PR TITLE
feat: add multi-channel notification system

### DIFF
--- a/app/notifier.py
+++ b/app/notifier.py
@@ -1,0 +1,307 @@
+"""Notification system for DOCSight – supports multiple channels.
+
+Supported backends:
+    - Webhook (generic HTTP POST with JSON payload)
+    - Telegram (Bot API)
+    - Discord (webhook URL)
+    - Email (SMTP)
+    - Gotify (push notification server)
+    - ntfy (ntfy.sh or self-hosted)
+
+Each backend is optional and only activated when configured.
+"""
+
+import json
+import logging
+import smtplib
+import threading
+import time
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+
+import requests
+
+log = logging.getLogger("docsis.notifier")
+
+
+class Notifier:
+    """Dispatches notifications to configured channels."""
+
+    def __init__(self, config_mgr):
+        self.config_mgr = config_mgr
+        self._cooldown: dict[str, float] = {}
+        self._cooldown_seconds = 300  # 5 min between duplicate alerts
+        self._lock = threading.Lock()
+
+    def _get(self, key, default=""):
+        return self.config_mgr.get(key, default)
+
+    def _in_cooldown(self, key: str) -> bool:
+        """Check if a notification key is in cooldown."""
+        now = time.time()
+        with self._lock:
+            last = self._cooldown.get(key, 0)
+            if now - last < self._cooldown_seconds:
+                return True
+            self._cooldown[key] = now
+        return False
+
+    # ── Public API ──
+
+    def is_configured(self) -> bool:
+        """True if at least one notification channel is configured."""
+        return any([
+            self._get("notify_webhook_url"),
+            self._get("notify_telegram_token") and self._get("notify_telegram_chat_id"),
+            self._get("notify_discord_webhook_url"),
+            self._get("notify_email_smtp_host"),
+            self._get("notify_gotify_url"),
+            self._get("notify_ntfy_url"),
+        ])
+
+    def send(self, title: str, message: str, level: str = "warning",
+             dedup_key: str | None = None):
+        """Send a notification to all configured channels.
+
+        Args:
+            title: Short notification title.
+            message: Notification body text.
+            level: Severity level (info, warning, critical).
+            dedup_key: Optional key for deduplication/cooldown.
+        """
+        if dedup_key and self._in_cooldown(dedup_key):
+            log.debug("Notification suppressed (cooldown): %s", dedup_key)
+            return
+
+        channels = []
+        if self._get("notify_webhook_url"):
+            channels.append(("webhook", self._send_webhook))
+        if self._get("notify_telegram_token") and self._get("notify_telegram_chat_id"):
+            channels.append(("telegram", self._send_telegram))
+        if self._get("notify_discord_webhook_url"):
+            channels.append(("discord", self._send_discord))
+        if self._get("notify_email_smtp_host"):
+            channels.append(("email", self._send_email))
+        if self._get("notify_gotify_url"):
+            channels.append(("gotify", self._send_gotify))
+        if self._get("notify_ntfy_url"):
+            channels.append(("ntfy", self._send_ntfy))
+
+        if not channels:
+            return
+
+        for name, func in channels:
+            try:
+                func(title, message, level)
+                log.info("Notification sent via %s: %s", name, title)
+            except Exception as e:
+                log.error("Notification failed (%s): %s", name, e)
+
+    def send_digest(self, subject: str, body: str):
+        """Send a digest (longer message, no cooldown)."""
+        for name, func in [
+            ("webhook", self._send_webhook),
+            ("telegram", self._send_telegram),
+            ("discord", self._send_discord),
+            ("email", self._send_email),
+            ("gotify", self._send_gotify),
+            ("ntfy", self._send_ntfy),
+        ]:
+            try:
+                if name == "webhook" and self._get("notify_webhook_url"):
+                    func(subject, body, "info")
+                elif name == "telegram" and self._get("notify_telegram_token"):
+                    func(subject, body, "info")
+                elif name == "discord" and self._get("notify_discord_webhook_url"):
+                    func(subject, body, "info")
+                elif name == "email" and self._get("notify_email_smtp_host"):
+                    func(subject, body, "info")
+                elif name == "gotify" and self._get("notify_gotify_url"):
+                    func(subject, body, "info")
+                elif name == "ntfy" and self._get("notify_ntfy_url"):
+                    func(subject, body, "info")
+            except Exception as e:
+                log.error("Digest failed (%s): %s", name, e)
+
+    # ── Backend implementations ──
+
+    def _send_webhook(self, title: str, message: str, level: str):
+        """Send generic JSON webhook POST."""
+        url = self._get("notify_webhook_url")
+        payload = {
+            "title": title,
+            "message": message,
+            "level": level,
+            "source": "docsight",
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+        r = requests.post(url, json=payload, timeout=10)
+        r.raise_for_status()
+
+    def _send_telegram(self, title: str, message: str, level: str):
+        """Send via Telegram Bot API."""
+        token = self._get("notify_telegram_token")
+        chat_id = self._get("notify_telegram_chat_id")
+        icon = {"info": "ℹ️", "warning": "⚠️", "critical": "🚨"}.get(level, "📡")
+        text = f"{icon} *{title}*\n\n{message}"
+        r = requests.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            json={
+                "chat_id": chat_id,
+                "text": text,
+                "parse_mode": "Markdown",
+            },
+            timeout=10,
+        )
+        r.raise_for_status()
+
+    def _send_discord(self, title: str, message: str, level: str):
+        """Send via Discord webhook."""
+        url = self._get("notify_discord_webhook_url")
+        color = {"info": 0x3498DB, "warning": 0xF39C12, "critical": 0xE74C3C}.get(level, 0x95A5A6)
+        payload = {
+            "embeds": [{
+                "title": title,
+                "description": message,
+                "color": color,
+                "footer": {"text": "DOCSight"},
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }]
+        }
+        r = requests.post(url, json=payload, timeout=10)
+        r.raise_for_status()
+
+    def _send_email(self, title: str, message: str, level: str):
+        """Send via SMTP."""
+        host = self._get("notify_email_smtp_host")
+        port = int(self._get("notify_email_smtp_port") or 587)
+        user = self._get("notify_email_smtp_user")
+        password = self._get("notify_email_smtp_password")
+        sender = self._get("notify_email_from") or user
+        recipient = self._get("notify_email_to")
+        use_tls = self._get("notify_email_tls") != "false"
+
+        if not recipient:
+            log.warning("Email notification skipped: no recipient configured")
+            return
+
+        msg = MIMEMultipart()
+        msg["From"] = sender
+        msg["To"] = recipient
+        msg["Subject"] = f"[DOCSight] {title}"
+        msg.attach(MIMEText(message, "plain", "utf-8"))
+
+        if use_tls:
+            server = smtplib.SMTP(host, port, timeout=10)
+            server.starttls()
+        else:
+            server = smtplib.SMTP(host, port, timeout=10)
+
+        if user:
+            server.login(user, password)
+        server.send_message(msg)
+        server.quit()
+
+    def _send_gotify(self, title: str, message: str, level: str):
+        """Send via Gotify push notification server."""
+        url = self._get("notify_gotify_url").rstrip("/")
+        token = self._get("notify_gotify_token")
+        priority = {"info": 2, "warning": 5, "critical": 8}.get(level, 5)
+        r = requests.post(
+            f"{url}/message",
+            params={"token": token},
+            json={
+                "title": title,
+                "message": message,
+                "priority": priority,
+            },
+            timeout=10,
+        )
+        r.raise_for_status()
+
+    def _send_ntfy(self, title: str, message: str, level: str):
+        """Send via ntfy.sh or self-hosted ntfy."""
+        url = self._get("notify_ntfy_url")
+        token = self._get("notify_ntfy_token")
+        priority = {"info": "default", "warning": "high", "critical": "urgent"}.get(level, "default")
+        headers = {
+            "Title": title,
+            "Priority": priority,
+            "Tags": "satellite,docsight",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        r = requests.post(url, data=message.encode("utf-8"), headers=headers, timeout=10)
+        r.raise_for_status()
+
+
+def build_health_notification(analysis: dict, prev_health: str | None = None) -> tuple[str, str, str] | None:
+    """Build a notification message from health analysis.
+
+    Returns (title, message, level) or None if no notification needed.
+    """
+    summary = analysis.get("summary", {})
+    health = summary.get("health", "good")
+
+    # Only notify on degradation or persistent poor
+    if health == "good":
+        return None
+
+    issues = summary.get("health_issues", [])
+    if not issues:
+        return None
+
+    level = "critical" if health == "poor" else "warning"
+    title = f"DOCSIS Health: {health.upper()}"
+
+    lines = [f"Connection health changed to {health}."]
+    for issue in issues:
+        if "ds_power" in issue:
+            lines.append(f"• DS Power: {summary.get('ds_power_min')}/{summary.get('ds_power_max')} dBmV")
+        elif "us_power" in issue:
+            lines.append(f"• US Power: {summary.get('us_power_max')} dBmV")
+        elif "snr" in issue:
+            lines.append(f"• SNR: {summary.get('ds_snr_min')} dB")
+        elif "uncorr" in issue:
+            lines.append(f"• Uncorrectable Errors: {summary.get('ds_uncorrectable_errors'):,}")
+
+    return title, "\n".join(lines), level
+
+
+def build_digest(analysis: dict, watchdog_events: list | None = None,
+                 ping_stats: dict | None = None) -> tuple[str, str]:
+    """Build a scheduled health digest message.
+
+    Returns (subject, body).
+    """
+    summary = analysis.get("summary", {})
+    health = summary.get("health", "unknown")
+
+    lines = [
+        "📊 DOCSight Health Digest",
+        f"Overall Health: {health.upper()}",
+        "",
+        "Signal Summary:",
+        f"  DS Channels: {summary.get('ds_total', 0)}",
+        f"  DS Power: {summary.get('ds_power_min')}..{summary.get('ds_power_max')} dBmV (avg {summary.get('ds_power_avg')})",
+        f"  DS SNR: {summary.get('ds_snr_min')}..{summary.get('ds_snr_avg')} dB",
+        f"  Correctable Errors: {summary.get('ds_correctable_errors', 0):,}",
+        f"  Uncorrectable Errors: {summary.get('ds_uncorrectable_errors', 0):,}",
+        f"  US Channels: {summary.get('us_total', 0)}",
+        f"  US Power: {summary.get('us_power_min')}..{summary.get('us_power_max')} dBmV (avg {summary.get('us_power_avg')})",
+    ]
+
+    if watchdog_events:
+        lines += ["", "Recent Watchdog Events:"]
+        for evt in watchdog_events[-5:]:
+            lines.append(f"  • {evt.get('type', '?')}: {evt.get('message', '')}")
+
+    if ping_stats:
+        lines += [
+            "",
+            "Ping Statistics:",
+            f"  Avg Latency: {ping_stats.get('avg_ms', 0):.1f} ms",
+            f"  Packet Loss: {ping_stats.get('loss_pct', 0):.1f}%",
+        ]
+
+    return "DOCSight Health Digest", "\n".join(lines)

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,290 @@
+"""Tests for the notification system."""
+
+import time
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+from app.notifier import Notifier, build_health_notification, build_digest
+
+
+@pytest.fixture
+def mock_config():
+    """ConfigManager mock with no channels configured."""
+    mgr = MagicMock()
+    mgr.get.return_value = ""
+    return mgr
+
+
+@pytest.fixture
+def notifier(mock_config):
+    return Notifier(mock_config)
+
+
+def _config_with(**overrides):
+    """Build a mock ConfigManager that returns overrides for matching keys."""
+    mgr = MagicMock()
+    def _get(key, default=""):
+        return overrides.get(key, default)
+    mgr.get.side_effect = _get
+    return mgr
+
+
+# ── is_configured ──
+
+class TestIsConfigured:
+    def test_not_configured_by_default(self, notifier):
+        assert notifier.is_configured() is False
+
+    def test_configured_webhook(self):
+        n = Notifier(_config_with(notify_webhook_url="http://example.com/hook"))
+        assert n.is_configured() is True
+
+    def test_configured_telegram(self):
+        n = Notifier(_config_with(
+            notify_telegram_token="123:ABC",
+            notify_telegram_chat_id="456",
+        ))
+        assert n.is_configured() is True
+
+    def test_telegram_incomplete(self):
+        """Only token without chat_id is not sufficient."""
+        n = Notifier(_config_with(notify_telegram_token="123:ABC"))
+        assert n.is_configured() is False
+
+    def test_configured_discord(self):
+        n = Notifier(_config_with(notify_discord_webhook_url="https://discord.com/api/webhooks/x/y"))
+        assert n.is_configured() is True
+
+    def test_configured_email(self):
+        n = Notifier(_config_with(notify_email_smtp_host="smtp.example.com"))
+        assert n.is_configured() is True
+
+    def test_configured_gotify(self):
+        n = Notifier(_config_with(notify_gotify_url="http://gotify.local"))
+        assert n.is_configured() is True
+
+    def test_configured_ntfy(self):
+        n = Notifier(_config_with(notify_ntfy_url="https://ntfy.sh/docsight"))
+        assert n.is_configured() is True
+
+
+# ── Cooldown ──
+
+class TestCooldown:
+    def test_no_dedup_key_sends_always(self, notifier):
+        """Without dedup_key, no cooldown is applied."""
+        assert notifier._in_cooldown("key1") is False
+        assert notifier._in_cooldown("key1") is True  # 2nd call within window
+
+    def test_different_keys_independent(self, notifier):
+        assert notifier._in_cooldown("a") is False
+        assert notifier._in_cooldown("b") is False
+
+    def test_cooldown_expires(self, notifier):
+        notifier._cooldown_seconds = 0  # instant expiry
+        assert notifier._in_cooldown("x") is False
+        assert notifier._in_cooldown("x") is False  # already expired
+
+
+# ── Send routing ──
+
+class TestSendRouting:
+    @patch("app.notifier.requests.post")
+    def test_webhook_called(self, mock_post):
+        n = Notifier(_config_with(notify_webhook_url="http://example.com/hook"))
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        n.send("Test Title", "Test Message", "warning")
+        mock_post.assert_called_once()
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["title"] == "Test Title"
+        assert payload["source"] == "docsight"
+
+    @patch("app.notifier.requests.post")
+    def test_telegram_called(self, mock_post):
+        n = Notifier(_config_with(
+            notify_telegram_token="123:ABC",
+            notify_telegram_chat_id="456",
+        ))
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        n.send("Alert", "Body", "critical")
+        mock_post.assert_called_once()
+        url = mock_post.call_args[0][0] if mock_post.call_args[0] else mock_post.call_args.kwargs.get("url", "")
+        assert "api.telegram.org" in url
+
+    @patch("app.notifier.requests.post")
+    def test_discord_embed(self, mock_post):
+        n = Notifier(_config_with(notify_discord_webhook_url="https://discord.com/hook"))
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        n.send("Title", "Msg", "info")
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "embeds" in payload
+        assert payload["embeds"][0]["title"] == "Title"
+
+    @patch("app.notifier.requests.post")
+    def test_gotify_priority(self, mock_post):
+        n = Notifier(_config_with(
+            notify_gotify_url="http://gotify.local",
+            notify_gotify_token="tok",
+        ))
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        n.send("Title", "Msg", "critical")
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["priority"] == 8  # critical → 8
+
+    @patch("app.notifier.requests.post")
+    def test_ntfy_headers(self, mock_post):
+        n = Notifier(_config_with(
+            notify_ntfy_url="https://ntfy.sh/docsight",
+            notify_ntfy_token="tok",
+        ))
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        n.send("Title", "Body", "warning")
+        headers = mock_post.call_args.kwargs.get("headers") or mock_post.call_args[1].get("headers")
+        assert headers["Title"] == "Title"
+        assert headers["Priority"] == "high"
+        assert "Bearer" in headers["Authorization"]
+
+    def test_send_no_channels_configured(self, notifier):
+        """Should not raise if nothing is configured."""
+        notifier.send("X", "Y")  # no-op
+
+    @patch("app.notifier.requests.post")
+    def test_send_dedup_suppresses_second(self, mock_post):
+        n = Notifier(_config_with(notify_webhook_url="http://example.com"))
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        n.send("A", "B", dedup_key="dup1")
+        n.send("A", "B", dedup_key="dup1")
+        assert mock_post.call_count == 1
+
+    @patch("app.notifier.requests.post")
+    def test_backend_error_logged_not_raised(self, mock_post):
+        """Backend errors should be caught and logged."""
+        n = Notifier(_config_with(notify_webhook_url="http://example.com"))
+        mock_post.side_effect = ConnectionError("fail")
+        # Should not raise
+        n.send("A", "B")
+
+
+# ── Email backend ──
+
+class TestEmailBackend:
+    @patch("app.notifier.smtplib.SMTP")
+    def test_email_sent(self, mock_smtp_class):
+        mock_server = MagicMock()
+        mock_smtp_class.return_value = mock_server
+
+        n = Notifier(_config_with(
+            notify_email_smtp_host="smtp.test.com",
+            notify_email_smtp_port="587",
+            notify_email_smtp_user="user@test.com",
+            notify_email_smtp_password="pass",
+            notify_email_from="noreply@test.com",
+            notify_email_to="admin@test.com",
+            notify_email_tls="true",
+        ))
+        n.send("Subject", "Body", "info")
+
+        mock_smtp_class.assert_called_once_with("smtp.test.com", 587, timeout=10)
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("user@test.com", "pass")
+        mock_server.send_message.assert_called_once()
+        mock_server.quit.assert_called_once()
+
+
+# ── build_health_notification ──
+
+class TestBuildHealthNotification:
+    def test_good_health_returns_none(self):
+        analysis = {"summary": {"health": "good", "health_issues": []}}
+        assert build_health_notification(analysis) is None
+
+    def test_poor_health_returns_critical(self):
+        analysis = {
+            "summary": {
+                "health": "poor",
+                "health_issues": ["ds_power_critical", "snr_critical"],
+                "ds_power_min": -2,
+                "ds_power_max": 12,
+                "ds_snr_min": 22,
+            }
+        }
+        title, message, level = build_health_notification(analysis)
+        assert "POOR" in title
+        assert level == "critical"
+        assert "DS Power" in message
+
+    def test_marginal_health_warning(self):
+        analysis = {
+            "summary": {
+                "health": "marginal",
+                "health_issues": ["us_power_warn"],
+                "us_power_max": 52,
+            }
+        }
+        title, message, level = build_health_notification(analysis)
+        assert level == "warning"
+        assert "US Power" in message
+
+    def test_no_issues_returns_none(self):
+        analysis = {"summary": {"health": "marginal", "health_issues": []}}
+        assert build_health_notification(analysis) is None
+
+
+# ── build_digest ──
+
+class TestBuildDigest:
+    def test_basic_digest(self):
+        analysis = {
+            "summary": {
+                "health": "good",
+                "ds_total": 33,
+                "us_total": 4,
+                "ds_power_min": -1,
+                "ds_power_max": 5,
+                "ds_power_avg": 2.5,
+                "ds_snr_min": 35,
+                "ds_snr_avg": 37,
+                "ds_correctable_errors": 1234,
+                "ds_uncorrectable_errors": 56,
+                "us_power_min": 40,
+                "us_power_max": 45,
+                "us_power_avg": 42.5,
+            },
+        }
+        subject, body = build_digest(analysis)
+        assert "DOCSight" in subject
+        assert "GOOD" in body
+        assert "33" in body
+
+    def test_digest_with_watchdog_events(self):
+        analysis = {"summary": {"health": "poor", "ds_total": 10, "us_total": 2,
+                                "ds_power_min": 0, "ds_power_max": 5, "ds_power_avg": 3,
+                                "ds_snr_min": 30, "ds_snr_avg": 33,
+                                "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0,
+                                "us_power_min": 40, "us_power_max": 44, "us_power_avg": 42}}
+        events = [{"type": "modulation_drop", "message": "CH3 dropped"}]
+        subject, body = build_digest(analysis, watchdog_events=events)
+        assert "Watchdog" in body
+
+    def test_digest_with_ping_stats(self):
+        analysis = {"summary": {"health": "good", "ds_total": 10, "us_total": 2,
+                                "ds_power_min": 0, "ds_power_max": 5, "ds_power_avg": 3,
+                                "ds_snr_min": 30, "ds_snr_avg": 33,
+                                "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0,
+                                "us_power_min": 40, "us_power_max": 44, "us_power_avg": 42}}
+        ping = {"avg_ms": 12.3, "loss_pct": 0.1}
+        subject, body = build_digest(analysis, ping_stats=ping)
+        assert "12.3" in body
+        assert "0.1" in body


### PR DESCRIPTION
- Add Notifier class with 6 backends: webhook, Telegram, Discord, email/SMTP, Gotify, ntfy
- Add cooldown/deduplication (5 min) to prevent notification spam
- Add build_health_notification() for automated health alerts
- Add build_digest() for scheduled health summary messages
- Add 24 tests covering all notification channels and logic