### PR TITLE
fix: correct small errors in US DOCSIS 3.1 power levels

### DIFF
--- a/app/thresholds.json
+++ b/app/thresholds.json
@@ -36,9 +36,9 @@
     "DOCSIS 3.1": {
       "_comment": "Values adjusted for Fritz!Box display (-6 dB from actual). Actual regelkonform: 44.1-47.0",
       "good_min": 38.1, "good_max": 41.0,
-      "tolerated_min": 34.1, "tolerated_max": 44.0,
-      "monthly_min": 32.1, "monthly_max": 50.0,
-      "immediate_min": 32.0, "immediate_max": 50.0
+      "tolerated_min": 34.1, "tolerated_max": 42.0,
+      "monthly_min": 32.1, "monthly_max": 44.0,
+      "immediate_min": 32.0, "immediate_max": 44.0
     },
     "_default": "EuroDOCSIS 3.0"
   },


### PR DESCRIPTION
As per https://www.vodafonekabelforum.de/viewtopic.php?p=619250&sid=3c32a83a7ca45a36852605e82251b9aa#p619250 (at end of post) the values were off by a small amount. This PR corrects them.