### PR TITLE
Fix upstream OFDM transmit power for CM3500B

### DIFF
--- a/app/drivers/cm3500.py
+++ b/app/drivers/cm3500.py
@@ -343,7 +343,7 @@ class CM3500Driver(ModemDriver):
             try:
                 first_freq = self._parse_number(cells[4])
                 last_freq = self._parse_number(cells[5])
-                power = self._parse_number(cells[6])
+                power = self._parse_number(cells[8])
 
                 result.append({
                     "channelID": chan_id,


### PR DESCRIPTION
## Description

Extracts cell `8` instead of `6` from upstream OFDM table.

Fixes #93 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New modem driver
- [ ] Performance improvement

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] I have read the [Contributing Guidelines](https://github.com/itsDNNS/docsight/blob/main/CONTRIBUTING.md)
- [x] I have opened an issue **before** starting work on this PR
- [x] My code follows the project's code style
- [ ] I have tested my changes locally
- [ ] All tests pass (`python -m pytest tests/ -v`)
- [ ] I have added tests for new functionality
- [ ] I have updated the documentation (if applicable)
- [ ] I have added i18n translations for new strings (EN/DE/FR/ES)

## Testing

<!-- Describe how you tested this change -->

**Test Environment:**
- Modem: <!-- e.g., Fritz!Box 6660 Cable -->
- Deployment: <!-- e.g., Docker on Linux -->
- Browser: <!-- if UI changes -->

**Test Steps:**
1. <!-- Step 1 -->
2. <!-- Step 2 -->

**Screenshots (if applicable):**

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any additional context, known issues, or follow-up work needed -->
