### PR TITLE
fix(cm3500): correct upstream OFDM Tx power and frequency parsing

### DIFF
--- a/app/drivers/cm3500.py
+++ b/app/drivers/cm3500.py
@@ -323,7 +323,8 @@ class CM3500Driver(ModemDriver):
         """Parse Upstream OFDM table.
 
         Columns: (label), FFT Type, Channel Width(MHz), # Active Subcarriers,
-                 First Active Subcarrier(MHz), Last Active Subcarrier(MHz),
+                 First Active Subcarrier, Last Active Subcarrier,
+                 Lower Frequency(MHz), Upper Frequency(MHz),
                  Tx Power(dBmV)
         """
         rows = table.find("tbody")
@@ -335,15 +336,15 @@ class CM3500Driver(ModemDriver):
         chan_id = 200
         for row in data_rows:
             cells = [td.get_text(strip=True) for td in row.find_all("td")]
-            if len(cells) < 7:
+            if len(cells) < 9:
                 continue
             label = cells[0].lower()
             if "upstream" not in label:
                 continue
             try:
-                first_freq = self._parse_number(cells[4])
-                last_freq = self._parse_number(cells[5])
-                power = self._parse_number(cells[6])
+                first_freq = self._parse_number(cells[6])
+                last_freq = self._parse_number(cells[7])
+                power = self._parse_number(cells[8])
 
                 result.append({
                     "channelID": chan_id,


### PR DESCRIPTION
## Summary
This PR fixes CM3500B upstream OFDM parsing by reading values from the correct columns in malformed modem HTML tables.

### What changed
- Updated `_parse_us_ofdm` in `app/drivers/cm3500.py`:
  - Require at least 9 cells for valid upstream OFDM data rows
  - Parse frequency range from `cells[6]` and `cells[7]` (Lower/Upper Frequency)
  - Parse Tx power from `cells[8]`
- Updated parser docstring to reflect real column layout
- Added regression test coverage in `tests/test_cm3500.py`:
  - New fixture with one real upstream OFDM data row
  - New test verifying channelID, type, parsed frequency range, and Tx power
  - Existing empty-table behavior remains covered

## Why
Issue #93 reported that upstream OFDM Tx power is wrong for CM3500B.
The previous parser interpreted subcarrier indices as frequencies and lower frequency as Tx power.

## Validation
- `pytest -q tests/test_cm3500.py`
- Result: 34 passed

Closes #93
