### PR TITLE
fix CH7465 login for CH7465VF variant

### DIFF
--- a/app/drivers/ch7465.py
+++ b/app/drivers/ch7465.py
@@ -96,9 +96,10 @@ class CH7465Driver(ModemDriver):
             payload = {"Username": "NULL", "Password": self._password}
         else:
             pw_hash = hashlib.sha256(self._password.encode()).hexdigest()
-            payload = {"Password": pw_hash}
+            payload = {}
             if self._user:
                 payload["Username"] = self._user
+            payload["Password"] = pw_hash
 
         response_text = self._set_data(Action.LOGIN, payload)
 
@@ -267,6 +268,8 @@ class CH7465Driver(ModemDriver):
         r = self._session.post(
             f"{self._url}/xml/getter.xml",
             data = {
+                "fun": str(function.value),
+            } if self._is_play is False else {
                 "token": self._session.cookies.get("sessionToken", ""),
                 "fun": str(function.value),
             },
@@ -283,10 +286,12 @@ class CH7465Driver(ModemDriver):
             raise ValueError("invalid data key in CH7465VF command")
         r = self._session.post(
             f"{self._url}/xml/setter.xml",
-            data = {
+            data = ({
+                "fun": str(function.value),
+            } if self._is_play is False else {
                 "token": self._session.cookies.get("sessionToken", ""),
                 "fun": str(function.value),
-            } | data,
+            }) | data,
             timeout=10,
             allow_redirects=False,
         )


### PR DESCRIPTION
## Description

The CH7465VF firmware is extremely finicky with the query parameters. Different ordering and unexpected parameters can cause queries to fail.

This ensures that for non-PLAY firmware variants the parameters are kept in the working order and extra parameters are omitted.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New modem driver
- [ ] Performance improvement

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] I have read the [Contributing Guidelines](https://github.com/itsDNNS/docsight/blob/main/CONTRIBUTING.md)
- [ ] I have opened an issue **before** starting work on this PR
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] All tests pass (`python -m pytest tests/ -v`)
- [ ] I have added tests for new functionality
- [ ] I have updated the documentation (if applicable)
- [ ] I have added i18n translations for new strings (EN/DE/FR/ES)

## Testing

Test Environment:

- Modem: Compal CH7465LG-LC (CH7465VF firmware)
- Deployment: Docker on Linux
- Browser: Firefox

## Additional Notes

The bug was introduced in commit ece86b4 in the context of #149.
