### PR TITLE
fix: surfboard session lifecycle and multi-firmware namespace

### DIFF
--- a/app/drivers/surfboard.py
+++ b/app/drivers/surfboard.py
@@ -349,31 +349,12 @@ class SurfboardDriver(ModemDriver):
     def get_device_info(self) -> dict:
         """Retrieve device model and firmware from HNAP."""
         try:
-            body = {
-                "GetMultipleHNAPs": self._make_actions(
-                    "StartupSequence", "ConnectionInfo"
-                )
-            }
-            resp = self._hnap_post("GetMultipleHNAPs", body)
-            multi = resp.get("GetMultipleHNAPsResponse", {})
-
-            conn = multi.get(self._response_key("ConnectionInfo"), {})
-            model = conn.get("StatusSoftwareModelName", "")
-            sw = conn.get("StatusSoftwareSfVer", "")
+            model, sw = self._fetch_device_fields()
 
             # Fallback to other namespace if no model and namespace unknown
             if not model and not self._action_ns:
                 self._action_ns = "Moto"
-                body = {
-                    "GetMultipleHNAPs": self._make_actions(
-                        "StartupSequence", "ConnectionInfo"
-                    )
-                }
-                resp = self._hnap_post("GetMultipleHNAPs", body)
-                multi = resp.get("GetMultipleHNAPsResponse", {})
-                conn = multi.get(self._response_key("ConnectionInfo"), {})
-                model = conn.get("StatusSoftwareModelName", "")
-                sw = conn.get("StatusSoftwareSfVer", "")
+                model, sw = self._fetch_device_fields()
                 if not model:
                     self._action_ns = ""
 
@@ -385,6 +366,44 @@ class SurfboardDriver(ModemDriver):
         except Exception:
             log.warning("Failed to retrieve device info, will retry next poll")
             return {"manufacturer": "Arris", "model": "", "sw_version": ""}
+
+    def _fetch_device_fields(self) -> tuple[str, str]:
+        """Fetch model and firmware from HNAP, with HTTP 500 namespace fallback.
+
+        Returns (model, sw_version) strings. On HTTP 500 with unknown
+        namespace, tries the other namespace before propagating.
+        """
+        try:
+            body = {
+                "GetMultipleHNAPs": self._make_actions(
+                    "StartupSequence", "ConnectionInfo"
+                )
+            }
+            resp = self._hnap_post("GetMultipleHNAPs", body)
+        except requests.HTTPError as e:
+            status = e.response.status_code if e.response is not None else 0
+            if status == 500 and not self._action_ns:
+                current = self._action_ns or "Customer"
+                other = "Moto" if current == "Customer" else "Customer"
+                log.warning(
+                    "Device info HTTP 500, trying %s namespace", other,
+                )
+                self._action_ns = other
+                body = {
+                    "GetMultipleHNAPs": self._make_actions(
+                        "StartupSequence", "ConnectionInfo"
+                    )
+                }
+                resp = self._hnap_post("GetMultipleHNAPs", body)
+            else:
+                raise
+
+        multi = resp.get("GetMultipleHNAPsResponse", {})
+        conn = multi.get(self._response_key("ConnectionInfo"), {})
+        return (
+            conn.get("StatusSoftwareModelName", ""),
+            conn.get("StatusSoftwareSfVer", ""),
+        )
 
     def get_connection_info(self) -> dict:
         """Standalone modem -- no connection info available."""

--- a/tests/test_surfboard_driver.py
+++ b/tests/test_surfboard_driver.py
@@ -978,6 +978,28 @@ class TestActionNamespace:
         assert info["model"] == "SB8200"
         assert info["sw_version"] == "AB01.02.053.05_080901_193.0A.NSH"
 
+    def test_device_info_http_500_namespace_fallback(self, driver):
+        """HTTP 500 on Customer device info triggers Moto fallback."""
+        import requests as req
+        assert driver._action_ns == ""
+
+        def side_effect(action, body, **kwargs):
+            if action == "GetMultipleHNAPs":
+                keys = body.get("GetMultipleHNAPs", {})
+                if "GetCustomerStatusConnectionInfo" in keys:
+                    resp = MagicMock()
+                    resp.status_code = 500
+                    raise req.HTTPError(response=resp)
+                if "GetMotoStatusConnectionInfo" in keys:
+                    return HNAP_DEVICE_RESPONSE_MOTO
+            return {}
+
+        with patch.object(driver, "_hnap_post", side_effect=side_effect):
+            info = driver.get_device_info()
+
+        assert info["model"] == "SB8200"
+        assert driver._action_ns == "Moto"
+
 
 # -- HTTP 500 namespace resilience --
 


### PR DESCRIPTION
## Summary

Fixes the RELOAD loop reported in #165 by two users (S34 + SB8200).

- **Session lifecycle fix**: Removed `_fresh_session()` from the default login path - it was destroying local HTTP state while the modem still considered the previous session active, causing the RELOAD loop. New retry strategy: 1st RELOAD waits 5s on same session, 2nd RELOAD creates fresh session + 15s wait, 3rd RELOAD fails.
- **Multi-firmware namespace**: Restored support for both `GetCustomerStatus*` (S34) and `GetMotoStatus*` (SB8200) action namespaces with auto-detection on first data fetch.
- **HTTP 500 resilience**: On HTTP 500, tries the other action namespace before re-authenticating - prevents unnecessary session churn when the issue is a wrong action bundle, not an expired session.

## Test plan

- [x] All 55 existing surfboard tests pass unchanged
- [x] 12 new tests added (session lifecycle, namespace detection, HTTP 500 handling)
- [x] Full suite (1285 tests) passes with no regressions
- [ ] Manual verification by S34 and SB8200 users from #165