### PR TITLE
fix: add TR-064 fallback for FritzBox device info

### DIFF
--- a/app/fritzbox.py
+++ b/app/fritzbox.py
@@ -8,6 +8,7 @@ import xml.etree.ElementTree as ET
 import requests
 
 log = logging.getLogger("docsis.fritzbox")
+_TR064_NS = {"tr64": "urn:dslforum-org:device-1-0"}
 
 
 def login(url: str, user: str, password: str) -> str:
@@ -95,7 +96,23 @@ def get_device_info(url: str, sid: str) -> dict:
             except (ValueError, TypeError):
                 pass
         return result
-    except Exception:
+    except Exception as e:
+        log.debug("FritzBox overview device info unavailable, trying TR-064 fallback: %s", e)
+
+    try:
+        r = requests.get(f"{url}/tr064/tr64desc.xml", timeout=10)
+        r.raise_for_status()
+        root = ET.fromstring(r.text)
+        model = (
+            root.findtext(".//tr64:modelName", namespaces=_TR064_NS)
+            or root.findtext(".//tr64:modelDescription", namespaces=_TR064_NS)
+            or root.findtext(".//tr64:friendlyName", namespaces=_TR064_NS)
+            or "FRITZ!Box"
+        )
+        sw_version = root.findtext(".//tr64:systemVersion/tr64:Display", namespaces=_TR064_NS) or ""
+        return {"model": model, "sw_version": sw_version}
+    except Exception as e:
+        log.debug("FritzBox TR-064 device info fallback unavailable: %s", e)
         return {"model": "FRITZ!Box", "sw_version": ""}
 
 

--- a/tests/test_fritzbox_api.py
+++ b/tests/test_fritzbox_api.py
@@ -1,0 +1,79 @@
+"""Tests for the direct FritzBox API helpers in app.fritzbox."""
+
+from unittest.mock import MagicMock, patch
+
+from app import fritzbox as fb
+
+
+TR064_DESC_XML = """<?xml version="1.0"?>
+<root xmlns="urn:dslforum-org:device-1-0">
+  <systemVersion>
+    <Display>267.08.21</Display>
+  </systemVersion>
+  <device>
+    <modelName>FRITZ!Box 6690 Cable</modelName>
+    <modelDescription>FRITZ!Box 6690 Cable</modelDescription>
+    <friendlyName>FRITZ!Box 6690 Cable</friendlyName>
+  </device>
+</root>
+"""
+
+
+class TestGetDeviceInfo:
+    @patch("app.fritzbox.requests.post")
+    def test_uses_overview_json_when_available(self, mock_post):
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "data": {
+                "fritzos": {
+                    "Productname": "FRITZ!Box 6660 Cable",
+                    "nspver": "8.02",
+                    "Uptime": "1234",
+                }
+            }
+        }
+        mock_post.return_value = response
+
+        info = fb.get_device_info("http://fritz.box", "sid123")
+
+        assert info == {
+            "model": "FRITZ!Box 6660 Cable",
+            "sw_version": "8.02",
+            "uptime_seconds": 1234,
+        }
+
+    @patch("app.fritzbox.requests.get")
+    @patch("app.fritzbox.requests.post")
+    def test_falls_back_to_tr064_when_overview_returns_html(self, mock_post, mock_get):
+        html_response = MagicMock()
+        html_response.raise_for_status = MagicMock()
+        html_response.json.side_effect = ValueError("not json")
+        html_response.text = "<html>login</html>"
+        mock_post.return_value = html_response
+
+        tr064_response = MagicMock()
+        tr064_response.raise_for_status = MagicMock()
+        tr064_response.text = TR064_DESC_XML
+        mock_get.return_value = tr064_response
+
+        info = fb.get_device_info("http://fritz.box", "sid123")
+
+        assert info == {
+            "model": "FRITZ!Box 6690 Cable",
+            "sw_version": "267.08.21",
+        }
+
+    @patch("app.fritzbox.requests.get")
+    @patch("app.fritzbox.requests.post")
+    def test_returns_generic_fallback_when_overview_and_tr064_fail(self, mock_post, mock_get):
+        post_response = MagicMock()
+        post_response.raise_for_status = MagicMock()
+        post_response.json.side_effect = ValueError("not json")
+        mock_post.return_value = post_response
+
+        mock_get.side_effect = RuntimeError("network down")
+
+        info = fb.get_device_info("http://fritz.box", "sid123")
+
+        assert info == {"model": "FRITZ!Box", "sw_version": ""}


### PR DESCRIPTION
## Summary

- fall back to 	r064/tr64desc.xml when data.lua?page=overview does not return JSON device info
- extract model and firmware display version from the TR-064 device description
- add direct unit tests for overview JSON, TR-064 fallback, and generic fallback behavior

## Why

On a live FRITZ!Box 6690 Cable test device, docInfo and NetMoni returned valid JSON, but overview returned HTML instead of JSON. That caused Docsight to fall back to the generic FRITZ!Box / empty firmware result even though the box exposes accurate model/version data via TR-064.

## Test plan

- [x] py -3.12 -m pytest tests/test_fritzbox_api.py tests/test_collectors.py -q
- [x] live test against a FRITZ!Box 6690 Cable
  - login via login_sid.lua succeeded
  - docInfo still returned DOCSIS data
  - NetMoni still returned connection info
  - get_device_info() now returns FRITZ!Box 6690 Cable and 267.08.21
