### PR TITLE
fix: prefer stable FritzBox device info pages

### DIFF
--- a/app/fritzbox.py
+++ b/app/fritzbox.py
@@ -11,6 +11,43 @@ log = logging.getLogger("docsis.fritzbox")
 _TR064_NS = {"tr64": "urn:dslforum-org:device-1-0"}
 
 
+def _get_data_page(url: str, sid: str, page: str) -> dict:
+    """Fetch a FritzBox data.lua page and return its data payload."""
+    r = requests.post(
+        f"{url}/data.lua",
+        data={
+            "xhr": 1,
+            "sid": sid,
+            "lang": "de",
+            "page": page,
+            "xhrId": "all",
+            "no_sidrenew": "",
+        },
+        timeout=10,
+    )
+    r.raise_for_status()
+    return r.json().get("data", {})
+
+
+def _parse_fritzos_device_info(data: dict) -> dict:
+    """Extract model/version/uptime from a FritzBox fritzos object."""
+    fritzos = data.get("fritzos", {})
+    if not fritzos:
+        return {}
+
+    result = {
+        "model": fritzos.get("Productname", "FRITZ!Box"),
+        "sw_version": fritzos.get("nspver", ""),
+    }
+    uptime = fritzos.get("Uptime")
+    if uptime is not None:
+        try:
+            result["uptime_seconds"] = int(uptime)
+        except (ValueError, TypeError):
+            pass
+    return result
+
+
 def login(url: str, user: str, password: str) -> str:
     """Authenticate to FritzBox and return session ID."""
     r = requests.get(
@@ -51,53 +88,18 @@ def login(url: str, user: str, password: str) -> str:
 
 def get_docsis_data(url: str, sid: str) -> dict:
     """Query DOCSIS channel data from FritzBox."""
-    r = requests.post(
-        f"{url}/data.lua",
-        data={
-            "xhr": 1,
-            "sid": sid,
-            "lang": "de",
-            "page": "docInfo",
-            "xhrId": "all",
-            "no_sidrenew": "",
-        },
-        timeout=10,
-    )
-    r.raise_for_status()
-    return r.json().get("data", {})
+    return _get_data_page(url, sid, "docInfo")
 
 
 def get_device_info(url: str, sid: str) -> dict:
     """Try to get FritzBox model info."""
-    try:
-        r = requests.post(
-            f"{url}/data.lua",
-            data={
-                "xhr": 1,
-                "sid": sid,
-                "lang": "de",
-                "page": "overview",
-                "xhrId": "all",
-                "no_sidrenew": "",
-            },
-            timeout=10,
-        )
-        r.raise_for_status()
-        data = r.json().get("data", {})
-        fritzos = data.get("fritzos", {})
-        result = {
-            "model": fritzos.get("Productname", "FRITZ!Box"),
-            "sw_version": fritzos.get("nspver", ""),
-        }
-        uptime = fritzos.get("Uptime")
-        if uptime is not None:
-            try:
-                result["uptime_seconds"] = int(uptime)
-            except (ValueError, TypeError):
-                pass
-        return result
-    except Exception as e:
-        log.debug("FritzBox overview device info unavailable, trying TR-064 fallback: %s", e)
+    for page in ("home", "boxinfo", "overview"):
+        try:
+            result = _parse_fritzos_device_info(_get_data_page(url, sid, page))
+            if result:
+                return result
+        except Exception as e:
+            log.debug("FritzBox %s device info unavailable: %s", page, e)
 
     try:
         r = requests.get(f"{url}/tr064/tr64desc.xml", timeout=10)
@@ -119,20 +121,7 @@ def get_device_info(url: str, sid: str) -> dict:
 def get_connection_info(url: str, sid: str) -> dict:
     """Get internet connection info (speeds, type) from netMoni page."""
     try:
-        r = requests.post(
-            f"{url}/data.lua",
-            data={
-                "xhr": 1,
-                "sid": sid,
-                "lang": "de",
-                "page": "netMoni",
-                "xhrId": "all",
-                "no_sidrenew": "",
-            },
-            timeout=10,
-        )
-        r.raise_for_status()
-        data = r.json().get("data", {})
+        data = _get_data_page(url, sid, "netMoni")
         conns = data.get("connections", [])
         if not conns:
             return {}

--- a/tests/test_fritzbox_api.py
+++ b/tests/test_fritzbox_api.py
@@ -21,7 +21,7 @@ TR064_DESC_XML = """<?xml version="1.0"?>
 
 class TestGetDeviceInfo:
     @patch("app.fritzbox.requests.post")
-    def test_uses_overview_json_when_available(self, mock_post):
+    def test_uses_home_json_when_available(self, mock_post):
         response = MagicMock()
         response.raise_for_status = MagicMock()
         response.json.return_value = {
@@ -42,15 +42,46 @@ class TestGetDeviceInfo:
             "sw_version": "8.02",
             "uptime_seconds": 1234,
         }
+        assert mock_post.call_args.kwargs["data"]["page"] == "home"
+
+    @patch("app.fritzbox.requests.post")
+    def test_falls_back_to_boxinfo_when_home_is_not_json(self, mock_post):
+        home_response = MagicMock()
+        home_response.raise_for_status = MagicMock()
+        home_response.json.side_effect = ValueError("not json")
+
+        boxinfo_response = MagicMock()
+        boxinfo_response.raise_for_status = MagicMock()
+        boxinfo_response.json.return_value = {
+            "data": {
+                "fritzos": {
+                    "Productname": "FRITZ!Box 6690 Cable",
+                    "nspver": "8.21",
+                }
+            }
+        }
+
+        mock_post.side_effect = [home_response, boxinfo_response]
+
+        info = fb.get_device_info("http://fritz.box", "sid123")
+
+        assert info == {
+            "model": "FRITZ!Box 6690 Cable",
+            "sw_version": "8.21",
+        }
+        assert [call.kwargs["data"]["page"] for call in mock_post.call_args_list] == [
+            "home",
+            "boxinfo",
+        ]
 
     @patch("app.fritzbox.requests.get")
     @patch("app.fritzbox.requests.post")
-    def test_falls_back_to_tr064_when_overview_returns_html(self, mock_post, mock_get):
+    def test_falls_back_to_tr064_when_data_pages_return_html(self, mock_post, mock_get):
         html_response = MagicMock()
         html_response.raise_for_status = MagicMock()
         html_response.json.side_effect = ValueError("not json")
         html_response.text = "<html>login</html>"
-        mock_post.return_value = html_response
+        mock_post.side_effect = [html_response, html_response, html_response]
 
         tr064_response = MagicMock()
         tr064_response.raise_for_status = MagicMock()
@@ -63,14 +94,19 @@ class TestGetDeviceInfo:
             "model": "FRITZ!Box 6690 Cable",
             "sw_version": "267.08.21",
         }
+        assert [call.kwargs["data"]["page"] for call in mock_post.call_args_list] == [
+            "home",
+            "boxinfo",
+            "overview",
+        ]
 
     @patch("app.fritzbox.requests.get")
     @patch("app.fritzbox.requests.post")
-    def test_returns_generic_fallback_when_overview_and_tr064_fail(self, mock_post, mock_get):
+    def test_returns_generic_fallback_when_all_sources_fail(self, mock_post, mock_get):
         post_response = MagicMock()
         post_response.raise_for_status = MagicMock()
         post_response.json.side_effect = ValueError("not json")
-        mock_post.return_value = post_response
+        mock_post.side_effect = [post_response, post_response, post_response]
 
         mock_get.side_effect = RuntimeError("network down")
 


### PR DESCRIPTION
## Summary
- prefer data.lua?page=home and data.lua?page=boxinfo before falling back to overview
- keep the TR-064 device-info fallback for boxes that still return HTML on those pages
- extend direct API tests to cover the new priority order

## Verification
- py -3.12 -m pytest tests/test_fritzbox_api.py tests/test_collectors.py -q
- live-tested against a FRITZ!Box 6690 Cable where overview returns HTML but home/oxinfo return JSON
