### PR TITLE
fix: clear stale modem dashboard state after modem switch

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -212,6 +212,7 @@ def main():
         if poll_thread and poll_thread.is_alive():
             poll_stop.set()
             poll_thread.join(timeout=10)
+        web.reset_modem_state()
         poll_stop = threading.Event()
         poll_thread = threading.Thread(
             target=polling_loop, args=(config_mgr, storage, poll_stop), daemon=True

--- a/app/web.py
+++ b/app/web.py
@@ -581,6 +581,21 @@ def get_state() -> dict:
         return dict(_state)
 
 
+def reset_modem_state():
+    """Clear modem-specific dashboard state before switching drivers.
+
+    Keeps unrelated collector data like speedtest/weather cache intact so
+    the dashboard only drops the modem-derived sections while a new poll
+    is starting.
+    """
+    with _state_lock:
+        _state["analysis"] = None
+        _state["last_update"] = None
+        _state["error"] = None
+        _state["connection_info"] = None
+        _state["device_info"] = None
+
+
 @app.route("/sw.js")
 def service_worker():
     return send_from_directory(app.static_folder, "sw.js", mimetype="application/javascript")
@@ -733,4 +748,3 @@ def add_security_headers(response):
 # ── Blueprint Registration ──
 from .blueprints import register_blueprints
 register_blueprints(app)
-

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,7 +3,7 @@
 import io
 import json
 import pytest
-from app.web import app, update_state, init_config, init_storage
+from app.web import app, update_state, init_config, init_storage, reset_modem_state, get_state
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.modules.bnetz.storage import BnetzStorage
@@ -207,6 +207,24 @@ class TestHealthEndpoint:
         data = json.loads(resp.data)
         assert data["status"] == "ok"
         assert data["docsis_health"] == "good"
+
+    def test_reset_modem_state_clears_stale_dashboard_data(self, client, sample_analysis):
+        update_state(
+            analysis=sample_analysis,
+            device_info={"model": "Generic Router"},
+            connection_info={"connection_type": "generic"},
+            speedtest_latest={"download_mbps": 230.5},
+        )
+
+        reset_modem_state()
+        state = get_state()
+
+        assert state["analysis"] is None
+        assert state["device_info"] is None
+        assert state["connection_info"] is None
+        assert state["last_update"] is None
+        assert state["error"] is None
+        assert state["speedtest_latest"] == {"download_mbps": 230.5}
 
 
 class TestExportEndpoint:


### PR DESCRIPTION
## Summary
Fix a stale dashboard state bug when switching modem types in settings.

If a user changes from `Generic Router` to a DOCSIS modem like `Netgear CM3000`, the polling loop restarts, but the web state previously kept the old modem-derived dashboard data until the next successful poll. That can leave the homepage looking stuck in generic mode even though the new modem type was saved.

## What changed
- add `web.reset_modem_state()` to clear modem-derived dashboard state before starting a new polling loop
- keep unrelated cached data like speedtest/weather intact
- add a regression test covering stale `analysis`, `device_info`, and `connection_info`

## Why this fixes #164
The reporter was able to switch the setup to `CM3000`, but the homepage still showed the previous generic state. Clearing the old modem dashboard state on config change ensures the UI no longer renders stale Generic Router data while the first CM3000 poll is pending or if it fails.

## Testing
- `pytest tests/test_web.py -q`
- `pytest tests/test_collectors.py tests/test_cm3000_driver.py -q`

Closes #164