### PR TITLE
feat: add Comcast/Xfinity to ISP options

### DIFF
--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -175,7 +175,8 @@
     "Telekom",
     "NetCologne",
     "M-net",
-    "Wilhelm.tel"
+    "Wilhelm.tel",
+    "Comcast/Xfinity"
   ],
   "tariff": "Tarif",
   "max_downstream": "Max Downstream",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -175,7 +175,8 @@
     "Telekom",
     "NetCologne",
     "M-net",
-    "Wilhelm.tel"
+    "Wilhelm.tel",
+    "Comcast/Xfinity"
   ],
   "tariff": "Tariff",
   "max_downstream": "Max Downstream",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -170,7 +170,8 @@
     "Vodafone",
     "Euskaltel",
     "R",
-    "Telecable"
+    "Telecable",
+    "Comcast/Xfinity"
   ],
   "tariff": "Tarifa",
   "max_downstream": "Bajada máxima",

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -167,7 +167,8 @@
   "isp_other_placeholder": "Nom du fournisseur",
   "isp_select": "Choisir un fournisseur",
   "isp_options": [
-    "SFR"
+    "SFR",
+    "Comcast/Xfinity"
   ],
   "tariff": "Forfait",
   "max_downstream": "Débit descendant max",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -190,6 +190,13 @@ class TestIndexRoute:
         assert b"12 ms Ping" in html
 
 
+class TestSettingsRoute:
+    def test_settings_contains_comcast_xfinity_isp_option(self, client):
+        resp = client.get("/settings?lang=en")
+        assert resp.status_code == 200
+        assert b"Comcast/Xfinity" in resp.data
+
+
 class TestHealthEndpoint:
     def test_health_waiting(self, client):
         update_state(analysis=None)


### PR DESCRIPTION
## Summary
Add `Comcast/Xfinity` to the built-in ISP selection list in settings.

This follows up on the request in issue #164 after the CM3000 connection test succeeded and the user asked for Comcast/Xfinity to be available as a provider option.

## What changed
- add `Comcast/Xfinity` to the ISP option lists in `en`, `de`, `es`, and `fr`
- add a small web test to verify the option renders on the settings page

## Notes
There is no dedicated Comcast/Xfinity logo asset yet, so the existing settings UI will fall back to the generic provider icon. The provider can still be selected and saved normally.

## Testing
- `pytest tests/test_web.py -q`

Refs #164