### PR TITLE
fix: restore segment load in correlation chart

### DIFF
--- a/app/modules/weather/storage.py
+++ b/app/modules/weather/storage.py
@@ -6,6 +6,15 @@ import sqlite3
 log = logging.getLogger("docsis.storage.weather")
 
 
+def _normalize_range_ts(ts, separator=" "):
+    """Accept either ISO 'T' or legacy space-separated timestamps for queries."""
+    if not ts or len(ts) < 19:
+        return ts
+    if ts[10] not in ("T", " "):
+        return ts
+    return ts[:10] + separator + ts[11:]
+
+
 class WeatherStorage:
     """Standalone weather data storage (not a mixin).
 
@@ -60,6 +69,8 @@ class WeatherStorage:
 
     def get_weather_in_range(self, start_ts, end_ts):
         """Return weather data within a timestamp range, oldest first."""
+        start_ts = _normalize_range_ts(start_ts, " ")
+        end_ts = _normalize_range_ts(end_ts, " ")
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -51,8 +51,8 @@ function loadCorrelationData() {
 
     /* Calculate time range for weather fetch */
     var now = new Date();
-    var wEnd = now.toISOString().replace('T', ' ').substring(0, 19) + 'Z';
-    var wStart = new Date(now.getTime() - parseInt(hours) * 3600000).toISOString().replace('T', ' ').substring(0, 19) + 'Z';
+    var wEnd = now.toISOString().substring(0, 19) + 'Z';
+    var wStart = new Date(now.getTime() - parseInt(hours) * 3600000).toISOString().substring(0, 19) + 'Z';
     var weatherUrl = '/api/weather/range?start=' + encodeURIComponent(wStart) + '&end=' + encodeURIComponent(wEnd);
 
     var segmentUrl = '/api/fritzbox/segment-utilization/range?start=' + encodeURIComponent(wStart) + '&end=' + encodeURIComponent(wEnd);

--- a/app/storage/segment_utilization.py
+++ b/app/storage/segment_utilization.py
@@ -5,6 +5,15 @@ import threading
 from datetime import datetime, timezone
 
 
+def _normalize_range_ts(ts, separator="T"):
+    """Accept either ISO 'T' or legacy space-separated timestamps for queries."""
+    if not ts or len(ts) < 19:
+        return ts
+    if ts[10] not in ("T", " "):
+        return ts
+    return ts[:10] + separator + ts[11:]
+
+
 class SegmentUtilizationStorage:
     """Standalone storage for cable segment utilization data.
 
@@ -63,6 +72,8 @@ class SegmentUtilizationStorage:
 
     def get_range(self, start_ts, end_ts):
         """Return records within a time range, sorted by timestamp ascending."""
+        start_ts = _normalize_range_ts(start_ts, "T")
+        end_ts = _normalize_range_ts(end_ts, "T")
         conn = self._connect()
         try:
             rows = conn.execute(
@@ -87,6 +98,8 @@ class SegmentUtilizationStorage:
 
     def get_stats(self, start_ts, end_ts):
         """Return min/max/avg statistics for the given time range."""
+        start_ts = _normalize_range_ts(start_ts, "T")
+        end_ts = _normalize_range_ts(end_ts, "T")
         conn = self._connect()
         try:
             row = conn.execute(

--- a/tests/modules/test_fritzbox_cable_storage.py
+++ b/tests/modules/test_fritzbox_cable_storage.py
@@ -41,6 +41,13 @@ class TestGetRange:
         ranged = storage.get_range(start, end)
         assert len(ranged) == 2
 
+    def test_get_range_accepts_legacy_space_separated_query_timestamps(self, storage):
+        storage.save_at("2026-03-09T10:00:00Z", 1.0, 2.0, 0.1, 0.2)
+        storage.save_at("2026-03-09T10:01:00Z", 3.0, 4.0, 0.3, 0.4)
+        ranged = storage.get_range("2026-03-09 09:59:00Z", "2026-03-09 10:00:30Z")
+        assert len(ranged) == 1
+        assert ranged[0]["ds_total"] == pytest.approx(1.0)
+
     def test_get_range_empty(self, storage):
         assert storage.get_range("2000-01-01T00:00:00Z", "2000-01-02T00:00:00Z") == []
 

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -131,6 +131,18 @@ class TestWeatherStorage:
         assert len(results) == 1
         assert results[0]["temperature"] == 4.0
 
+    def test_get_weather_in_range_accepts_iso_t_query_timestamps(self, tmp_path):
+        storage = WeatherStorage(str(tmp_path / "test.db"))
+        records = [
+            {"timestamp": "2026-02-25 10:00:00Z", "temperature": 3.0},
+            {"timestamp": "2026-02-26 10:00:00Z", "temperature": 4.0},
+            {"timestamp": "2026-02-27 10:00:00Z", "temperature": 5.0},
+        ]
+        storage.save_weather_data(records)
+        results = storage.get_weather_in_range("2026-02-26T00:00:00Z", "2026-02-27T00:00:00Z")
+        assert len(results) == 1
+        assert results[0]["temperature"] == 4.0
+
     def test_get_weather_count(self, tmp_path):
         storage = WeatherStorage(str(tmp_path / "test.db"))
         assert storage.get_weather_count() == 0


### PR DESCRIPTION
## Summary
- restore ISO `T` timestamps for correlation range requests so the segment overlay can query stored samples again
- normalize incoming range timestamps in segment storage so older space-separated callers still work
- normalize weather range timestamps as well to keep the weather overlay compatible with ISO queries

## Root cause
`correlation.js` started sending range parameters as `YYYY-MM-DD HH:MM:SSZ` after the JS refactor on 2026-02-27. Segment utilization samples are stored as `YYYY-MM-DDTHH:MM:SSZ`, and the SQLite range filter compares timestamps as strings. That made segment range queries come back empty, so Segment Load DS/US disappeared from the correlation chart.

## Testing
- `python -m pytest tests/modules/test_fritzbox_cable_storage.py -q`
- `python -m pytest tests/test_weather.py -q`
- `python -m pytest tests/e2e/test_segment_utilization.py -k correlation_hover -q`
