### PR TITLE
fix: simplify correlation chart defaults

### DIFF
--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -3,7 +3,7 @@
 /* ═══ Correlation Analysis ═══ */
 var _correlationData = [];
 var _correlationChart = null;
-var _corrVisible = { snr: true, txPower: true, dsPower: true, download: true, upload: true, events: false, errors: true, poorSignal: true, temperature: true, segmentDs: true, segmentUs: false };
+var _corrVisible = { snr: true, txPower: true, dsPower: true, download: true, upload: true, events: false, errors: true, poorSignal: false, temperature: true, segmentDs: true, segmentUs: false };
 var _corrWeatherData = [];
 var _corrSegmentData = [];
 var _corrChartState = null; // Stores scales/data for tooltip lookups
@@ -172,7 +172,7 @@ function renderCorrelationChart(data) {
 
     // Segment utilization axis (0-100% scale)
     var segment = _corrSegmentData || [];
-    var segDsColor = '#a855f7'; // purple
+    var segDsColor = '#0ea5e9'; // sky blue
     var segUsColor = '#6366f1'; // indigo
     function ySegment(v) { return pad.top + plotH - (v / 100) * plotH; }
 
@@ -270,22 +270,8 @@ function renderCorrelationChart(data) {
         ctx.restore();
     }
 
-    // Draw modem SNR line with gradient fill
+    // Draw modem SNR line without an area fill to keep the chart uncluttered
     if (_corrVisible.snr && modem.length > 1) {
-        var gradient = ctx.createLinearGradient(0, pad.top, 0, pad.top + plotH);
-        gradient.addColorStop(0, 'rgba(168,85,247,0.3)');
-        gradient.addColorStop(1, 'rgba(168,85,247,0)');
-        ctx.beginPath();
-        ctx.moveTo(xScale(new Date(modem[0].timestamp).getTime()), pad.top + plotH);
-        for (var i = 0; i < modem.length; i++) {
-            var x = xScale(new Date(modem[i].timestamp).getTime());
-            var y = ySnr(modem[i].ds_snr_min || snrMin);
-            ctx.lineTo(x, y);
-        }
-        ctx.lineTo(xScale(new Date(modem[modem.length - 1].timestamp).getTime()), pad.top + plotH);
-        ctx.closePath();
-        ctx.fillStyle = gradient;
-        ctx.fill();
         ctx.beginPath();
         for (var i = 0; i < modem.length; i++) {
             var x = xScale(new Date(modem[i].timestamp).getTime());
@@ -392,22 +378,8 @@ function renderCorrelationChart(data) {
 
     // Draw speedtest lines
     if (sortedSpeedtest.length > 1) {
-        // Download line with gradient fill
+        // Download line without an area fill
         if (_corrVisible.download) {
-            var dlGrad = ctx.createLinearGradient(0, pad.top, 0, pad.top + plotH);
-            dlGrad.addColorStop(0, 'rgba(76,175,80,0.2)');
-            dlGrad.addColorStop(1, 'rgba(76,175,80,0)');
-            ctx.beginPath();
-            ctx.moveTo(xScale(new Date(sortedSpeedtest[0].timestamp).getTime()), pad.top + plotH);
-            for (var i = 0; i < sortedSpeedtest.length; i++) {
-                var x = xScale(new Date(sortedSpeedtest[i].timestamp).getTime());
-                var y = yDl(sortedSpeedtest[i].download_mbps || 0);
-                ctx.lineTo(x, y);
-            }
-            ctx.lineTo(xScale(new Date(sortedSpeedtest[sortedSpeedtest.length - 1].timestamp).getTime()), pad.top + plotH);
-            ctx.closePath();
-            ctx.fillStyle = dlGrad;
-            ctx.fill();
             ctx.beginPath();
             for (var i = 0; i < sortedSpeedtest.length; i++) {
                 var x = xScale(new Date(sortedSpeedtest[i].timestamp).getTime());

--- a/tests/e2e/test_segment_utilization.py
+++ b/tests/e2e/test_segment_utilization.py
@@ -5,6 +5,8 @@ range switching, API responses, i18n, theme switching, correlation
 integration, and JS error-free operation.
 """
 
+import re
+
 import pytest
 
 
@@ -408,6 +410,61 @@ class TestSegmentCorrelation:
         if legend.count() > 0:
             text = legend.text_content()
             assert "Segment" in text, f"Legend should mention Segment, got: {text}"
+
+    def test_correlation_defaults_disable_poor_signal_and_line_metrics_have_no_area_fill(self, fritzbox_page):
+        """Poor Signal starts disabled and isolated line metrics render without area fills."""
+        fritzbox_page.locator('a.nav-item[data-view="correlation"]').click()
+        fritzbox_page.wait_for_timeout(3000)
+
+        poor_signal = fritzbox_page.locator('#correlation-legend span[data-metric="poorSignal"]')
+        assert poor_signal.count() == 1
+        assert re.search(r"\bdisabled\b", poor_signal.get_attribute("class") or "")
+
+        gradient_calls = fritzbox_page.evaluate("""
+            () => {
+                var originalGradient = CanvasRenderingContext2D.prototype.createLinearGradient;
+                var gradientCalls = 0;
+                CanvasRenderingContext2D.prototype.createLinearGradient = function() {
+                    gradientCalls += 1;
+                    return originalGradient.apply(this, arguments);
+                };
+                try {
+                    window._corrVisible = {
+                        snr: true,
+                        txPower: false,
+                        dsPower: false,
+                        download: false,
+                        upload: false,
+                        events: false,
+                        errors: false,
+                        poorSignal: false,
+                        temperature: false,
+                        segmentDs: false,
+                        segmentUs: false
+                    };
+                    window.renderCorrelationChart(window._correlationData);
+                    window._corrVisible = {
+                        snr: false,
+                        txPower: false,
+                        dsPower: false,
+                        download: true,
+                        upload: false,
+                        events: false,
+                        errors: false,
+                        poorSignal: false,
+                        temperature: false,
+                        segmentDs: false,
+                        segmentUs: false
+                    };
+                    window.renderCorrelationChart(window._correlationData);
+                    return gradientCalls;
+                } finally {
+                    CanvasRenderingContext2D.prototype.createLinearGradient = originalGradient;
+                }
+            }
+        """)
+
+        assert gradient_calls == 0
 
     def test_correlation_hover_shows_tooltip_and_highlights_timeline(self, fritzbox_page):
         """Hovering the correlation chart should keep tooltip and timeline sync working with segment data."""


### PR DESCRIPTION
## Summary
- disable `Poor Signal` by default in the correlation chart
- remove area fills from SNR and download so correlation lines render line-only
- give `Segment DS` its own color instead of reusing the SNR purple

## Verification
- `python -m pytest tests/e2e/test_segment_utilization.py -k "correlation_defaults_disable_poor_signal_and_line_metrics_have_no_area_fill or correlation_view_loads_for_fritzbox or correlation_legend_has_segment_entries" -q`
- `python -m pytest tests/test_correlation_segment.py -q`

## Notes
- `tests/e2e/test_segment_utilization.py -k correlation_hover_shows_tooltip_and_highlights_timeline -q` still fails on this branch, but reproduces the same way on `origin/main`, so it is not introduced by this change.
