### PR TITLE
fix: handle bool config value for mqtt_tls_insecure

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -76,7 +76,7 @@ def polling_loop(config_mgr, storage, stop_event):
     if mqtt_cls and config_mgr.is_mqtt_configured():
         mqtt_user = config["mqtt_user"] or None
         mqtt_password = config["mqtt_password"] or None
-        mqtt_tls_insecure = (config["mqtt_tls_insecure"] or "").strip().lower() == "true"
+        mqtt_tls_insecure = str(config.get("mqtt_tls_insecure", "")).strip().lower() in ("true", "1", "yes", "on")
         mqtt_pub = mqtt_cls(
             host=config["mqtt_host"],
             port=int(config["mqtt_port"]),


### PR DESCRIPTION
## Summary

- Fixes crash in polling thread when `mqtt_tls_insecure` config value is a `bool` instead of a string
- The manifest default is `false` (bool), but the code called `.strip()` on it, causing `AttributeError: 'bool' object has no attribute 'strip'`
- This killed the polling thread entirely, leaving the dashboard stuck on "Waiting for first DOCSIS query"
- Fix: use `str()` to safely coerce before string comparison

Reported by @jdavis7765 in #165

## Test plan

- [ ] Configure MQTT with TLS insecure checkbox enabled - polling works
- [ ] Configure MQTT with TLS insecure checkbox disabled - polling works
- [ ] Fresh install without MQTT configured - polling works