### PR TITLE
fix: harden backup module config coercion

### DIFF
--- a/app/modules/backup/collector.py
+++ b/app/modules/backup/collector.py
@@ -13,8 +13,27 @@ class BackupCollector(Collector):
     name = "backup"
 
     def __init__(self, config_mgr, poll_interval=86400, **kwargs):
-        super().__init__(poll_interval)
         self._config_mgr = config_mgr
+        interval_hours = self._get_interval_hours(config_mgr, poll_interval // 3600)
+        super().__init__(interval_hours * 3600)
+
+    @staticmethod
+    def _get_interval_hours(config_mgr, default_hours=24):
+        """Return configured backup interval in hours as int."""
+        try:
+            value = int(config_mgr.get("backup_interval_hours", default_hours))
+        except (TypeError, ValueError):
+            return default_hours
+        return value if value > 0 else default_hours
+
+    @staticmethod
+    def _get_retention(config_mgr, default_keep=5):
+        """Return backup retention as int."""
+        try:
+            value = int(config_mgr.get("backup_retention", default_keep))
+        except (TypeError, ValueError):
+            return default_keep
+        return value if value > 0 else default_keep
 
     def is_enabled(self):
         return self._config_mgr.is_backup_configured()
@@ -24,7 +43,7 @@ class BackupCollector(Collector):
 
         data_dir = self._config_mgr.data_dir
         backup_path = self._config_mgr.get("backup_path", "/backup")
-        retention = self._config_mgr.get("backup_retention", 5)
+        retention = self._get_retention(self._config_mgr)
 
         try:
             filename = create_backup_to_file(data_dir, backup_path)

--- a/app/modules/backup/routes.py
+++ b/app/modules/backup/routes.py
@@ -20,6 +20,15 @@ log = logging.getLogger("docsis.web")
 bp = Blueprint("backup_bp", __name__)
 
 
+def _int_config(config_mgr, key, default):
+    """Read an integer-like config value safely."""
+    try:
+        value = int(config_mgr.get(key, default))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
 @bp.route("/api/backup", methods=["POST"])
 @require_auth
 def api_backup_download():
@@ -47,7 +56,7 @@ def api_backup_scheduled():
     if not _config_manager:
         return jsonify({"error": "Not initialized"}), 500
     backup_path = _config_manager.get("backup_path", "/backup")
-    retention = _config_manager.get("backup_retention", 5)
+    retention = _int_config(_config_manager, "backup_retention", 5)
     try:
         from .backup import create_backup_to_file, cleanup_old_backups
         filename = create_backup_to_file(_config_manager.data_dir, backup_path)

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 import tarfile
+from unittest.mock import MagicMock
 
 import pytest
 from io import BytesIO
@@ -20,6 +21,7 @@ from app.modules.backup.backup import (
     restore_backup,
     validate_backup,
 )
+from app.modules.backup.collector import BackupCollector
 
 
 # ── Fixtures ──
@@ -262,6 +264,46 @@ class TestListAndCleanup:
             f.write(b"fake")
         deleted = cleanup_old_backups(backup_dir, keep=5)
         assert deleted == 0
+
+
+class TestBackupCollectorConfig:
+    def test_uses_configured_interval_hours_from_string(self):
+        mgr = MagicMock()
+        mgr.get.side_effect = lambda key, default=None: {
+            "backup_interval_hours": "168",
+        }.get(key, default)
+
+        collector = BackupCollector(mgr)
+
+        assert collector.poll_interval_seconds == 168 * 3600
+
+    def test_collect_casts_retention_from_string(self, monkeypatch):
+        mgr = MagicMock()
+        mgr.data_dir = "/data"
+        mgr.get.side_effect = lambda key, default=None: {
+            "backup_path": "/backup",
+            "backup_retention": "5",
+        }.get(key, default)
+
+        calls = {}
+
+        def fake_create_backup_to_file(data_dir, backup_path):
+            calls["create"] = (data_dir, backup_path)
+            return "docsight_backup_test.tar.gz"
+
+        def fake_cleanup_old_backups(backup_path, keep=5):
+            calls["cleanup"] = (backup_path, keep)
+            return 0
+
+        monkeypatch.setattr("app.modules.backup.backup.create_backup_to_file", fake_create_backup_to_file)
+        monkeypatch.setattr("app.modules.backup.backup.cleanup_old_backups", fake_cleanup_old_backups)
+
+        collector = BackupCollector(mgr)
+        result = collector.collect()
+
+        assert result.success is True
+        assert calls["create"] == ("/data", "/backup")
+        assert calls["cleanup"] == ("/backup", 5)
 
 
 # ── TestBrowseDirectory ──


### PR DESCRIPTION
## Summary
- coerce backup module config values to integers before using them in scheduling and retention logic
- honor the configured `backup_interval_hours` in `BackupCollector` instead of always falling back to the default interval
- add regression tests for string-backed interval and retention values

## Problem
Backup settings are stored via module config and can come back as strings. The backup module treated these values like integers:
- scheduled backup retention could fail when `backup_retention` was string-backed
- the backup collector ignored `backup_interval_hours` and always used the default poll interval

This could break scheduled backups even though the UI configuration looked valid.

## Fix
- added safe integer coercion in the backup collector
- added safe integer coercion in the scheduled backup route
- wired the collector poll interval to the configured backup interval
- added focused regression coverage in `tests/test_backup.py`

## Verification
- `pytest -q tests/test_backup.py`
- result: `29 passed`
