### PR TITLE
fix: show existing backups in settings

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -40,7 +40,7 @@ function switchSection(id) {
 
     /* Auto-load data for certain panels */
     if (id === 'security') loadApiTokens();
-    if (id === 'backup') loadBackupList();
+    if (target && target.querySelector('#backup-list')) loadBackupList();
     if (id === 'themes') refreshRegistry();
 
     /* URL hash */
@@ -710,8 +710,9 @@ function loadBackupList() {
     fetch('/api/backup/list')
     .then(function(r) { return r.json(); })
     .then(function(res) {
+        var backups = Array.isArray(res) ? res : (res && Array.isArray(res.backups) ? res.backups : []);
         el.textContent = '';
-        if (!res.backups || res.backups.length === 0) {
+        if (backups.length === 0) {
             var emptySpan = document.createElement('span');
             emptySpan.style.cssText = 'color:var(--muted);font-style:italic;';
             emptySpan.textContent = T.backup_none || 'No backups found';
@@ -721,9 +722,9 @@ function loadBackupList() {
         var table = document.createElement('table');
         table.style.cssText = 'width:100%;border-collapse:collapse;';
         var tbody = document.createElement('tbody');
-        res.backups.forEach(function(b) {
+        backups.forEach(function(b) {
             var sizeMB = (b.size / 1048576).toFixed(1);
-            var date = new Date(b.modified * 1000).toLocaleString();
+            var date = b.modified ? new Date(b.modified).toLocaleString() : '';
             var tr = document.createElement('tr');
             tr.style.cssText = 'border-bottom:1px solid var(--card-border);';
 

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -57,3 +57,31 @@ class TestSettingsFormElements:
     def test_back_to_dashboard_link(self, settings_page):
         link = settings_page.locator('a[href="/"]')
         assert link.count() > 0
+
+
+class TestBackupModule:
+    """Backup module settings interactions."""
+
+    def test_backup_section_loads_existing_backups(self, settings_page):
+        settings_page.route(
+            "**/api/backup/list",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="application/json",
+                body="""
+                [
+                  {
+                    "filename": "docsight_backup_2026-03-14_120000.tar.gz",
+                    "size": 3145728,
+                    "modified": "2026-03-14T12:00:00"
+                  }
+                ]
+                """,
+            ),
+        )
+
+        settings_page.locator('button[data-section="mod-docsight_backup"]').click()
+
+        backup_list = settings_page.locator("#backup-list")
+        assert backup_list.locator("code").first.text_content() == "docsight_backup_2026-03-14_120000.tar.gz"
+        assert backup_list.get_by_text("3.0 MB").count() > 0


### PR DESCRIPTION
## Summary
- load the backup list for the actual backup module settings panel instead of only a non-existent `backup` section
- accept the backup list API's array response in the settings UI and parse ISO timestamps correctly
- add an E2E regression test that verifies existing backups render in the settings panel

## Testing
- `/home/dnns/Projects/docsight/.venv/bin/python -m pytest tests/test_backup.py -q`
- `/home/dnns/Projects/docsight/.venv/bin/python -m pytest tests/e2e/test_settings.py -q`