### PR TITLE
fix: prevent duplicate backups on container restart

### DIFF
--- a/app/modules/backup/collector.py
+++ b/app/modules/backup/collector.py
@@ -1,6 +1,7 @@
 """Scheduled backup collector."""
 
 import logging
+import time
 
 from app.collectors.base import Collector, CollectorResult
 
@@ -16,6 +17,30 @@ class BackupCollector(Collector):
         self._config_mgr = config_mgr
         interval_hours = self._get_interval_hours(config_mgr, poll_interval // 3600)
         super().__init__(interval_hours * 3600)
+        self._seed_last_poll()
+
+    def _seed_last_poll(self):
+        """Set _last_poll from newest backup on disk to survive container restarts.
+
+        Seeds from the newest file regardless of source (scheduled or manual).
+        This means a manual backup can shift the automatic schedule after a
+        restart, which is acceptable: the guarantee is "at least one backup
+        every <interval>", not "backups at a fixed time of day".
+        """
+        from datetime import datetime
+        from .backup import list_backups
+
+        backup_path = self._config_mgr.get("backup_path", "/backup")
+        backups = list_backups(backup_path)
+        if not backups:
+            return
+        try:
+            dt = datetime.fromisoformat(backups[0]["modified"])
+            self._last_poll = dt.timestamp()
+            age_hours = (time.time() - self._last_poll) / 3600
+            log.info("Backup schedule seeded from disk — newest backup is %.1fh old", age_hours)
+        except (ValueError, TypeError):
+            pass
 
     @staticmethod
     def _get_interval_hours(config_mgr, default_hours=24):

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -627,6 +627,96 @@ class TestSpeedtestCollector:
         assert c.name == "speedtest"
 
 
+# ── BackupCollector Tests ──
+
+
+class TestBackupCollector:
+    def _make_collector(self, configured=True, interval_hours=24, backups=None):
+        config_mgr = MagicMock()
+        config_mgr.is_backup_configured.return_value = configured
+        config_mgr.data_dir = "/data"
+        config_mgr.get.side_effect = lambda k, *a: {
+            "backup_path": "/backup",
+            "backup_interval_hours": interval_hours,
+            "backup_retention": 5,
+        }.get(k, a[0] if a else None)
+
+        from app.modules.backup.collector import BackupCollector
+        with patch("app.modules.backup.backup.list_backups", return_value=backups or []):
+            c = BackupCollector(config_mgr=config_mgr)
+        return c, config_mgr
+
+    def test_name(self):
+        c, _ = self._make_collector()
+        assert c.name == "backup"
+
+    def test_is_enabled(self):
+        c, _ = self._make_collector(configured=True)
+        assert c.is_enabled() is True
+        c2, _ = self._make_collector(configured=False)
+        assert c2.is_enabled() is False
+
+    def test_interval_from_config(self):
+        c, _ = self._make_collector(interval_hours=168)
+        assert c._poll_interval_seconds == 168 * 3600
+
+    def test_seed_last_poll_from_disk(self):
+        """_last_poll is seeded from newest backup file on init."""
+        from datetime import datetime, timedelta
+        two_hours_ago = (datetime.now() - timedelta(hours=2)).isoformat()
+        backups = [{"filename": "docsight_backup_test.tar.gz", "size": 100, "modified": two_hours_ago}]
+        c, _ = self._make_collector(backups=backups)
+        # _last_poll should be close to 2h ago, not 0
+        assert c._last_poll > 0
+        age = time.time() - c._last_poll
+        assert 7000 < age < 7400  # ~2h in seconds
+
+    def test_seed_no_backups_leaves_last_poll_zero(self):
+        """No backups on disk → _last_poll stays 0, first backup runs immediately."""
+        c, _ = self._make_collector(backups=[])
+        assert c._last_poll == 0.0
+
+    def test_should_poll_false_after_seed(self):
+        """Container restart with recent backup → should_poll() returns False."""
+        from datetime import datetime, timedelta
+        one_hour_ago = (datetime.now() - timedelta(hours=1)).isoformat()
+        backups = [{"filename": "docsight_backup_test.tar.gz", "size": 100, "modified": one_hour_ago}]
+        c, _ = self._make_collector(interval_hours=24, backups=backups)
+        assert c.should_poll() is False
+
+    def test_should_poll_true_when_backup_expired(self):
+        """Backup older than interval → should_poll() returns True."""
+        from datetime import datetime, timedelta
+        two_days_ago = (datetime.now() - timedelta(days=2)).isoformat()
+        backups = [{"filename": "docsight_backup_old.tar.gz", "size": 100, "modified": two_days_ago}]
+        c, _ = self._make_collector(interval_hours=24, backups=backups)
+        assert c.should_poll() is True
+
+    def test_seed_includes_manual_backups(self):
+        """Seed uses newest backup regardless of source (scheduled or manual).
+
+        After a restart, _last_poll anchors to the newest file on disk.
+        This means a manual backup can shift the automatic schedule, which
+        is by design: the guarantee is "at least one backup every <interval>".
+        """
+        from datetime import datetime, timedelta
+        one_hour_ago = (datetime.now() - timedelta(hours=1)).isoformat()
+        backups = [{"filename": "docsight_backup_2026-03-15_120000.tar.gz", "size": 100, "modified": one_hour_ago}]
+        c, _ = self._make_collector(interval_hours=24, backups=backups)
+        # _last_poll is seeded from the file, so should_poll() waits
+        assert c.should_poll() is False
+
+    @patch("app.modules.backup.backup.create_backup_to_file")
+    @patch("app.modules.backup.backup.cleanup_old_backups")
+    def test_collect_creates_backup(self, mock_cleanup, mock_create):
+        mock_create.return_value = "docsight_backup_2026-03-15.tar.gz"
+        c, _ = self._make_collector()
+        result = c.collect()
+        assert result.success is True
+        mock_create.assert_called_once()
+        mock_cleanup.assert_called_once()
+
+
 # ── BQMCollector Tests ──
 
 


### PR DESCRIPTION
## Problem

The `BackupCollector` creates a backup immediately on every container startup because `_last_poll` is initialized to `0.0` — meaning `should_poll()` always returns `True` on the first tick. In environments where the container restarts frequently (e.g. via Dockhand auto-updates during active development), this leads to multiple backups per day despite a 24h interval being configured.

**Observed on production instance (`v2026-03-14.726`):**

| monitoring_started | Backup created |
|---|---|
| 00:55:13 | 00:55:10 |
| 00:55:45 | 00:55:41 |
| 03:00:36 | 03:00:31 |
| 04:00:57 | 04:00:54 |

5 backups in 7 hours with a daily interval configured — each one triggered by a container restart.

## Fix

On init, `_seed_last_poll()` reads the newest backup file's modification timestamp from disk and sets `_last_poll` accordingly. This way `should_poll()` correctly waits until the configured interval has elapsed since the last actual backup, even after a container restart.

**Design decision:** The seed uses the newest backup file regardless of whether it was created by the scheduled collector or a manual "Backup Now" click. This means a manual backup can shift the automatic schedule after a restart. This is intentional — the guarantee is **"at least one backup every \<interval\>"**, not "backups at a fixed time of day". A manual backup is a valid backup, and waiting another full interval after it is operationally correct.

## Changes

| File | Change |
|------|--------|
| `app/modules/backup/collector.py` | Add `_seed_last_poll()` in `__init__`, documented design decision |
| `tests/test_collectors.py` | 9 new `TestBackupCollector` tests covering seed behavior, `should_poll()`, and manual backup inclusion |

## Test plan

- [x] 1580 tests pass locally
- [ ] Container restart no longer creates duplicate backup
- [ ] First startup with no existing backups → backup created immediately
- [ ] Backup older than interval on disk → `should_poll()` returns True → backup created
- [ ] Recent backup on disk → `should_poll()` returns False → no duplicate