### PR TITLE
fix(cgm4981): return None for missing numeric fields

### DIFF
--- a/app/drivers/cgm4981.py
+++ b/app/drivers/cgm4981.py
@@ -75,10 +75,10 @@ def _text(html: str) -> str:
     return _RE_STRIP.sub("", html).strip()
 
 
-def _float(raw: str) -> float:
-    """Return first float found in a string, e.g. '44.1 dB' → 44.1."""
+def _float(raw: str) -> float | None:
+    """Return first float found in a string, or None if absent."""
     m = _RE_NUMBER.search(raw.strip())
-    return float(m.group()) if m else 0.0
+    return float(m.group()) if m else None
 
 
 def _freq_mhz(raw: str) -> str:

--- a/tests/test_cgm4981_driver.py
+++ b/tests/test_cgm4981_driver.py
@@ -1,0 +1,55 @@
+"""Tests for the CGM4981 driver helpers and channel parsing."""
+
+import pytest
+
+from app.drivers.cgm4981 import _float, _modulation
+
+
+class TestFloat:
+    """_float() should return None for blank/unparseable input."""
+
+    def test_normal_value(self):
+        assert _float("44.1 dB") == 44.1
+
+    def test_negative(self):
+        assert _float("-6.2 dBmV") == -6.2
+
+    def test_integer(self):
+        assert _float("256") == 256.0
+
+    def test_blank(self):
+        assert _float("") is None
+
+    def test_no_number(self):
+        assert _float("N/A") is None
+
+    def test_whitespace(self):
+        assert _float("   ") is None
+
+    def test_zero_is_real(self):
+        assert _float("0.0 dBmV") == 0.0
+
+
+class TestModulation:
+    """_modulation() must return the project-standard format."""
+
+    def test_256qam(self):
+        assert _modulation("256 QAM") == "256QAM"
+
+    def test_64qam(self):
+        assert _modulation("64QAM") == "64QAM"
+
+    def test_ofdm(self):
+        assert _modulation("OFDM") == "OFDM"
+
+    def test_ofdma(self):
+        assert _modulation("OFDMA") == "OFDMA"
+
+    def test_qam_bare(self):
+        assert _modulation("QAM") == "QAM"
+
+    def test_case_insensitive(self):
+        assert _modulation("256 qam") == "256QAM"
+
+    def test_empty(self):
+        assert _modulation("") == ""


### PR DESCRIPTION
## Summary
- `_float()` now returns `None` instead of `0.0` when no number is found in the input
- Prevents the analyzer from treating blank SNR/power cells as real 0 dB / 0 dBmV readings, which would trigger false critical health assessments
- Adds 14 unit tests for `_float()` and `_modulation()` helpers

## Test plan
- `.venv/bin/pytest tests/test_cgm4981_driver.py -v` (14 passed)
- Full suite: 1808 passed

Fixes #260