### PR TITLE
fix(speedtest): increase trigger timeout to 90s

### DIFF
--- a/app/modules/speedtest/routes.py
+++ b/app/modules/speedtest/routes.py
@@ -224,7 +224,7 @@ def api_speedtest_run():
         resp = requests.post(
             f"{url}/api/v1/speedtests/run",
             headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
-            timeout=15,
+            timeout=90,
         )
         if resp.status_code == 201:
             _last_trigger_ts = now

--- a/app/static/js/speedtest.js
+++ b/app/static/js/speedtest.js
@@ -478,7 +478,11 @@ function runSpeedtest() {
         .then(function(latest) {
             var lastId = (latest && latest.length > 0) ? latest[0].id : 0;
             return fetch('/api/speedtest/run', {method: 'POST'})
-                .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
+                .then(function(r) {
+                    return r.json()
+                        .catch(function() { return {error: 'Unexpected response'}; })
+                        .then(function(d) { return {ok: r.ok, data: d}; });
+                })
                 .then(function(res) {
                     if (!res.ok) {
                         _setRunBtnState(btn, false);


### PR DESCRIPTION
## Summary
The Speedtest Tracker `/api/v1/speedtests/run` endpoint can take 30-60s to respond (it initializes the test before replying with 201). The 15s timeout caused every manual trigger to fail.

Verified from inside the container:
- 15s timeout: `Read timed out`
- 90s timeout: `201 Created` after ~30s

Also makes the JSON response parser defensive against malformed/empty responses.

## Test plan
- `.venv/bin/pytest tests/test_speedtest.py -q` (27 passed)
- Manually verified STT trigger from container with 90s timeout succeeds