### PR TITLE
Fix speedtest page mobile view

### DIFF
--- a/app/modules/speedtest/static/style.css
+++ b/app/modules/speedtest/static/style.css
@@ -126,7 +126,14 @@
     background: rgba(168,85,247,0.08);
 }
 
-/* Responsive table card */
+/* Speedtest controls bar */
+.speedtest-controls {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+/* Responsive */
 @media (max-width: 768px) {
     .speedtest-chart-card {
         padding: var(--space-md, 16px);
@@ -135,5 +142,57 @@
     #speedtest-table tbody td {
         padding: 8px 12px;
         font-size: 0.8em;
+    }
+}
+
+@media (max-width: 640px) {
+    .speedtest-controls {
+        flex-wrap: wrap;
+        justify-content: center;
+        width: 100%;
+    }
+    .speedtest-controls .trend-tabs {
+        order: 1;
+        width: 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+    .speedtest-controls .trend-tabs .trend-tab {
+        padding: 6px 14px;
+        font-size: 0.82em;
+    }
+    .speedtest-controls #speedtest-run-btn {
+        order: 2;
+    }
+    .speedtest-controls #speedtest-refresh-btn {
+        order: 3;
+    }
+    .speedtest-chart-card {
+        padding: var(--space-sm, 12px);
+    }
+    .speedtest-chart-wrap canvas {
+        height: 180px;
+    }
+    .speedtest-chart-legend {
+        flex-wrap: wrap;
+        gap: 8px 14px;
+    }
+    #speedtest-table thead th,
+    #speedtest-table tbody td {
+        padding: 6px 8px;
+        font-size: 0.78em;
+    }
+    .st-signal-detail {
+        grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+        gap: 6px 10px;
+        padding: 8px 10px;
+    }
+    .st-signal-detail .st-us-mods span {
+        word-break: break-word;
+    }
+    .trend-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
     }
 }

--- a/app/static/js/speedtest.js
+++ b/app/static/js/speedtest.js
@@ -265,8 +265,9 @@ function renderSpeedtestChart() {
     canvas.height = h * dpr;
     var ctx = canvas.getContext('2d');
     ctx.scale(dpr, dpr);
-    // Padding
-    var padL = 60, padR = 60, padT = 20, padB = 30;
+    // Padding (reduced on narrow screens)
+    var mobile = w < 500;
+    var padL = mobile ? 40 : 60, padR = mobile ? 30 : 60, padT = 20, padB = 30;
     var cw = w - padL - padR;
     var ch = h - padT - padB;
     // Extract data arrays

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1655,7 +1655,7 @@
 <div id="view-speedtest" class="view">
     <div class="trend-header">
         <span class="trend-title">{{ t.speedtest_tracker }}</span>
-        <div style="display:flex; gap:8px; align-items:center;">
+        <div class="speedtest-controls">
             <div class="trend-tabs" id="speedtest-tabs">
                 <button class="trend-tab" data-value="1" onclick="selectPill(this, filterSpeedtestData)">1d</button>
                 <button class="trend-tab active" data-value="7" onclick="selectPill(this, filterSpeedtestData)">7d</button>


### PR DESCRIPTION
## Summary
- Fixes mobile responsiveness on the speedtest page as reported in #255 (comment)
- Controls bar (pill tabs + Run/Refresh buttons) now wraps properly on small screens
- Chart canvas uses reduced padding on narrow viewports for more drawing area
- Table, legend, and signal detail grid adapt to phone-sized screens

## Changes
- **index.html**: Replace inline `style="display:flex"` with `.speedtest-controls` class
- **speedtest/style.css**: Add `@media (max-width: 640px)` breakpoint with full mobile layout
- **speedtest.js**: Reduce chart padding from 60/60px to 40/30px on screens < 500px

## Test plan
- [ ] Open speedtest page on desktop, verify no visual change
- [ ] Open on mobile/responsive mode at 360px width
- [ ] Verify pill tabs wrap to full width row
- [ ] Verify Run Speedtest + Refresh buttons sit below tabs
- [ ] Verify chart is readable (reduced padding, 180px height)
- [ ] Verify table scrolls horizontally with tighter padding
- [ ] Expand a signal detail row, verify grid adapts