### PR TITLE
Fix Sagemcom session recovery after manual modem login

### DIFF
--- a/app/drivers/sagemcom.py
+++ b/app/drivers/sagemcom.py
@@ -254,13 +254,13 @@ class SagemcomDriver(ModemDriver):
         resp = r.json()
         error = resp.get("reply", {}).get("error", {})
         if error.get("description") not in ("XMO_REQUEST_NO_ERR", None):
-            # Log action-level errors for debugging
             for action in resp.get("reply", {}).get("actions", []):
                 act_err = action.get("error", {})
                 if act_err.get("description") != "XMO_NO_ERR":
                     log.debug("Sagemcom action error: %s", act_err)
-            if error.get("code") == 16777236:
-                raise RuntimeError(f"Sagemcom action error: {error.get('description')}")
+            raise RuntimeError(
+                f"Sagemcom XMO error: {error.get('description')} (code={error.get('code')})"
+            )
         return resp
 
     @staticmethod

--- a/tests/test_sagemcom_driver.py
+++ b/tests/test_sagemcom_driver.py
@@ -546,6 +546,64 @@ class TestFullDataFlow:
         result = driver.get_docsis_data()
         assert len(result["channelDs"]["docsis30"]) == 1
 
+    def test_docsis_retry_on_xmo_session_error(self, driver):
+        """When modem returns HTTP 200 with XMO error (e.g. after manual login
+        invalidates DOCSight's session), driver must re-authenticate and retry."""
+        ds = [{"uid": 1, "ChannelID": 1, "LockStatus": True,
+               "Frequency": 300000000.0, "SNR": 40.0, "PowerLevel": 5.0,
+               "Modulation": "Qam256", "BandWidth": 8000000,
+               "UnerroredCodewords": 0, "CorrectableCodewords": 0,
+               "UncorrectableCodewords": 0, "SymbolRate": 6952}]
+        xmo_error_response = {
+            "reply": {
+                "uid": 0, "id": 1,
+                "error": {"code": 16777242, "description": "XMO_UNKNOWN_PATH_ERR"},
+                "actions": [{
+                    "uid": 1, "id": 0,
+                    "error": {"code": 16777242, "description": "XMO_UNKNOWN_PATH_ERR"},
+                    "callbacks": [],
+                }],
+                "events": [],
+            }
+        }
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            resp = MagicMock()
+            resp.ok = True
+            resp.status_code = 200
+            if call_count[0] == 1:
+                resp.json.return_value = xmo_error_response
+            elif call_count[0] == 2:
+                resp.json.return_value = _login_response()
+            else:
+                resp.json.return_value = _docsis_response(ds, [])
+            return resp
+
+        driver._logged_in = True
+        driver._credential_hash = "fake"
+        driver._session_id = 1
+        driver._server_nonce = "1"
+        driver._session.post = side_effect
+        result = driver.get_docsis_data()
+        assert len(result["channelDs"]["docsis30"]) == 1
+        assert call_count[0] == 3  # error + re-login + successful fetch
+
+    def test_xmo_error_raises_runtime_error(self, driver):
+        """Any non-success XMO error in _raw_post must raise RuntimeError."""
+        xmo_error_response = {
+            "reply": {
+                "uid": 0, "id": 1,
+                "error": {"code": 16777242, "description": "XMO_UNKNOWN_PATH_ERR"},
+                "actions": [],
+                "events": [],
+            }
+        }
+        driver._session.post = _mock_post([xmo_error_response])
+        with pytest.raises(RuntimeError, match="XMO_UNKNOWN_PATH_ERR"):
+            driver._raw_post({"request": {}})
+
 
 # -- Connection info --
 


### PR DESCRIPTION
## Summary

Fixes #285 - DOCSight falls back to "Generic Router Mode" when a user manually logs into the modem web UI.

**Root cause:** When the modem invalidates DOCSight's session (e.g. another client logs in), it returns HTTP 200 with XMO error codes like `XMO_UNKNOWN_PATH_ERR` instead of HTTP errors. The driver's `_raw_post()` only raised a `RuntimeError` for one specific error code (`16777236`), silently ignoring all others. This meant:
- Empty channel data was returned as a valid success
- `_logged_in` stayed `True`, preventing re-authentication  
- The collector recorded every empty poll as successful (no backoff)
- The UI showed "Generic Router Mode" (DS=0, US=0) until restart

**Fix:** `_raw_post()` now raises `RuntimeError` for any non-success XMO response. The existing re-auth mechanism in `get_docsis_data()` catches this and automatically re-authenticates + retries.

## Test plan

- [x] 1871 tests pass (full suite)
- [x] New test: `test_docsis_retry_on_xmo_session_error` - simulates HTTP 200 + XMO_UNKNOWN_PATH_ERR, verifies re-auth + successful retry
- [x] New test: `test_xmo_error_raises_runtime_error` - verifies _raw_post raises for any XMO error
- [x] Existing test `test_docsis_retry_on_failure` still passes (HTTP 401 path)