### PR TITLE
fix(correlation): keep TX/DS Power and Errors in tooltip when SNR is hidden

### DIFF
--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -752,11 +752,14 @@ function _setupCorrelationTooltip(overlay, octx) {
         // Convert mouseX to timestamp
         var tHover = st.tMin + (mouseX - st.pad.left) / st.plotW * (st.tMax - st.tMin);
 
-        // Find nearest modem point — always when modem data exists, since TX Power,
-        // DS Power, and Errors each have their own visibility flags and must survive
-        // SNR being toggled off (see issue #331).
+        // Find nearest modem point whenever any modem-derived series is visible.
+        // Previously gated on SNR alone, which hid TX Power / DS Power / Errors from
+        // the tooltip when SNR was toggled off (see issue #331). Keeping a multi-flag
+        // guard ensures displayTs and the table highlight do not snap to a modem
+        // timestamp when every modem series has been hidden.
+        var anyModemVisible = _corrVisible.snr || _corrVisible.txPower || _corrVisible.dsPower || _corrVisible.errors;
         var nearestModem = null;
-        if (st.modem.length > 0) {
+        if (st.modem.length > 0 && anyModemVisible) {
             var bestDist = Infinity;
             for (var i = 0; i < st.modem.length; i++) {
                 var ts = new Date(st.modem[i].timestamp).getTime();

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -752,9 +752,11 @@ function _setupCorrelationTooltip(overlay, octx) {
         // Convert mouseX to timestamp
         var tHover = st.tMin + (mouseX - st.pad.left) / st.plotW * (st.tMax - st.tMin);
 
-        // Find nearest modem point
+        // Find nearest modem point — always when modem data exists, since TX Power,
+        // DS Power, and Errors each have their own visibility flags and must survive
+        // SNR being toggled off (see issue #331).
         var nearestModem = null;
-        if (st.modem.length > 0 && _corrVisible.snr) {
+        if (st.modem.length > 0) {
             var bestDist = Infinity;
             for (var i = 0; i < st.modem.length; i++) {
                 var ts = new Date(st.modem[i].timestamp).getTime();


### PR DESCRIPTION
## Summary

Fixes #331. Deselecting SNR in the Correlation view removed TX Power, DS Power, and Errors from the hover tooltip, even though those metrics have independent visibility toggles.

## Cause

`nearestModem` was only computed when `_corrVisible.snr` was true. With SNR hidden, the variable stayed `null`, which silenced every tooltip row that reads from it (TX, DS, Errors) and every highlight dot that depends on modem data.

## Fix

Compute `nearestModem` whenever there is modem data. The per-metric guards on the individual tooltip rows and highlight dots already gate their own rendering, so SNR-specific visuals remain hidden when SNR is off while the other metrics keep working.

## Test plan

- [ ] Open Correlation view
- [ ] Deselect SNR in legend
- [ ] Hover over the chart and confirm TX Power, DS Power, and Errors rows still appear in the tooltip
- [ ] Re-enable SNR and confirm the SNR row and highlight dot return
- [ ] Toggle each of TX, DS, Errors individually and confirm they follow their own legend state