### PR TITLE
fix(dashboard): let hero-right shrink so the hero-title no longer collapses (#336)

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -841,12 +841,14 @@ body.is-offline .offline-banner { display: flex; }
   .health-overview { grid-template-columns: 1fr 1fr; }
   .hero-header { flex-direction: row; align-items: flex-start; justify-content: space-between; }
   .hero-status { flex: 1; min-width: 0; }
-  .hero-right { flex-shrink: 0; justify-content: flex-end; }
+  .hero-right { flex-shrink: 1; min-width: 0; justify-content: flex-end; }
+  .hero-meta { min-width: 0; }
   /* .hero-meta keeps its base `flex-wrap: wrap` at this breakpoint.
      A prior `flex-wrap: nowrap` override forced the meta strip onto one line,
      which exceeded the flex row width on modems with long model and firmware
-     strings. Because `.hero-right` cannot shrink and `.hero-status` has
-     `min-width: 0`, the left column got squeezed too far, making the
+     strings. Letting `.hero-right` and `.hero-meta` shrink to the available
+     width allows the wrap behavior to engage before the left column gets
+     squeezed too far, which prevents the
      hero-title overflow horizontally and the hero-subtitle collapse into a
      narrow vertical column (reported as issue #336). On wider desktops the
      meta items still render on a single line because `flex-wrap: wrap` only


### PR DESCRIPTION
Follow-up on #336. The first pass did not hold: reporter confirmed the hero-title still collapsed on the latest build.

## Remaining cause

At `@media (min-width: 640px)`, `.hero-right` had `flex-shrink: 0` and `.hero-meta` relied on its default `min-width: auto` (min-content). With `white-space: nowrap` on each meta item, hero-meta's min-content equals the widest single item (typically a long model or firmware string). Together these two rules pinned hero-right to its full max-content width, so the flex algorithm fed the remaining 0 width into `.hero-status` (which carries `min-width: 0`). The title "Critical" then broke letter by letter.

## Fix

- `.hero-right { flex-shrink: 1; min-width: 0; justify-content: flex-end; }`
- `.hero-meta { min-width: 0; }`

The existing `flex-wrap: wrap` on `.hero-meta` from the first pass now actually engages: the right side can shrink when needed, hero-meta can drop below its longest item's width, and items wrap to multiple lines. hero-status keeps enough width for the title and subtitle.

## Test plan

- [x] `luac` / syntax: pure CSS change, Python tests unaffected (will let CI confirm).
- [ ] Visual verification by the reporter on the latest build.