### PR TITLE
fix(dashboard): give .hero-status a content flex-basis so the title has room (#336)

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -840,19 +840,26 @@ body.is-offline .offline-banner { display: flex; }
   .metrics-grid { grid-template-columns: 1fr 1fr; gap: var(--space-md); }
   .health-overview { grid-template-columns: 1fr 1fr; }
   .hero-header { flex-direction: row; align-items: flex-start; justify-content: space-between; }
-  .hero-status { flex: 1; min-width: 0; }
+  /* .hero-status uses flex-basis: auto (content-based) rather than the
+     shorthand `flex: 1` (which expands to `1 1 0%`). With a 0 basis the
+     flex algorithm only fed the left column the leftover free space after
+     .hero-right took its full content width, which was not enough for the
+     hero-title on long health labels such as "Critical" on top of the
+     hero-subtitle. An auto basis gives .hero-status its intrinsic content
+     width up front, so the available space is shared proportionally
+     between both sides during shrink and the hero-title always has room
+     to render (reported as issue #336). */
+  .hero-status { flex: 1 1 auto; min-width: 0; }
   .hero-right { flex-shrink: 1; min-width: 0; justify-content: flex-end; }
   .hero-meta { min-width: 0; }
-  /* .hero-meta keeps its base `flex-wrap: wrap` at this breakpoint.
-     A prior `flex-wrap: nowrap` override forced the meta strip onto one line,
-     which exceeded the flex row width on modems with long model and firmware
-     strings. Letting `.hero-right` and `.hero-meta` shrink to the available
-     width allows the wrap behavior to engage before the left column gets
-     squeezed too far, which prevents the
-     hero-title overflow horizontally and the hero-subtitle collapse into a
-     narrow vertical column (reported as issue #336). On wider desktops the
-     meta items still render on a single line because `flex-wrap: wrap` only
-     wraps when content actually overflows. */
+  /* .hero-meta keeps its base `flex-wrap: wrap` at this breakpoint. A prior
+     `flex-wrap: nowrap` override forced the meta strip onto one line, which
+     combined with `.hero-right { flex-shrink: 0 }` and `.hero-status`'s
+     0 flex-basis squeezed the left column. Allowing both sides to shrink
+     plus letting .hero-meta wrap now produces a balanced two-row meta
+     layout on narrow viewports without touching the single-row layout on
+     wider desktops, because `flex-wrap: wrap` only wraps when content
+     actually overflows. */
   /* hero-title uses clamp() for fluid scaling */
   .hero-chart-wrap { height: 120px; }
   .hero-card { padding: var(--space-lg); }


### PR DESCRIPTION
Round 3 on #336. Reporter confirmed the hero card still collapsed on the latest build after #337 and #338.

## What was still wrong

Even after #338 unlocked `.hero-right { flex-shrink: 1 }` and `.hero-meta { min-width: 0 }`, `.hero-status` kept `flex: 1` (shorthand for `flex: 1 1 0%`). A zero flex-basis means the left column only receives whatever free space is left after the right column takes its content width. On the reporter's worst case (health "Critical", long ISP / model / firmware strings, 1440 px viewport) that came out to around 100 px on the left, which is not enough for the word "Critical" plus the health description, so the title pushed into the meta strip and the subtitle collapsed.

## Fix

Change `.hero-status { flex: 1; min-width: 0; }` to `.hero-status { flex: 1 1 auto; min-width: 0; }`. With a content-based basis, both sides start at their intrinsic widths, so when the row overflows the shrink is distributed proportionally between the two sides. The left column always keeps enough width for the title and the description, and `.hero-meta` wraps to a second row on the right when needed.

## Verification

Verified empirically through Playwright on a 1440 px viewport of the dev dashboard, with the DOM mutated to reproduce the reporter's data (health "Critical", full description text, two long FAST3896 firmware meta items):

- `.hero-status` widened from ~100 px to ~485 px.
- `.hero-right` dropped from ~944 px to ~559 px.
- `.hero-meta` laid out across two rows instead of one.
- Hero-title rendered without overflow or letter-wrap.
- Hero-subtitle rendered on two lines at full readable width.

## Test plan

- [x] Pure CSS change, Python tests unaffected (CI will confirm).
- [x] Empirical browser verification on 1440 px viewport with reporter's data.
- [ ] Reporter confirmation on the latest build once this ships.

Closes #336.