### PR TITLE
feat: support secret-aware community module config

### DIFF
--- a/app/collectors/__init__.py
+++ b/app/collectors/__init__.py
@@ -135,7 +135,7 @@ def discover_collectors(config_mgr, storage, event_detector, mqtt_pub, web, anal
                     else:
                         mod_cfg = _ModuleConfigProxy(
                             config_mgr,
-                            allowed_secret_keys=set(mod.config.keys()) & SECRET_KEYS,
+                            allowed_secret_keys=set(mod.config_secrets) & SECRET_KEYS,
                         )
                     c = mod.collector_class(
                         config_mgr=mod_cfg,

--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -44,6 +44,7 @@ class ModuleInfo:
     homepage: str = ""
     license: str = ""
     config: dict[str, Any] = field(default_factory=dict)
+    config_secrets: list[str] = field(default_factory=list)
     menu: dict[str, Any] = field(default_factory=dict)
     enabled: bool = True
     error: str | None = None
@@ -108,6 +109,22 @@ def validate_manifest(raw: dict[str, Any], module_path: str) -> ModuleInfo:
     norm = os.path.normpath(module_path).replace("\\", "/")
     builtin = "/app/modules/" in norm or "\\app\\modules\\" in os.path.normpath(module_path)
 
+    config_secrets_raw = raw.get("config_secrets", [])
+    if not isinstance(config_secrets_raw, list) or not all(isinstance(s, str) for s in config_secrets_raw):
+        raise ManifestError("'config_secrets' must be a list of strings")
+    config_defaults = raw.get("config", {}) or {}
+    if not builtin:
+        conflicting_keys = sorted(set(config_defaults) & set(_cfg.DEFAULTS))
+        if conflicting_keys:
+            raise ManifestError(
+                f"community module config keys conflict with existing core keys: {conflicting_keys}"
+            )
+    unknown_secrets = [s for s in config_secrets_raw if s not in config_defaults]
+    if unknown_secrets:
+        raise ManifestError(
+            f"'config_secrets' references keys not declared in 'config': {sorted(unknown_secrets)}"
+        )
+
     return ModuleInfo(
         id=mod_id,
         name=raw["name"],
@@ -121,7 +138,8 @@ def validate_manifest(raw: dict[str, Any], module_path: str) -> ModuleInfo:
         builtin=builtin,
         homepage=raw.get("homepage", ""),
         license=raw.get("license", ""),
-        config=raw.get("config", {}),
+        config=config_defaults,
+        config_secrets=list(config_secrets_raw),
         menu={**{"order": 999}, **raw.get("menu", {})},
         hints=raw.get("hints", {}),
     )
@@ -194,11 +212,16 @@ def discover_modules(
     return modules
 
 
-def register_module_config(config_defaults: dict[str, Any]) -> None:
+def register_module_config(
+    config_defaults: dict[str, Any],
+    secret_keys: list[str] | None = None,
+) -> None:
     """Register a module's config defaults into the global config system.
 
     - Adds defaults to config.DEFAULTS (without overwriting existing keys)
     - Auto-detects bool/int keys and adds them to BOOL_KEYS/INT_KEYS
+    - Adds any declared secret keys to SECRET_KEYS so they are encrypted at rest
+      and masked in /api/config responses.
     """
     for key, value in config_defaults.items():
         if key in _cfg.DEFAULTS:
@@ -209,6 +232,8 @@ def register_module_config(config_defaults: dict[str, Any]) -> None:
             _cfg.BOOL_KEYS.add(key)
         elif isinstance(value, int):
             _cfg.INT_KEYS.add(key)
+    for key in (secret_keys or []):
+        _cfg.SECRET_KEYS.add(key)
 
 
 def merge_module_i18n(module_id: str, i18n_dir: str) -> None:
@@ -632,7 +657,7 @@ class ModuleLoader:
 
         # Config defaults
         if mod.config:
-            register_module_config(mod.config)
+            register_module_config(mod.config, secret_keys=mod.config_secrets)
 
         # i18n
         if "i18n" in c:

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -265,7 +265,13 @@ function showToast(msg, ok) {
 
 /* ── Form Data ── */
 var MASK = '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022';
-var SECRET_FIELDS = ['modem_password', 'mqtt_password', 'admin_password', 'speedtest_tracker_token', 'notify_webhook_token'];
+var SECRET_FIELDS = window.SECRET_FIELDS || [
+    'modem_password',
+    'mqtt_password',
+    'admin_password',
+    'speedtest_tracker_token',
+    'notify_webhook_token'
+];
 
 function escHtml(s) {
     var d = document.createElement('div');

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -192,6 +192,7 @@ var currentLang = '{{ lang }}';
 var currentTz = '{{ config.timezone|default("", true) }}';
 try { var savedCooldowns = JSON.parse('{{ config.notify_cooldowns|default("{}")|e }}'); } catch(e) { var savedCooldowns = {}; }
 var DRIVER_HINTS = {{ driver_hints | tojson }};
+window.SECRET_FIELDS = {{ secret_fields | tojson }};
 </script>
 <script src="/static/js/utils.js"></script>
 <script src="/static/js/settings.js"></script>

--- a/app/web.py
+++ b/app/web.py
@@ -921,7 +921,31 @@ def settings():
             "manage_label": t.get("step_modem", "Modem"),
         },
     ]
-    return render_template("settings.html", config=config, theme=theme, poll_min=POLL_MIN, poll_max=POLL_MAX, t=t, lang=lang, languages=LANGUAGES, lang_flags=LANG_FLAGS, server_tz=tz_name, server_tz_offset=tz_offset, modem_types=modem_types, driver_hints=driver_hints, demo_mode=demo_mode, timezones=_get_iana_timezones(), iana_tz=iana_tz, tz_is_posix=tz_is_posix, all_modules=all_modules, built_in_features=built_in_features)
+    from .config import HASH_KEYS, SECRET_KEYS
+
+    secret_fields = sorted(SECRET_KEYS | HASH_KEYS)
+    return render_template(
+        "settings.html",
+        config=config,
+        theme=theme,
+        poll_min=POLL_MIN,
+        poll_max=POLL_MAX,
+        t=t,
+        lang=lang,
+        languages=LANGUAGES,
+        lang_flags=LANG_FLAGS,
+        server_tz=tz_name,
+        server_tz_offset=tz_offset,
+        modem_types=modem_types,
+        driver_hints=driver_hints,
+        demo_mode=demo_mode,
+        timezones=_get_iana_timezones(),
+        iana_tz=iana_tz,
+        tz_is_posix=tz_is_posix,
+        all_modules=all_modules,
+        built_in_features=built_in_features,
+        secret_fields=secret_fields,
+    )
 
 
 @app.after_request

--- a/tests/test_module_secret_config.py
+++ b/tests/test_module_secret_config.py
@@ -1,0 +1,67 @@
+import copy
+
+from app import config as cfg
+from app.module_loader import register_module_config, validate_manifest
+
+
+def test_validate_manifest_accepts_config_secrets(tmp_path):
+    raw = {
+        "id": "community.example_secret_module",
+        "name": "Example",
+        "description": "Example module",
+        "version": "0.1.0",
+        "author": "itsDNNS",
+        "minAppVersion": "2026.2",
+        "type": "integration",
+        "contributes": {"routes": "routes.py"},
+        "config": {"example_enabled": False, "example_password": ""},
+        "config_secrets": ["example_password"],
+    }
+    mod = validate_manifest(raw, str(tmp_path / "example"))
+    assert mod.config_secrets == ["example_password"]
+    assert mod.config["example_password"] == ""
+
+
+def test_register_module_config_registers_secret_keys():
+    old_defaults = copy.deepcopy(cfg.DEFAULTS)
+    old_secret_keys = set(cfg.SECRET_KEYS)
+    old_bool_keys = set(cfg.BOOL_KEYS)
+    old_int_keys = set(cfg.INT_KEYS)
+    try:
+        register_module_config(
+            {"example_enabled": False, "example_password": "", "example_interval": 30},
+            secret_keys=["example_password"],
+        )
+        assert cfg.DEFAULTS["example_password"] == ""
+        assert "example_password" in cfg.SECRET_KEYS
+        assert "example_enabled" in cfg.BOOL_KEYS
+        assert "example_interval" in cfg.INT_KEYS
+    finally:
+        cfg.DEFAULTS.clear()
+        cfg.DEFAULTS.update(old_defaults)
+        cfg.SECRET_KEYS.clear()
+        cfg.SECRET_KEYS.update(old_secret_keys)
+        cfg.BOOL_KEYS.clear()
+        cfg.BOOL_KEYS.update(old_bool_keys)
+        cfg.INT_KEYS.clear()
+        cfg.INT_KEYS.update(old_int_keys)
+
+
+def test_validate_manifest_rejects_core_config_key_collision(tmp_path):
+    raw = {
+        "id": "community.example_collision",
+        "name": "Example",
+        "description": "Example module",
+        "version": "0.1.0",
+        "author": "itsDNNS",
+        "minAppVersion": "2026.2",
+        "type": "integration",
+        "contributes": {"routes": "routes.py"},
+        "config": {"modem_password": "stealme"},
+    }
+    try:
+        validate_manifest(raw, str(tmp_path / "example"))
+    except Exception as exc:
+        assert 'conflict with existing core keys' in str(exc)
+    else:
+        raise AssertionError('expected config key collision to be rejected')

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -140,6 +140,19 @@ class TestModuleConfigProxy:
         )
         assert proxy.get("speedtest_tracker_token") == "mytoken"
 
+    def test_allowed_secret_does_not_unlock_other_secrets(self, tmp_path):
+        cfg = ConfigManager(str(tmp_path))
+        cfg.save({
+            "speedtest_tracker_token": "mytoken",
+            "modem_password": "secret123",
+        })
+
+        proxy = _ModuleConfigProxy(
+            cfg, allowed_secret_keys={"speedtest_tracker_token"}
+        )
+        assert proxy.get("speedtest_tracker_token") == "mytoken"
+        assert proxy.get("modem_password") is None
+
     def test_get_all_masks_secrets(self, tmp_path):
         cfg = ConfigManager(str(tmp_path))
         cfg.save({"modem_password": "secret", "language": "en"})


### PR DESCRIPTION
## Summary
- add manifest support for `config_secrets` so community modules can declare encrypted settings explicitly
- scope community-module secret access to declared keys only and reject config key collisions with core settings
- pass dynamic secret field metadata into the settings UI and cover the secret-handling path with regression tests

## Testing
- `pytest tests/test_module_secret_config.py tests/test_module_loader.py tests/test_security_hardening.py -q`
- `node --check app/static/js/settings.js`

## Notes
- companion module PR: `itsDNNS/docsight-modules#4`
- closes #333
