### PR TITLE
docs: add community routing and proof layer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug! Please fill out the information below.
+        Thanks for taking the time to report a bug.
+
+        If you are still unsure whether this is a bug, a setup problem, or a modem-specific limitation, please start in [Q&A Discussions](https://github.com/itsDNNS/docsight/discussions/categories/q-a) first.
 
   - type: dropdown
     id: version

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,23 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 Community Discussions
-    url: https://github.com/itsDNNS/docsight/discussions
-    about: Ask questions, share ideas, or discuss DOCSight with the community
+  - name: 🙋 Q&A and troubleshooting
+    url: https://github.com/itsDNNS/docsight/discussions/categories/q-a
+    about: Use Discussions for setup help, reverse proxy questions, and troubleshooting
+  - name: 💡 Ideas and roadmap feedback
+    url: https://github.com/itsDNNS/docsight/discussions/categories/ideas
+    about: Discuss new features and product ideas before opening implementation work
+  - name: 🧰 Show and tell
+    url: https://github.com/itsDNNS/docsight/discussions/categories/show-and-tell
+    about: Share your setup, exports, dashboards, and evidence workflow with the community
   - name: 📚 Documentation
     url: https://github.com/itsDNNS/docsight/wiki
-    about: Read the full documentation and setup guides
+    about: Read the wiki, install guides, and architecture docs first
+  - name: 🔐 Security vulnerability reporting
+    url: https://github.com/itsDNNS/docsight/security/advisories/new
+    about: Report vulnerabilities privately instead of opening a public issue
   - name: ☕ Support the Project (Ko-fi)
     url: https://ko-fi.com/itsdnns
-    about: Buy me a coffee if DOCSight helps you fight your ISP!
+    about: Support DOCSight development on Ko-fi
   - name: 💙 Donate via PayPal
     url: https://paypal.me/itsDNNS
     about: Support DOCSight development via PayPal

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for your feature suggestion! Please check the [Roadmap](https://github.com/itsDNNS/docsight/wiki/Roadmap) first to see if it's already planned.
+        Thanks for your feature suggestion. Please check the [Roadmap](https://github.com/itsDNNS/docsight/wiki/Roadmap) first to see if it is already planned.
+
+        If you want to discuss scope, tradeoffs, or rough direction before opening a formal request, start in [Ideas Discussions](https://github.com/itsDNNS/docsight/discussions/categories/ideas).
 
   - type: textarea
     id: problem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,12 @@
 # Contributing to DOCSight
 
-Thanks for your interest in contributing!
+Thanks for your interest in contributing.
+
+If you need setup help, troubleshooting, or want to share a real-world DOCSight deployment, start with [SUPPORT.md](SUPPORT.md) so you end up in the right place first.
 
 ## Before You Start
 
-**Please open an issue first** before working on any new feature or significant change. This lets us discuss the approach and make sure it fits the project architecture. PRs without a prior issue may be closed.
+**Please open an issue or start an Ideas discussion first** before working on any new feature or significant change. This lets us discuss the approach and make sure it fits the project architecture. PRs without prior discussion may be closed.
 
 This is especially important for:
 - New features or modules

--- a/README.md
+++ b/README.md
@@ -295,9 +295,24 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for detailed technical documentation.
 - A supported DOCSIS cable modem/router (see above), or any router via Generic Router mode
 - MQTT broker (optional, for Home Assistant)
 
+## Community and Support
+
+Use the right channel so questions, bug reports, modem requests, and real-world examples do not get mixed together.
+
+| Need | Best place |
+| --- | --- |
+| Setup help and troubleshooting | [GitHub Discussions: Q&A](https://github.com/itsDNNS/docsight/discussions/categories/q-a) |
+| Feature ideas and roadmap feedback | [GitHub Discussions: Ideas](https://github.com/itsDNNS/docsight/discussions/categories/ideas) |
+| Share your setup, exports, or evidence workflow | [GitHub Discussions: Show and tell](https://github.com/itsDNNS/docsight/discussions/categories/show-and-tell) |
+| Confirmed bugs and regressions | [Bug report issue form](https://github.com/itsDNNS/docsight/issues/new?template=bug_report.yml) |
+| New modem support requests | [Modem support request form](https://github.com/itsDNNS/docsight/issues/new?template=modem_support.yml) |
+| Security vulnerabilities | [Private security advisory](https://github.com/itsDNNS/docsight/security/advisories/new) |
+
+For the full routing guide, see [SUPPORT.md](SUPPORT.md).
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). **Please open an issue before working on new features.**
+See [CONTRIBUTING.md](CONTRIBUTING.md). **Please open an issue or start an Ideas discussion before working on new features.**
 
 ## Roadmap
 
@@ -329,6 +344,7 @@ See [TRADEMARKS.md](TRADEMARKS.md) for the full brand and trademark policy.
 |---|---|
 | [Wiki](https://github.com/itsDNNS/docsight/wiki) | User guides, feature docs, setup instructions |
 | [GitHub Releases](https://github.com/itsDNNS/docsight/releases) | Versioned builds and release notes |
+| [SUPPORT.md](SUPPORT.md) | Support routing, community channels, and issue guidance |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Technical architecture and extension guide |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Development and contribution guidelines |
 | [TRADEMARKS.md](TRADEMARKS.md) | Brand, logo, and official-use policy |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,53 @@
+# Support and Community Routing
+
+DOCSight has a few different channels on purpose. Using the right one keeps troubleshooting faster, feature planning cleaner, and security issues private.
+
+## Where to ask what
+
+| Need | Best place | Why |
+| --- | --- | --- |
+| Setup help, troubleshooting, reverse proxy questions, Docker questions | [GitHub Discussions: Q&A](https://github.com/itsDNNS/docsight/discussions/categories/q-a) | Best for support threads that may help the next person too |
+| Product ideas, feature suggestions, roadmap feedback | [GitHub Discussions: Ideas](https://github.com/itsDNNS/docsight/discussions/categories/ideas) | Good for shaping scope before work starts |
+| Share your setup, dashboards, exports, or evidence workflow | [GitHub Discussions: Show and tell](https://github.com/itsDNNS/docsight/discussions/categories/show-and-tell) | Builds a public proof layer and gives others real-world examples |
+| Confirmed bugs or regressions | [Bug report issue form](https://github.com/itsDNNS/docsight/issues/new?template=bug_report.yml) | Best when there is a reproducible problem to fix |
+| Request support for a new modem model | [Modem support request form](https://github.com/itsDNNS/docsight/issues/new?template=modem_support.yml) | Collects the HAR file, screenshots, and firmware details needed for a driver |
+| Security vulnerabilities | [Private security advisory](https://github.com/itsDNNS/docsight/security/advisories/new) | Keeps users safe and avoids publishing exploit details too early |
+| Documentation, install, and architecture references | [Wiki](https://github.com/itsDNNS/docsight/wiki), [INSTALL.md](INSTALL.md), [ARCHITECTURE.md](ARCHITECTURE.md) | Start here before opening support threads |
+
+## Before opening a bug
+
+Please use a Q&A discussion first if you are still in the "not sure whether this is a bug or setup issue" stage.
+
+When opening a bug, include:
+
+- DOCSight version
+- deployment method
+- modem model or Generic Router mode
+- steps to reproduce
+- relevant logs or screenshots
+- whether the issue also happens in demo mode, if applicable
+
+## Before requesting modem support
+
+Please follow the [Requesting Modem Support](https://github.com/itsDNNS/docsight/wiki/Requesting-Modem-Support) guide first. Driver work usually depends on:
+
+- the full modem model
+- firmware version
+- a clean HAR capture including the login flow
+- the DOCSIS status page screenshot
+- debug logs when login or polling fails
+
+Without that data, modem support requests usually stall.
+
+## Build the proof layer
+
+If DOCSight helped you prove packet loss, recurring instability, signal degradation, or a before-and-after change after ISP work, share it in [Show and tell](https://github.com/itsDNNS/docsight/discussions/categories/show-and-tell).
+
+Useful posts include:
+
+- your hardware and deployment setup
+- what problem you were tracking
+- which DOCSight views or exports helped most
+- what changed after a technician visit, modem swap, or escalation
+
+Real setups and real evidence workflows help new users understand what DOCSight is for before they deploy it.


### PR DESCRIPTION
## Summary
- add a SUPPORT.md routing guide for questions, ideas, modem requests, and security
- add community/support routing to the README, contributing guide, and issue templates
- seed Discussions with one routing thread and one show-and-tell proof thread

## Test Plan
- docs-only changes
- verified discussion creation and wiki Home update
