### PR TITLE
docs: shorten README hero headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <strong>Your ISP says everything is fine. DOCSight gives you the DOCSIS evidence that it isn't.</strong>
+  <strong>Your ISP says everything is fine. DOCSight gives you proof.</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- shorten the README hero headline to make the top area lighter
- keep the punch while removing extra technical wording above the fold

## Test Plan
- [x] reviewed the updated headline locally
- [x] checked the exact README diff