### PR TITLE
docs: shorten README hero subline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  DOCSight tracks cable signal health, recurring slowdowns, and outages so you have evidence when your ISP says everything is fine.
+  Track signal issues, slowdowns, and outages so you have proof when your ISP says everything is fine.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- shorten the README hero subline to make the top area lighter
- align the wording more closely with the new short hero headline

## Test Plan
- [x] reviewed the updated subline locally
- [x] checked the exact README diff