### PR TITLE
docs: tighten README trust strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 </p>
 
 <p align="center">
-  <strong>Self-hosted</strong> • <strong>Demo mode</strong> • <strong>Exports</strong> • <strong>16 modem families</strong> • <strong>Home Assistant + MQTT</strong> • <strong>4 languages</strong> • <strong>MIT license</strong>
+  <strong>Self-hosted</strong> • <strong>Demo</strong> • <strong>Exports</strong> • <strong>16 modem families</strong> • <strong>HA + MQTT</strong> • <strong>4 languages</strong> • <strong>MIT</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- shorten the README trust strip so it is less likely to wrap awkwardly
- keep the same signals while making the top area lighter

## Test Plan
- [x] reviewed the updated trust strip locally
- [x] checked the exact README diff