### PR TITLE
docs: remove repeated wording in README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  Track signal issues, slowdowns, and outages so you have proof when your ISP says everything is fine.
+  Track signal issues, slowdowns, and outages so you have proof when your ISP says the line looks normal.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- remove the repeated 'fine' phrasing from the README hero
- keep the stronger short headline while making the subline read cleaner

## Test Plan
- [x] reviewed the updated hero copy locally
- [x] checked the exact README diff