### PR TITLE
fix(backup): reject restore without config manager

### DIFF
--- a/app/modules/backup/routes.py
+++ b/app/modules/backup/routes.py
@@ -164,9 +164,11 @@ def api_restore():
     Auth required if already configured.
     """
     _config_manager = get_config_manager()
-    if _config_manager and _config_manager.is_configured() and _auth_required():
+    if _config_manager is None:
+        return jsonify({"error": "Not initialized"}), 500
+    if _config_manager.is_configured() and _auth_required():
         return redirect("/login")
-    if not (_config_manager and _config_manager.is_configured()):
+    if not _config_manager.is_configured():
         if _check_restore_rate_limit():
             audit_log.warning("Restore rate limit exceeded: ip=%s", _get_client_ip())
             return jsonify({"error": "Too many attempts"}), 429
@@ -180,23 +182,20 @@ def api_restore():
     if len(data) > 500 * 1024 * 1024:
         return jsonify({"error": "File too large"}), 400
     try:
-        data_dir = _config_manager.data_dir if _config_manager else "/data"
-        result = restore_backup(data, data_dir)
+        result = restore_backup(data, _config_manager.data_dir)
         audit_log.info(
             "Backup restored: ip=%s files=%s",
             _get_client_ip(), result["restored_files"],
         )
         # Reload config so the app recognizes the restored state
-        if _config_manager:
-            _config_manager._load()
+        _config_manager._load()
         _on_config_changed = get_on_config_changed()
         if _on_config_changed:
             _on_config_changed()
-        configured = bool(_config_manager and _config_manager.is_configured())
         return jsonify({
             "success": True,
             "restored_files": result["restored_files"],
-            "configured": configured,
+            "configured": _config_manager.is_configured(),
         })
     except ValueError as e:
         return jsonify({"error": str(e)}), 400

--- a/tests/test_security_audit_fixes.py
+++ b/tests/test_security_audit_fixes.py
@@ -142,6 +142,36 @@ class TestRestoreRateLimit:
         )
         assert resp.status_code == 429
 
+    def test_restore_without_config_manager_rejected(self):
+        """If the config manager is not initialized, /api/restore must bail out
+        before touching the filesystem — no fallback to a hardcoded data dir."""
+        from flask import Flask
+        from app.modules.backup import routes as br
+        from app.modules.backup.routes import bp as backup_bp
+
+        test_app = Flask(__name__)
+        test_app.config["TESTING"] = True
+        test_app.secret_key = "test-secret"
+
+        with patch("app.modules.backup.routes.get_config_manager", return_value=None), \
+             patch("app.modules.backup.routes._auth_required", return_value=False), \
+             patch("app.modules.backup.routes._get_client_ip", return_value="127.0.0.1"), \
+             patch("app.modules.backup.routes.restore_backup") as mock_restore:
+            test_app.register_blueprint(backup_bp)
+            with test_app.test_client() as c:
+                resp = c.post(
+                    "/api/restore",
+                    data={"file": (io.BytesIO(b"dummy"), "backup.tar.gz")},
+                    content_type="multipart/form-data",
+                )
+            assert resp.status_code == 500
+            assert resp.get_json() == {"error": "Not initialized"}
+            # The missing guard previously let restore_backup run against "/data".
+            mock_restore.assert_not_called()
+            # Must not count as a rate-limit attempt either — the request never
+            # reached the rate-limited code path.
+            assert br._restore_attempts.get("127.0.0.1", []) == []
+
     def test_authenticated_restore_not_rate_limited(self):
         """Configured+authenticated instances skip the rate limit path entirely."""
         from flask import Flask


### PR DESCRIPTION
## Summary

- Reject `/api/restore` when the ConfigManager is not initialized
- Return the same `{"error": "Not initialized"}` 500 response pattern used by the backup endpoints
- Add regression coverage to ensure restore does not run without a ConfigManager

## Validation

- `git diff --check`
- `python3 -m pytest tests/test_security_audit_fixes.py tests/test_backup.py -q`

Result: `66 passed`

Closes #357
