### PR TITLE
fix: modulation normalization (Vodafone Stations, TC4400, CH7465)

### DIFF
--- a/app/drivers/ch7465.py
+++ b/app/drivers/ch7465.py
@@ -311,14 +311,17 @@ class CH7465Driver(ModemDriver):
         """Normalize modulation string to analyzer format.
 
         Input: "256qam", "64qam", "qpsk", ..
-        Output: "qam_256", "qam_64", "qpsk", ..
+        Output: "256QAM", "64QAM", "QPSK", ..
         """
         if not modulation:
             return ""
-        mod = modulation.lower().replace("-", "")
+        mod = modulation.lower().replace("-", "").replace(" ", "").strip()        
+    
         if "qpsk" in mod:
-            return "qpsk"
+            return "QPSK"
+    
         if "qam" in mod:
-            num = mod.replace("qam", "").strip()
-            return f"qam_{num}" if num else "qam"
-        return modulation
+            num = mod.replace("qam", "")
+            return f"{num}QAM" if num else "QAM"
+    
+        return modulation.upper()

--- a/app/drivers/ch7465.py
+++ b/app/drivers/ch7465.py
@@ -17,6 +17,7 @@ import re
 import weakref
 from enum import Enum
 from .base import ModemDriver
+from .utils import normalize_modulation
 from ..types import DocsisData, DeviceInfo, ConnectionInfo
 
 log = logging.getLogger("docsis.driver.ch7465")
@@ -313,15 +314,4 @@ class CH7465Driver(ModemDriver):
         Input: "256qam", "64qam", "qpsk", ..
         Output: "256QAM", "64QAM", "QPSK", ..
         """
-        if not modulation:
-            return ""
-        mod = modulation.lower().replace("-", "").replace(" ", "").strip()        
-    
-        if "qpsk" in mod:
-            return "QPSK"
-    
-        if "qam" in mod:
-            num = mod.replace("qam", "")
-            return f"{num}QAM" if num else "QAM"
-    
-        return modulation.upper()
+        return normalize_modulation(modulation)

--- a/app/drivers/tc4400.py
+++ b/app/drivers/tc4400.py
@@ -18,6 +18,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from .base import ModemDriver
+from .utils import normalize_modulation
 from ..types import DocsisData, DeviceInfo, ConnectionInfo, RawChannel
 
 log = logging.getLogger("docsis.driver.tc4400")
@@ -147,11 +148,11 @@ class TC4400Driver(ModemDriver):
                 )
                 
                 # For OFDM channels, channel_type gives us OFDM vs SC-QAM
-                # For SC-QAM, modulation gives us qam_256 etc.
+                # For SC-QAM, modulation gives us "256QAM" etc.
                 if channel_type.upper() in ("OFDM",):
-                    final_type = "ofdm"
+                    final_type = "OFDM"
                 elif channel_type.upper() in ("SC-QAM",):
-                    final_type = modulation if modulation else "qam"
+                    final_type = modulation if modulation else "QAM"
                 else:
                     final_type = modulation if modulation else "unknown"
                 
@@ -165,7 +166,7 @@ class TC4400Driver(ModemDriver):
                     self._parse_number(self._cell(cells, col["uncorrected"]))
                 )
 
-                is_ofdm = final_type == "ofdm"
+                is_ofdm = final_type == "OFDM"
 
                 result.append({
                     "channelID": channel_id,
@@ -351,7 +352,7 @@ class TC4400Driver(ModemDriver):
     def _normalize_modulation(modulation: str) -> str:
         """Normalize modulation string to analyzer format.
 
-        Input: "256QAM", "OFDM", "ATDMA", "OFDMA"
-        Output: "256QAM", "OFDM", "ATDMA", "OFDMA"
+        Input: "256QAM", "256-qam", "qam_256", "OFDM", "ATDMA", "OFDMA"
+        Output: "256QAM", "256QAM", "256QAM", "OFDM", "ATDMA", "OFDMA"
         """
-        return modulation.strip() if modulation else ""
+        return normalize_modulation(modulation)

--- a/app/drivers/tc4400.py
+++ b/app/drivers/tc4400.py
@@ -352,18 +352,6 @@ class TC4400Driver(ModemDriver):
         """Normalize modulation string to analyzer format.
 
         Input: "256QAM", "OFDM", "ATDMA", "OFDMA"
-        Output: "qam_256", "ofdm", "atdma", "ofdma"
+        Output: "256QAM", "OFDM", "ATDMA", "OFDMA"
         """
-        if not modulation:
-            return ""
-        mod = modulation.upper().replace("-", "")
-        if "OFDMA" in mod:
-            return "ofdma"
-        if "OFDM" in mod:
-            return "ofdm"
-        if "ATDMA" in mod:
-            return "atdma"
-        if "QAM" in mod:
-            num = mod.replace("QAM", "").strip()
-            return f"qam_{num}" if num else "qam"
-        return modulation.lower()
+        return modulation.strip() if modulation else ""

--- a/app/drivers/utils.py
+++ b/app/drivers/utils.py
@@ -6,6 +6,7 @@ automatically.
 """
 
 import logging
+import re
 import ssl
 
 from requests.adapters import HTTPAdapter
@@ -94,6 +95,48 @@ def hz_to_mhz(freq) -> str:
     if mhz == int(mhz):
         return f"{int(mhz)} MHz"
     return f"{mhz:.1f} MHz"
+
+
+_MOD_TOKEN_SPLIT = re.compile(r"[\s_\-]+")
+
+
+def normalize_modulation(modulation) -> str:
+    """Normalise a modulation string to a canonical analyzer label.
+
+    Handles vendor variations like "256QAM" / "256-qam" / "256 qam" /
+    "qam256" / "qam_256" -> "256QAM", "QPSK" / "qpsk" -> "QPSK",
+    "OFDM" / "ofdm" -> "OFDM", and similarly for OFDMA / ATDMA / TDMA.
+
+    Unknown non-empty values are returned uppercased and stripped so
+    downstream code keeps a stable, readable label.
+    """
+    if modulation is None:
+        return ""
+    if not isinstance(modulation, str):
+        modulation = str(modulation)
+    raw = modulation.strip()
+    if not raw:
+        return ""
+    mod = _MOD_TOKEN_SPLIT.sub("", raw).lower()
+    if not mod:
+        return raw.upper()
+
+    if "qpsk" in mod:
+        return "QPSK"
+    if "ofdma" in mod:
+        return "OFDMA"
+    if "ofdm" in mod:
+        return "OFDM"
+    if "atdma" in mod:
+        return "ATDMA"
+    if mod == "tdma":
+        return "TDMA"
+    if "qam" in mod:
+        num = mod.replace("qam", "")
+        if num.isdigit():
+            return f"{num}QAM"
+        return "QAM" if not num else f"{num.upper()}QAM"
+    return raw.upper()
 
 
 def normalize_mhz(freq_str: str) -> str:

--- a/app/drivers/vodafone_station.py
+++ b/app/drivers/vodafone_station.py
@@ -917,16 +917,6 @@ class VodafoneStationDriver(ModemDriver):
         """Normalize modulation string to analyzer format.
 
         Input: "256QAM", "64QAM", "OFDM", "4096QAM"
-        Output: "qam_256", "qam_64", "ofdm", "qam_4096"
+        Output: "256QAM", "64QAM", "OFDM", "4096QAM"
         """
-        if not modulation:
-            return ""
-        mod = modulation.upper().replace("-", "")
-        if "OFDMA" in mod:
-            return "ofdma"
-        if "OFDM" in mod:
-            return "ofdm"
-        if "QAM" in mod:
-            num = mod.replace("QAM", "")
-            return f"qam_{num}" if num else "qam"
-        return modulation.lower()
+        return modulation.strip() if modulation else ""

--- a/app/drivers/vodafone_station.py
+++ b/app/drivers/vodafone_station.py
@@ -23,6 +23,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from .base import ModemDriver
+from .utils import normalize_modulation
 from ..types import DocsisData, DeviceInfo, ConnectionInfo
 
 log = logging.getLogger("docsis.driver.vodafone_station")
@@ -328,7 +329,7 @@ class VodafoneStationDriver(ModemDriver):
 
                 ds_31.append({
                     "channelID": channel_id,
-                    "type": "ofdm",
+                    "type": "OFDM",
                     "frequency": f"{int(freq)} MHz" if freq else "",
                     "powerLevel": power,
                     "mse": -snr if snr else None,
@@ -373,7 +374,7 @@ class VodafoneStationDriver(ModemDriver):
 
                 us_31.append({
                     "channelID": channel_id,
-                    "type": "ofdma",
+                    "type": "OFDMA",
                     "frequency": f"{int(freq)} MHz" if freq else "",
                     "powerLevel": power,
                     "multiplex": "",
@@ -719,7 +720,7 @@ class VodafoneStationDriver(ModemDriver):
                 is_ofdm = "OFDM" in ch_type.upper()
 
                 if is_ofdm:
-                    modulation = modulation or "ofdm"
+                    modulation = modulation or "OFDM"
 
                 ch_dict = {
                     "channelID": channel_id,
@@ -746,7 +747,7 @@ class VodafoneStationDriver(ModemDriver):
                 is_ofdma = "OFDMA" in ch_type.upper()
 
                 if is_ofdma:
-                    modulation = modulation or "ofdma"
+                    modulation = modulation or "OFDMA"
 
                 ch_dict = {
                     "channelID": channel_id,
@@ -916,7 +917,7 @@ class VodafoneStationDriver(ModemDriver):
     def _normalize_modulation(modulation: str) -> str:
         """Normalize modulation string to analyzer format.
 
-        Input: "256QAM", "64QAM", "OFDM", "4096QAM"
-        Output: "256QAM", "64QAM", "OFDM", "4096QAM"
+        Input: "256QAM", "64QAM", "OFDM", "4096QAM", "256-qam", "qam_64"
+        Output: "256QAM", "64QAM", "OFDM", "4096QAM", "256QAM", "64QAM"
         """
-        return modulation.strip() if modulation else ""
+        return normalize_modulation(modulation)

--- a/tests/drivers/test_modulation_normalization.py
+++ b/tests/drivers/test_modulation_normalization.py
@@ -1,0 +1,132 @@
+"""Regression tests for driver modulation normalization."""
+
+from unittest.mock import patch
+
+from bs4 import BeautifulSoup
+
+import pytest
+
+from app.drivers.ch7465 import CH7465Driver
+from app.drivers.tc4400 import TC4400Driver
+from app.drivers.vodafone_station import VodafoneStationDriver
+from app.drivers.utils import normalize_modulation
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, ""),
+        ("", ""),
+        (" 256QAM ", "256QAM"),
+        ("256qam", "256QAM"),
+        ("256-qam", "256QAM"),
+        ("256 qam", "256QAM"),
+        ("qam256", "256QAM"),
+        ("qam_256", "256QAM"),
+        ("64 qam", "64QAM"),
+        ("4096-qam", "4096QAM"),
+        ("qpsk", "QPSK"),
+        ("ofdm", "OFDM"),
+        ("ofdma", "OFDMA"),
+        ("atdma", "ATDMA"),
+        ("tdma", "TDMA"),
+        ("mystery mode", "MYSTERY MODE"),
+    ],
+)
+def test_shared_modulation_normalization(raw, expected):
+    assert normalize_modulation(raw) == expected
+
+
+@pytest.mark.parametrize("driver", [CH7465Driver, TC4400Driver, VodafoneStationDriver])
+def test_driver_helpers_use_canonical_modulation_labels(driver):
+    assert driver._normalize_modulation("256-qam") == "256QAM"
+    assert driver._normalize_modulation("64 qam") == "64QAM"
+    assert driver._normalize_modulation("qpsk") == "QPSK"
+    assert driver._normalize_modulation("ofdm") == "OFDM"
+    assert driver._normalize_modulation("ofdma") == "OFDMA"
+
+
+def test_tc4400_downstream_ofdm_type_is_uppercase():
+    table = BeautifulSoup(
+        """
+        <table>
+          <tr>
+            <th>Channel ID</th><th>Lock Status</th><th>Channel Type</th>
+            <th>Modulation</th><th>Frequency</th><th>Power</th><th>SNR</th>
+            <th>Corrected</th><th>Uncorrected</th>
+          </tr>
+          <tr>
+            <td>193</td><td>Locked</td><td>OFDM</td><td></td>
+            <td>957000000 Hz</td><td>0.1 dBmV</td><td>43.0 dB</td>
+            <td>7</td><td>0</td>
+          </tr>
+        </table>
+        """,
+        "html.parser",
+    ).find("table")
+
+    driver = TC4400Driver("http://192.168.100.1", "user", "pass")
+    channels = driver._parse_downstream(table)
+
+    assert channels[0]["type"] == "OFDM"
+    assert channels[0]["mse"] is None
+
+
+def test_tc4400_downstream_sc_qam_type_is_canonical():
+    table = BeautifulSoup(
+        """
+        <table>
+          <tr>
+            <th>Channel ID</th><th>Lock Status</th><th>Channel Type</th>
+            <th>Modulation</th><th>Frequency</th><th>Power</th><th>SNR</th>
+            <th>Corrected</th><th>Uncorrected</th>
+          </tr>
+          <tr>
+            <td>1</td><td>Locked</td><td>SC-QAM</td><td>256-qam</td>
+            <td>602000000 Hz</td><td>2.0 dBmV</td><td>39.5 dB</td>
+            <td>1</td><td>0</td>
+          </tr>
+        </table>
+        """,
+        "html.parser",
+    ).find("table")
+
+    driver = TC4400Driver("http://192.168.100.1", "user", "pass")
+    channels = driver._parse_downstream(table)
+
+    assert channels[0]["type"] == "256QAM"
+    assert channels[0]["mse"] == -39.5
+
+
+def test_vodafone_cga_docsis31_types_are_uppercase():
+    class Response:
+        def json(self):
+            return {
+                "data": {
+                    "downstream": [],
+                    "upstream": [],
+                    "ofdm_downstream": [
+                        {
+                            "channelid_ofdm": "193",
+                            "CentralFrequency_ofdm": "957000000",
+                            "power_ofdm": "0.1",
+                            "SNR_ofdm": "43.0",
+                        }
+                    ],
+                    "ofdma_upstream": [
+                        {
+                            "channelidup": "41",
+                            "CentralFrequency": "36200000",
+                            "power": "43.8",
+                        }
+                    ],
+                }
+            }
+
+    driver = VodafoneStationDriver("http://192.168.100.1", "user", "pass")
+
+    with patch.object(driver, "_cga_request", return_value=Response()):
+        data = driver._get_docsis_cga()
+
+    assert data["channelDs"]["docsis31"][0]["type"] == "OFDM"
+    assert data["channelUs"]["docsis31"][0]["type"] == "OFDMA"


### PR DESCRIPTION
## Description

Fix: Modulation is not shown in "Modulation Performance" and "Prometheus metrics".

- It is only displayed on the home screen in the channel view due to incorrect modulation normalization (e.g., normalized to “qam_256” and “ofdma” instead of “256QAM” and “OFDMA”).

- Issue detected on Vodafone Station TG; also fixed for TC4400 and CH7465.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New modem driver
- [ ] Performance improvement

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] I have tested my changes locally
- [x] All tests pass (`python -m pytest tests/ -v`)

## Testing

<!-- Describe how you tested this change -->

**Test Environment:**
- Modem: Vodafone Station
- Deployment: local Python
- Browser: Firefox