### PR TITLE
fix WAN IP integration by adding to Prometheus metrics

### DIFF
--- a/app/prometheus.py
+++ b/app/prometheus.py
@@ -295,9 +295,9 @@ def format_metrics(
         if wan_ipv4 not in (None, ""):
             _metric(
                 lines,
-                "WAN IPv4 address",
+                "WAN IPv4 address (label carries the value, metric is always 1)",
                 "gauge",
-                "docsight_device_wan_ipv4",
+                "docsight_device_wan_ipv4_info",
                 1,
                 {"wan_ipv4": wan_ipv4},
             )
@@ -306,9 +306,9 @@ def format_metrics(
         if wan_ipv6 not in (None, ""):
             _metric(
                 lines,
-                "WAN IPv6 address",
+                "WAN IPv6 address (label carries the value, metric is always 1)",
                 "gauge",
-                "docsight_device_wan_ipv6",
+                "docsight_device_wan_ipv6_info",
                 1,
                 {"wan_ipv6": wan_ipv6},
             )

--- a/app/prometheus.py
+++ b/app/prometheus.py
@@ -269,6 +269,17 @@ def format_metrics(
                 1 if str(docsis_status).lower() == "online" else 0,
             )
 
+        # dynamic numeric metric: uptime
+        uptime = device_info.get("uptime_seconds")
+        if uptime is not None:
+            _metric(
+                lines,
+                "Device uptime in seconds",
+                "gauge",
+                "docsight_device_uptime_seconds",
+                uptime,
+            )
+
         reboot_reason = device_info.get("reboot_reason")
         if reboot_reason not in (None, ""):
             _metric(
@@ -280,15 +291,26 @@ def format_metrics(
                 {"reason": reboot_reason},
             )
 
-        # dynamic numeric metric: uptime
-        uptime = device_info.get("uptime_seconds")
-        if uptime is not None:
+        wan_ipv4 = device_info.get("wan_ipv4")
+        if wan_ipv4 not in (None, ""):
             _metric(
                 lines,
-                "Device uptime in seconds",
+                "WAN IPv4 address",
                 "gauge",
-                "docsight_device_uptime_seconds",
-                uptime,
+                "docsight_device_wan_ipv4",
+                1,
+                {"wan_ipv4": wan_ipv4},
+            )
+
+        wan_ipv6 = device_info.get("wan_ipv6")
+        if wan_ipv6 not in (None, ""):
+            _metric(
+                lines,
+                "WAN IPv6 address",
+                "gauge",
+                "docsight_device_wan_ipv6",
+                1,
+                {"wan_ipv6": wan_ipv6},
             )
 
     # --- Connection info ---

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -436,22 +436,68 @@ class TestDeviceInfoMetrics:
     def test_wan_ipv4_info_emitted_with_label(self):
         info = {"model": "TG6442VF", "wan_ipv4": "192.0.2.1"}
         out = format_metrics(None, info, None, 0.0)
-        assert _has_metric(out, 'docsight_wan_ipv4{wan_ipv4="192.0.2.1"} 1')
+        assert _has_metric(out, 'docsight_device_wan_ipv4_info{wan_ipv4="192.0.2.1"} 1')
 
-    def test_wan_ipv4_info_emitted_with_label(self):
+    def test_wan_ipv4_info_omitted_when_missing(self):
         info = {"model": "TG6442VF"}
         out = format_metrics(None, info, None, 0.0)
-        assert not _has_metric_approx(out, "docsight_wan_ipv4")
+        assert not _has_metric_approx(out, "docsight_device_wan_ipv4_info")
+
+    def test_wan_ipv4_info_omitted_when_empty_string(self):
+        info = {"model": "TG6442VF", "wan_ipv4": ""}
+        out = format_metrics(None, info, None, 0.0)
+        assert not _has_metric_approx(out, "docsight_device_wan_ipv4_info")
+
+    def test_wan_ipv4_info_excluded_from_device_info_labels(self):
+        info = {"model": "TG6442VF", "wan_ipv4": "192.0.2.1"}
+        out = format_metrics(None, info, None, 0.0)
+        device_info_lines = [
+            line for line in out.splitlines()
+            if line.startswith("docsight_device_info{")
+        ]
+        assert device_info_lines, "docsight_device_info line missing"
+        assert "wan_ipv4" not in "\n".join(device_info_lines)
 
     def test_wan_ipv6_info_emitted_with_label(self):
         info = {"model": "TG6442VF", "wan_ipv6": "2001:db8::1"}
         out = format_metrics(None, info, None, 0.0)
-        assert _has_metric(out, 'docsight_wan_ipv6{wan_ipv6="2001:db8::1"} 1')
+        assert _has_metric(out, 'docsight_device_wan_ipv6_info{wan_ipv6="2001:db8::1"} 1')
 
-    def test_wan_ipv6_info_emitted_with_label(self):
+    def test_wan_ipv6_info_omitted_when_missing(self):
         info = {"model": "TG6442VF"}
         out = format_metrics(None, info, None, 0.0)
-        assert not _has_metric_approx(out, "docsight_wan_ipv6")
+        assert not _has_metric_approx(out, "docsight_device_wan_ipv6_info")
+
+    def test_wan_ipv6_info_omitted_when_empty_string(self):
+        info = {"model": "TG6442VF", "wan_ipv6": ""}
+        out = format_metrics(None, info, None, 0.0)
+        assert not _has_metric_approx(out, "docsight_device_wan_ipv6_info")
+
+    def test_wan_ipv6_info_excluded_from_device_info_labels(self):
+        info = {"model": "TG6442VF", "wan_ipv6": "2001:db8::1"}
+        out = format_metrics(None, info, None, 0.0)
+        device_info_lines = [
+            line for line in out.splitlines()
+            if line.startswith("docsight_device_info{")
+        ]
+        assert device_info_lines, "docsight_device_info line missing"
+        assert "wan_ipv6" not in "\n".join(device_info_lines)
+
+    def test_wan_label_values_are_escaped(self):
+        info = {
+            "model": "TG6442VF",
+            "wan_ipv4": 'bogus"value',
+            "wan_ipv6": "line1\nline2",
+        }
+        out = format_metrics(None, info, None, 0.0)
+        assert _has_metric(
+            out,
+            'docsight_device_wan_ipv4_info{wan_ipv4="bogus\\"value"} 1',
+        )
+        assert _has_metric(
+            out,
+            'docsight_device_wan_ipv6_info{wan_ipv6="line1\\nline2"} 1',
+        )
 
     def test_label_values_are_escaped(self):
         """Backslash, double-quote, and newline in label values must be

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -90,6 +90,8 @@ DEVICE_INFO_FULL = {
     "sw_version": "7.57",
     "manufacturer": "AVM",
     "uptime_seconds": 86400,
+    "wan_ipv4": "192.0.2.1",
+    "wan_ipv6": "2001:db8::1"
 }
 
 CONNECTION_INFO_FULL = {
@@ -430,6 +432,26 @@ class TestDeviceInfoMetrics:
         info = {"model": "TG6442VF"}
         out = format_metrics(None, info, None, 0.0)
         assert not _has_metric_approx(out, "docsight_last_reboot_reason_info")
+
+    def test_wan_ipv4_info_emitted_with_label(self):
+        info = {"model": "TG6442VF", "wan_ipv4": "192.0.2.1"}
+        out = format_metrics(None, info, None, 0.0)
+        assert _has_metric(out, 'docsight_wan_ipv4{wan_ipv4="192.0.2.1"} 1')
+
+    def test_wan_ipv4_info_emitted_with_label(self):
+        info = {"model": "TG6442VF"}
+        out = format_metrics(None, info, None, 0.0)
+        assert not _has_metric_approx(out, "docsight_wan_ipv4")
+
+    def test_wan_ipv6_info_emitted_with_label(self):
+        info = {"model": "TG6442VF", "wan_ipv6": "2001:db8::1"}
+        out = format_metrics(None, info, None, 0.0)
+        assert _has_metric(out, 'docsight_wan_ipv6{wan_ipv6="2001:db8::1"} 1')
+
+    def test_wan_ipv6_info_emitted_with_label(self):
+        info = {"model": "TG6442VF"}
+        out = format_metrics(None, info, None, 0.0)
+        assert not _has_metric_approx(out, "docsight_wan_ipv6")
 
     def test_label_values_are_escaped(self):
         """Backslash, double-quote, and newline in label values must be


### PR DESCRIPTION
## Description

- adds WAN IPv4/v6 addresses also to Prometheus metrics for complete integration
- adds tests for WAN IP-integration in Prometheus

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/itsDNNS/docsight/blob/main/CONTRIBUTING.md)
- [x] I have tested my changes locally
- [x] All tests pass (`python -m pytest tests/ -v`)
- [x] I have added tests for new functionality
- [x] I have tested both success and failure paths (if applicable)

## Testing

- tested extraction with "curl -s http://localhost:8765/metrics"

**Test Environment:**
- Modem: Vodafone Station TG
- Deployment: local Python

## Additional Notes

- Useful for retrieving the IPv6 WAN address for DynDNS updates
- Particularly relevant for devices that only support IPv4 through built-in DynDNS functionality
- (e.g., Vodafone Stations and many other devices)
