### PR TITLE
docs(security): add defensive review checklist

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -153,6 +153,36 @@ Security-relevant events are logged to the `docsis.audit` logger:
 4. **Review audit logs:** Check `docker logs docsight` or enable JSON audit logging for structured analysis
 5. **Backup your data:** `data/` directory contains all configuration and history
 
+## Defensive Review Checklist
+
+Maintainers use this checklist when reviewing changes that touch integration or export boundaries. Each boundary lists the regression tests that exercise it; those tests should pass before merging changes that affect the corresponding area.
+
+- **Modem/router response parsing** — driver code parses untrusted modem firmware output and must tolerate missing, malformed, or unexpected fields without crashing the poller.
+  - `tests/test_vodafone_station_tg.py`
+  - `tests/test_driver_registry.py`
+- **Import/export paths** — backup, history import, and report export flows handle user-supplied files and produce shareable output.
+  - `tests/test_import_parser.py`
+  - `tests/test_report.py`
+- **Local authentication/session handling** — login, session cookies, the `require_auth` decorator, and Bearer token verification.
+  - `tests/test_auth.py`
+  - `tests/test_security_hardening.py`
+- **Token and credential storage** — Fernet-at-rest storage for modem and webhook secrets, hash-only persistence for the admin password and API tokens, and config redaction.
+  - `tests/test_security_hardening.py`
+  - `tests/test_config.py`
+- **MQTT/Home Assistant integration payloads** — outbound notifier payload shaping, severity mapping, length limits, and log redaction for webhook URLs.
+  - `tests/test_notifier.py`
+- **Module/plugin manifest loading** — manifest validation and the install/list API surface.
+  - `tests/test_module_install_api.py`
+  - `tests/test_modules_api.py`
+- **Docker/self-hosted runtime defaults** — bundled image defaults, secret bootstrap, and end-to-end auth on a fresh deployment.
+  - `tests/test_config.py`
+  - `tests/e2e/test_auth.py`
+- **Rate limiting or abuse resistance** — login backoff and capture guardrails.
+  - `tests/test_auth.py`
+  - `tests/test_smart_capture_guardrails.py`
+- **Test fixtures and documentation examples** — keeps fixtures and public docs free of reusable-looking secrets so that example values cannot be mistaken for credentials.
+  - `tests/test_defensive_review_docs.py`
+
 ## Third-Party Dependencies
 
 DOCSight uses Python libraries from PyPI. We monitor dependencies for known vulnerabilities:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -179,7 +179,7 @@ class TestApiTokenAuth:
         """An invalid Bearer token returns 401 JSON."""
         resp = auth_client_with_storage.get(
             "/api/snapshots",
-            headers={"Authorization": "Bearer dsk_invalid_garbage"},
+            headers={"Authorization": "Bearer dsk_nope"},
         )
         assert resp.status_code == 401
         data = resp.get_json()

--- a/tests/test_defensive_review_docs.py
+++ b/tests/test_defensive_review_docs.py
@@ -1,0 +1,62 @@
+"""Regression tests for the maintainer defensive review checklist."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SECURITY_MD = ROOT / "SECURITY.md"
+
+REQUIRED_BOUNDARIES = {
+    "modem/router response parsing": ["tests/test_vodafone_station_tg.py", "tests/test_driver_registry.py"],
+    "import/export paths": ["tests/test_import_parser.py", "tests/test_report.py"],
+    "local authentication/session handling": ["tests/test_auth.py", "tests/test_security_hardening.py"],
+    "token and credential storage": ["tests/test_security_hardening.py", "tests/test_config.py"],
+    "mqtt/home assistant integration payloads": ["tests/test_notifier.py"],
+    "module/plugin manifest loading": ["tests/test_module_install_api.py", "tests/test_modules_api.py"],
+    "docker/self-hosted runtime defaults": ["tests/test_config.py", "tests/e2e/test_auth.py"],
+    "rate limiting or abuse resistance": ["tests/test_auth.py", "tests/test_smart_capture_guardrails.py"],
+    "test fixtures and documentation examples": ["tests/test_defensive_review_docs.py"],
+}
+
+SECRET_PATTERNS = [
+    re.compile(r"dsk_[A-Za-z0-9_-]{12,}"),
+    re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
+    re.compile(r"(?i)(api[_-]?key|secret|password|token)\s*=\s*['\"][^'\"]{8,}['\"]"),
+]
+
+
+def test_security_policy_has_defensive_review_checklist():
+    text = SECURITY_MD.read_text(encoding="utf-8").lower()
+
+    assert "defensive review checklist" in text
+    for boundary in REQUIRED_BOUNDARIES:
+        assert boundary in text
+
+
+def test_defensive_review_checklist_references_existing_tests():
+    text = SECURITY_MD.read_text(encoding="utf-8")
+
+    for boundary, test_paths in REQUIRED_BOUNDARIES.items():
+        for rel_path in test_paths:
+            assert rel_path in text, f"{boundary} should reference {rel_path}"
+            assert (ROOT / rel_path).exists(), f"referenced test path missing: {rel_path}"
+
+
+def test_public_docs_and_text_fixtures_do_not_contain_reusable_secret_examples():
+    scanned = []
+    candidates = list((ROOT / "docs").rglob("*")) + list((ROOT / "tests").rglob("*"))
+    candidates.extend(ROOT.glob("*.md"))
+
+    for candidate in candidates:
+        if not candidate.is_file() or candidate.suffix.lower() not in {".md", ".py", ".json", ".txt", ".csv", ".html", ".yaml", ".yml"}:
+            continue
+        rel = candidate.relative_to(ROOT).as_posix()
+        text = candidate.read_text(encoding="utf-8", errors="ignore")
+        scanned.append(rel)
+        for pattern in SECRET_PATTERNS:
+            assert not pattern.search(text), f"secret-like reusable example in {rel}"
+
+    assert "SECURITY.md" in scanned
+    assert "tests/test_defensive_review_docs.py" in scanned

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -248,14 +248,14 @@ class TestDiscordWebhookSend:
         resp = MagicMock(status_code=404)
         resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
         mock_post.return_value = resp
-        secret = "super-secret-token-xyz"
+        url_tail_marker = "REDACTED-PLACEHOLDER-VALUE"
         channel = DiscordWebhookChannel(
-            f"https://discord.com/api/webhooks/123/{secret}",
+            f"https://discord.com/api/webhooks/123/{url_tail_marker}",
         )
         with caplog.at_level(logging.WARNING, logger="docsis.notifier"):
             channel.send({"severity": "info", "event_type": "test",
                           "message": "x", "details": {}})
-        assert secret not in caplog.text
+        assert url_tail_marker not in caplog.text
         assert "123" not in caplog.text
         assert "404" in caplog.text
 
@@ -296,7 +296,7 @@ class TestDispatcherChannelSetup:
         dispatcher = NotificationDispatcher(
             self._make_config(
                 "https://discord.com/api/webhooks/123/abc",
-                token="should-be-ignored",
+                token="UNUSED",
             ),
         )
         channels = dispatcher._get_channels()


### PR DESCRIPTION
## Summary
- Adds a defensive review checklist to `SECURITY.md` for integration, export, auth, credential, notifier, module, runtime, rate-limit, and fixture/documentation boundaries.
- Adds regression coverage that keeps the checklist mapped to existing tests and scans public docs/test fixtures for reusable-looking secret examples.
- Replaces a few realistic-looking test placeholders with safer non-secret values.

## Test Plan
- `python3 -m pytest tests/test_defensive_review_docs.py -q` initially failed before the checklist and fixture cleanup were added.
- `.venv/bin/python -m pytest tests/test_defensive_review_docs.py tests/test_notifier.py tests/test_auth.py -q`
- `.venv/bin/python -m pytest --collect-only -q tests/e2e`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m pytest tests/e2e -q`
- `git diff --check`

Closes #365
