### PR TITLE
fix: hide unsupported DOCSIS error charts

### DIFF
--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -253,6 +253,21 @@ function _makeInfoSep() {
     return el;
 }
 
+function _hasChannelDocsisErrorSeries(data) {
+    return !!(data && data.some(function(d) {
+        return d && (d.correctable_errors != null || d.uncorrectable_errors != null);
+    }));
+}
+
+function _setChartCardVisible(cardId, chartId, visible) {
+    var card = document.getElementById(cardId);
+    if (card) card.style.display = visible ? '' : 'none';
+    if (!visible && charts[chartId]) {
+        charts[chartId].destroy();
+        delete charts[chartId];
+    }
+}
+
 function _updateChannelInfoBar(direction, channelId) {
     var bar = document.getElementById('channel-info-bar');
     if (!bar) return;
@@ -341,19 +356,21 @@ function loadChannelTimeline() {
             var powerThresholds = direction === 'ds' ? DS_POWER_THRESHOLDS : US_POWER_THRESHOLDS;
             var powerCard = document.querySelector('#channel-charts .chart-card:first-child');
             var powerLabel = powerCard ? powerCard.querySelector('.chart-label') : null;
-            var errorsCard = document.getElementById('channel-errors-card');
             if (direction === 'ds') {
                 powerDatasets.push({label: T.snr_db || 'SNR (dB)', data: data.map(function(d){ return d.snr; }), color: '#66ff77'});
                 powerThresholds = null; /* DS combines Power + SNR, thresholds don't apply */
                 if (powerLabel) powerLabel.textContent = (T.power_dbmv || 'Power') + ' & ' + (T.snr_db || 'SNR');
-                errorsCard.style.display = '';
-                renderChart('chart-ch-errors', xLabels, [
-                    {label: T.correctable || 'Correctable', data: data.map(function(d){ return d.correctable_errors; }), color: '#2196f3'},
-                    {label: T.uncorrectable || 'Uncorrectable', data: data.map(function(d){ return d.uncorrectable_errors; }), color: '#f44336'}
-                ], 'bar');
+                var showErrors = _hasChannelDocsisErrorSeries(data);
+                _setChartCardVisible('channel-errors-card', 'chart-ch-errors', showErrors);
+                if (showErrors) {
+                    renderChart('chart-ch-errors', xLabels, [
+                        {label: T.correctable || 'Correctable', data: data.map(function(d){ return d.correctable_errors; }), color: '#2196f3'},
+                        {label: T.uncorrectable || 'Uncorrectable', data: data.map(function(d){ return d.uncorrectable_errors; }), color: '#f44336'}
+                    ], 'bar');
+                }
             } else {
                 if (powerLabel) powerLabel.textContent = T.power_dbmv || 'Power (dBmV)';
-                errorsCard.style.display = 'none';
+                _setChartCardVisible('channel-errors-card', 'chart-ch-errors', false);
             }
             renderChart('chart-ch-power', xLabels, powerDatasets, null, powerThresholds);
 
@@ -707,28 +724,32 @@ function loadCompareCharts() {
             }
 
             // Errors Chart (DS only, lines not bars)
-            var errorsCard = document.getElementById('compare-errors-card');
             if (dir === 'ds') {
-                errorsCard.style.display = '';
-                var errorDatasets = [];
-                _compareChannels.forEach(function(ch) {
-                    errorDatasets.push({
-                        label: 'CH ' + ch.id + ' ' + (T.uncorrectable || 'Uncorr.'),
-                        data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.uncorrectable_errors : null; }),
-                        color: ch.color,
-                        showPoints: showPoints
-                    });
-                    errorDatasets.push({
-                        label: 'CH ' + ch.id + ' ' + (T.correctable || 'Corr.'),
-                        data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.correctable_errors : null; }),
-                        color: ch.color,
-                        dashed: true,
-                        showPoints: showPoints
-                    });
+                var compareHasErrors = _compareChannels.some(function(ch) {
+                    return _hasChannelDocsisErrorSeries(data[String(ch.id)] || []);
                 });
-                renderChart('chart-cmp-errors', xLabels, errorDatasets);
+                _setChartCardVisible('compare-errors-card', 'chart-cmp-errors', compareHasErrors);
+                if (compareHasErrors) {
+                    var errorDatasets = [];
+                    _compareChannels.forEach(function(ch) {
+                        errorDatasets.push({
+                            label: 'CH ' + ch.id + ' ' + (T.uncorrectable || 'Uncorr.'),
+                            data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.uncorrectable_errors != null ? d.uncorrectable_errors : null; }),
+                            color: ch.color,
+                            showPoints: showPoints
+                        });
+                        errorDatasets.push({
+                            label: 'CH ' + ch.id + ' ' + (T.correctable || 'Corr.'),
+                            data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.correctable_errors != null ? d.correctable_errors : null; }),
+                            color: ch.color,
+                            dashed: true,
+                            showPoints: showPoints
+                        });
+                    });
+                    renderChart('chart-cmp-errors', xLabels, errorDatasets);
+                }
             } else {
-                errorsCard.style.display = 'none';
+                _setChartCardVisible('compare-errors-card', 'chart-cmp-errors', false);
             }
 
             // Modulation Chart

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -74,6 +74,25 @@ function _alignWeatherToTrends(trendData, weatherData, range) {
     return temps;
 }
 
+function _supportsTrendDocsisErrors(row) {
+    if (!row) return false;
+    if (row.errors_supported === false) return false;
+    return row.errors_supported === true || row.ds_correctable_errors != null || row.ds_uncorrectable_errors != null;
+}
+
+function _hasTrendDocsisErrorSeries(data) {
+    return !!(data && data.some(_supportsTrendDocsisErrors));
+}
+
+function _setTrendErrorsVisible(visible) {
+    var card = document.getElementById('trend-errors-card');
+    if (card) card.style.display = visible ? '' : 'none';
+    if (!visible && charts['chart-errors']) {
+        charts['chart-errors'].destroy();
+        delete charts['chart-errors'];
+    }
+}
+
 function _renderTrendCharts() {
     var data = _lastTrendData;
     var range = _lastTrendRange;
@@ -94,10 +113,14 @@ function _renderTrendCharts() {
     renderChart('chart-us-power', xLabels,
         [{label: 'US Power Avg', data: data.map(function(d){ return d.us_power_avg; }), color: '#a855f7'}],
         null, US_POWER_THRESHOLDS, tempOpts);
-    renderChart('chart-errors', xLabels, [
-        {label: T.correctable, data: data.map(function(d){ return d.ds_correctable_errors; }), color: '#2196f3'},
-        {label: T.uncorrectable, data: data.map(function(d){ return d.ds_uncorrectable_errors; }), color: '#f44336'}
-    ], 'bar');
+    var showErrors = _hasTrendDocsisErrorSeries(data);
+    _setTrendErrorsVisible(showErrors);
+    if (showErrors) {
+        renderChart('chart-errors', xLabels, [
+            {label: T.correctable, data: data.map(function(d){ return d.ds_correctable_errors; }), color: '#2196f3'},
+            {label: T.uncorrectable, data: data.map(function(d){ return d.ds_uncorrectable_errors; }), color: '#f44336'}
+        ], 'bar');
+    }
 }
 
 function loadTrends(range) {

--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -190,8 +190,8 @@ class AnalysisMixin:
                         "timestamp": ts,
                         "power": ch.get("power"),
                         "snr": ch.get("snr"),
-                        "correctable_errors": ch.get("correctable_errors", 0),
-                        "uncorrectable_errors": ch.get("uncorrectable_errors", 0),
+                        "correctable_errors": ch.get("correctable_errors"),
+                        "uncorrectable_errors": ch.get("uncorrectable_errors"),
                         "modulation": ch.get("modulation", ""),
                         "health": ch.get("health", ""),
                     })
@@ -223,8 +223,8 @@ class AnalysisMixin:
                         "timestamp": ts,
                         "power": ch.get("power"),
                         "snr": ch.get("snr"),
-                        "correctable_errors": ch.get("correctable_errors", 0),
-                        "uncorrectable_errors": ch.get("uncorrectable_errors", 0),
+                        "correctable_errors": ch.get("correctable_errors"),
+                        "uncorrectable_errors": ch.get("uncorrectable_errors"),
                         "modulation": ch.get("modulation", ""),
                         "frequency": ch.get("frequency", ""),
                     })

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -577,20 +577,13 @@
         </div>
 
         {# Card 4: Errors #}
-        <div class="metric-card glass">
+        {% if s.errors_supported is not defined or s.errors_supported %}
+        <div class="metric-card glass" id="metric-errors-card">
             <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_errors }}</div></span>
             <div class="metric-header">
                 <span class="metric-label">{{ t.card_errors }}</span>
                 <div class="metric-icon amber"><i data-lucide="alert-triangle"></i></div>
             </div>
-            {% if s.errors_supported is defined and not s.errors_supported %}
-            <div class="metric-value-row">
-                <div class="metric-value" style="color:var(--text-muted);">N/A</div>
-            </div>
-            <div class="metric-sub">
-                <span class="badge badge-muted">{{ t.errors_not_available }}</span>
-            </div>
-            {% else %}
             <div class="metric-value-row">
                 <div class="metric-value" style="color:var(--{{ error_health }});">{{ s.ds_uncorr_pct }}<span class="unit">%</span></div>
                 <canvas class="metric-spark" id="spark-errors" width="144" height="56"></canvas>
@@ -599,8 +592,8 @@
                 <span class="badge badge-{{ error_health }}">{{ health_labels[error_health] }}</span>
                 <span class="range">{{ s.ds_correctable_errors|fmt_k }} {{ t.corr }} / {{ s.ds_uncorrectable_errors|fmt_k }} {{ t.uncorr }}</span>
             </div>
-            {% endif %}
         </div>
+        {% endif %}
 
         {# Card 4: Speed (conditional) #}
         {% if speedtest_configured and speedtest_latest %}
@@ -968,7 +961,7 @@
         </div>
 
         <!-- Errors Chart -->
-        <div class="chart-card">
+        <div class="chart-card" id="trend-errors-card">
             <div class="chart-card-header">
                 <div class="chart-header-content">
                     <svg class="chart-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -305,6 +305,76 @@ class TestCompareCharts:
                 assert chips.count() >= 1
 
 
+class TestUnsupportedDocsisErrorCharts:
+    """Unsupported DOCSIS error counters should remove misleading error charts."""
+
+    def test_trends_hide_errors_chart_when_error_counters_are_unsupported(self, demo_page):
+        demo_page.route(
+            "**/api/trends**",
+            lambda route: route.fulfill(json=[{
+                "timestamp": "2026-05-01T12:00:00",
+                "ds_power_avg": 1.2,
+                "ds_snr_avg": 38.5,
+                "us_power_avg": 42.1,
+                "errors_supported": False,
+                "ds_correctable_errors": None,
+                "ds_uncorrectable_errors": None,
+            }]),
+        )
+
+        navigate_to_trends(demo_page)
+
+        assert demo_page.locator("#trend-errors-card").is_hidden()
+        assert demo_page.locator("#chart-errors .uplot").count() == 0
+        wait_for_uplot(demo_page, "chart-ds-power")
+
+    def test_channel_timeline_hides_errors_chart_when_error_counters_are_unsupported(self, demo_page):
+        demo_page.route(
+            "**/api/channel-history**",
+            lambda route: route.fulfill(json=[{
+                "timestamp": "2026-05-01T12:00:00",
+                "power": 1.2,
+                "snr": 38.5,
+                "modulation": "256QAM",
+                "correctable_errors": None,
+                "uncorrectable_errors": None,
+            }]),
+        )
+
+        navigate_to_channels(demo_page)
+        select = demo_page.locator("#channel-select")
+        select.select_option(index=1)
+        wait_for_uplot(demo_page, "chart-ch-power")
+
+        assert demo_page.locator("#channel-errors-card").is_hidden()
+        assert demo_page.locator("#chart-ch-errors .uplot").count() == 0
+
+    def test_compare_hides_errors_chart_when_error_counters_are_unsupported(self, demo_page):
+        demo_page.route(
+            "**/api/channel-compare**",
+            lambda route: route.fulfill(json={
+                "1": [{
+                    "timestamp": "2026-05-01T12:00:00",
+                    "power": 1.2,
+                    "snr": 38.5,
+                    "modulation": "256QAM",
+                    "correctable_errors": None,
+                    "uncorrectable_errors": None,
+                }]
+            }),
+        )
+
+        navigate_to_channels(demo_page)
+        compare_tab = demo_page.locator('.trend-tab[data-value="compare"]')
+        compare_tab.first.click()
+        demo_page.wait_for_timeout(500)
+        demo_page.locator("#compare-add-all-btn").click()
+        wait_for_uplot(demo_page, "chart-cmp-power")
+
+        assert demo_page.locator("#compare-errors-card").is_hidden()
+        assert demo_page.locator("#chart-cmp-errors .uplot").count() == 0
+
+
 # ── Theme Toggle ──
 
 

--- a/tests/e2e/test_segment_utilization.py
+++ b/tests/e2e/test_segment_utilization.py
@@ -477,14 +477,27 @@ class TestSegmentCorrelation:
         box = overlay.bounding_box()
         assert box, "Correlation overlay should be present for hover interactions"
 
-        fritzbox_page.mouse.move(box["x"] + box["width"] * 0.55, box["y"] + box["height"] * 0.45)
+        modem_row = fritzbox_page.locator('#correlation-tbody tr[data-src="modem"]').first
+        row_ts = modem_row.get_attribute("data-ts")
+        assert row_ts, "Correlation table should include at least one modem transition row"
+        hover_x = fritzbox_page.evaluate(
+            """
+            (rowTs) => {
+                const st = window._corrChartState;
+                return st.xScale(new Date(rowTs).getTime());
+            }
+            """,
+            row_ts,
+        )
+        fritzbox_page.mouse.move(box["x"] + hover_x, box["y"] + box["height"] * 0.45)
         fritzbox_page.wait_for_timeout(400)
 
         tooltip = fritzbox_page.locator("#correlation-tooltip")
         assert tooltip.is_visible(), "Correlation tooltip should appear on hover"
 
-        highlighted = fritzbox_page.locator("#correlation-tbody tr.corr-highlight")
-        assert highlighted.count() > 0, "Unified timeline should highlight at least one hovered entry"
+        assert modem_row.evaluate("el => el.classList.contains('corr-highlight')"), (
+            "Unified timeline should highlight the hovered modem transition row"
+        )
 
         hover_errors = [e for e in errors if "hoverT" in e or "undefined" in e.lower()]
         assert len(hover_errors) == 0, f"Correlation hover should not raise JS errors: {hover_errors}"

--- a/tests/test_channel_timeline.py
+++ b/tests/test_channel_timeline.py
@@ -119,6 +119,59 @@ class TestGetChannelHistory:
         result_30 = storage.get_channel_history(1, "ds", days=30)
         assert len(result_30) == 2
 
+    def test_preserves_unsupported_error_values(self, storage):
+        ds = [
+            {"channel_id": 1, "frequency": "114.0 MHz", "power": 5.2,
+             "modulation": "256QAM", "snr": 38.1, "correctable_errors": None,
+             "uncorrectable_errors": None, "docsis_version": "3.0",
+             "health": "good", "health_detail": ""},
+        ]
+        storage.save_snapshot(_make_analysis(ds_channels=ds))
+
+        result = storage.get_channel_history(1, "ds", days=7)
+
+        assert result[0]["correctable_errors"] is None
+        assert result[0]["uncorrectable_errors"] is None
+
+    def test_multi_channel_preserves_unsupported_error_values(self, storage):
+        ds = [
+            {"channel_id": 1, "frequency": "114.0 MHz", "power": 5.2,
+             "modulation": "256QAM", "snr": 38.1, "correctable_errors": None,
+             "uncorrectable_errors": None, "docsis_version": "3.0",
+             "health": "good", "health_detail": ""},
+        ]
+        storage.save_snapshot(_make_analysis(ds_channels=ds))
+
+        result = storage.get_multi_channel_history([1], "ds", days=7)
+
+        assert result[1][0]["correctable_errors"] is None
+        assert result[1][0]["uncorrectable_errors"] is None
+
+    def test_missing_error_values_are_unsupported(self, storage):
+        ds = [
+            {"channel_id": 1, "frequency": "114.0 MHz", "power": 5.2,
+             "modulation": "256QAM", "snr": 38.1, "docsis_version": "3.0",
+             "health": "good", "health_detail": ""},
+        ]
+        storage.save_snapshot(_make_analysis(ds_channels=ds))
+
+        result = storage.get_channel_history(1, "ds", days=7)
+
+        assert result[0]["correctable_errors"] is None
+        assert result[0]["uncorrectable_errors"] is None
+
+    def test_multi_channel_missing_error_values_are_unsupported(self, storage):
+        ds = [
+            {"channel_id": 1, "frequency": "114.0 MHz", "power": 5.2,
+             "modulation": "256QAM", "snr": 38.1, "docsis_version": "3.0",
+             "health": "good", "health_detail": ""},
+        ]
+        storage.save_snapshot(_make_analysis(ds_channels=ds))
+
+        result = storage.get_multi_channel_history([1], "ds", days=7)
+
+        assert result[1][0]["correctable_errors"] is None
+        assert result[1][0]["uncorrectable_errors"] is None
 
     def test_string_channel_id_matches(self, storage):
         """Drivers like Vodafone Station store channelID as string.

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -27,6 +27,20 @@ class TestIndexRoute:
         resp = client.get("/?lang=de")
         assert resp.status_code == 200
 
+    def test_index_hides_error_card_when_unsupported(self, client, sample_analysis):
+        sample_analysis["summary"]["errors_supported"] = False
+        sample_analysis["summary"]["ds_correctable_errors"] = 0
+        sample_analysis["summary"]["ds_uncorrectable_errors"] = 0
+        sample_analysis["ds_channels"][0]["correctable_errors"] = None
+        sample_analysis["ds_channels"][0]["uncorrectable_errors"] = None
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/")
+
+        assert resp.status_code == 200
+        assert b'id="metric-errors-card"' not in resp.data
+        assert b"N/A</div>" not in resp.data
+
     def test_index_with_incomplete_bnetz(self, tmp_path, sample_analysis):
         """Dashboard hides BNetzA card when entry has NULL fields (#148)."""
         mgr = ConfigManager(str(tmp_path / "data_bnetz"))


### PR DESCRIPTION
## Summary
- Hide the dashboard DOCSIS error card when a modem does not report error counters
- Hide Signal Trends, channel timeline, and channel comparison error charts when error data is unsupported
- Preserve missing channel error counters as null so unsupported data is not treated as zero
- Stabilize the correlation hover E2E check by targeting an actual modem transition row

## Test plan
- `pytest -q tests/web/test_index.py::TestIndexRoute::test_index_hides_error_card_when_unsupported tests/test_channel_timeline.py::TestGetChannelHistory::test_preserves_unsupported_error_values tests/test_channel_timeline.py::TestGetChannelHistory::test_multi_channel_preserves_unsupported_error_values tests/test_channel_timeline.py::TestGetChannelHistory::test_missing_error_values_are_unsupported tests/test_channel_timeline.py::TestGetChannelHistory::test_multi_channel_missing_error_values_are_unsupported tests/e2e/test_charts.py::TestUnsupportedDocsisErrorCharts tests/e2e/test_segment_utilization.py::TestSegmentCorrelation::test_correlation_hover_shows_tooltip_and_highlights_timeline`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e`

Closes #372
