### PR TITLE
Add privacy-preserving maintainer notices

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,10 @@ DOCSight is designed to run **100% locally** on your network:
 - No telemetry or analytics
 - No cloud dependencies
 
+### Maintainer notices and privacy
+
+DOCSight maintainer notices are bundled with the installed release and evaluated locally. DOCSight does not fetch a remote notices feed, render remote HTML, or send telemetry when showing or dismissing notices. Dismissals are stored locally in your DOCSight configuration by stable notice ID. If a remote notice feed is ever added, it should be explicitly opt-in and documented separately.
+
 ## Security Features
 
 ### Authentication

--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -9,6 +9,7 @@ def register_blueprints(app):
     from .events_bp import events_bp
     from .modules_bp import modules_bp
     from .metrics_bp import metrics_bp
+    from .notices_bp import notices_bp
     from .segment_bp import segment_bp
     from .smart_capture_bp import smart_capture_bp
 
@@ -19,5 +20,6 @@ def register_blueprints(app):
     app.register_blueprint(events_bp)
     app.register_blueprint(modules_bp)
     app.register_blueprint(metrics_bp)
+    app.register_blueprint(notices_bp)
     app.register_blueprint(segment_bp)
     app.register_blueprint(smart_capture_bp)

--- a/app/blueprints/notices_bp.py
+++ b/app/blueprints/notices_bp.py
@@ -1,0 +1,55 @@
+"""Local maintainer notices API."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from app.maintainer_notices import (
+    coerce_dismissed_notice_ids,
+    get_active_notices,
+    is_valid_notice_id,
+)
+from app.web import APP_VERSION, get_config_manager, require_auth
+
+notices_bp = Blueprint("notices_bp", __name__)
+
+
+def _dismissed_ids(config_mgr) -> list[str]:
+    raw = config_mgr.get("dismissed_notice_ids", []) if config_mgr else []
+    return coerce_dismissed_notice_ids(raw)
+
+
+@notices_bp.route("/api/notices")
+@require_auth
+def api_notices_list():
+    """List active local maintainer notices."""
+    location = request.args.get("location")
+    if location not in (None, "dashboard", "settings"):
+        return jsonify({"success": False, "error": "Invalid notice location"}), 400
+
+    config_mgr = get_config_manager()
+    notices = get_active_notices(
+        APP_VERSION,
+        dismissed_ids=_dismissed_ids(config_mgr),
+        location=location,
+    )
+    return jsonify({"success": True, "notices": notices})
+
+
+@notices_bp.route("/api/notices/<notice_id>/dismiss", methods=["POST"])
+@require_auth
+def api_notice_dismiss(notice_id):
+    """Persist a local notice dismissal by stable notice id."""
+    if not is_valid_notice_id(notice_id):
+        return jsonify({"success": False, "error": "Invalid notice id"}), 400
+
+    config_mgr = get_config_manager()
+    if not config_mgr:
+        return jsonify({"success": False, "error": "Config not initialized"}), 500
+
+    dismissed = _dismissed_ids(config_mgr)
+    if notice_id not in dismissed:
+        dismissed.append(notice_id)
+    persisted = coerce_dismissed_notice_ids(dismissed)
+    config_mgr.save({"dismissed_notice_ids": persisted})
+    return jsonify({"success": True, "dismissed_notice_ids": persisted})

--- a/app/config.py
+++ b/app/config.py
@@ -37,6 +37,7 @@ DEFAULTS = {
     "temperature_unit": "celsius",
     "isp_name": "",
     "admin_password": "",
+    "dismissed_notice_ids": [],
     "demo_mode": False,
     "gaming_quality_enabled": True,
     "segment_utilization_enabled": True,

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -918,5 +918,21 @@
   "reboot_reason_tooltip": "Grund für den letzten Neustart",
   "channel_count_tooltip": "Anzahl der Downstream/Upstream DOCSIS-Kanäle",
   "wan_ipv4_tooltip": "WAN IPv4-Adresse",
-  "wan_ipv6_tooltip": "WAN IPv6-Adresse"
+  "wan_ipv6_tooltip": "WAN IPv6-Adresse",
+  "about_project": "Über das Projekt",
+  "about_project_subtitle": "Version, Projekthinweise und Datenschutzmodell",
+  "project_version": "Version",
+  "notice_delivery": "Hinweisbereitstellung",
+  "notice_delivery_local": "Mit dieser Version gebündelt",
+  "maintainer_notices": "Maintainer-Hinweise",
+  "maintainer_notice": "Maintainer-Hinweis",
+  "maintainer_notices_subtitle": "Gebündelte Projektupdates vom DOCSight-Maintainer",
+  "notice_dismiss": "Ausblenden",
+  "notice_dismiss_error": "Hinweis konnte nicht ausgeblendet werden",
+  "notice_privacy_title": "Datenschutzmodell",
+  "notice_privacy_body": "Maintainer-Hinweise sind mit DOCSight gebündelt und werden lokal ausgewertet. DOCSight ruft keinen entfernten Hinweis-Feed ab, rendert kein entferntes HTML und sendet beim Anzeigen oder Ausblenden von Hinweisen keine Telemetrie.",
+  "notice_severity_info": "Info",
+  "notice_severity_warning": "Warnung",
+  "notice_severity_critical": "Kritisch",
+  "no_active_notices": "Keine aktiven Maintainer-Hinweise."
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -918,5 +918,21 @@
   "reboot_reason_tooltip": "Reason for the last reboot",
   "channel_count_tooltip": "Number of downstream/upstream DOCSIS channels",
   "wan_ipv4_tooltip": "WAN IPv4 address",
-  "wan_ipv6_tooltip": "WAN IPv6 address"
+  "wan_ipv6_tooltip": "WAN IPv6 address",
+  "about_project": "About Project",
+  "about_project_subtitle": "Version, project notices, and privacy model",
+  "project_version": "Version",
+  "notice_delivery": "Notice delivery",
+  "notice_delivery_local": "Bundled with this release",
+  "maintainer_notices": "Maintainer notices",
+  "maintainer_notice": "Maintainer notice",
+  "maintainer_notices_subtitle": "Bundled project updates from the DOCSight maintainer",
+  "notice_dismiss": "Dismiss",
+  "notice_dismiss_error": "Could not dismiss notice",
+  "notice_privacy_title": "Privacy model",
+  "notice_privacy_body": "Maintainer notices are bundled with DOCSight and evaluated locally. DOCSight does not fetch a remote notices feed, render remote HTML, or send telemetry when showing or dismissing notices.",
+  "notice_severity_info": "Info",
+  "notice_severity_warning": "Warning",
+  "notice_severity_critical": "Critical",
+  "no_active_notices": "No active maintainer notices."
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -913,5 +913,21 @@
   "reboot_reason_tooltip": "motivo del ultimo reinicio",
   "channel_count_tooltip": "numero de canales DOCSIS de bajada/subida",
   "wan_ipv4_tooltip": "direccion IPv4 WAN",
-  "wan_ipv6_tooltip": "direccion IPv6 WAN"
+  "wan_ipv6_tooltip": "direccion IPv6 WAN",
+  "about_project": "Acerca del proyecto",
+  "about_project_subtitle": "Versión, avisos del proyecto y modelo de privacidad",
+  "project_version": "Versión",
+  "notice_delivery": "Entrega de avisos",
+  "notice_delivery_local": "Incluido con esta versión",
+  "maintainer_notices": "Avisos del mantenedor",
+  "maintainer_notice": "Aviso del mantenedor",
+  "maintainer_notices_subtitle": "Actualizaciones del proyecto incluidas por el mantenedor de DOCSight",
+  "notice_dismiss": "Descartar",
+  "notice_dismiss_error": "No se pudo descartar el aviso",
+  "notice_privacy_title": "Modelo de privacidad",
+  "notice_privacy_body": "Los avisos del mantenedor se incluyen con DOCSight y se evalúan localmente. DOCSight no obtiene un feed remoto de avisos, no renderiza HTML remoto ni envía telemetría al mostrar o descartar avisos.",
+  "notice_severity_info": "Info",
+  "notice_severity_warning": "Advertencia",
+  "notice_severity_critical": "Crítico",
+  "no_active_notices": "No hay avisos activos del mantenedor."
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -910,5 +910,21 @@
   "reboot_reason_tooltip": "raison du dernier redémarrage",
   "channel_count_tooltip": "nombre de canaux DOCSIS descendants/montants",
   "wan_ipv4_tooltip": "adresse IPv4 WAN",
-  "wan_ipv6_tooltip": "adresse IPv6 WAN"
+  "wan_ipv6_tooltip": "adresse IPv6 WAN",
+  "about_project": "À propos du projet",
+  "about_project_subtitle": "Version, avis du projet et modèle de confidentialité",
+  "project_version": "Version",
+  "notice_delivery": "Diffusion des avis",
+  "notice_delivery_local": "Intégré à cette version",
+  "maintainer_notices": "Avis du mainteneur",
+  "maintainer_notice": "Avis du mainteneur",
+  "maintainer_notices_subtitle": "Mises à jour du projet intégrées par le mainteneur DOCSight",
+  "notice_dismiss": "Masquer",
+  "notice_dismiss_error": "Impossible de masquer l'avis",
+  "notice_privacy_title": "Modèle de confidentialité",
+  "notice_privacy_body": "Les avis du mainteneur sont intégrés à DOCSight et évalués localement. DOCSight ne récupère pas de flux d'avis distant, n'affiche pas de HTML distant et n'envoie aucune télémétrie lors de l'affichage ou du masquage des avis.",
+  "notice_severity_info": "Info",
+  "notice_severity_warning": "Avertissement",
+  "notice_severity_critical": "Critique",
+  "no_active_notices": "Aucun avis du mainteneur actif."
 }

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "_meta": {
     "language_name": "",
     "flag": ""
@@ -763,5 +763,21 @@
   "font_family": "",
   "font_family_desc": "",
   "use_system_font": "",
-  "use_system_font_hint": ""
+  "use_system_font_hint": "",
+  "about_project": "",
+  "about_project_subtitle": "",
+  "project_version": "",
+  "notice_delivery": "",
+  "notice_delivery_local": "",
+  "maintainer_notices": "",
+  "maintainer_notice": "",
+  "maintainer_notices_subtitle": "",
+  "notice_dismiss": "",
+  "notice_dismiss_error": "",
+  "notice_privacy_title": "",
+  "notice_privacy_body": "",
+  "notice_severity_info": "",
+  "notice_severity_warning": "",
+  "notice_severity_critical": "",
+  "no_active_notices": ""
 }

--- a/app/maintainer_notices.py
+++ b/app/maintainer_notices.py
@@ -1,0 +1,249 @@
+"""Local maintainer notices for DOCSight.
+
+Notices in this module are bundled with the installed release and evaluated
+locally. They never fetch remote content, execute remote HTML, or report
+telemetry when displayed or dismissed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+SEVERITY_ORDER = {"critical": 0, "warning": 1, "info": 2}
+ALLOWED_SEVERITIES = frozenset(SEVERITY_ORDER)
+ALLOWED_LOCATIONS = frozenset({"dashboard", "settings"})
+PLAIN_TEXT_FIELDS = ("title", "body", "link_label")
+NOTICE_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{1,80}$")
+MAX_DISMISSED_NOTICE_IDS = 200
+
+LOCAL_NOTICES: tuple[dict[str, Any], ...] = (
+    {
+        "id": "docsight-local-notices-2026-05",
+        "severity": "info",
+        "title": "Maintainer notices are now local-first",
+        "body": (
+            "DOCSight can show bundled project notices without contacting a remote "
+            "feed or sending telemetry. Dismissals are stored only in your local "
+            "DOCSight configuration."
+        ),
+        "locations": ("dashboard", "settings"),
+        "link_label": "View release notes",
+        "link_url": "https://github.com/itsDNNS/docsight/releases",
+    },
+)
+
+
+class NoticeValidationError(ValueError):
+    """Raised when a bundled notice violates the local notice contract."""
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _version_parts(value: str) -> tuple[tuple[int, Any], ...]:
+    raw = (value or "").strip().lstrip("v")
+    if not raw or raw == "dev":
+        return ()
+    parts: list[tuple[int, Any]] = []
+    for token in raw.replace("-", ".").split("."):
+        if token.isdigit():
+            parts.append((0, int(token)))
+        else:
+            parts.append((1, token))
+    return tuple(parts)
+
+
+def _version_gte(current: str, minimum: str) -> bool:
+    cur = _version_parts(current)
+    min_parts = _version_parts(minimum)
+    if not cur or not min_parts:
+        return True
+    return cur >= min_parts
+
+
+def _version_lte(current: str, maximum: str) -> bool:
+    cur = _version_parts(current)
+    max_parts = _version_parts(maximum)
+    if not cur or not max_parts:
+        return True
+    return cur <= max_parts
+
+
+def is_valid_notice_id(value: str) -> bool:
+    """Return True when value is safe as a stable notice identifier."""
+    return bool(NOTICE_ID_PATTERN.fullmatch(value))
+
+
+def _is_plain_text(value: str) -> bool:
+    return "<" not in value and ">" not in value
+
+
+def _is_safe_link(value: str | None) -> bool:
+    if not value:
+        return True
+    if not isinstance(value, str):
+        return False
+    if value.startswith("/") and not value.startswith("//"):
+        return True
+    parsed = urlparse(value)
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+def validate_notice_schema(notice: dict[str, Any]) -> None:
+    """Validate the strict local-only notice schema."""
+    if not isinstance(notice, dict):
+        raise NoticeValidationError("Notice must be a mapping")
+
+    notice_id = notice.get("id")
+    if not isinstance(notice_id, str) or not is_valid_notice_id(notice_id):
+        raise NoticeValidationError("Notice requires a stable safe string id")
+
+    severity = notice.get("severity", "info")
+    if severity not in ALLOWED_SEVERITIES:
+        raise NoticeValidationError(f"Unsupported notice severity: {severity}")
+
+    title = notice.get("title")
+    body = notice.get("body")
+    if not isinstance(title, str) or not title.strip():
+        raise NoticeValidationError("Notice requires a plain-text title")
+    if not isinstance(body, str) or not body.strip():
+        raise NoticeValidationError("Notice requires a plain-text body")
+
+    for field in PLAIN_TEXT_FIELDS:
+        value = notice.get(field)
+        if value is not None:
+            if not isinstance(value, str):
+                raise NoticeValidationError(f"Notice field {field} must be text")
+            if not _is_plain_text(value):
+                raise NoticeValidationError(f"Notice field {field} must not contain HTML")
+
+    locations = notice.get("locations", ("dashboard", "settings"))
+    if not isinstance(locations, (list, tuple, set)) or not locations:
+        raise NoticeValidationError("Notice requires at least one location")
+    if not all(isinstance(location, str) for location in locations):
+        raise NoticeValidationError("Notice locations must be text")
+    unknown = set(locations) - ALLOWED_LOCATIONS
+    if unknown:
+        raise NoticeValidationError(f"Unsupported notice locations: {', '.join(sorted(unknown))}")
+
+    if not _is_safe_link(notice.get("link_url")):
+        raise NoticeValidationError("Notice links must be relative or HTTPS URLs")
+
+    for key in ("starts_at", "expires_at"):
+        value = notice.get(key)
+        if value:
+            if not isinstance(value, str):
+                raise NoticeValidationError(f"Invalid {key} timestamp")
+            try:
+                _parse_datetime(value)
+            except ValueError as exc:
+                raise NoticeValidationError(f"Invalid {key} timestamp") from exc
+
+
+def coerce_dismissed_notice_ids(dismissed_ids: Any) -> list[str]:
+    """Normalize persisted dismissal values into bounded stable IDs."""
+    if not dismissed_ids:
+        return []
+    if isinstance(dismissed_ids, str):
+        values = [item.strip() for item in dismissed_ids.split(",")]
+    elif isinstance(dismissed_ids, (list, tuple, set)):
+        values = [str(item).strip() for item in dismissed_ids]
+    else:
+        return []
+
+    normalized = list(dict.fromkeys(item for item in values if item and is_valid_notice_id(item)))
+    return normalized[-MAX_DISMISSED_NOTICE_IDS:]
+
+
+def _coerce_dismissed_ids(dismissed_ids: Any) -> set[str]:
+    return set(coerce_dismissed_notice_ids(dismissed_ids))
+
+
+def _matches_constraints(
+    notice: dict[str, Any],
+    *,
+    app_version: str,
+    location: str | None,
+    now: datetime,
+) -> bool:
+    locations = set(notice.get("locations", ("dashboard", "settings")))
+    if location and location not in locations:
+        return False
+
+    starts_at = _parse_datetime(notice.get("starts_at"))
+    if starts_at and starts_at > now:
+        return False
+
+    expires_at = _parse_datetime(notice.get("expires_at"))
+    if expires_at and expires_at <= now:
+        return False
+
+    min_version = notice.get("min_version")
+    if min_version and not _version_gte(app_version, str(min_version)):
+        return False
+
+    max_version = notice.get("max_version")
+    if max_version and not _version_lte(app_version, str(max_version)):
+        return False
+
+    return True
+
+
+def serialize_notice(notice: dict[str, Any]) -> dict[str, Any]:
+    """Return the public notice fields safe for APIs and templates."""
+    validate_notice_schema(notice)
+    data = {
+        "id": notice["id"],
+        "severity": notice.get("severity", "info"),
+        "title": notice["title"],
+        "body": notice["body"],
+    }
+    for key in ("link_label", "link_url", "min_version", "max_version"):
+        if notice.get(key):
+            data[key] = notice[key]
+    return data
+
+
+def get_active_notices(
+    app_version: str,
+    dismissed_ids: Any = None,
+    location: str | None = None,
+    *,
+    now: datetime | None = None,
+    notices: tuple[dict[str, Any], ...] | list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Return active bundled notices after local filtering and dismissal."""
+    if location is not None and location not in ALLOWED_LOCATIONS:
+        return []
+
+    dismissed = _coerce_dismissed_ids(dismissed_ids)
+    evaluated_at = now or datetime.now(timezone.utc)
+    source = LOCAL_NOTICES if notices is None else notices
+    active: list[dict[str, Any]] = []
+
+    for notice in source:
+        try:
+            validate_notice_schema(notice)
+            if notice["id"] in dismissed:
+                continue
+            if not _matches_constraints(notice, app_version=app_version, location=location, now=evaluated_at):
+                continue
+            active.append(serialize_notice(notice))
+        except (NoticeValidationError, AttributeError, TypeError, ValueError):
+            # Notices must never block the local dashboard/settings surfaces.
+            # Invalid bundled entries are treated as inactive instead of
+            # turning core pages into 500s.
+            continue
+
+    active.sort(key=lambda item: (SEVERITY_ORDER[item["severity"]], item["id"]))
+    return active

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -211,6 +211,94 @@ body {
 .skel-row { height: 40px; width: 100%; margin-bottom: 8px; }
 .skel-bar { height: 160px; width: 100%; border-radius: var(--radius-lg); }
 
+/* ── Maintainer Notices ── */
+.notice-stack {
+  display: grid;
+  gap: var(--space-sm);
+}
+.dashboard-notice-stack {
+  margin-bottom: var(--space-lg);
+}
+.maintainer-notice {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-sm);
+  align-items: flex-start;
+  padding: var(--space-md);
+  border: 1px solid color-mix(in srgb, var(--info) 24%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--info) 8%, var(--glass-bg));
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+}
+.maintainer-notice.notice-warning {
+  border-color: color-mix(in srgb, var(--warn) 34%, transparent);
+  background: color-mix(in srgb, var(--warn) 8%, var(--glass-bg));
+}
+.maintainer-notice.notice-critical {
+  border-color: color-mix(in srgb, var(--crit) 38%, transparent);
+  background: color-mix(in srgb, var(--crit) 9%, var(--glass-bg));
+}
+.notice-icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--info) 14%, transparent);
+  color: var(--info);
+}
+.notice-warning .notice-icon { background: var(--warn-muted); color: var(--warn); }
+.notice-critical .notice-icon { background: var(--crit-muted); color: var(--crit); }
+.notice-icon svg { width: 18px; height: 18px; }
+.notice-content {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+.notice-title-row {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+  flex-wrap: wrap;
+}
+.notice-title-row h2,
+.notice-title-row h3 {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.25;
+  color: var(--text-primary);
+}
+.notice-content p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+.notice-link {
+  color: var(--info);
+  font-weight: 600;
+  font-size: 0.86rem;
+  text-decoration: none;
+}
+.notice-link:hover { text-decoration: underline; }
+.notice-dismiss {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: rgba(255,255,255,0.04);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.2s var(--ease-out-expo);
+}
+.notice-dismiss:hover {
+  color: var(--text-primary);
+  background: rgba(255,255,255,0.08);
+}
+.notice-dismiss svg { width: 16px; height: 16px; }
+
 /* ── Scrollbar ── */
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -1822,3 +1822,43 @@ html, body {
   animation: confirmPulse 0.3s var(--ease-out-expo);
 }
 @keyframes confirmPulse { 0% { transform: scale(0.95); } 100% { transform: scale(1); } }
+
+
+/* ─── About Project / Maintainer Notices ─── */
+.about-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-sm);
+}
+.about-meta-item {
+  display: grid;
+  gap: 4px;
+  padding: var(--space-md);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: rgba(255,255,255,0.035);
+}
+.about-meta-label {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.settings-notice-stack {
+  margin-top: var(--space-sm);
+}
+.privacy-card .card-subtitle {
+  max-width: 760px;
+}
+.empty-state.compact {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  color: var(--text-secondary);
+}
+.empty-state.compact svg {
+  color: var(--good);
+  width: 18px;
+  height: 18px;
+}

--- a/app/static/js/notices.js
+++ b/app/static/js/notices.js
@@ -1,0 +1,29 @@
+/* DOCSight local maintainer notices. No remote feed or telemetry. */
+(function() {
+  'use strict';
+
+  function removeNoticeElement(noticeId) {
+    document.querySelectorAll('[data-notice-id]').forEach(function(el) {
+      if (el.getAttribute('data-notice-id') === noticeId) el.remove();
+    });
+  }
+
+  window.dismissMaintainerNotice = function(noticeId) {
+    if (!noticeId) return;
+    fetch('/api/notices/' + encodeURIComponent(noticeId) + '/dismiss', {
+      method: 'POST',
+      headers: {'Accept': 'application/json'}
+    }).then(function(response) {
+      if (!response.ok) throw new Error('dismiss failed');
+      return response.json();
+    }).then(function(data) {
+      if (data && data.success) {
+        removeNoticeElement(noticeId);
+      }
+    }).catch(function() {
+      if (typeof showToast === 'function') {
+        showToast((window.T && (T.notice_dismiss_error || T.error_prefix)) || 'Could not dismiss notice', false);
+      }
+    });
+  };
+})();

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -7,7 +7,7 @@
 
 /* ── Section Controller ── */
 var _currentSection = 'connection';
-var _saveHiddenSections = { support: true, themes: true };
+var _saveHiddenSections = { support: true, themes: true, about: true };
 
 function switchSection(id) {
     _currentSection = id;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -259,6 +259,29 @@
 <div id="view-dashboard" class="view active">
 
 
+{% if dashboard_notices %}
+<div class="notice-stack dashboard-notice-stack">
+    {% for notice in dashboard_notices %}
+    <article class="maintainer-notice notice-{{ notice.severity }}" data-notice-id="{{ notice.id }}">
+        <div class="notice-icon"><i data-lucide="{{ 'alert-triangle' if notice.severity == 'warning' else ('shield-alert' if notice.severity == 'critical' else 'info') }}"></i></div>
+        <div class="notice-content">
+            <div class="notice-title-row">
+                <h2>{{ notice.title }}</h2>
+                <span class="badge badge-{{ 'crit' if notice.severity == 'critical' else ('warn' if notice.severity == 'warning' else 'info') }}">{{ t.get('notice_severity_' ~ notice.severity, notice.severity|capitalize) }}</span>
+            </div>
+            <p>{{ notice.body }}</p>
+            {% if notice.link_url and notice.link_label %}
+            <a class="notice-link" href="{{ notice.link_url }}" target="_blank" rel="noopener noreferrer">{{ notice.link_label }}</a>
+            {% endif %}
+        </div>
+        <button type="button" class="notice-dismiss" onclick="dismissMaintainerNotice('{{ notice.id }}')" aria-label="{{ t.get('notice_dismiss', 'Dismiss') }}">
+            <i data-lucide="x"></i>
+        </button>
+    </article>
+    {% endfor %}
+</div>
+{% endif %}
+
 {% if error %}
 <div class="error-box">{{ t.error_label }}: {{ error }}</div>
 {% endif %}
@@ -2720,6 +2743,7 @@ var TEMPERATURE_UNIT = {{ temperature_unit|tojson }};
 <script src="/static/js/integrations.js"></script>
 <script src="/static/js/events.js"></script>
 <script src="/static/js/utils.js"></script>
+<script src="/static/js/notices.js"></script>
 <script src="/static/js/speedtest.js"></script>
 <script src="/static/js/correlation.js"></script>
 <script src="/static/js/segment-utilization.js"></script>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -81,6 +81,10 @@
                 <i data-lucide="package" class="nav-icon"></i>
                 {{ t.get('settings_extensions', 'Extensions') }}
             </button>
+            <button class="nav-item" data-section="about" onclick="switchSection('about')">
+                <i data-lucide="info" class="nav-icon"></i>
+                {{ t.get('about_project', 'About Project') }}
+            </button>
             {% set settings_modules = [] %}
             {% for mod in modules if mod.template_paths.get('settings') %}
                 {% if settings_modules.append(mod) %}{% endif %}
@@ -149,6 +153,7 @@
             {% include 'settings/appearance.html' %}
             {% include 'settings/security.html' %}
             {% include 'settings/extensions.html' %}
+            {% include 'settings/about.html' %}
             {% include 'settings/support.html' %}
 
             {# ── Module Settings Panels ── #}
@@ -181,6 +186,7 @@ var SECTION_TITLES = {
     appearance: T.appearance || 'Appearance',
     security: T.get ? (T.get('security') || 'Security') : 'Security',
     extensions: T.get ? (T.get('settings_extensions') || 'Extensions') : 'Extensions',
+    about: T.about_project || 'About Project',
     support: T.support_title || 'Support DOCSight'
 };
 {% for mod in modules if mod.template_paths.get('settings') %}
@@ -194,6 +200,7 @@ try { var savedCooldowns = JSON.parse({{ config.notify_cooldowns|default("{}")|t
 var DRIVER_HINTS = {{ driver_hints | tojson }};
 </script>
 <script src="/static/js/utils.js"></script>
+<script src="/static/js/notices.js"></script>
 <script src="/static/js/settings.js"></script>
 {% for mod in modules if mod.has_js %}
 <script src="/modules/{{ mod.id }}/static/main.js"></script>

--- a/app/templates/settings/about.html
+++ b/app/templates/settings/about.html
@@ -1,0 +1,82 @@
+<section class="settings-panel" id="panel-about">
+    <div class="settings-card glass">
+        <div class="card-header">
+            <div class="card-title-group">
+                <div class="card-icon blue">
+                    <i data-lucide="info"></i>
+                </div>
+                <div>
+                    <div class="card-title">{{ t.get('about_project', 'About Project') }}</div>
+                    <div class="card-subtitle">{{ t.get('about_project_subtitle', 'Version, project notices, and privacy model') }}</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="about-meta-grid">
+            <div class="about-meta-item">
+                <span class="about-meta-label">{{ t.get('project_version', 'Version') }}</span>
+                <strong>{{ app_version }}</strong>
+            </div>
+            <div class="about-meta-item">
+                <span class="about-meta-label">{{ t.get('notice_delivery', 'Notice delivery') }}</span>
+                <strong>{{ t.get('notice_delivery_local', 'Bundled with this release') }}</strong>
+            </div>
+        </div>
+    </div>
+
+    <div class="settings-card glass">
+        <div class="card-header">
+            <div class="card-title-group">
+                <div class="card-icon purple">
+                    <i data-lucide="megaphone"></i>
+                </div>
+                <div>
+                    <div class="card-title">{{ t.get('maintainer_notices', 'Maintainer notices') }}</div>
+                    <div class="card-subtitle">{{ t.get('maintainer_notices_subtitle', 'Bundled project updates from the DOCSight maintainer') }}</div>
+                </div>
+            </div>
+        </div>
+
+        {% if settings_notices %}
+        <div class="notice-stack settings-notice-stack">
+            {% for notice in settings_notices %}
+            <article class="maintainer-notice notice-{{ notice.severity }}" data-notice-id="{{ notice.id }}">
+                <div class="notice-icon"><i data-lucide="{{ 'alert-triangle' if notice.severity == 'warning' else ('shield-alert' if notice.severity == 'critical' else 'info') }}"></i></div>
+                <div class="notice-content">
+                    <div class="notice-title-row">
+                        <h3>{{ notice.title }}</h3>
+                        <span class="badge badge-{{ 'crit' if notice.severity == 'critical' else ('warn' if notice.severity == 'warning' else 'info') }}">{{ t.get('notice_severity_' ~ notice.severity, notice.severity|capitalize) }}</span>
+                    </div>
+                    <p>{{ notice.body }}</p>
+                    {% if notice.link_url and notice.link_label %}
+                    <a class="notice-link" href="{{ notice.link_url }}" target="_blank" rel="noopener noreferrer">{{ notice.link_label }}</a>
+                    {% endif %}
+                </div>
+                <button type="button" class="notice-dismiss" onclick="dismissMaintainerNotice('{{ notice.id }}')" aria-label="{{ t.get('notice_dismiss', 'Dismiss') }}">
+                    <i data-lucide="x"></i>
+                </button>
+            </article>
+            {% endfor %}
+        </div>
+        {% else %}
+        <div class="empty-state compact">
+            <i data-lucide="check-circle"></i>
+            <p>{{ t.get('no_active_notices', 'No active maintainer notices.') }}</p>
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="settings-card glass privacy-card">
+        <div class="card-header">
+            <div class="card-title-group">
+                <div class="card-icon green">
+                    <i data-lucide="lock"></i>
+                </div>
+                <div>
+                    <div class="card-title">{{ t.get('notice_privacy_title', 'Privacy model') }}</div>
+                    <div class="card-subtitle">{{ t.get('notice_privacy_body', 'Maintainer notices are bundled with DOCSight and evaluated locally. DOCSight does not fetch a remote notices feed, render remote HTML, or send telemetry when showing or dismissing notices.') }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/app/web.py
+++ b/app/web.py
@@ -22,6 +22,7 @@ from zoneinfo import available_timezones
 from .config import POLL_MIN, POLL_MAX
 from .gaming_index import compute_gaming_index
 from .i18n import get_translations, LANGUAGES, LANG_FLAGS
+from .maintainer_notices import coerce_dismissed_notice_ids, get_active_notices
 
 _IANA_REGIONS = {"Africa", "America", "Antarctica", "Arctic", "Asia",
                  "Atlantic", "Australia", "Europe", "Indian", "Pacific"}
@@ -475,6 +476,13 @@ def get_module_loader():
     return _module_loader
 
 
+def _get_dismissed_notice_ids():
+    """Return locally persisted maintainer notice dismissals."""
+    if not _config_manager:
+        return []
+    return coerce_dismissed_notice_ids(_config_manager.get("dismissed_notice_ids", []))
+
+
 def get_on_config_changed():
     """Get the config changed callback."""
     return _on_config_changed
@@ -840,6 +848,11 @@ def index():
         bnetz_latest=bnetz_latest,
         t=t, lang=lang, languages=LANGUAGES, lang_flags=LANG_FLAGS,
         temperature_unit=_config_manager.get("temperature_unit", "celsius") if _config_manager else "celsius",
+        dashboard_notices=get_active_notices(
+            APP_VERSION,
+            dismissed_ids=_get_dismissed_notice_ids(),
+            location="dashboard",
+        ),
     )
 
 
@@ -921,7 +934,33 @@ def settings():
             "manage_label": t.get("step_modem", "Modem"),
         },
     ]
-    return render_template("settings.html", config=config, theme=theme, poll_min=POLL_MIN, poll_max=POLL_MAX, t=t, lang=lang, languages=LANGUAGES, lang_flags=LANG_FLAGS, server_tz=tz_name, server_tz_offset=tz_offset, modem_types=modem_types, driver_hints=driver_hints, demo_mode=demo_mode, timezones=_get_iana_timezones(), iana_tz=iana_tz, tz_is_posix=tz_is_posix, all_modules=all_modules, built_in_features=built_in_features)
+    return render_template(
+        "settings.html",
+        config=config,
+        theme=theme,
+        poll_min=POLL_MIN,
+        poll_max=POLL_MAX,
+        t=t,
+        lang=lang,
+        languages=LANGUAGES,
+        lang_flags=LANG_FLAGS,
+        server_tz=tz_name,
+        server_tz_offset=tz_offset,
+        modem_types=modem_types,
+        driver_hints=driver_hints,
+        demo_mode=demo_mode,
+        timezones=_get_iana_timezones(),
+        iana_tz=iana_tz,
+        tz_is_posix=tz_is_posix,
+        all_modules=all_modules,
+        built_in_features=built_in_features,
+        app_version=APP_VERSION,
+        settings_notices=get_active_notices(
+            APP_VERSION,
+            dismissed_ids=_get_dismissed_notice_ids(),
+            location="settings",
+        ),
+    )
 
 
 @app.after_request

--- a/tests/test_maintainer_notices.py
+++ b/tests/test_maintainer_notices.py
@@ -1,0 +1,110 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app.maintainer_notices import (
+    NoticeValidationError,
+    coerce_dismissed_notice_ids,
+    get_active_notices,
+    validate_notice_schema,
+)
+
+
+def _notice(**overrides):
+    data = {
+        "id": "test-notice",
+        "severity": "info",
+        "title": "Local notice",
+        "body": "Bundled with DOCSight.",
+        "locations": ("dashboard", "settings"),
+    }
+    data.update(overrides)
+    return data
+
+
+def test_active_notice_matches_location_and_excludes_dismissed_ids():
+    notices = [_notice(id="visible"), _notice(id="dismissed")]
+
+    active = get_active_notices(
+        "v2026-05-02.1",
+        dismissed_ids=["dismissed"],
+        location="dashboard",
+        notices=notices,
+    )
+
+    assert [notice["id"] for notice in active] == ["visible"]
+
+
+def test_notice_severity_sorting_prioritizes_critical_then_warning_then_info():
+    notices = [
+        _notice(id="info", severity="info"),
+        _notice(id="critical", severity="critical"),
+        _notice(id="warning", severity="warning"),
+    ]
+
+    active = get_active_notices("v2026-05-02.1", notices=notices)
+
+    assert [notice["id"] for notice in active] == ["critical", "warning", "info"]
+
+
+def test_version_and_time_constraints_are_enforced():
+    now = datetime(2026, 5, 2, tzinfo=timezone.utc)
+    notices = [
+        _notice(id="current", min_version="2026-05-01.1", max_version="2026-05-03.1"),
+        _notice(id="too-new", min_version="2026-05-03.1"),
+        _notice(id="expired", expires_at="2026-05-01T00:00:00Z"),
+        _notice(id="future", starts_at="2026-05-03T00:00:00Z"),
+    ]
+
+    active = get_active_notices("v2026-05-02.1", notices=notices, now=now)
+
+    assert [notice["id"] for notice in active] == ["current"]
+
+
+def test_notices_reject_remote_html_and_unsafe_links():
+    with pytest.raises(NoticeValidationError):
+        validate_notice_schema(_notice(id="unsafe'id"))
+
+    with pytest.raises(NoticeValidationError):
+        validate_notice_schema(_notice(body="<strong>remote html</strong>"))
+
+    with pytest.raises(NoticeValidationError):
+        validate_notice_schema(_notice(link_url="javascript:alert(1)", link_label="Open"))
+
+
+def test_relative_and_https_links_are_allowed():
+    validate_notice_schema(_notice(link_url="/settings#about", link_label="Open"))
+    validate_notice_schema(_notice(link_url="https://github.com/itsDNNS/docsight", link_label="Open"))
+
+
+def test_mixed_version_tokens_do_not_crash_filtering():
+    notices = [_notice(id="rc-notice", min_version="1.0.rc1")]
+
+    active = get_active_notices("1.0.2", notices=notices)
+
+    assert active == []
+
+
+def test_invalid_notices_are_ignored_so_notices_remain_non_blocking():
+    notices = [
+        _notice(id="visible"),
+        _notice(id="bad-html", body="<strong>broken</strong>"),
+        "not-a-mapping",
+        _notice(id="bad-link", link_url=["https://example.com"], link_label="Open"),
+        _notice(id="bad-time", starts_at=123),
+        _notice(id="bad-location", locations=(["dashboard"],)),
+    ]
+
+    active = get_active_notices("v2026-05-02.1", notices=notices)
+
+    assert [notice["id"] for notice in active] == ["visible"]
+
+
+def test_dismissed_notice_ids_are_validated_deduped_and_bounded():
+    raw = [f"notice-{idx}" for idx in range(205)] + ["bad id", "notice-204"]
+
+    normalized = coerce_dismissed_notice_ids(raw)
+
+    assert len(normalized) == 200
+    assert "bad id" not in normalized
+    assert normalized[-1] == "notice-204"

--- a/tests/web/test_notices.py
+++ b/tests/web/test_notices.py
@@ -1,0 +1,83 @@
+import pytest
+
+from app import maintainer_notices
+from app.web import reset_modem_state
+
+
+@pytest.fixture
+def local_notices(monkeypatch):
+    notices = (
+        {
+            "id": "docsight-test-notice",
+            "severity": "info",
+            "title": "Bundled maintainer notice",
+            "body": "This notice is evaluated locally.",
+            "locations": ("dashboard", "settings"),
+            "link_label": "Release notes",
+            "link_url": "https://github.com/itsDNNS/docsight/releases",
+        },
+    )
+    monkeypatch.setattr(maintainer_notices, "LOCAL_NOTICES", notices)
+    yield notices
+
+
+def test_notices_api_returns_local_notices(client, local_notices):
+    response = client.get("/api/notices?location=dashboard")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert data["notices"][0]["id"] == "docsight-test-notice"
+    assert data["notices"][0]["title"] == "Bundled maintainer notice"
+
+
+def test_notice_dismissal_persists_and_hides_notice(client, config_mgr, local_notices):
+    response = client.post("/api/notices/docsight-test-notice/dismiss")
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert config_mgr.get("dismissed_notice_ids") == ["docsight-test-notice"]
+
+    response = client.get("/api/notices?location=dashboard")
+    assert response.get_json()["notices"] == []
+
+
+def test_notice_dismissal_preserves_order_and_keeps_new_id_at_cap(client, config_mgr, local_notices):
+    existing = [f"notice-{idx}" for idx in range(200)]
+    config_mgr.save({"dismissed_notice_ids": existing})
+
+    response = client.post("/api/notices/docsight-test-notice/dismiss")
+
+    assert response.status_code == 200
+    persisted = response.get_json()["dismissed_notice_ids"]
+    assert len(persisted) == 200
+    assert persisted[-1] == "docsight-test-notice"
+    assert "notice-0" not in persisted
+    assert config_mgr.get("dismissed_notice_ids") == persisted
+
+
+def test_notice_api_rejects_invalid_location_and_id(client, local_notices):
+    assert client.get("/api/notices?location=remote").status_code == 400
+    assert client.post("/api/notices/<script>/dismiss").status_code == 400
+
+
+def test_dashboard_renders_notice_until_dismissed(client, config_mgr, local_notices):
+    reset_modem_state()
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Bundled maintainer notice" in response.data
+    assert b"data-notice-id=\"docsight-test-notice\"" in response.data
+
+    config_mgr.save({"dismissed_notice_ids": ["docsight-test-notice"]})
+    response = client.get("/")
+    assert b"Bundled maintainer notice" not in response.data
+
+
+def test_settings_about_panel_renders_notices_and_privacy_copy(client, local_notices):
+    response = client.get("/settings")
+
+    assert response.status_code == 200
+    assert b"About Project" in response.data
+    assert b"Bundled maintainer notice" in response.data
+    assert b"DOCSight does not fetch a remote notices feed" in response.data


### PR DESCRIPTION
## Summary
- Adds bundled, local-only maintainer notices for dashboard and Settings/About Project
- Stores dismissals locally in DOCSight configuration with safe ID validation and bounded history
- Documents the privacy model: no telemetry, no remote notice feed, and no remote HTML

## Test Plan
- `python -m pytest tests/test_maintainer_notices.py tests/web/test_notices.py`
- `python -m pytest tests/web`
- `python -m pytest`
- Browser smoke: dashboard and Settings/About Project with no console errors

Closes #376
