### PR TITLE
Standardize modal interactions

### DIFF
--- a/app/modules/backup/templates/backup_settings.html
+++ b/app/modules/backup/templates/backup_settings.html
@@ -52,7 +52,7 @@
                 <label class="form-label">{{ t['docsight.backup.backup_path'] or 'Backup Path' }}</label>
                 <div class="input-with-action">
                     <input class="form-input" type="text" id="backup_path" name="backup_path" value="{{ config.backup_path }}" readonly style="cursor:pointer;">
-                    <button type="button" class="btn btn-ghost btn-sm" onclick="openBrowseModal()">
+                    <button type="button" class="btn btn-ghost btn-sm" onclick="openBrowseModal(this)">
                         <i data-lucide="folder-open" style="width:14px;height:14px;"></i>
                         {{ t['docsight.backup.backup_browse'] or 'Browse' }}
                     </button>
@@ -90,16 +90,21 @@
 </div>
 
 <!-- ═══ Directory Browser Modal ═══ -->
-<div id="browse-modal" class="browse-modal-overlay">
+<div id="browse-modal" class="browse-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="browse-modal-title" aria-describedby="browse-status" tabindex="-1">
     <div class="browse-modal">
         <div class="browse-modal-header">
-            <h3>{{ t['docsight.backup.backup_select_dir'] or 'Select Directory' }}</h3>
-            <button type="button" class="btn-icon" onclick="closeBrowseModal()">
+            <h3 id="browse-modal-title">{{ t['docsight.backup.backup_select_dir'] or 'Select Directory' }}</h3>
+            <button type="button" class="btn-icon" onclick="closeBrowseModal()" aria-label="{{ t.close or 'Close' }}">
                 <i data-lucide="x"></i>
             </button>
         </div>
+        <div class="browse-modal-summary">
+            <span>{{ t['docsight.backup.backup_path'] or 'Backup Path' }}</span>
+            <code id="browse-selected-path">{{ config.backup_path or '/backup' }}</code>
+        </div>
+        <div id="browse-status" class="browse-modal-status" role="status" aria-live="polite"></div>
         <div id="browse-breadcrumb" class="browse-modal-path"></div>
-        <div id="browse-dirs" class="browse-modal-body"></div>
+        <div id="browse-dirs" class="browse-modal-body" tabindex="0"></div>
         <div class="browse-modal-footer">
             <button type="button" class="btn btn-ghost" onclick="closeBrowseModal()">{{ t.cancel }}</button>
             <button type="button" class="btn btn-primary btn-sm" onclick="selectBrowsePath()">{{ t['docsight.backup.backup_select'] or 'Select' }}</button>

--- a/app/modules/speedtest/templates/speedtest_settings.html
+++ b/app/modules/speedtest/templates/speedtest_settings.html
@@ -28,7 +28,7 @@
                     <i data-lucide="plug-zap"></i>
                     {{ t.test_connection or 'Test Connection' }}
                 </button>
-                <button type="button" class="btn btn-secondary" onclick="clearSpeedtestCache(this)" title="{{ t['docsight.speedtest.clear_cache_hint'] or 'Delete cached results and re-sync from Speedtest Tracker' }}">
+                <button type="button" id="speedtest_clear_cache" class="btn btn-secondary" onclick="clearSpeedtestCache(this)" title="{{ t['docsight.speedtest.clear_cache_hint'] or 'Delete cached results and re-sync from Speedtest Tracker' }}">
                     <i data-lucide="trash-2"></i>
                     {{ t['docsight.speedtest.clear_cache'] or 'Clear Cache' }}
                 </button>

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -1268,6 +1268,31 @@ html, body {
   font-family: var(--font-mono);
   border-bottom: 1px solid var(--glass-border);
 }
+.browse-modal-summary {
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+.browse-modal-summary code {
+  color: var(--text-main);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.browse-modal-status {
+  min-height: 32px;
+  padding: 8px 24px;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  border-bottom: 1px solid var(--glass-border);
+}
 .browse-modal-body {
   flex: 1;
   overflow-y: auto;

--- a/app/static/js/bqm.js
+++ b/app/static/js/bqm.js
@@ -747,15 +747,23 @@ function deleteBqmImages() {
             .replace('{0}', rangeDates.length)
             .replace('{1}', _bqmRangeStart)
             .replace('{2}', _bqmRangeEnd);
-        if (!confirm(msg)) return;
-
-        fetch('/api/bqm/images', {
-            method: 'DELETE',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ start: _bqmRangeStart, end: _bqmRangeEnd })
+        docsightConfirm({
+            title: T.delete || 'Delete',
+            message: msg,
+            confirmText: T.delete || 'Delete',
+            cancelText: T.cancel || 'Cancel',
+            danger: true
+        }).then(function(confirmed) {
+            if (!confirmed) return null;
+            return fetch('/api/bqm/images', {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ start: _bqmRangeStart, end: _bqmRangeEnd })
+            });
         })
-        .then(function(r) { return r.json(); })
+        .then(function(r) { return r ? r.json() : null; })
         .then(function(data) {
+            if (!data) return;
             var successMsg = (T.bqm_delete_success || '{0} images deleted').replace('{0}', data.deleted);
             showToast(successMsg, 'success');
             _bqmRangeStart = null;
@@ -766,17 +774,25 @@ function deleteBqmImages() {
     } else {
         // Delete all
         var msg = (T.bqm_delete_all || 'Delete all {0} BQM images?').replace('{0}', totalCount);
-        if (!confirm(msg)) return;
-        var confirmText = prompt(T.bqm_delete_confirm || 'Type DELETE to confirm');
-        if (confirmText !== 'DELETE') return;
-
-        fetch('/api/bqm/images', {
-            method: 'DELETE',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ all: true, confirm: 'DELETE_ALL' })
+        docsightConfirm({
+            title: T.delete || 'Delete',
+            message: msg,
+            confirmText: T.delete || 'Delete',
+            cancelText: T.cancel || 'Cancel',
+            danger: true,
+            requireText: 'DELETE',
+            requireLabel: T.bqm_delete_confirm || 'Type DELETE to confirm'
+        }).then(function(confirmed) {
+            if (!confirmed) return null;
+            return fetch('/api/bqm/images', {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ all: true, confirm: 'DELETE_ALL' })
+            });
         })
-        .then(function(r) { return r.json(); })
+        .then(function(r) { return r ? r.json() : null; })
         .then(function(data) {
+            if (!data) return;
             var successMsg = (T.bqm_delete_success || '{0} images deleted').replace('{0}', data.deleted);
             showToast(successMsg, 'success');
             _bqmRangeStart = null;

--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -540,7 +540,7 @@ function addCompareChannel() {
     var opt = sel.options[sel.selectedIndex];
     if (!opt || !opt.value) return;
     if (_compareChannels.length >= 6) {
-        alert(T.max_channels_reached || 'Maximum 6 channels in manual selection');
+        showToast(T.max_channels_reached || 'Maximum 6 channels in manual selection', 'error');
         return;
     }
     _comparePreset = null;

--- a/app/static/js/integrations.js
+++ b/app/static/js/integrations.js
@@ -164,15 +164,23 @@ function uploadBnetzFromView(input) {
         .then(function(r) { return r.json(); })
         .then(function(data) {
             input.value = '';
-            if (data.error) { alert(data.error); return; }
+            if (data.error) { showToast(data.error, 'error'); return; }
             loadBnetzData();
         })
-        .catch(function(e) { alert((T.bnetz_upload_failed || 'Upload failed') + ': ' + e); input.value = ''; });
+        .catch(function(e) { showToast((T.bnetz_upload_failed || 'Upload failed') + ': ' + e, 'error'); input.value = ''; });
 }
 
 function deleteBnetzFromView(id) {
-    if (!confirm(T.bnetz_delete_confirm)) return;
-    fetch('/api/bnetz/' + id, {method: 'DELETE'})
-        .then(function() { loadBnetzData(); });
+    docsightConfirm({
+        title: T.delete || 'Delete',
+        message: T.bnetz_delete_confirm || 'Delete this measurement?',
+        confirmText: T.delete || 'Delete',
+        cancelText: T.cancel || 'Cancel',
+        danger: true
+    }).then(function(confirmed) {
+        if (!confirmed) return null;
+        return fetch('/api/bnetz/' + id, {method: 'DELETE'});
+    })
+        .then(function(r) { if (r) loadBnetzData(); });
 }
 

--- a/app/static/js/journal.js
+++ b/app/static/js/journal.js
@@ -432,10 +432,19 @@ function saveEntry() {
 function deleteEntry() {
     var entryId = document.getElementById('entry-id').value;
     if (!entryId) return;
-    if (!confirm(T.confirm_delete || 'Are you sure?')) return;
-    fetch('/api/journal/' + entryId, {method: 'DELETE'})
-        .then(function(r) { return r.json(); })
-        .then(function() {
+    docsightConfirm({
+        title: T.delete || 'Delete',
+        message: T.confirm_delete || 'Are you sure?',
+        confirmText: T.delete || 'Delete',
+        cancelText: T.cancel || 'Cancel',
+        danger: true
+    }).then(function(confirmed) {
+        if (!confirmed) return null;
+        return fetch('/api/journal/' + entryId, {method: 'DELETE'});
+    })
+        .then(function(r) { return r ? r.json() : null; })
+        .then(function(res) {
+            if (!res) return;
             closeEntryModal();
             loadJournal();
         })
@@ -706,19 +715,28 @@ function confirmImport() {
 function deleteAllEntries() {
     var count = document.querySelectorAll('#journal-tbody tr').length;
     if (count === 0) return;
-    if (!confirm(T.delete_all_confirm.replace('{n}', count))) return;
-    var confirmation = prompt(T.delete_all_type_confirm);
-    if (confirmation !== 'DELETE') {
-        showToast(T.delete_all_cancelled, 'error');
-        return;
-    }
-    fetch('/api/journal/batch', {
-        method: 'DELETE',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({all: true, confirm: 'DELETE_ALL'})
+    docsightConfirm({
+        title: T.delete_all || 'Delete all entries',
+        message: T.delete_all_confirm.replace('{n}', count),
+        confirmText: T.delete || 'Delete',
+        cancelText: T.cancel || 'Cancel',
+        danger: true,
+        requireText: 'DELETE',
+        requireLabel: T.delete_all_type_confirm || 'Type DELETE to confirm'
+    }).then(function(confirmed) {
+        if (!confirmed) {
+            showToast(T.delete_all_cancelled, 'error');
+            return null;
+        }
+        return fetch('/api/journal/batch', {
+            method: 'DELETE',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({all: true, confirm: 'DELETE_ALL'})
+        });
     })
-        .then(function(r) { return r.json().then(function(d) { return {status: r.status, data: d}; }); })
+        .then(function(r) { return r ? r.json().then(function(d) { return {status: r.status, data: d}; }) : null; })
         .then(function(res) {
+            if (!res) return;
             if (res.status >= 400) {
                 showToast(res.data.error || T.delete_failed, 'error');
                 return;
@@ -901,7 +919,7 @@ window.downloadIncidentPdf = function(incidentId, incidentName) {
             URL.revokeObjectURL(a.href);
         })
         .catch(function() {
-            alert(T.network_error || 'Error generating report');
+            showToast(T.network_error || 'Error generating report', 'error');
         })
         .finally(function() {
             if (btn) { btn.disabled = false; btn.innerHTML = origHtml; }
@@ -1447,10 +1465,19 @@ function saveIncident() {
 function deleteIncident() {
     var incidentId = document.getElementById('incident-container-id').value;
     if (!incidentId) return;
-    if (!confirm(T.incident_delete_confirm || 'Delete this incident? Entries will become unassigned.')) return;
-    fetch('/api/incidents/' + incidentId, {method: 'DELETE'})
-        .then(function(r) { return r.json(); })
-        .then(function() {
+    docsightConfirm({
+        title: T.delete || 'Delete',
+        message: T.incident_delete_confirm || 'Delete this incident? Entries will become unassigned.',
+        confirmText: T.delete || 'Delete',
+        cancelText: T.cancel || 'Cancel',
+        danger: true
+    }).then(function(confirmed) {
+        if (!confirmed) return null;
+        return fetch('/api/incidents/' + incidentId, {method: 'DELETE'});
+    })
+        .then(function(r) { return r ? r.json() : null; })
+        .then(function(res) {
+            if (!res) return;
             closeIncidentModal();
             _activeIncidentFilter = null;
             loadIncidents();

--- a/app/static/js/modals.js
+++ b/app/static/js/modals.js
@@ -1,0 +1,274 @@
+/* ═══ DOCSight modal helpers ═══ */
+(function() {
+    'use strict';
+
+    var activeStack = [];
+    var lastOpener = new WeakMap();
+    var confirmState = null;
+
+    var FOCUSABLE = [
+        'a[href]',
+        'area[href]',
+        'button:not([disabled])',
+        'input:not([disabled]):not([type="hidden"])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        'iframe',
+        '[tabindex]:not([tabindex="-1"])',
+        '[contenteditable="true"]'
+    ].join(',');
+
+    function getModal(idOrEl) {
+        if (!idOrEl) return null;
+        if (typeof idOrEl === 'string') return document.getElementById(idOrEl.replace(/^#/, ''));
+        return idOrEl;
+    }
+
+    function isOpen(modal) {
+        return !!modal && (modal.classList.contains('open') || modal.style.display === 'flex' || modal.getAttribute('data-modal-open') === 'true');
+    }
+
+    function focusables(modal) {
+        return Array.prototype.slice.call(modal.querySelectorAll(FOCUSABLE)).filter(function(el) {
+            return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length) && el.getAttribute('aria-hidden') !== 'true';
+        });
+    }
+
+    function firstFocusTarget(modal) {
+        return modal.querySelector('[data-modal-initial-focus]') || focusables(modal)[0] || modal;
+    }
+
+    function ensureModalSemantics(modal) {
+        if (!modal) return;
+        if (!modal.hasAttribute('role')) modal.setAttribute('role', 'dialog');
+        if (!modal.hasAttribute('aria-modal')) modal.setAttribute('aria-modal', 'true');
+        if (!modal.hasAttribute('tabindex')) modal.setAttribute('tabindex', '-1');
+        modal.querySelectorAll('.modal-close, .btn-icon').forEach(function(btn) {
+            if (!btn.getAttribute('aria-label')) {
+                btn.setAttribute('aria-label', (window.T && (T.close || T.cancel)) || 'Close');
+            }
+        });
+    }
+
+    function activate(modal, opener) {
+        if (!modal) return;
+        ensureModalSemantics(modal);
+        if (opener) lastOpener.set(modal, opener);
+        if (activeStack.indexOf(modal) === -1) activeStack.push(modal);
+        window.setTimeout(function() {
+            if (!isOpen(modal)) return;
+            var target = firstFocusTarget(modal);
+            if (target && typeof target.focus === 'function') target.focus({preventScroll: true});
+        }, 0);
+    }
+
+    function deactivate(modal) {
+        if (!modal) return;
+        activeStack = activeStack.filter(function(item) { return item !== modal; });
+        var opener = lastOpener.get(modal);
+        if (opener && document.contains(opener) && typeof opener.focus === 'function') {
+            window.setTimeout(function() { opener.focus({preventScroll: true}); }, 0);
+        }
+    }
+
+    function openModal(idOrEl, options) {
+        var modal = getModal(idOrEl);
+        if (!modal) return null;
+        var opts = options || {};
+        if (opts.labelledBy && !modal.getAttribute('aria-labelledby')) {
+            modal.setAttribute('aria-labelledby', opts.labelledBy);
+        }
+        if (opts.dismissible === false) modal.setAttribute('data-modal-dismissible', 'false');
+        modal.classList.add('open');
+        modal.style.display = modal.classList.contains('browse-modal-overlay') ? 'flex' : '';
+        modal.setAttribute('data-modal-open', 'true');
+        activate(modal, opts.opener || document.activeElement);
+        return modal;
+    }
+
+    function closeModal(idOrEl, options) {
+        var modal = getModal(idOrEl);
+        if (!modal) return;
+        var opts = options || {};
+        modal.classList.remove('open');
+        modal.removeAttribute('data-modal-open');
+        if (modal.classList.contains('browse-modal-overlay') || opts.hideDisplay) modal.style.display = 'none';
+        deactivate(modal);
+    }
+
+    function topModal() {
+        for (var i = activeStack.length - 1; i >= 0; i--) {
+            if (isOpen(activeStack[i])) return activeStack[i];
+        }
+        return null;
+    }
+
+    function handleTab(event, modal) {
+        var items = focusables(modal);
+        if (!items.length) {
+            event.preventDefault();
+            modal.focus({preventScroll: true});
+            return;
+        }
+        var first = items[0];
+        var last = items[items.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus({preventScroll: true});
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus({preventScroll: true});
+        } else if (!modal.contains(document.activeElement)) {
+            event.preventDefault();
+            first.focus({preventScroll: true});
+        }
+    }
+
+    document.addEventListener('keydown', function(event) {
+        var modal = topModal();
+        if (!modal) return;
+        if (event.key === 'Tab') {
+            handleTab(event, modal);
+            return;
+        }
+        if (event.key === 'Escape' && modal.getAttribute('data-modal-dismissible') !== 'false') {
+            event.preventDefault();
+            if (modal.id === 'docsight-confirm-modal' && confirmState) {
+                resolveConfirm(false);
+            } else if (modal.id) {
+                closeModal(modal, {hideDisplay: modal.classList.contains('browse-modal-overlay')});
+            }
+        }
+    }, true);
+
+    document.addEventListener('focusin', function() {
+        var modal = topModal();
+        if (!modal || modal.contains(document.activeElement)) return;
+        var target = firstFocusTarget(modal);
+        if (target && typeof target.focus === 'function') target.focus({preventScroll: true});
+    });
+
+    document.addEventListener('click', function(event) {
+        var modal = topModal();
+        if (!modal || event.target !== modal || modal.getAttribute('data-modal-dismissible') === 'false') return;
+        closeModal(modal, {hideDisplay: modal.classList.contains('browse-modal-overlay')});
+    });
+
+    function createConfirmModal() {
+        var existing = document.getElementById('docsight-confirm-modal');
+        if (existing) return existing;
+        var modal = document.createElement('div');
+        modal.id = 'docsight-confirm-modal';
+        modal.className = 'modal-overlay docsight-confirm-overlay';
+        modal.setAttribute('role', 'dialog');
+        modal.setAttribute('aria-modal', 'true');
+        modal.setAttribute('aria-labelledby', 'docsight-confirm-title');
+        modal.innerHTML = [
+            '<div class="modal docsight-confirm-modal" style="max-width:520px;">',
+            '  <div class="modal-header">',
+            '    <h2 id="docsight-confirm-title"></h2>',
+            '    <button type="button" class="modal-close" id="docsight-confirm-x" aria-label="Close">&times;</button>',
+            '  </div>',
+            '  <div class="modal-body">',
+            '    <p id="docsight-confirm-message" class="docsight-confirm-message"></p>',
+            '    <label id="docsight-confirm-typed-wrap" class="docsight-confirm-typed-wrap" style="display:none;">',
+            '      <span id="docsight-confirm-typed-label"></span>',
+            '      <input id="docsight-confirm-typed-input" class="docsight-confirm-typed-input" autocomplete="off" spellcheck="false">',
+            '    </label>',
+            '  </div>',
+            '  <div class="incident-modal-footer">',
+            '    <div class="modal-footer-left"></div>',
+            '    <div style="display:flex; gap:10px;">',
+            '      <button type="button" class="btn btn-muted" id="docsight-confirm-cancel"></button>',
+            '      <button type="button" class="btn btn-accent" id="docsight-confirm-ok"></button>',
+            '    </div>',
+            '  </div>',
+            '</div>'
+        ].join('');
+        modal.addEventListener('click', function(event) {
+            if (event.target === modal) resolveConfirm(false);
+        });
+        document.body.appendChild(modal);
+        document.getElementById('docsight-confirm-x').addEventListener('click', function() { resolveConfirm(false); });
+        document.getElementById('docsight-confirm-cancel').addEventListener('click', function() { resolveConfirm(false); });
+        document.getElementById('docsight-confirm-ok').addEventListener('click', function() { resolveConfirm(true); });
+        var typedInput = document.getElementById('docsight-confirm-typed-input');
+        typedInput.addEventListener('input', updateConfirmOk);
+        typedInput.addEventListener('keydown', function(event) {
+            if (event.key !== 'Enter' || !confirmState) return;
+            updateConfirmOk();
+            if (document.getElementById('docsight-confirm-ok').disabled) return;
+            event.preventDefault();
+            resolveConfirm(true);
+        });
+        return modal;
+    }
+
+    function updateConfirmOk() {
+        if (!confirmState) return;
+        var ok = document.getElementById('docsight-confirm-ok');
+        var typed = document.getElementById('docsight-confirm-typed-input');
+        if (confirmState.requireText) {
+            ok.disabled = typed.value !== confirmState.requireText;
+        } else {
+            ok.disabled = false;
+        }
+    }
+
+    function resolveConfirm(value) {
+        if (!confirmState) return;
+        var state = confirmState;
+        confirmState = null;
+        closeModal('docsight-confirm-modal');
+        state.resolve(value);
+    }
+
+    function docsightConfirm(options) {
+        var opts = typeof options === 'string' ? {message: options} : (options || {});
+        var modal = createConfirmModal();
+        if (confirmState) resolveConfirm(false);
+        document.getElementById('docsight-confirm-title').textContent = opts.title || (window.T && T.confirm_title) || 'Confirm action';
+        document.getElementById('docsight-confirm-message').textContent = opts.message || '';
+        document.getElementById('docsight-confirm-cancel').textContent = opts.cancelText || (window.T && T.cancel) || 'Cancel';
+        var ok = document.getElementById('docsight-confirm-ok');
+        ok.textContent = opts.confirmText || (window.T && T.confirm) || 'Confirm';
+        ok.className = 'btn ' + (opts.danger ? 'btn-danger' : 'btn-accent');
+        var typedWrap = document.getElementById('docsight-confirm-typed-wrap');
+        var typedLabel = document.getElementById('docsight-confirm-typed-label');
+        var typedInput = document.getElementById('docsight-confirm-typed-input');
+        typedInput.value = '';
+        if (opts.requireText) {
+            typedWrap.style.display = '';
+            typedLabel.textContent = opts.requireLabel || ('Type ' + opts.requireText + ' to confirm');
+            typedInput.setAttribute('data-modal-initial-focus', '');
+        } else {
+            typedWrap.style.display = 'none';
+            typedInput.removeAttribute('data-modal-initial-focus');
+        }
+        return new Promise(function(resolve) {
+            confirmState = {resolve: resolve, requireText: opts.requireText || ''};
+            updateConfirmOk();
+            openModal(modal, {opener: document.activeElement});
+        });
+    }
+
+    function observeExistingModals() {
+        document.querySelectorAll('.modal-overlay, .browse-modal-overlay, .chart-zoom-overlay').forEach(function(modal) {
+            ensureModalSemantics(modal);
+            var observer = new MutationObserver(function() {
+                if (isOpen(modal)) activate(modal, document.activeElement);
+                else deactivate(modal);
+            });
+            observer.observe(modal, {attributes: true, attributeFilter: ['class', 'style', 'data-modal-open']});
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', observeExistingModals);
+
+    window.DOCSightModal = {
+        open: openModal,
+        close: closeModal,
+        confirm: docsightConfirm
+    };
+    window.docsightConfirm = docsightConfirm;
+})();

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -157,10 +157,19 @@ function copyToken() {
 
 function revokeToken(id, name) {
     var msg = (T.api_token_revoke_confirm || 'Revoke token "{name}"?').replace('{name}', name);
-    if (!confirm(msg)) return;
-    fetch('/api/tokens/' + id, {method: 'DELETE'})
-    .then(function(r) { return r.json(); })
+    docsightConfirm({
+        title: T.api_token_revoke || 'Revoke token',
+        message: msg,
+        confirmText: T.revoke || 'Revoke',
+        cancelText: T.cancel || 'Cancel',
+        danger: true
+    }).then(function(confirmed) {
+        if (!confirmed) return null;
+        return fetch('/api/tokens/' + id, {method: 'DELETE'});
+    })
+    .then(function(r) { return r ? r.json() : null; })
     .then(function(data) {
+        if (!data) return;
         if (data.success) {
             showToast(T.api_token_revoked || 'Token revoked', true);
             document.getElementById('api-token-created-banner').style.display = 'none';
@@ -448,11 +457,21 @@ function testSpeedtest() {
 
 /* ── Speedtest Cache Clear ── */
 function clearSpeedtestCache(btn) {
-    if (!confirm(T.clear_cache_confirm || 'Clear all cached speedtest results? They will be re-synced on the next poll cycle.')) return;
-    btn.disabled = true;
-    fetch('/api/speedtest/cache', { method: 'DELETE' })
-        .then(function(r) { return r.json(); })
+    var message = T.clear_cache_confirm || 'Clear all cached speedtest results? They will be re-synced on the next poll cycle.';
+    docsightConfirm({
+        title: T['docsight.speedtest.clear_cache'] || 'Clear Cache',
+        message: message,
+        confirmText: T['docsight.speedtest.clear_cache'] || 'Clear Cache',
+        cancelText: T.cancel || 'Cancel',
+        danger: true
+    }).then(function(confirmed) {
+        if (!confirmed) return null;
+        btn.disabled = true;
+        return fetch('/api/speedtest/cache', { method: 'DELETE' });
+    })
+        .then(function(r) { return r ? r.json() : null; })
         .then(function(res) {
+            if (!res) return;
             btn.disabled = false;
             if (res.success) {
                 var count = res.cleared || 0;
@@ -516,7 +535,19 @@ function testNotifications() {
 /* ── Demo Migration ── */
 function migrateToLive() {
     var msg = T.demo_migrate_confirm || 'This will delete all demo data and switch to live mode. Your own entries will be kept. Continue?';
-    if (!confirm(msg)) return;
+    docsightConfirm({
+        title: T.demo_migrate || 'Switch to live mode',
+        message: msg,
+        confirmText: T.continue || 'Continue',
+        cancelText: T.cancel || 'Cancel',
+        danger: true
+    }).then(function(confirmed) {
+        if (!confirmed) return;
+        runDemoMigration();
+    });
+}
+
+function runDemoMigration() {
     var el = document.getElementById('migrate-result');
     el.className = 'test-result test-loading';
     el.style.display = 'flex';
@@ -640,11 +671,16 @@ function _saveForm() {
 function _guardUnsaved() {
     if (!_formDirty) return Promise.resolve(true);
     var msg = T.unsaved_confirm || 'You have unsaved settings changes. Save them before continuing?';
-    if (confirm(msg)) {
-        return _saveForm();
-    }
-    /* User chose Cancel - abort the action, keep unsaved changes */
-    return Promise.resolve(false);
+    return docsightConfirm({
+        title: T.unsaved_changes || 'Unsaved changes',
+        message: msg,
+        confirmText: T.save || 'Save',
+        cancelText: T.cancel || 'Cancel'
+    }).then(function(confirmed) {
+        if (confirmed) return _saveForm();
+        /* User chose Cancel - abort the action, keep unsaved changes */
+        return false;
+    });
 }
 
 /* ── Submit ── */
@@ -867,31 +903,44 @@ function loadBackupList() {
 }
 
 function deleteBackup(filename) {
-    if (!confirm(T.backup_delete_confirm || 'Delete this backup?')) return;
-    fetch('/api/backup/' + encodeURIComponent(filename), { method: 'DELETE' })
-    .then(function(r) { return r.json(); })
+    docsightConfirm({
+        title: T.delete || 'Delete',
+        message: T.backup_delete_confirm || 'Delete this backup?',
+        confirmText: T.delete || 'Delete',
+        cancelText: T.cancel || 'Cancel',
+        danger: true
+    }).then(function(confirmed) {
+        if (!confirmed) return null;
+        return fetch('/api/backup/' + encodeURIComponent(filename), { method: 'DELETE' });
+    })
+    .then(function(r) { return r ? r.json() : null; })
     .then(function(res) {
+        if (!res) return;
         if (res.success) {
             loadBackupList();
         } else {
-            alert(res.error || T.save_failed || 'Failed');
+            showToast(res.error || T.save_failed || 'Failed', false);
         }
     })
-    .catch(function() { alert(T.network_error || 'Network error'); });
+    .catch(function() { showToast(T.network_error || 'Network error', false); });
 }
 
 /* ── Directory Browser ── */
 var _browsePath = '/backup';
 
-function openBrowseModal() {
+function openBrowseModal(opener) {
     var modal = document.getElementById('browse-modal');
-    modal.style.display = 'flex';
     _browsePath = document.getElementById('backup_path').value || '/backup';
+    var selected = document.getElementById('browse-selected-path');
+    var status = document.getElementById('browse-status');
+    if (selected) selected.textContent = _browsePath;
+    if (status) status.textContent = T.loading || 'Loading...';
+    DOCSightModal.open(modal, {opener: opener || document.activeElement, labelledBy: 'browse-modal-title'});
     browseTo(_browsePath);
 }
 
 function closeBrowseModal() {
-    document.getElementById('browse-modal').style.display = 'none';
+    DOCSightModal.close('browse-modal');
 }
 
 function selectBrowsePath() {
@@ -903,12 +952,16 @@ function browseTo(path) {
     _browsePath = path;
     var bc = document.getElementById('browse-breadcrumb');
     var dirs = document.getElementById('browse-dirs');
+    var selected = document.getElementById('browse-selected-path');
+    var status = document.getElementById('browse-status');
     bc.textContent = path;
+    if (selected) selected.textContent = path;
     dirs.textContent = '';
     var loadingDiv = document.createElement('div');
     loadingDiv.style.cssText = 'padding:16px;color:var(--muted);text-align:center;';
     loadingDiv.textContent = '\u23F3 ' + (T.loading || 'Loading...');
     dirs.appendChild(loadingDiv);
+    if (status) status.textContent = T.loading || 'Loading...';
     fetch('/api/browse?path=' + encodeURIComponent(path))
     .then(function(r) { return r.json(); })
     .then(function(res) {
@@ -918,10 +971,12 @@ function browseTo(path) {
             errDiv.style.cssText = 'padding:16px;color:var(--error);';
             errDiv.textContent = res.error;
             dirs.appendChild(errDiv);
+            if (status) status.textContent = res.error;
             return;
         }
         _browsePath = res.path;
         bc.textContent = res.path;
+        if (selected) selected.textContent = res.path;
 
         if (res.parent) {
             var parentItem = _createBrowseItem('..', res.parent, 'corner-left-up', true);
@@ -937,6 +992,11 @@ function browseTo(path) {
             var item = _createBrowseItem(d.name, d.path, 'folder', false);
             dirs.appendChild(item);
         });
+        if (status) {
+            status.textContent = res.directories.length
+                ? res.directories.length + ' ' + (T.directories || 'directories')
+                : (T.backup_empty_dir || 'Empty directory');
+        }
         if (typeof lucide !== 'undefined') lucide.createIcons();
     })
     .catch(function() {
@@ -945,14 +1005,23 @@ function browseTo(path) {
         errDiv.style.cssText = 'padding:16px;color:var(--error);';
         errDiv.textContent = T.network_error;
         dirs.appendChild(errDiv);
+        if (status) status.textContent = T.network_error;
     });
 }
 
 function _createBrowseItem(label, targetPath, iconName, isMuted) {
     var div = document.createElement('div');
     div.className = 'browse-item';
+    div.setAttribute('role', 'button');
+    div.setAttribute('tabindex', '0');
+    div.setAttribute('aria-label', label);
     div.style.cssText = 'padding:8px 12px;cursor:pointer;display:flex;align-items:center;gap:8px;border-radius:var(--radius-sm);';
     div.addEventListener('click', function() { browseTo(targetPath); });
+    div.addEventListener('keydown', function(event) {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        browseTo(targetPath);
+    });
     div.addEventListener('mouseenter', function() { this.style.background = 'var(--hover-bg)'; });
     div.addEventListener('mouseleave', function() { this.style.background = ''; });
 

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -107,7 +107,7 @@ function generateComplaint() {
             document.getElementById('report-copy-btn').style.display = '';
             document.getElementById('report-pdf-btn').style.display = '';
         })
-        .catch(function(e) { alert('Error: ' + e); })
+        .catch(function(e) { showToast('Error: ' + e, 'error'); })
         .finally(function() { btn.disabled = false; btn.textContent = '\u270E ' + (T.generate_letter || 'Generate Letter'); });
 }
 function generateBnetzComplaint(bnetzId) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2735,6 +2735,7 @@ var TEMPERATURE_UNIT = {{ temperature_unit|tojson }};
 })();
 
 </script>
+<script src="/static/js/modals.js"></script>
 <script src="/static/js/journal.js"></script>
 <script src="/modules/docsight.bqm/static/js/bqm-chart.js"></script>
 <script src="/static/js/bqm.js"></script>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="/static/css/fonts.css">
     <link rel="stylesheet" href="/static/css/tokens.css">
     <link rel="stylesheet" href="/static/css/components.css">
+    <link rel="stylesheet" href="/static/css/modals.css">
     <link rel="stylesheet" href="/static/css/settings.css">
     {% for mod in modules|sort(attribute='menu.order') if mod.has_css %}
     <link rel="stylesheet" href="/modules/{{ mod.id }}/static/style.css">
@@ -199,6 +200,7 @@ var currentTz = '{{ config.timezone|default("", true) }}';
 try { var savedCooldowns = JSON.parse({{ config.notify_cooldowns|default("{}")|tojson }}); } catch(e) { var savedCooldowns = {}; }
 var DRIVER_HINTS = {{ driver_hints | tojson }};
 </script>
+<script src="/static/js/modals.js"></script>
 <script src="/static/js/utils.js"></script>
 <script src="/static/js/notices.js"></script>
 <script src="/static/js/settings.js"></script>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -257,6 +257,8 @@
             <strong>{{ t.timezone }}:</strong> <span id="review-tz"></span>
         </div>
 
+        <div class="test-result" id="setup-submit-result" role="status" aria-live="polite" tabindex="-1"></div>
+
         <div class="setup-actions">
             <button type="button" class="btn btn-ghost" onclick="prevStep(2)">
                 <i data-lucide="arrow-left" class="setup-icon-sm"></i>
@@ -363,6 +365,15 @@ async function testConnection() {
     _setButtonLoading(btn, 'wifi', '{{ t.test_connection }}');
 }
 
+function showSetupSubmitError(message) {
+    var resultDiv = document.getElementById('setup-submit-result');
+    if (!resultDiv) return;
+    resultDiv.className = 'test-result error';
+    resultDiv.textContent = '✗ ' + message;
+    resultDiv.style.display = 'block';
+    resultDiv.focus && resultDiv.focus({preventScroll: true});
+}
+
 // Form submission
 document.getElementById('setup-form').addEventListener('submit', async function(e) {
     e.preventDefault();
@@ -384,12 +395,12 @@ document.getElementById('setup-form').addEventListener('submit', async function(
         if(response.ok) {
             window.location.href = '/';
         } else {
-            alert('{{ t.setup_failed }}');
+            showSetupSubmitError('{{ t.setup_failed }}');
             btn.disabled = false;
             _setButtonLoading(btn, 'check-circle', '{{ t.complete_setup }}');
         }
     } catch(err) {
-        alert('{{ t.error_generic }}: ' + err.message);
+        showSetupSubmitError('{{ t.error_generic }}: ' + err.message);
         btn.disabled = false;
         _setButtonLoading(btn, 'check-circle', '{{ t.complete_setup }}');
     }

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -1,0 +1,113 @@
+"""E2E coverage for DOCSight modal behavior."""
+
+from playwright.sync_api import expect
+
+
+def _open_journal(demo_page):
+    demo_page.locator('.nav-item[data-view="journal"]').click()
+    expect(demo_page.locator("#view-journal")).to_be_visible()
+
+
+def test_modal_focus_trap_escape_and_return_focus(demo_page):
+    """Dashboard modals move focus inside, trap Tab, close on Escape, and restore focus."""
+    _open_journal(demo_page)
+    opener = demo_page.get_by_role("button", name="New Entry")
+    opener.click()
+
+    modal = demo_page.locator("#entry-modal")
+    expect(modal).to_be_visible()
+    expect(modal).to_have_attribute("role", "dialog")
+    expect(modal).to_have_attribute("aria-modal", "true")
+
+    focused_inside = demo_page.evaluate(
+        """
+        () => {
+            const modal = document.querySelector('#entry-modal');
+            return modal && modal.contains(document.activeElement);
+        }
+        """
+    )
+    assert focused_inside
+
+    for _ in range(12):
+        demo_page.keyboard.press("Tab")
+        assert demo_page.evaluate(
+            """
+            () => {
+                const modal = document.querySelector('#entry-modal');
+                return modal && modal.contains(document.activeElement);
+            }
+            """
+        )
+
+    demo_page.keyboard.press("Escape")
+    expect(modal).not_to_be_visible()
+    assert opener.evaluate("el => el === document.activeElement")
+
+
+def test_settings_backup_browser_uses_accessible_modal_contract(settings_page):
+    """Backup directory browser follows the shared modal semantics and safety contract."""
+    settings_page.locator('button[data-section="mod-docsight_backup"]').click()
+    backup_enabled = settings_page.locator("#backup_enabled")
+    if not backup_enabled.is_checked():
+        backup_enabled.evaluate("el => { el.checked = true; el.dispatchEvent(new Event('change', { bubbles: true })); }")
+    opener = settings_page.get_by_role("button", name="Browse")
+    settings_page.locator("#backup_path").evaluate("el => { el.value = '/'; }")
+    opener.click()
+
+    modal = settings_page.locator("#browse-modal")
+    expect(modal).to_be_visible()
+    expect(modal).to_have_attribute("role", "dialog")
+    expect(modal).to_have_attribute("aria-modal", "true")
+    expect(modal).to_have_attribute("aria-labelledby", "browse-modal-title")
+    expect(modal.locator("#browse-selected-path")).to_be_visible()
+    expect(modal.locator("#browse-status")).to_be_visible()
+
+    assert settings_page.evaluate(
+        """
+        () => {
+            const modal = document.querySelector('#browse-modal');
+            return modal && modal.contains(document.activeElement);
+        }
+        """
+    )
+
+    settings_page.evaluate(
+        """
+        () => {
+            const dirs = document.querySelector('#browse-dirs');
+            dirs.textContent = '';
+            dirs.appendChild(_createBrowseItem('tmp', '/tmp', 'folder', false));
+        }
+        """
+    )
+    first_dir = modal.locator(".browse-item").first
+    expect(first_dir).to_be_visible()
+    expect(first_dir).to_have_attribute("role", "button")
+    expect(first_dir).to_have_attribute("tabindex", "0")
+    first_dir.focus()
+    assert first_dir.evaluate("el => el === document.activeElement")
+    first_dir.press("Enter")
+    expect(modal.locator("#browse-status")).not_to_have_text("Loading...")
+
+    settings_page.keyboard.press("Escape")
+    expect(modal).not_to_be_visible()
+    settings_page.wait_for_function("el => el === document.activeElement", arg=opener.element_handle())
+
+
+def test_styled_confirm_dialog_replaces_native_confirm_for_speedtest_cache(settings_page):
+    """Important settings actions use DOCSight confirmation UI instead of native dialogs."""
+    native_dialogs = []
+    settings_page.on("dialog", lambda dialog: (native_dialogs.append(dialog.message), dialog.dismiss()))
+    settings_page.locator('button[data-section="mod-docsight_speedtest"]').click()
+    settings_page.locator("#speedtest_clear_cache").click()
+
+    confirm_modal = settings_page.locator("#docsight-confirm-modal")
+    expect(confirm_modal).to_be_visible()
+    expect(confirm_modal).to_have_attribute("role", "dialog")
+    expect(confirm_modal).to_contain_text("Clear")
+    expect(confirm_modal.get_by_role("button", name="Cancel")).to_be_visible()
+    assert native_dialogs == []
+
+    settings_page.keyboard.press("Escape")
+    expect(confirm_modal).not_to_be_visible()


### PR DESCRIPTION
## Summary
- add a shared DOCSight modal helper for focus management, Escape/backdrop handling, opener restoration, and styled confirmation dialogs
- replace native browser alert/confirm/prompt flows with DOCSight-styled confirmations or inline/toast feedback
- polish the backup directory browser with dialog semantics, live status, keyboard-operable entries, and clearer selected-path feedback
- add Playwright coverage for modal focus behavior, backup-browser accessibility, and styled confirmation flows

## Verification
- `node --check app/static/js/modals.js app/static/js/settings.js app/static/js/journal.js app/static/js/bqm.js app/static/js/integrations.js app/static/js/channels.js app/static/js/utils.js`
- `git diff --check`
- native dialog scan: `0` app matches for `alert(`, `confirm(`, or `prompt(`
- `TZ=UTC pytest -q tests --ignore=tests/e2e --tb=short` — 2200 passed, 11 skipped, 1 warning
- `TZ=UTC pytest -q tests/e2e --tb=short` — 311 passed
- Browser smoke: dashboard journal modal, Settings backup browser, and Speedtest clear-cache confirmation verified with no console errors

Closes #379
Closes #380
Closes #386
Refs #381
Refs #382
Refs #383
Refs #384
Refs #385
