### PR TITLE
Improve evidence journal flow

### DIFF
--- a/app/modules/journal/i18n/de.json
+++ b/app/modules/journal/i18n/de.json
@@ -93,5 +93,20 @@
   "timeline_source_modem": "Modem",
   "timeline_source_speedtest": "Speedtest",
   "timeline_source_event": "Ereignis",
-  "timeline_no_data": "Keine Signaldaten für diesen Zeitraum"
+  "timeline_no_data": "Keine Signaldaten für diesen Zeitraum",
+  "entry_modal_intro": "Erfasse, was passiert ist, und verknüpfe Nachweise, die DOCSight später in eine ISP-taugliche Timeline übersetzen kann.",
+  "entry_icon_hint": "Wähle eine sichtbare Kategorie wie Ausfall, Paketverlust, Geschwindigkeitseinbruch, Wartung oder ISP-Kontakt.",
+  "entry_description_hint": "Notiere konkrete Symptome, Zeiten, Support-Referenzen, Modemzustände oder was sich an der Verbindung geändert hat.",
+  "entry_evidence_hint": "Nachweise können Modem-Screenshots, BQM-Bilder, Speedtest-Ergebnisse, SmokePing-Charts oder Support-Schreiben sein.",
+  "entry_create_action": "Eintrag erstellen",
+  "entry_update_action": "Eintrag aktualisieren",
+  "incident_modal_intro": "Gruppiere zusammengehörige Einträge und Nachweise, damit DOCSight eine klare Vorfall-Timeline und einen Berichtspfad bauen kann.",
+  "incident_icon_hint": "Wähle die Kategorie, die später in Filtern, Timelines und Exporten sofort verständlich ist.",
+  "incident_linked_evidence": "Verknüpfte Nachweise",
+  "incident_linked_entries_hint": "Journal-Einträge sind mit diesem Vorfall verknüpft",
+  "incident_empty_evidence_hint": "Ordne während des Vorfalls Journal-Einträge, Screenshots, Modem-Snapshots, BQM-Bilder, Speedtest-Ergebnisse oder SmokePing-Charts zu.",
+  "incident_build_report": "Bericht bauen",
+  "incident_create_action": "Vorfall erstellen",
+  "incident_update_action": "Vorfall aktualisieren",
+  "entry_save_before_upload": "Erstelle zuerst den Eintrag und hänge danach Nachweisdateien an."
 }

--- a/app/modules/journal/i18n/en.json
+++ b/app/modules/journal/i18n/en.json
@@ -93,5 +93,20 @@
   "timeline_source_modem": "Modem",
   "timeline_source_speedtest": "Speedtest",
   "timeline_source_event": "Event",
-  "timeline_no_data": "No signal data for this period"
+  "timeline_no_data": "No signal data for this period",
+  "entry_modal_intro": "Capture what happened and link the evidence DOCSight can turn into an ISP-ready timeline.",
+  "entry_icon_hint": "Choose a visible category such as outage, packet loss, speed degradation, maintenance, or contact with your ISP.",
+  "entry_description_hint": "Add concrete symptoms, times, support references, modem states, or what changed for the connection.",
+  "entry_evidence_hint": "Evidence can include modem screenshots, BQM images, Speedtest results, SmokePing charts, or support letters.",
+  "entry_create_action": "Create entry",
+  "entry_update_action": "Update entry",
+  "incident_modal_intro": "Group related entries and evidence so DOCSight can build one clear incident timeline and report path.",
+  "incident_icon_hint": "Pick the category users will recognize later in filters, timelines, and exports.",
+  "incident_linked_evidence": "Linked evidence",
+  "incident_linked_entries_hint": "journal entries linked to this incident",
+  "incident_empty_evidence_hint": "Assign journal entries, screenshots, modem snapshots, BQM images, Speedtest results, or SmokePing charts as the incident develops.",
+  "incident_build_report": "Build report",
+  "incident_create_action": "Create incident",
+  "incident_update_action": "Update incident",
+  "entry_save_before_upload": "Create the entry first, then attach evidence files."
 }

--- a/app/modules/journal/static/style.css
+++ b/app/modules/journal/static/style.css
@@ -1231,3 +1231,79 @@ mark.search-highlight {
         padding: var(--space-md);
     }
 }
+/* Evidence-first journal and incident modals */
+.incident-modal-intro,
+.incident-field-hint {
+    margin: -2px 0 var(--space-sm);
+    color: var(--text-secondary, var(--muted));
+    font-size: 0.84rem;
+    line-height: 1.45;
+}
+.incident-modal-intro {
+    margin: 0 0 var(--space-md);
+    padding: var(--space-sm) var(--space-md);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-sm);
+    background: rgba(168,85,247,0.08);
+}
+.incident-evidence-summary {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    color: var(--text-secondary, var(--muted));
+    font-size: 0.86rem;
+    margin-bottom: var(--space-sm);
+}
+.icon-pick {
+    min-width: 82px;
+    min-height: 42px;
+    padding: 4px 8px;
+    flex-direction: column;
+    gap: 2px;
+}
+.icon-pick-symbol {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 18px;
+}
+.icon-pick-label {
+    font-size: 0.68rem;
+    line-height: 1;
+    color: var(--text-secondary, var(--muted));
+    max-width: 72px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.icon-pick.active .icon-pick-label,
+.icon-pick:hover .icon-pick-label {
+    color: inherit;
+}
+.incident-summary-evidence {
+    font-size: 0.78rem;
+    color: var(--accent-purple, var(--accent));
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+    background: rgba(168,85,247,0.12);
+}
+.incident-summary-report-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--accent-purple, var(--accent));
+    border-radius: var(--radius-sm);
+    background: rgba(168,85,247,0.12);
+    color: var(--accent-purple, var(--accent));
+    padding: 4px 10px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+.incident-summary-report-btn:hover {
+    background: rgba(168,85,247,0.22);
+}
+.incident-summary-report-btn:focus-visible {
+    outline: 2px solid var(--accent-purple, var(--accent));
+    outline-offset: 2px;
+}

--- a/app/static/js/journal.js
+++ b/app/static/js/journal.js
@@ -73,30 +73,39 @@ function renderIconPicker(selectedLabel) {
     var picker = document.getElementById('entry-icon-picker');
     var hiddenInput = document.getElementById('entry-icon-value');
     picker.innerHTML = '';
+    function markSelected(selectedButton) {
+        picker.querySelectorAll('.icon-pick').forEach(function(b) {
+            b.classList.remove('active');
+            b.setAttribute('aria-pressed', 'false');
+        });
+        selectedButton.classList.add('active');
+        selectedButton.setAttribute('aria-pressed', 'true');
+    }
     // "None" button
     var noneBtn = document.createElement('button');
     noneBtn.type = 'button';
     noneBtn.className = 'icon-pick' + (!selectedLabel ? ' active' : '');
     noneBtn.title = T.icon_auto;
-    noneBtn.innerHTML = '<span style="font-size:14px;color:var(--muted);">' + T.icon_auto.toLowerCase() + '</span>';
+    noneBtn.setAttribute('aria-pressed', !selectedLabel ? 'true' : 'false');
+    noneBtn.innerHTML = '<span class="icon-pick-symbol">' + T.icon_auto.toLowerCase() + '</span><span class="icon-pick-label">' + T.icon_auto + '</span>';
     noneBtn.onclick = function() {
         hiddenInput.value = '';
-        picker.querySelectorAll('.icon-pick').forEach(function(b) { b.classList.remove('active'); });
-        noneBtn.classList.add('active');
+        markSelected(noneBtn);
         updateModalIcon();
     };
     picker.appendChild(noneBtn);
 
     INCIDENT_ICONS.forEach(function(entry) {
         var btn = document.createElement('button');
+        var label = T['icon_' + entry.label] || entry.label;
         btn.type = 'button';
         btn.className = 'icon-pick' + (selectedLabel === entry.label ? ' active' : '');
-        btn.title = T['icon_' + entry.label] || entry.label;
-        btn.innerHTML = entry.icon;
+        btn.title = label;
+        btn.setAttribute('aria-pressed', selectedLabel === entry.label ? 'true' : 'false');
+        btn.innerHTML = '<span class="icon-pick-symbol">' + entry.icon + '</span><span class="icon-pick-label">' + label + '</span>';
         btn.onclick = function() {
             hiddenInput.value = entry.label;
-            picker.querySelectorAll('.icon-pick').forEach(function(b) { b.classList.remove('active'); });
-            btn.classList.add('active');
+            markSelected(btn);
             updateModalIcon();
         };
         picker.appendChild(btn);
@@ -314,11 +323,15 @@ function openEntryModal(entryId) {
     var deleteBtn = document.getElementById('entry-delete-btn');
     var attachSection = document.getElementById('entry-attachments-section');
     var attachList = document.getElementById('entry-attachment-list');
+    var uploadBtn = document.getElementById('entry-upload-btn');
+    var uploadHint = document.getElementById('entry-upload-hint');
+    var saveBtn = document.getElementById('entry-save-btn');
 
     attachList.innerHTML = '';
 
     if (entryId) {
         titleEl.textContent = T.edit_entry || 'Edit Entry';
+        if (saveBtn) saveBtn.textContent = T.entry_update_action || 'Update entry';
         deleteBtn.style.display = '';
         fetch('/api/journal/' + entryId)
             .then(function(r) { return r.json(); })
@@ -333,10 +346,13 @@ function openEntryModal(entryId) {
                 populateIncidentSelect(entry.incident_id);
                 renderAttachments(entry.attachments || [], attachList, entryId);
                 attachSection.style.display = '';
+                if (uploadBtn) uploadBtn.disabled = false;
+                if (uploadHint) uploadHint.textContent = '';
                 modal.classList.add('open');
             });
     } else {
         titleEl.textContent = T.new_entry || 'New Entry';
+        if (saveBtn) saveBtn.textContent = T.entry_create_action || 'Create entry';
         idEl.value = '';
         dateEl.value = todayStr();
         titleInput.value = '';
@@ -346,7 +362,9 @@ function openEntryModal(entryId) {
         updateModalIcon();
         populateIncidentSelect(_activeIncidentFilter > 0 ? _activeIncidentFilter : null);
         deleteBtn.style.display = 'none';
-        attachSection.style.display = 'none';
+        attachSection.style.display = '';
+        if (uploadBtn) uploadBtn.disabled = true;
+        if (uploadHint) uploadHint.textContent = T.entry_save_before_upload || 'Create the entry first, then attach evidence files.';
         modal.classList.add('open');
     }
 }
@@ -421,6 +439,12 @@ function saveEntry() {
                 document.getElementById('entry-modal-title').textContent = T.edit_entry || 'Edit Entry';
                 document.getElementById('entry-delete-btn').style.display = '';
                 document.getElementById('entry-attachments-section').style.display = '';
+                var uploadBtn = document.getElementById('entry-upload-btn');
+                var uploadHint = document.getElementById('entry-upload-hint');
+                var saveBtn = document.getElementById('entry-save-btn');
+                if (uploadBtn) uploadBtn.disabled = false;
+                if (uploadHint) uploadHint.textContent = '';
+                if (saveBtn) saveBtn.textContent = T.entry_update_action || 'Update entry';
                 showToast(T.saved || 'Saved', 'ok');
             } else {
                 closeEntryModal();
@@ -453,7 +477,12 @@ function deleteEntry() {
 
 function handleEntryFileUpload(input) {
     var incidentId = document.getElementById('entry-id').value;
-    if (!incidentId || !input.files || input.files.length === 0) return;
+    if (!incidentId) {
+        showToast(T.entry_save_before_upload || 'Create the entry first, then attach evidence files.', 'info');
+        input.value = '';
+        return;
+    }
+    if (!input.files || input.files.length === 0) return;
     var spinner = document.getElementById('entry-upload-spinner');
     var uploadBtn = document.getElementById('entry-upload-btn');
     spinner.style.display = 'inline';
@@ -838,8 +867,10 @@ function renderIncidentSummary(incidentId) {
     html += '<span class="incident-summary-badge ' + statusClass + '">' + statusLabel + '</span>';
     if (dateRange) html += '<span class="incident-summary-date">' + dateRange + '</span>';
     html += '<span class="incident-summary-count">' + (inc.entry_count || 0) + ' ' + (T.incident_entry_count || 'Entries') + '</span>';
+    html += '<span class="incident-summary-evidence">' + (T.incident_linked_evidence || 'Linked evidence') + '</span>';
     html += '<button class="incident-summary-edit" onclick="openIncidentModal(' + inc.id + ')" title="' + (T.incident_edit || 'Edit') + '">&#9998;</button>';
     html += '<button class="incident-summary-timeline-btn" onclick="openIncidentTimeline(' + inc.id + ')">' + (T.incident_view_timeline || 'View Timeline') + '</button>';
+    html += '<button class="incident-summary-report-btn" onclick="openIncidentTimeline(' + inc.id + ')">' + (T.incident_build_report || 'Build report') + '</button>';
     html += '</div>';
     if (inc.description) {
         var desc = inc.description.length > 200 ? inc.description.substring(0, 200) + '\u2026' : inc.description;
@@ -1347,27 +1378,36 @@ function renderContainerIconPicker(selectedLabel) {
     var picker = document.getElementById('incident-container-icon-picker');
     var hiddenInput = document.getElementById('incident-container-icon-value');
     picker.innerHTML = '';
+    function markSelected(selectedButton) {
+        picker.querySelectorAll('.icon-pick').forEach(function(b) {
+            b.classList.remove('active');
+            b.setAttribute('aria-pressed', 'false');
+        });
+        selectedButton.classList.add('active');
+        selectedButton.setAttribute('aria-pressed', 'true');
+    }
     var noneBtn = document.createElement('button');
     noneBtn.type = 'button';
     noneBtn.className = 'icon-pick' + (!selectedLabel ? ' active' : '');
     noneBtn.title = T.icon_auto || 'Auto';
-    noneBtn.innerHTML = '<span style="font-size:14px;color:var(--muted);">' + (T.icon_auto || 'auto').toLowerCase() + '</span>';
+    noneBtn.setAttribute('aria-pressed', !selectedLabel ? 'true' : 'false');
+    noneBtn.innerHTML = '<span class="icon-pick-symbol">' + (T.icon_auto || 'auto').toLowerCase() + '</span><span class="icon-pick-label">' + (T.icon_auto || 'Auto') + '</span>';
     noneBtn.onclick = function() {
         hiddenInput.value = '';
-        picker.querySelectorAll('.icon-pick').forEach(function(b) { b.classList.remove('active'); });
-        noneBtn.classList.add('active');
+        markSelected(noneBtn);
     };
     picker.appendChild(noneBtn);
     INCIDENT_ICONS.forEach(function(entry) {
         var btn = document.createElement('button');
+        var label = T['icon_' + entry.label] || entry.label;
         btn.type = 'button';
         btn.className = 'icon-pick' + (selectedLabel === entry.label ? ' active' : '');
-        btn.title = T['icon_' + entry.label] || entry.label;
-        btn.innerHTML = entry.icon;
+        btn.title = label;
+        btn.setAttribute('aria-pressed', selectedLabel === entry.label ? 'true' : 'false');
+        btn.innerHTML = '<span class="icon-pick-symbol">' + entry.icon + '</span><span class="icon-pick-label">' + label + '</span>';
         btn.onclick = function() {
             hiddenInput.value = entry.label;
-            picker.querySelectorAll('.icon-pick').forEach(function(b) { b.classList.remove('active'); });
-            btn.classList.add('active');
+            markSelected(btn);
         };
         picker.appendChild(btn);
     });
@@ -1385,10 +1425,13 @@ function openIncidentModal(incidentId) {
     var iconVal = document.getElementById('incident-container-icon-value');
     var deleteBtn = document.getElementById('incident-container-delete-btn');
     var countSection = document.getElementById('incident-container-entry-count-section');
+    var emptyEvidenceSection = document.getElementById('incident-container-empty-evidence-section');
     var countEl = document.getElementById('incident-container-entry-count');
+    var saveBtn = document.getElementById('incident-container-save-btn');
 
     if (incidentId) {
         titleEl.textContent = T.incident_edit || 'Edit Incident';
+        if (saveBtn) saveBtn.textContent = T.incident_update_action || 'Update incident';
         deleteBtn.style.display = '';
         fetch('/api/incidents/' + incidentId)
             .then(function(r) { return r.json(); })
@@ -1404,13 +1447,16 @@ function openIncidentModal(incidentId) {
                 if (inc.entry_count !== undefined) {
                     countEl.textContent = inc.entry_count;
                     countSection.style.display = '';
+                    if (emptyEvidenceSection) emptyEvidenceSection.style.display = 'none';
                 } else {
                     countSection.style.display = 'none';
+                    if (emptyEvidenceSection) emptyEvidenceSection.style.display = '';
                 }
                 modal.classList.add('open');
             });
     } else {
         titleEl.textContent = T.incident_new || 'New Incident';
+        if (saveBtn) saveBtn.textContent = T.incident_create_action || 'Create incident';
         idEl.value = '';
         nameEl.value = '';
         statusEl.value = 'open';
@@ -1421,8 +1467,16 @@ function openIncidentModal(incidentId) {
         renderContainerIconPicker('');
         deleteBtn.style.display = 'none';
         countSection.style.display = 'none';
+        if (emptyEvidenceSection) emptyEvidenceSection.style.display = '';
         modal.classList.add('open');
     }
+}
+
+function openIncidentReportFromModal() {
+    var incidentId = document.getElementById('incident-container-id').value;
+    if (!incidentId) return;
+    closeIncidentModal();
+    openIncidentTimeline(parseInt(incidentId, 10));
 }
 
 function closeIncidentModal() {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1588,6 +1588,7 @@
             <button class="modal-close" onclick="closeEntryModal()">&times;</button>
         </div>
         <div class="modal-body" style="overflow-y:auto;">
+            <p class="incident-modal-intro">{{ t.get('entry_modal_intro', 'Capture what happened and link the evidence DOCSight can turn into an ISP-ready timeline.') }}</p>
             <input type="hidden" id="entry-id">
             <div class="incident-form-group">
                 <label for="entry-date">{{ t.incident_date }}</label>
@@ -1599,11 +1600,13 @@
             </div>
             <div class="incident-form-group">
                 <label>{{ t.icon }}</label>
+                <p class="incident-field-hint">{{ t.get('entry_icon_hint', 'Choose a visible category such as outage, packet loss, speed degradation, maintenance, or contact with your ISP.') }}</p>
                 <input type="hidden" id="entry-icon-value">
                 <div class="icon-picker" id="entry-icon-picker"></div>
             </div>
             <div class="incident-form-group">
                 <label for="entry-desc">{{ t.incident_description }}</label>
+                <p class="incident-field-hint">{{ t.get('entry_description_hint', 'Add concrete symptoms, times, support references, modem states, or what changed for the connection.') }}</p>
                 <textarea id="entry-desc" maxlength="10000" placeholder="{{ t.incident_description }}"></textarea>
             </div>
             <div class="incident-form-group">
@@ -1614,10 +1617,12 @@
             </div>
             <div class="incident-form-group" id="entry-attachments-section">
                 <label>{{ t.attachments }}</label>
+                <p class="incident-field-hint">{{ t.get('entry_evidence_hint', 'Evidence can include modem screenshots, BQM images, Speedtest results, SmokePing charts, or support letters.') }}</p>
                 <div class="attachment-list" id="entry-attachment-list"></div>
                 <button class="btn-upload" id="entry-upload-btn" onclick="document.getElementById('entry-file-input').click()">
                     &#128206; {{ t.upload_file }}
                 </button>
+                <p class="incident-field-hint" id="entry-upload-hint"></p>
                 <span id="entry-upload-spinner" style="display:none;"><span class="upload-spinner"></span></span>
                 <input type="file" id="entry-file-input" style="display:none;" multiple
                        accept="image/png,image/jpeg,image/gif,image/webp,application/pdf,text/plain"
@@ -1630,7 +1635,7 @@
             </div>
             <div style="display:flex; gap:10px;">
                 <button class="btn btn-muted" onclick="closeEntryModal()">{{ t.cancel }}</button>
-                <button class="btn btn-accent" onclick="saveEntry()">{{ t.save }}</button>
+                <button class="btn btn-accent" id="entry-save-btn" onclick="saveEntry()">{{ t.get('entry_create_action', 'Create entry') }}</button>
             </div>
         </div>
     </div>
@@ -1644,6 +1649,7 @@
             <button class="modal-close" onclick="closeIncidentModal()">&times;</button>
         </div>
         <div class="modal-body" style="overflow-y:auto;">
+            <p class="incident-modal-intro">{{ t.get('incident_modal_intro', 'Group related entries and evidence so DOCSight can build one clear incident timeline and report path.') }}</p>
             <input type="hidden" id="incident-container-id">
             <div class="incident-form-group">
                 <label for="incident-container-name">{{ t.incident_name }}</label>
@@ -1669,6 +1675,7 @@
             </div>
             <div class="incident-form-group">
                 <label>{{ t.icon }}</label>
+                <p class="incident-field-hint">{{ t.get('incident_icon_hint', 'Pick the category users will recognize later in filters, timelines, and exports.') }}</p>
                 <input type="hidden" id="incident-container-icon-value">
                 <div class="icon-picker" id="incident-container-icon-picker"></div>
             </div>
@@ -1677,8 +1684,16 @@
                 <textarea id="incident-container-desc" maxlength="5000" placeholder="{{ t.incident_description }}"></textarea>
             </div>
             <div class="incident-form-group" id="incident-container-entry-count-section" style="display:none;">
-                <label>{{ t.incident_entry_count }}</label>
-                <span id="incident-container-entry-count" style="font-weight:600;"></span>
+                <label>{{ t.get('incident_linked_evidence', 'Linked evidence') }}</label>
+                <div class="incident-evidence-summary">
+                    <span id="incident-container-entry-count" style="font-weight:600;"></span>
+                    <span>{{ t.get('incident_linked_entries_hint', 'journal entries linked to this incident') }}</span>
+                </div>
+                <button type="button" class="btn-small btn-accent" id="incident-container-report-btn" onclick="openIncidentReportFromModal()">{{ t.get('incident_build_report', 'Build report') }}</button>
+            </div>
+            <div class="incident-form-group" id="incident-container-empty-evidence-section">
+                <label>{{ t.get('incident_linked_evidence', 'Linked evidence') }}</label>
+                <p class="incident-field-hint">{{ t.get('incident_empty_evidence_hint', 'Assign journal entries, screenshots, modem snapshots, BQM images, Speedtest results, or SmokePing charts as the incident develops.') }}</p>
             </div>
         </div>
         <div class="incident-modal-footer">
@@ -1687,7 +1702,7 @@
             </div>
             <div style="display:flex; gap:10px;">
                 <button class="btn btn-muted" onclick="closeIncidentModal()">{{ t.cancel }}</button>
-                <button class="btn btn-accent" onclick="saveIncident()">{{ t.save }}</button>
+                <button class="btn btn-accent" id="incident-container-save-btn" onclick="saveIncident()">{{ t.get('incident_create_action', 'Create incident') }}</button>
             </div>
         </div>
     </div>

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -111,3 +111,57 @@ def test_styled_confirm_dialog_replaces_native_confirm_for_speedtest_cache(setti
 
     settings_page.keyboard.press("Escape")
     expect(confirm_modal).not_to_be_visible()
+
+
+def test_journal_entry_modal_guides_evidence_capture(demo_page):
+    """Journal entries guide evidence-first capture with clear actions and icon labels."""
+    _open_journal(demo_page)
+    demo_page.get_by_role("button", name="New Entry").click()
+
+    modal = demo_page.locator("#entry-modal")
+    expect(modal).to_be_visible()
+    expect(modal).to_contain_text("Capture what happened")
+    expect(modal).to_contain_text("outage, packet loss, speed degradation")
+    expect(modal).to_contain_text("Evidence")
+    expect(modal.get_by_role("button", name="Create entry")).to_be_visible()
+    expect(modal.get_by_role("button", name="Outage")).to_be_visible()
+    expect(modal.get_by_role("button", name="Measurement")).to_be_visible()
+    assert modal.get_by_text("Incident Container").count() == 0
+
+
+def test_incident_modal_and_summary_offer_report_path(demo_page):
+    """Incidents use user-facing copy, show linked evidence counts, and offer report entry points."""
+    _open_journal(demo_page)
+    demo_page.evaluate("openIncidentModal()")
+
+    modal = demo_page.locator("#incident-container-modal")
+    expect(modal).to_be_visible()
+    expect(modal).to_contain_text("Group related entries and evidence")
+    expect(modal).to_contain_text("Linked evidence")
+    expect(modal.get_by_role("button", name="Create incident")).to_be_visible()
+    assert modal.get_by_text("Incident Container").count() == 0
+
+    demo_page.keyboard.press("Escape")
+    expect(modal).not_to_be_visible()
+
+    demo_page.evaluate(
+        """
+        () => {
+            window._incidentsData = [{
+                id: 381,
+                name: 'Packet loss evening window',
+                description: 'Repeated evening packet loss with attached modem evidence.',
+                status: 'open',
+                start_date: '2026-05-01',
+                end_date: null,
+                entry_count: 3
+            }];
+            renderIncidentSummary(381);
+        }
+        """
+    )
+    summary = demo_page.locator("#incident-summary")
+    expect(summary).to_be_visible()
+    expect(summary).to_contain_text("3 Entries")
+    expect(summary).to_contain_text("Linked evidence")
+    expect(summary.get_by_role("button", name="Build report")).to_be_visible()


### PR DESCRIPTION
## Summary
- Reworks journal entry and incident modals around evidence capture instead of internal container language
- Adds visible icon labels, pressed-state semantics, and task-specific create/update actions
- Surfaces linked evidence and a report-building path from incident context
- Prevents pre-save attachment uploads from silently doing nothing by showing a save-first hint

## Test Plan
- `node --check app/static/js/journal.js`
- `TZ=UTC pytest -q tests/e2e/test_modals.py --tb=short`
- `TZ=UTC pytest -q tests/e2e --tb=short`
- `TZ=UTC pytest -q tests --ignore=tests/e2e --tb=short`
- Browser smoke: journal entry modal, incident modal, incident summary/report path, console errors

Closes #381
