### PR TITLE
Improve report evidence builder

### DIFF
--- a/app/modules/reports/i18n/de.json
+++ b/app/modules/reports/i18n/de.json
@@ -151,5 +151,21 @@
     "us_modulation_marginal": "Upstream-Modulation herabgesetzt",
     "uncorr_errors_high": "Hohe Anzahl unkorrigierbarer Fehler",
     "uncorr_errors_critical": "Unkorrigierbare Fehlerrate kritisch"
-  }
+  },
+  "report_builder_title": "ISP-fertiges Nachweispaket",
+  "report_builder_intro": "Erstelle ein lokales Nachweispaket für ISP-Support oder Beschwerde-Eskalation.",
+  "report_builder_preview_title": "Was DOCSight einschließt",
+  "report_builder_section_signal": "Signalzusammenfassung",
+  "report_builder_section_incidents": "Vorfall-Timeline und Journalnotizen",
+  "report_builder_section_measurements": "BQM-, SmokePing- und Speedtest-Nachweise, sofern vorhanden",
+  "report_builder_section_letter": "Bearbeitbarer Beschwerdetext plus PDF-Paket",
+  "report_builder_privacy_title": "Lokal erstellt",
+  "report_builder_privacy_note": "DOCSight erstellt den Report aus lokalen Monitoringdaten und sendet ihn nicht automatisch an deinen ISP.",
+  "report_build_package": "Nachweispaket erstellen",
+  "report_copy_letter_text": "Brieftext kopieren",
+  "report_download_package": "PDF-Paket herunterladen",
+  "report_builder_building": "Nachweispaket wird erstellt...",
+  "report_builder_ready": "Nachweispaket bereit. Prüfe den Brieftext und kopiere ihn oder lade das PDF-Paket herunter.",
+  "report_builder_error": "Report-Erstellung fehlgeschlagen. Wähle einen anderen Zeitraum oder prüfe, ob Monitoringdaten vorhanden sind.",
+  "report_builder_copied": "Brieftext kopiert. Hänge das PDF-Paket an, wenn du deinen ISP kontaktierst."
 }

--- a/app/modules/reports/i18n/en.json
+++ b/app/modules/reports/i18n/en.json
@@ -151,5 +151,21 @@
     "us_modulation_marginal": "Upstream modulation degraded",
     "uncorr_errors_high": "High uncorrectable errors",
     "uncorr_errors_critical": "Uncorrectable error rate critical"
-  }
+  },
+  "report_builder_title": "ISP-ready evidence package",
+  "report_builder_intro": "Build a local evidence package for ISP support or complaint escalation.",
+  "report_builder_preview_title": "What DOCSight will include",
+  "report_builder_section_signal": "Signal summary",
+  "report_builder_section_incidents": "Incident timeline and journal notes",
+  "report_builder_section_measurements": "BQM, SmokePing, and Speedtest evidence when available",
+  "report_builder_section_letter": "Editable complaint letter text plus a PDF package",
+  "report_builder_privacy_title": "Generated locally",
+  "report_builder_privacy_note": "DOCSight builds the report from local monitoring data and does not send it to your ISP automatically.",
+  "report_build_package": "Build evidence package",
+  "report_copy_letter_text": "Copy letter text",
+  "report_download_package": "Download PDF package",
+  "report_builder_building": "Building evidence package...",
+  "report_builder_ready": "Evidence package ready. Review the letter text, then copy it or download the PDF package.",
+  "report_builder_error": "Report generation failed. Try a different report period or verify that monitoring data exists.",
+  "report_builder_copied": "Letter text copied. Attach the PDF package when you contact your ISP."
 }

--- a/app/modules/reports/i18n/es.json
+++ b/app/modules/reports/i18n/es.json
@@ -151,5 +151,21 @@
     "us_modulation_marginal": "Modulación ascendente degradada",
     "uncorr_errors_high": "Alto número de errores no corregibles",
     "uncorr_errors_critical": "Tasa de errores no corregibles crítica"
-  }
+  },
+  "report_builder_title": "Paquete de pruebas listo para el ISP",
+  "report_builder_intro": "Crea un paquete local de pruebas para soporte del ISP o escalada de reclamaciones.",
+  "report_builder_preview_title": "Qué incluirá DOCSight",
+  "report_builder_section_signal": "Resumen de señal",
+  "report_builder_section_incidents": "Cronología de incidentes y notas del diario",
+  "report_builder_section_measurements": "Pruebas de BQM, SmokePing y Speedtest cuando estén disponibles",
+  "report_builder_section_letter": "Texto editable de reclamación más un paquete PDF",
+  "report_builder_privacy_title": "Generado localmente",
+  "report_builder_privacy_note": "DOCSight crea el informe a partir de datos locales de monitorización y no lo envía automáticamente a tu ISP.",
+  "report_build_package": "Crear paquete de pruebas",
+  "report_copy_letter_text": "Copiar texto de la carta",
+  "report_download_package": "Descargar paquete PDF",
+  "report_builder_building": "Creando paquete de pruebas...",
+  "report_builder_ready": "Paquete de pruebas listo. Revisa el texto de la carta y cópialo o descarga el paquete PDF.",
+  "report_builder_error": "No se pudo generar el informe. Prueba otro período o verifica que existan datos de monitorización.",
+  "report_builder_copied": "Texto de la carta copiado. Adjunta el paquete PDF cuando contactes con tu ISP."
 }

--- a/app/modules/reports/i18n/fr.json
+++ b/app/modules/reports/i18n/fr.json
@@ -151,5 +151,21 @@
     "us_modulation_marginal": "Modulation montante dégradée",
     "uncorr_errors_high": "Nombre élevé d'erreurs non corrigeables",
     "uncorr_errors_critical": "Taux d'erreurs non corrigeables critique"
-  }
+  },
+  "report_builder_title": "Dossier de preuves prêt pour le FAI",
+  "report_builder_intro": "Créez un dossier de preuves local pour le support FAI ou une réclamation.",
+  "report_builder_preview_title": "Ce que DOCSight inclura",
+  "report_builder_section_signal": "Résumé du signal",
+  "report_builder_section_incidents": "Chronologie des incidents et notes du journal",
+  "report_builder_section_measurements": "Preuves BQM, SmokePing et Speedtest si disponibles",
+  "report_builder_section_letter": "Texte de réclamation modifiable plus un dossier PDF",
+  "report_builder_privacy_title": "Généré localement",
+  "report_builder_privacy_note": "DOCSight crée le rapport à partir des données de surveillance locales et ne l’envoie pas automatiquement à votre FAI.",
+  "report_build_package": "Créer le dossier de preuves",
+  "report_copy_letter_text": "Copier le texte de la lettre",
+  "report_download_package": "Télécharger le dossier PDF",
+  "report_builder_building": "Création du dossier de preuves...",
+  "report_builder_ready": "Dossier de preuves prêt. Relisez le texte de la lettre, puis copiez-le ou téléchargez le dossier PDF.",
+  "report_builder_error": "La génération du rapport a échoué. Essayez une autre période ou vérifiez que des données de surveillance existent.",
+  "report_builder_copied": "Texte de la lettre copié. Joignez le dossier PDF lorsque vous contactez votre FAI."
 }

--- a/app/modules/reports/i18n/template.json
+++ b/app/modules/reports/i18n/template.json
@@ -151,5 +151,21 @@
     "us_modulation_marginal": "",
     "uncorr_errors_high": "",
     "uncorr_errors_critical": ""
-  }
+  },
+  "report_builder_title": "",
+  "report_builder_intro": "",
+  "report_builder_preview_title": "",
+  "report_builder_section_signal": "",
+  "report_builder_section_incidents": "",
+  "report_builder_section_measurements": "",
+  "report_builder_section_letter": "",
+  "report_builder_privacy_title": "",
+  "report_builder_privacy_note": "",
+  "report_build_package": "",
+  "report_copy_letter_text": "",
+  "report_download_package": "",
+  "report_builder_building": "",
+  "report_builder_ready": "",
+  "report_builder_error": "",
+  "report_builder_copied": ""
 }

--- a/app/static/css/modals.css
+++ b/app/static/css/modals.css
@@ -120,7 +120,54 @@
 .modal-body {
     flex: 1;
     overflow-y: auto;
+    min-height: 0;
     margin-bottom: var(--space-sm);
+}
+
+/* ── Report evidence builder ── */
+.report-builder-status {
+    min-height: 1.4em;
+    margin: var(--space-xs) 0 var(--space-sm);
+    color: var(--text-muted);
+    font-size: 0.9em;
+}
+.report-builder-status.is-progress { color: var(--accent); }
+.report-builder-status.is-success { color: var(--success, #43d18a); }
+.report-builder-status.is-error { color: var(--danger, #ff6b6b); }
+.report-builder-preview {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 0.55fr);
+    gap: var(--space-md);
+    padding: var(--space-md);
+    margin-bottom: var(--space-md);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+}
+.report-builder-preview h3 {
+    margin: 0 0 var(--space-xs);
+    font-size: 0.95em;
+    color: var(--text);
+}
+.report-builder-list {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+}
+.report-builder-privacy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding: var(--space-sm);
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    color: var(--text-muted);
+    font-size: 0.9em;
+}
+.report-builder-privacy strong { color: var(--text); }
+@media (max-width: 720px) {
+    .report-builder-preview { grid-template-columns: 1fr; }
 }
 .modal-body textarea {
     width: 100%;

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -36,8 +36,14 @@ function openBqmSetupModal() {
 function closeBqmSetupModal() {
     document.getElementById('bqm-setup-modal').classList.remove('open');
 }
+var reportGenerationId = 0;
 function openReportModal() {
-    document.getElementById('report-modal').classList.add('open');
+    resetReportModalState();
+    if (window.DOCSightModal) {
+        window.DOCSightModal.open('report-modal');
+    } else {
+        document.getElementById('report-modal').classList.add('open');
+    }
     syncComparisonReportState();
     // Close sidebar on mobile
     var sb = document.getElementById('sidebar');
@@ -48,16 +54,38 @@ function openReportModal() {
     }
 }
 function closeReportModal() {
-    document.getElementById('report-modal').classList.remove('open');
-    // Reset to step 1
+    if (window.DOCSightModal) {
+        window.DOCSightModal.close('report-modal');
+    } else {
+        document.getElementById('report-modal').classList.remove('open');
+    }
+    resetReportModalState();
+}
+function resetReportModalState() {
+    reportGenerationId += 1;
     document.getElementById('report-step1').style.display = '';
     document.getElementById('report-step2').style.display = 'none';
-    document.getElementById('report-generate-btn').style.display = '';
+    var generateBtn = document.getElementById('report-generate-btn');
+    generateBtn.style.display = '';
+    generateBtn.disabled = false;
+    generateBtn.textContent = '\u270E ' + (T.report_build_package || 'Build evidence package');
     document.getElementById('report-copy-btn').style.display = 'none';
     document.getElementById('report-pdf-btn').style.display = 'none';
     // Reset BNetzA complaint source
     var bnetzIdField = document.getElementById('report-bnetz-id');
     if (bnetzIdField) bnetzIdField.value = '';
+    var complaintText = document.getElementById('report-complaint-text');
+    if (complaintText) complaintText.value = '';
+    setReportBuilderStatus('');
+}
+function setReportBuilderStatus(message, type) {
+    var status = document.getElementById('report-builder-status');
+    if (!status) return;
+    status.textContent = message || '';
+    status.classList.remove('is-success', 'is-error', 'is-progress');
+    if (type) {
+        status.classList.add('is-' + type);
+    }
 }
 function syncComparisonReportState() {
     var toggle = document.getElementById('report-include-comparison');
@@ -83,7 +111,7 @@ function generateComplaint() {
     var comparisonParam = '';
     var bnetzIdField = document.getElementById('report-bnetz-id');
     if (bnetzIdField && bnetzIdField.value) {
-        bnetzParam = '&bnetz_id=' + bnetzIdField.value;
+        bnetzParam = '&bnetz_id=' + encodeURIComponent(bnetzIdField.value);
     }
     var includeComparison = document.getElementById('report-include-comparison');
     if (includeComparison && includeComparison.checked && window.__docsightComparisonResult) {
@@ -97,25 +125,45 @@ function generateComplaint() {
     var btn = document.getElementById('report-generate-btn');
     btn.disabled = true;
     btn.textContent = '...';
+    setReportBuilderStatus(T.report_builder_building || 'Building evidence package...', 'progress');
+    var generationId = reportGenerationId;
     fetch('/api/complaint?days=' + days + '&lang=' + lang + '&name=' + name + '&number=' + number + '&address=' + address + bnetzParam + comparisonParam)
-        .then(function(r) { return r.json(); })
+        .then(function(r) {
+            return r.json().then(function(data) {
+                if (!r.ok || data.error) {
+                    throw new Error(data.error || (T.report_builder_error || 'Report generation failed.'));
+                }
+                return data;
+            });
+        })
         .then(function(data) {
+            if (generationId !== reportGenerationId) return;
             document.getElementById('report-complaint-text').value = data.text;
             document.getElementById('report-step1').style.display = 'none';
             document.getElementById('report-step2').style.display = 'block';
             document.getElementById('report-generate-btn').style.display = 'none';
             document.getElementById('report-copy-btn').style.display = '';
             document.getElementById('report-pdf-btn').style.display = '';
+            setReportBuilderStatus(T.report_builder_ready || 'Evidence package ready. Review the letter text, then copy it or download the PDF package.', 'success');
         })
-        .catch(function(e) { showToast('Error: ' + e, 'error'); })
-        .finally(function() { btn.disabled = false; btn.textContent = '\u270E ' + (T.generate_letter || 'Generate Letter'); });
+        .catch(function(e) {
+            if (generationId !== reportGenerationId) return;
+            var message = e && e.message ? e.message : (T.report_builder_error || 'Report generation failed. Try a different report period or verify that monitoring data exists.');
+            setReportBuilderStatus(message, 'error');
+            showToast(message, 'error');
+        })
+        .finally(function() {
+            if (generationId !== reportGenerationId) return;
+            btn.disabled = false;
+            btn.textContent = '\u270E ' + (T.report_build_package || 'Build evidence package');
+        });
 }
 function generateBnetzComplaint(bnetzId) {
+    openReportModal();
     var bnetzIdField = document.getElementById('report-bnetz-id');
     if (bnetzIdField) bnetzIdField.value = bnetzId;
     var checkbox = document.getElementById('report-include-bnetz');
     if (checkbox) checkbox.checked = true;
-    openReportModal();
 }
 function copyComplaint() {
     var textarea = document.getElementById('report-complaint-text');
@@ -126,6 +174,7 @@ function copyComplaint() {
         navigator.clipboard.writeText(textarea.value).then(function() {
             var orig = btn.innerHTML;
             btn.innerHTML = '&#10003; ' + (T.copied || 'Copied!');
+            setReportBuilderStatus(T.report_builder_copied || 'Letter text copied. Attach the PDF package when you contact your ISP.', 'success');
             setTimeout(function() { btn.innerHTML = orig; }, 2000);
         });
     } else {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2099,13 +2099,29 @@
 <div class="modal-overlay" id="report-modal" role="dialog" aria-modal="true" aria-labelledby="report-modal-title" onclick="if(event.target===this)closeReportModal()">
     <div class="modal" style="max-width:800px;">
         <div class="modal-header">
-            <h2 id="report-modal-title">{{ t.incident_report }}</h2>
+            <h2 id="report-modal-title">{{ t.get('report_builder_title', 'ISP-ready evidence package') }}</h2>
             <button class="modal-close" onclick="closeReportModal()">&times;</button>
         </div>
-        <p class="modal-hint">{{ t.report_description }}</p>
+        <p class="modal-hint">{{ t.get('report_builder_intro', 'Build a local evidence package for ISP support or complaint escalation.') }}</p>
+        <div id="report-builder-status" class="report-builder-status" role="status" aria-live="polite"></div>
         <div class="modal-body" style="padding: 10px 0;">
             <!-- Step 1: Settings & Customer Info -->
             <div id="report-step1">
+                <div class="report-builder-preview" aria-labelledby="report-builder-preview-title">
+                    <div>
+                        <h3 id="report-builder-preview-title">{{ t.get('report_builder_preview_title', 'What DOCSight will include') }}</h3>
+                        <ul class="report-builder-list">
+                            <li>{{ t.get('report_builder_section_signal', 'Signal summary') }}</li>
+                            <li>{{ t.get('report_builder_section_incidents', 'Incident timeline and journal notes') }}</li>
+                            <li>{{ t.get('report_builder_section_measurements', 'BQM, SmokePing, and Speedtest evidence when available') }}</li>
+                            <li>{{ t.get('report_builder_section_letter', 'Editable complaint letter text plus a PDF package') }}</li>
+                        </ul>
+                    </div>
+                    <div class="report-builder-privacy">
+                        <strong>{{ t.get('report_builder_privacy_title', 'Generated locally') }}</strong>
+                        <span>{{ t.get('report_builder_privacy_note', 'DOCSight builds the report from local monitoring data and does not send it to your ISP automatically.') }}</span>
+                    </div>
+                </div>
                 <div style="display:flex; gap:16px; flex-wrap:wrap; margin-bottom:14px;">
                     <div>
                         <label style="font-size:13px; color:var(--muted);">{{ t.report_days }}</label><br>
@@ -2159,9 +2175,9 @@
         </div>
         <div class="modal-footer">
             <button class="btn btn-muted" onclick="closeReportModal()">{{ t.close }}</button>
-            <button class="btn btn-accent" id="report-generate-btn" onclick="generateComplaint()">&#9998; {{ t.report_generate_letter }}</button>
-            <button class="btn btn-accent" id="report-copy-btn" style="display:none;" onclick="copyComplaint()">&#128203; {{ t.report_copy_letter }}</button>
-            <button class="btn btn-accent" id="report-pdf-btn" style="display:none;" onclick="downloadReport()">&#128196; {{ t.report_download_pdf }}</button>
+            <button class="btn btn-accent" id="report-generate-btn" onclick="generateComplaint()">&#9998; {{ t.get('report_build_package', 'Build evidence package') }}</button>
+            <button class="btn btn-accent" id="report-copy-btn" style="display:none;" onclick="copyComplaint()">&#128203; {{ t.get('report_copy_letter_text', 'Copy letter text') }}</button>
+            <button class="btn btn-accent" id="report-pdf-btn" style="display:none;" onclick="downloadReport()">&#128196; {{ t.get('report_download_package', 'Download PDF package') }}</button>
         </div>
     </div>
 </div>

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -42,7 +42,7 @@ def test_modal_focus_trap_escape_and_return_focus(demo_page):
 
     demo_page.keyboard.press("Escape")
     expect(modal).not_to_be_visible()
-    assert opener.evaluate("el => el === document.activeElement")
+    expect(opener).to_be_focused()
 
 
 def test_settings_backup_browser_uses_accessible_modal_contract(settings_page):
@@ -165,3 +165,111 @@ def test_incident_modal_and_summary_offer_report_path(demo_page):
     expect(summary).to_contain_text("3 Entries")
     expect(summary).to_contain_text("Linked evidence")
     expect(summary.get_by_role("button", name="Build report")).to_be_visible()
+
+
+def test_report_modal_frames_isp_ready_evidence_builder(demo_page):
+    """The report modal previews evidence contents, privacy expectations, and output actions before generation."""
+    demo_page.locator("#report-link").click()
+
+    modal = demo_page.locator("#report-modal")
+    expect(modal).to_be_visible()
+    expect(modal.get_by_role("heading", name="ISP-ready evidence package")).to_be_visible()
+    expect(modal).to_contain_text("Build a local evidence package for ISP support or complaint escalation.")
+    expect(modal).to_contain_text("Signal summary")
+    expect(modal).to_contain_text("Incident timeline and journal notes")
+    expect(modal).to_contain_text("BQM, SmokePing, and Speedtest evidence when available")
+    expect(modal).to_contain_text("Generated locally")
+    expect(modal.get_by_role("button", name="Build evidence package")).to_be_visible()
+
+
+def test_report_modal_shows_generation_success_and_error_states(demo_page):
+    """Report generation exposes progress, success, and actionable error states in the modal."""
+    request_urls = []
+    demo_page.route(
+        "**/api/complaint?**",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"text":"Subject: DOCSIS Signal Quality Issues\\n\\nEvidence summary ready."}',
+        ),
+    )
+    demo_page.locator("#report-link").click()
+    modal = demo_page.locator("#report-modal")
+    modal.get_by_role("button", name="Build evidence package").click()
+
+    expect(modal.locator("#report-builder-status")).to_contain_text("Evidence package ready")
+    expect(modal.locator("#report-complaint-text")).to_have_value("Subject: DOCSIS Signal Quality Issues\n\nEvidence summary ready.")
+    expect(modal.get_by_role("button", name="Copy letter text")).to_be_visible()
+    expect(modal.get_by_role("button", name="Download PDF package")).to_be_visible()
+
+    demo_page.keyboard.press("Escape")
+    expect(modal).not_to_be_visible()
+    demo_page.locator("#report-link").click()
+    expect(modal.locator("#report-step1")).to_be_visible()
+    expect(modal.locator("#report-step2")).not_to_be_visible()
+    expect(modal.locator("#report-builder-status")).to_have_text("")
+    expect(modal.locator("#report-complaint-text")).to_have_value("")
+    expect(modal.get_by_role("button", name="Build evidence package")).to_be_visible()
+    expect(modal.get_by_role("button", name="Copy letter text")).not_to_be_visible()
+    modal.locator(".modal-footer").get_by_role("button", name="Close").click()
+
+    demo_page.unroute("**/api/complaint?**")
+    demo_page.route(
+        "**/api/complaint?**",
+        lambda route: route.fulfill(
+            status=500,
+            content_type="application/json",
+            body='{"error":"No report data is available for this period."}',
+        ),
+    )
+    demo_page.locator("#report-link").click()
+    modal.get_by_role("button", name="Build evidence package").click()
+
+    expect(modal.locator("#report-builder-status")).to_contain_text("No report data is available for this period")
+    expect(modal.locator("#report-step1")).to_be_visible()
+
+
+
+def test_report_modal_preserves_bnetz_source_and_ignores_stale_generation(demo_page):
+    """Report modal keeps selected BNetzA source and ignores stale async results after dismissal."""
+    demo_page.evaluate("""
+        window.__reportTestRequests = [];
+        window.__resolveReportTestFetch = null;
+        window.__originalReportFetch = window.fetch;
+        window.fetch = function(url, options) {
+            if (String(url).startsWith('/api/complaint?')) {
+                window.__reportTestRequests.push(String(url));
+                return new Promise(function(resolve) {
+                    window.__resolveReportTestFetch = function() {
+                        resolve(new Response(JSON.stringify({ text: 'Stale evidence package should not reopen.' }), {
+                            status: 200,
+                            headers: { 'Content-Type': 'application/json' }
+                        }));
+                    };
+                });
+            }
+            return window.__originalReportFetch(url, options);
+        };
+    """)
+    demo_page.evaluate("generateBnetzComplaint('measurement-42')")
+    modal = demo_page.locator("#report-modal")
+    expect(modal).to_be_visible()
+    expect(modal.locator("#report-bnetz-id")).to_have_value("measurement-42")
+    modal.get_by_role("button", name="Build evidence package").click()
+    expect(modal.locator("#report-builder-status")).to_contain_text("Building evidence package")
+    demo_page.keyboard.press("Escape")
+    expect(modal).not_to_be_visible()
+
+    demo_page.locator("#report-link").click()
+    expect(modal.locator("#report-step1")).to_be_visible()
+    expect(modal.locator("#report-step2")).not_to_be_visible()
+    expect(modal.locator("#report-builder-status")).to_have_text("")
+    demo_page.evaluate("window.__resolveReportTestFetch()")
+    demo_page.wait_for_timeout(250)
+    expect(modal.locator("#report-step1")).to_be_visible()
+    expect(modal.locator("#report-step2")).not_to_be_visible()
+    expect(modal.locator("#report-complaint-text")).to_have_value("")
+    request_urls = demo_page.evaluate("window.__reportTestRequests")
+    assert any("bnetz_id=measurement-42" in url for url in request_urls)
+
+    demo_page.evaluate("window.fetch = window.__originalReportFetch")


### PR DESCRIPTION
## Summary
- Turns the report modal into an ISP-ready evidence package builder with a clearer preview, quality checklist, and local-processing context.
- Adds progress, success, and error status states for complaint generation.
- Resets stale report state on reopen, guards pending generation responses, and preserves BNetzA-specific report sources.
- Keeps copy and PDF actions available only after a package is generated.

## Testing
- `node --check app/static/js/utils.js`
- `TZ=UTC pytest -q tests/e2e/test_modals.py tests/e2e/test_comparison.py --tb=short`
- `TZ=UTC pytest -q tests/test_report.py tests/web/test_reports.py --tb=short`
- `TZ=UTC pytest -q tests/e2e --tb=short`
- `TZ=UTC pytest -q tests --ignore=tests/e2e --tb=short`
- Browser smoke: report modal focus, success state, Escape/reopen reset, BNetzA source URL, console errors

Closes #382
