### PR TITLE
Guide integration setup modals

### DIFF
--- a/app/modules/smokeping/static/main.js
+++ b/app/modules/smokeping/static/main.js
@@ -60,10 +60,18 @@ window.loadSmokepingGraphs = loadSmokepingGraphs;
 
 /* ── Smokeping Setup Modal ── */
 function openSmokepingSetupModal() {
-    document.getElementById('smokeping-setup-modal').classList.add('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.open('smokeping-setup-modal');
+    } else {
+        document.getElementById('smokeping-setup-modal').classList.add('open');
+    }
 }
 function closeSmokepingSetupModal() {
-    document.getElementById('smokeping-setup-modal').classList.remove('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.close('smokeping-setup-modal');
+    } else {
+        document.getElementById('smokeping-setup-modal').classList.remove('open');
+    }
 }
 window.openSmokepingSetupModal = openSmokepingSetupModal;
 window.closeSmokepingSetupModal = closeSmokepingSetupModal;

--- a/app/static/css/modals.css
+++ b/app/static/css/modals.css
@@ -360,3 +360,60 @@
     outline: 2px solid var(--amethyst);
     outline-offset: 2px;
 }
+
+/* ── Guided integration setup modals ── */
+.setup-guide-modal {
+    max-width: 920px;
+}
+.setup-guide-body {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+    padding: var(--space-sm) 0;
+}
+.setup-guide-card {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    padding: var(--space-md);
+}
+.setup-guide-card h3 {
+    margin: 0 0 var(--space-xs);
+    color: var(--text);
+    font-size: 0.95em;
+}
+.setup-guide-card p,
+.setup-guide-card li {
+    color: var(--text-muted);
+    font-size: 0.9em;
+    line-height: 1.55;
+}
+.setup-guide-card ul {
+    margin: 0;
+    padding-left: 1.15rem;
+}
+.setup-guide-command code {
+    display: block;
+    overflow-x: auto;
+    margin: var(--space-sm) 0;
+    padding: var(--space-sm);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-sm);
+    background: var(--void);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.82em;
+    white-space: nowrap;
+}
+.setup-validation-status {
+    min-height: 1.4em;
+    color: var(--text-muted);
+    font-size: 0.9em;
+}
+.setup-validation-status.is-success { color: var(--success, #43d18a); }
+.setup-validation-status.is-error { color: var(--danger, #ff6b6b); }
+.setup-validation-status.is-progress { color: var(--accent); }
+@media (max-width: 720px) {
+    .setup-guide-body { grid-template-columns: 1fr; }
+    .setup-guide-command code { white-space: pre-wrap; }
+}

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -126,10 +126,18 @@ function updateExportSize() {
     indicator.textContent = chars.toLocaleString() + ' ' + (T.export_size_characters || 'characters') + ' · ~' + approxTokens.toLocaleString() + ' ' + (T.export_size_tokens || 'tokens');
 }
 function openBqmSetupModal() {
-    document.getElementById('bqm-setup-modal').classList.add('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.open('bqm-setup-modal');
+    } else {
+        document.getElementById('bqm-setup-modal').classList.add('open');
+    }
 }
 function closeBqmSetupModal() {
-    document.getElementById('bqm-setup-modal').classList.remove('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.close('bqm-setup-modal');
+    } else {
+        document.getElementById('bqm-setup-modal').classList.remove('open');
+    }
 }
 var reportGenerationId = 0;
 function openReportModal() {
@@ -338,8 +346,46 @@ function toggleCard(el) {
     el.classList.toggle('open');
 }
 function openSpeedtestSetupModal() {
-    document.getElementById('speedtest-setup-modal').classList.add('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.open('speedtest-setup-modal');
+    } else {
+        document.getElementById('speedtest-setup-modal').classList.add('open');
+    }
 }
 function closeSpeedtestSetupModal() {
-    document.getElementById('speedtest-setup-modal').classList.remove('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.close('speedtest-setup-modal');
+    } else {
+        document.getElementById('speedtest-setup-modal').classList.remove('open');
+    }
+}
+function setSetupStatus(statusId, message, type) {
+    var status = document.getElementById(statusId);
+    if (!status) return;
+    status.textContent = message || '';
+    status.classList.remove('is-success', 'is-error', 'is-progress');
+    if (type) status.classList.add('is-' + type);
+}
+function copySetupSnippet(sourceId, statusId) {
+    var source = document.getElementById(sourceId);
+    var text = source ? source.textContent.trim() : '';
+    var copied = (T.setup_copied || 'Copied. Paste it into your setup notes or terminal when ready.');
+    var copyError = (T.setup_copy_error || 'Could not copy automatically. Select the snippet and copy it manually.');
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(function() {
+            setSetupStatus(statusId, copied, 'success');
+        }).catch(function() {
+            setSetupStatus(statusId, copyError, 'error');
+        });
+    } else {
+        setSetupStatus(statusId, copyError, 'error');
+    }
+}
+function validateSetupGuidance(statusId, integration) {
+    var messages = {
+        speedtest: T.speedtest_setup_validation_path || 'Speedtest can be tested in Speedtest settings after the base URL and API token are saved. DOCSight uses the saved credentials for the live connection test.',
+        bqm: T.bqm_setup_validation_path || 'BQM can be validated in BQM settings after the share URL is saved. DOCSight checks the saved share URL before importing graphs.',
+        smokeping: T.smokeping_setup_validation_path || 'SmokePing validation depends on the saved base URL and target in SmokePing settings. Save those values first, then refresh this view to confirm live data.'
+    };
+    setSetupStatus(statusId, messages[integration] || (T.setup_guidance_ready || 'Open Settings, save the integration details, then use the settings test or refresh this view to confirm live data.'), 'progress');
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2002,95 +2002,85 @@
 </div><!-- /app-layout -->
 
 <!-- Speedtest Setup Modal -->
-<div class="modal-overlay" id="speedtest-setup-modal" role="dialog" aria-modal="true" aria-labelledby="speedtest-setup-modal-title" onclick="if(event.target===this)closeSpeedtestSetupModal()">
-    <div class="modal">
+<div class="modal-overlay" id="speedtest-setup-modal" role="dialog" aria-modal="true" aria-labelledby="speedtest-setup-modal-title">
+    <div class="modal modal-wide setup-guide-modal">
         <div class="modal-header">
-            <h2 id="speedtest-setup-modal-title">&#9889; {{ t.speedtest_setup_title }}</h2>
-            <button class="modal-close" onclick="closeSpeedtestSetupModal()">&times;</button>
+            <h2 id="speedtest-setup-modal-title">⚡ {{ t.get('speedtest_setup_guided_title', 'Speedtest Tracker setup') }}</h2>
+            <button class="modal-close" onclick="closeSpeedtestSetupModal()" aria-label="{{ t.close }}">&times;</button>
         </div>
-        <div class="modal-body" style="padding: 10px 0; font-size: 0.9em; line-height: 1.6;">
-            <p style="margin-bottom:12px;">{{ t.speedtest_setup_intro }}</p>
-            <div style="background:var(--bg); border-radius:8px; padding:14px; margin-bottom:14px;">
-                <p style="font-weight:bold; margin-bottom:8px; color:var(--accent);">{{ t.speedtest_setup_benefits_title }}</p>
-                <ul style="list-style:none; padding:0;">
-                    <li style="margin-bottom:6px;">&#10003; {{ t.speedtest_setup_benefit_1 }}</li>
-                    <li style="margin-bottom:6px;">&#10003; {{ t.speedtest_setup_benefit_2 }}</li>
-                    <li style="margin-bottom:6px;">&#10003; {{ t.speedtest_setup_benefit_3 }}</li>
+        <p class="modal-hint">{{ t.get('speedtest_setup_guided_intro', 'Connect your existing Speedtest Tracker instance so DOCSight can correlate real throughput with modem signal health.') }}</p>
+        <div class="modal-body setup-guide-body">
+            <section class="setup-guide-card">
+                <h3>{{ t.get('setup_why_title', 'Why connect it') }}</h3>
+                <ul>
+                    <li>{{ t.get('speedtest_setup_benefit_1', 'Correlate speed tests with DOCSIS signal levels') }}</li>
+                    <li>{{ t.get('speedtest_setup_benefit_2', 'Spot peak-hour performance drops') }}</li>
+                    <li>{{ t.get('speedtest_setup_benefit_3', 'Add throughput evidence to reports') }}</li>
                 </ul>
-            </div>
-            <div style="background:var(--bg); border-radius:8px; padding:14px;">
-                <p style="font-weight:bold; margin-bottom:8px; color:var(--accent);">{{ t.speedtest_setup_howto_title }}</p>
-                <ol style="padding-left:20px;">
-                    <li style="margin-bottom:6px;">{{ t.speedtest_setup_step_1|safe_html }}</li>
-                    <li style="margin-bottom:6px;">{{ t.speedtest_setup_step_2|safe_html }}</li>
-                    <li style="margin-bottom:6px;">{{ t.speedtest_setup_step_3|safe_html }}</li>
-                </ol>
-            </div>
+            </section>
+            <section class="setup-guide-card">
+                <h3>{{ t.get('setup_requirements_title', 'Requirements') }}</h3>
+                <ul>
+                    <li>{{ t.get('speedtest_setup_requirement_url', 'A reachable Speedtest Tracker URL') }}</li>
+                    <li>{{ t.get('speedtest_setup_requirement_api', 'API access enabled in Speedtest Tracker') }}</li>
+                </ul>
+            </section>
+            <section class="setup-guide-card setup-guide-command">
+                <h3>{{ t.get('setup_configure_title', 'Configure') }}</h3>
+                <p>{{ t.get('speedtest_setup_configure_text', 'Paste the Speedtest Tracker base URL in Settings, then save the integration.') }}</p>
+                <code id="speedtest-setup-command">docker run --name speedtest-tracker -p 8080:80 lscr.io/linuxserver/speedtest-tracker:latest</code>
+                <button class="btn btn-secondary" onclick="copySetupSnippet('speedtest-setup-command', 'speedtest-setup-status')">{{ t.get('speedtest_setup_copy_command', 'Copy Docker command') }}</button>
+            </section>
+            <section class="setup-guide-card">
+                <h3>{{ t.get('setup_validate_title', 'Validate') }}</h3>
+                <p>{{ t.get('speedtest_setup_validate_text', 'Use Settings to save the URL, then confirm DOCSight can read recent speed test results.') }}</p>
+                <button class="btn btn-muted" onclick="validateSetupGuidance('speedtest-setup-status', 'speedtest')">{{ t.get('speedtest_setup_test_guidance', 'Review validation path') }}</button>
+            </section>
         </div>
+        <div id="speedtest-setup-status" class="setup-validation-status" role="status" aria-live="polite"></div>
         <div class="modal-footer">
             <button class="btn btn-muted" onclick="closeSpeedtestSetupModal()">{{ t.close }}</button>
-            <a class="btn btn-accent" href="/settings" style="text-decoration:none;">&#9881; {{ t.settings }}</a>
+            <a class="btn btn-accent" href="/settings#mod-docsight_speedtest">⚙ {{ t.get('speedtest_setup_open_settings', 'Open Speedtest settings') }}</a>
         </div>
     </div>
 </div>
 
 <!-- BQM Setup Modal -->
-<div class="modal-overlay" id="bqm-setup-modal" role="dialog" aria-modal="true" aria-labelledby="bqm-setup-modal-title" onclick="if(event.target===this)closeBqmSetupModal()">
-    <div class="modal">
+<div class="modal-overlay" id="bqm-setup-modal" role="dialog" aria-modal="true" aria-labelledby="bqm-setup-modal-title">
+    <div class="modal modal-wide setup-guide-modal">
         <div class="modal-header">
-            <h2 id="bqm-setup-modal-title">&#128200; {{ t.bqm_setup_title }}</h2>
-            <button class="modal-close" onclick="closeBqmSetupModal()">&times;</button>
+            <h2 id="bqm-setup-modal-title">📈 {{ t.get('bqm_setup_guided_title', 'ThinkBroadband BQM setup') }}</h2>
+            <button class="modal-close" onclick="closeBqmSetupModal()" aria-label="{{ t.close }}">&times;</button>
         </div>
-        <div class="modal-body" style="padding: 10px 0; font-size: 0.9em; line-height: 1.6;">
-            <p style="margin-bottom:12px;">{{ t.bqm_setup_intro }}</p>
-            <div style="background:var(--bg); border-radius:8px; padding:14px; margin-bottom:14px;">
-                <p style="font-weight:bold; margin-bottom:8px; color:var(--accent);">{{ t.bqm_setup_benefits_title }}</p>
-                <ul style="list-style:none; padding:0;">
-                    <li style="margin-bottom:6px;">✅ {{ t.bqm_setup_benefit_1 }}</li>
-                    <li style="margin-bottom:6px;">✅ {{ t.bqm_setup_benefit_2 }}</li>
-                    <li style="margin-bottom:6px;">✅ {{ t.bqm_setup_benefit_3 }}</li>
-                </ul>
-            </div>
-            <div style="background:var(--bg); border-radius:8px; padding:14px;">
-                <p style="font-weight:bold; margin-bottom:8px; color:var(--accent);">{{ t.bqm_setup_howto_title }}</p>
-                <ol style="padding-left:20px;">
-                    <li style="margin-bottom:6px;">{{ t.bqm_setup_step_1|safe_html }}</li>
-                    <li style="margin-bottom:6px;">{{ t.bqm_setup_step_2|safe_html }}</li>
-                    <li style="margin-bottom:6px;">{{ t.bqm_setup_step_3|safe_html }}</li>
-                    <li style="margin-bottom:6px;">{{ t.bqm_setup_step_4|safe_html }}</li>
-                </ol>
-            </div>
+        <p class="modal-hint">{{ t.get('bqm_setup_guided_intro', 'Link an existing ThinkBroadband Broadband Quality Monitor so DOCSight can show latency and packet loss beside modem evidence.') }}</p>
+        <div class="modal-body setup-guide-body">
+            <section class="setup-guide-card"><h3>{{ t.get('setup_why_title', 'Why connect it') }}</h3><ul><li>{{ t.get('bqm_setup_benefit_1', 'Track latency, packet loss, and outages') }}</li><li>{{ t.get('bqm_setup_benefit_2', 'Compare external reachability with modem signal state') }}</li><li>{{ t.get('bqm_setup_benefit_3', 'Attach graphs to ISP evidence packages') }}</li></ul></section>
+            <section class="setup-guide-card"><h3>{{ t.get('setup_requirements_title', 'Requirements') }}</h3><ul><li>{{ t.get('bqm_setup_requirement_monitor', 'A public or shareable BQM monitor URL') }}</li><li>{{ t.get('bqm_setup_requirement_static_ip', 'A stable public IP or DDNS target monitored by BQM') }}</li></ul></section>
+            <section class="setup-guide-card setup-guide-command"><h3>{{ t.get('setup_configure_title', 'Configure') }}</h3><p>{{ t.get('bqm_setup_configure_text', 'Create or open your BQM monitor, then save the graph URL in Settings.') }}</p><code id="bqm-setup-url">https://www.thinkbroadband.com/broadband/monitoring/quality/share/abc123def456789012345678901234567890abcd-2-y.csv</code><button class="btn btn-secondary" onclick="copySetupSnippet('bqm-setup-url', 'bqm-setup-status')">{{ t.get('bqm_setup_copy_url', 'Copy share URL format') }}</button></section>
+            <section class="setup-guide-card"><h3>{{ t.get('setup_validate_title', 'Validate') }}</h3><p>{{ t.get('bqm_setup_validate_text', 'After saving the URL, validate that DOCSight can load the current graph image.') }}</p><button class="btn btn-muted" onclick="validateSetupGuidance('bqm-setup-status', 'bqm')">{{ t.get('setup_validate_source', 'Review validation path') }}</button></section>
         </div>
-        <div class="modal-footer">
-            <button class="btn btn-muted" onclick="closeBqmSetupModal()">{{ t.close }}</button>
-            <a class="btn btn-accent" href="/settings" style="text-decoration:none;">&#9881; {{ t.settings }}</a>
-        </div>
+        <div id="bqm-setup-status" class="setup-validation-status" role="status" aria-live="polite"></div>
+        <div class="modal-footer"><button class="btn btn-muted" onclick="closeBqmSetupModal()">{{ t.close }}</button><a class="btn btn-accent" href="/settings#mod-docsight_bqm">⚙ {{ t.get('bqm_setup_open_settings', 'Open BQM settings') }}</a></div>
     </div>
 </div>
 
 <!-- Smokeping Setup Modal -->
 {% if modules|selectattr('id', 'equalto', 'docsight.smokeping')|list %}
-<div class="modal-overlay" id="smokeping-setup-modal" role="dialog" aria-modal="true" aria-labelledby="smokeping-setup-modal-title" onclick="if(event.target===this)closeSmokepingSetupModal()">
-    <div class="modal">
+<div class="modal-overlay" id="smokeping-setup-modal" role="dialog" aria-modal="true" aria-labelledby="smokeping-setup-modal-title">
+    <div class="modal modal-wide setup-guide-modal">
         <div class="modal-header">
-            <h2 id="smokeping-setup-modal-title">&#128225; {{ t.smokeping_setup_title }}</h2>
-            <button class="modal-close" onclick="closeSmokepingSetupModal()">&times;</button>
+            <h2 id="smokeping-setup-modal-title">📡 {{ t.get('smokeping_setup_guided_title', 'SmokePing setup') }}</h2>
+            <button class="modal-close" onclick="closeSmokepingSetupModal()" aria-label="{{ t.close }}">&times;</button>
         </div>
-        <div class="modal-body" style="padding: 10px 0; font-size: 0.9em; line-height: 1.6;">
-            <p style="margin-bottom:12px;">{{ t.smokeping_setup_intro }}</p>
-            <div style="background:var(--bg); border-radius:8px; padding:14px;">
-                <p style="font-weight:bold; margin-bottom:8px; color:var(--accent);">{{ t.bqm_setup_howto_title }}</p>
-                <ol style="padding-left:20px;">
-                    <li style="margin-bottom:6px;">{{ t.smokeping_setup_step_1|safe_html }}</li>
-                    <li style="margin-bottom:6px;">{{ t.smokeping_setup_step_2|safe_html }}</li>
-                    <li style="margin-bottom:6px;">{{ t.smokeping_setup_step_3|safe_html }}</li>
-                </ol>
-            </div>
+        <p class="modal-hint">{{ t.get('smokeping_setup_guided_intro', 'Connect an existing SmokePing target to compare latency history with DOCSIS signal and outage evidence.') }}</p>
+        <div class="modal-body setup-guide-body">
+            <section class="setup-guide-card"><h3>{{ t.get('setup_why_title', 'Why connect it') }}</h3><ul><li>{{ t.get('smokeping_setup_benefit_1', 'See long-term latency and packet loss trends') }}</li><li>{{ t.get('smokeping_setup_benefit_2', 'Correlate external symptoms with modem health') }}</li><li>{{ t.get('smokeping_setup_benefit_3', 'Use graphs as supporting ISP evidence') }}</li></ul></section>
+            <section class="setup-guide-card"><h3>{{ t.get('setup_requirements_title', 'Requirements') }}</h3><ul><li>{{ t.get('smokeping_setup_requirement_url', 'A reachable SmokePing web endpoint') }}</li><li>{{ t.get('smokeping_setup_requirement_target', 'At least one configured target graph') }}</li></ul></section>
+            <section class="setup-guide-card setup-guide-command"><h3>{{ t.get('setup_configure_title', 'Configure') }}</h3><p>{{ t.get('smokeping_setup_configure_text', 'Save the SmokePing base URL and target name in Settings.') }}</p><code id="smokeping-setup-target">https://smokeping.example.net/smokeping?target=Home.Router</code><button class="btn btn-secondary" onclick="copySetupSnippet('smokeping-setup-target', 'smokeping-setup-status')">{{ t.get('smokeping_setup_copy_target', 'Copy SmokePing target') }}</button></section>
+            <section class="setup-guide-card"><h3>{{ t.get('setup_validate_title', 'Validate') }}</h3><p>{{ t.get('smokeping_setup_validate_text', 'After saving the endpoint, validate that DOCSight can discover target graphs.') }}</p><button class="btn btn-muted" onclick="validateSetupGuidance('smokeping-setup-status', 'smokeping')">{{ t.get('setup_validate_source', 'Review validation path') }}</button></section>
         </div>
-        <div class="modal-footer">
-            <button class="btn btn-muted" onclick="closeSmokepingSetupModal()">{{ t.close }}</button>
-            <a class="btn btn-accent" href="/settings#integrations" style="text-decoration:none;">&#9881; {{ t.settings }}</a>
-        </div>
+        <div id="smokeping-setup-status" class="setup-validation-status" role="status" aria-live="polite"></div>
+        <div class="modal-footer"><button class="btn btn-muted" onclick="closeSmokepingSetupModal()">{{ t.close }}</button><a class="btn btn-accent" href="/settings#mod-docsight_smokeping">⚙ {{ t.get('smokeping_setup_open_settings', 'Open SmokePing settings') }}</a></div>
     </div>
 </div>
 {% endif %}

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -275,6 +275,56 @@ def test_report_modal_preserves_bnetz_source_and_ignores_stale_generation(demo_p
     demo_page.evaluate("window.fetch = window.__originalReportFetch")
 
 
+def test_integration_setup_modals_are_guided_and_actionable(demo_page):
+    """Integration setup modals should use scannable steps, settings links, copy actions, and validation states."""
+    cases = [
+        ("openSpeedtestSetupModal()", "#speedtest-setup-modal", "Speedtest Tracker setup", "Open Speedtest settings", "/settings#mod-docsight_speedtest", "Copy Docker command", "Review validation path", "Speedtest can be tested"),
+        ("openBqmSetupModal()", "#bqm-setup-modal", "ThinkBroadband BQM setup", "Open BQM settings", "/settings#mod-docsight_bqm", "Copy share URL format", "Review validation path", "BQM can be validated"),
+        ("openSmokepingSetupModal()", "#smokeping-setup-modal", "SmokePing setup", "Open SmokePing settings", "/settings#mod-docsight_smokeping", "Copy SmokePing target", "Review validation path", "SmokePing validation depends"),
+    ]
+    for opener, selector, title, settings_label, settings_href, copy_label, validate_label, status_text in cases:
+        demo_page.evaluate(opener)
+        modal = demo_page.locator(selector)
+        expect(modal).to_be_visible()
+        expect(modal.get_by_role("heading", name=title)).to_be_visible()
+        expect(modal).to_contain_text("Why connect it")
+        expect(modal).to_contain_text("Requirements")
+        expect(modal).to_contain_text("Configure")
+        expect(modal).to_contain_text("Validate")
+        expect(modal.get_by_role("link", name=settings_label)).to_have_attribute("href", settings_href)
+        expect(modal.get_by_role("button", name=copy_label)).to_be_visible()
+        modal.get_by_role("button", name=validate_label).click()
+        expect(modal.locator(".setup-validation-status")).to_contain_text(status_text)
+        demo_page.keyboard.press("Escape")
+        expect(modal).not_to_be_visible()
+
+
+def test_integration_setup_copy_actions_provide_feedback(demo_page):
+    """Copy actions in guided setup modals provide accessible feedback without native dialogs."""
+    demo_page.evaluate("""
+        window.__copiedSetupText = '';
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: {
+                writeText: async function(text) {
+                    window.__copiedSetupText = text;
+                }
+            }
+        });
+    """)
+
+    demo_page.evaluate("openSpeedtestSetupModal()")
+    modal = demo_page.locator("#speedtest-setup-modal")
+    expect(modal).to_be_visible()
+    modal.get_by_role("button", name="Copy Docker command").click()
+    expect(modal.locator(".setup-validation-status")).to_contain_text("Copied")
+    copied = demo_page.evaluate("window.__copiedSetupText")
+    assert "speedtest" in copied.lower()
+
+    demo_page.keyboard.press("Escape")
+    expect(modal).not_to_be_visible()
+
+
 def test_ai_export_modal_previews_privacy_scope_and_size(demo_page):
     """AI export modal explains local scope, included/excluded data, and output size before copying."""
     demo_page.route(


### PR DESCRIPTION
## Summary
- Turn the Speedtest, BQM, and SmokePing setup dialogs into guided setup flows with benefits, requirements, configuration examples, and validation guidance.
- Add actionable settings links that land on the matching integration panel, plus copy helpers for setup snippets and share URL formats.
- Route setup dialogs through the shared modal helpers for consistent focus handling, Escape close, and accessible status feedback.

## Tests
- `node --check app/static/js/utils.js`
- `node --check app/modules/smokeping/static/main.js`
- `TZ=UTC pytest -q tests/e2e/test_modals.py::test_integration_setup_modals_are_guided_and_actionable tests/e2e/test_modals.py::test_integration_setup_copy_actions_provide_feedback --tb=short`
- `TZ=UTC pytest -q tests/e2e/test_modals.py --tb=short`
- `TZ=UTC pytest -q tests/e2e --tb=short` → `321 passed`
- `TZ=UTC pytest -q tests --ignore=tests/e2e --tb=short` → `2200 passed, 11 skipped, 1 warning`
- `git diff --check`
- Native dialog scan: `native_dialog_matches 0`
- Browser smoke: Speedtest, BQM, and SmokePing setup modals open with focus inside, show neutral validation guidance, link to the correct settings panels, close with Escape, and emit no console errors.

Closes #384
