### PR TITLE
Add import preview validation states

### DIFF
--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -959,5 +959,10 @@
   "export_copy_error": "Automatisches Kopieren fehlgeschlagen. Markiere den Text und kopiere ihn manuell.",
   "export_download_markdown": "Markdown herunterladen",
   "export_download_ready": "Download bereit. Prüfe die Datei vor dem Teilen.",
-  "export_preview_label": "Exportvorschau"
+  "export_preview_label": "Exportvorschau",
+  "bqm_import_browse": "BQM-Bilder auswählen",
+  "bqm_import_validation_choose": "Wähle PNG- oder JPEG-BQM-Grafiken. DOCSight zeigt die Daten vor dem Import als Vorschau.",
+  "bqm_import_validation_unsupported": "Nicht unterstützter Dateityp. Nur PNG- und JPEG-Bilder werden unterstützt.",
+  "bqm_import_validation_ready": "{0} bereit",
+  "bqm_import_validation_dates": "{0} benötigt ein Datum"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -959,5 +959,10 @@
   "export_copy_error": "Could not copy automatically. Select the text and copy it manually.",
   "export_download_markdown": "Download Markdown",
   "export_download_ready": "Download ready. Review the file before sharing it.",
-  "export_preview_label": "Export preview"
+  "export_preview_label": "Export preview",
+  "bqm_import_browse": "Browse BQM images",
+  "bqm_import_validation_choose": "Choose PNG or JPEG BQM graph images. DOCSight will preview dates before importing.",
+  "bqm_import_validation_unsupported": "Unsupported file type. Only PNG and JPEG images are supported.",
+  "bqm_import_validation_ready": "{0} ready",
+  "bqm_import_validation_dates": "{0} needs a date"
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -954,5 +954,10 @@
   "export_copy_error": "No se pudo copiar automáticamente. Selecciona el texto y cópialo manualmente.",
   "export_download_markdown": "Descargar Markdown",
   "export_download_ready": "Descarga lista. Revisa el archivo antes de compartirlo.",
-  "export_preview_label": "Vista previa de la exportación"
+  "export_preview_label": "Vista previa de la exportación",
+  "bqm_import_browse": "Seleccionar imagenes BQM",
+  "bqm_import_validation_choose": "Seleccione imagenes BQM PNG o JPEG. DOCSight previsualizara las fechas antes de importar.",
+  "bqm_import_validation_unsupported": "Tipo de archivo no compatible. Solo se admiten imagenes PNG y JPEG.",
+  "bqm_import_validation_ready": "{0} listas",
+  "bqm_import_validation_dates": "{0} necesita fecha"
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -951,5 +951,10 @@
   "export_copy_error": "Copie automatique impossible. Sélectionnez le texte et copiez-le manuellement.",
   "export_download_markdown": "Télécharger Markdown",
   "export_download_ready": "Téléchargement prêt. Vérifiez le fichier avant de le partager.",
-  "export_preview_label": "Aperçu de l’export"
+  "export_preview_label": "Aperçu de l’export",
+  "bqm_import_browse": "Choisir des images BQM",
+  "bqm_import_validation_choose": "Selectionnez des images BQM PNG ou JPEG. DOCSight affiche les dates avant import.",
+  "bqm_import_validation_unsupported": "Type de fichier non pris en charge. Seules les images PNG et JPEG sont acceptees.",
+  "bqm_import_validation_ready": "{0} pretes",
+  "bqm_import_validation_dates": "{0} necessite une date"
 }

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -804,5 +804,10 @@
   "export_copy_error": "",
   "export_download_markdown": "",
   "export_download_ready": "",
-  "export_preview_label": "Export preview"
+  "export_preview_label": "Export preview",
+  "bqm_import_browse": "",
+  "bqm_import_validation_choose": "",
+  "bqm_import_validation_unsupported": "",
+  "bqm_import_validation_ready": "",
+  "bqm_import_validation_dates": ""
 }

--- a/app/modules/journal/i18n/de.json
+++ b/app/modules/journal/i18n/de.json
@@ -108,5 +108,16 @@
   "incident_build_report": "Bericht bauen",
   "incident_create_action": "Vorfall erstellen",
   "incident_update_action": "Vorfall aktualisieren",
-  "entry_save_before_upload": "Erstelle zuerst den Eintrag und hänge danach Nachweisdateien an."
+  "entry_save_before_upload": "Erstelle zuerst den Eintrag und hänge danach Nachweisdateien an.",
+  "import_browse_file": "CSV- oder Excel-Datei auswählen",
+  "import_validation_choose": "Wähle eine CSV- oder Excel-Datei. DOCSight zeigt die Zeilen vor dem Import als Vorschau.",
+  "import_validation_unsupported": "Nicht unterstützter Dateityp. Verwende CSV- oder Excel-Dateien.",
+  "import_validation_parsing": "Datei wird gelesen und Zeilen werden geprüft...",
+  "import_validation_none": "Keine Zeilen ausgewählt. Wähle mindestens eine gültige Zeile für den Import.",
+  "import_validation_ready": "{0} bereit",
+  "import_validation_duplicates": "{0} Duplikat",
+  "import_validation_dates": "{0} benötigt ein Datum",
+  "import_selected_one": "1 ausgewählten Eintrag importieren",
+  "import_selected_count": "{0} ausgewählte Einträge importieren",
+  "import_validation_no_valid": "Keine gültigen Zeilen ausgewählt. Wähle mindestens eine importbereite Zeile."
 }

--- a/app/modules/journal/i18n/en.json
+++ b/app/modules/journal/i18n/en.json
@@ -108,5 +108,16 @@
   "incident_build_report": "Build report",
   "incident_create_action": "Create incident",
   "incident_update_action": "Update incident",
-  "entry_save_before_upload": "Create the entry first, then attach evidence files."
+  "entry_save_before_upload": "Create the entry first, then attach evidence files.",
+  "import_browse_file": "Browse CSV or Excel file",
+  "import_validation_choose": "Choose a CSV or Excel file. DOCSight will preview rows before importing.",
+  "import_validation_unsupported": "Unsupported file type. Use CSV or Excel files.",
+  "import_validation_parsing": "Parsing file and checking rows...",
+  "import_validation_none": "No rows selected. Select at least one valid row to import.",
+  "import_validation_ready": "{0} ready",
+  "import_validation_duplicates": "{0} duplicate",
+  "import_validation_dates": "{0} needs a date",
+  "import_selected_one": "Import 1 selected entry",
+  "import_selected_count": "Import {0} selected entries",
+  "import_validation_no_valid": "No valid rows selected. Select at least one ready row to import."
 }

--- a/app/modules/journal/i18n/es.json
+++ b/app/modules/journal/i18n/es.json
@@ -93,5 +93,16 @@
   "timeline_source_modem": "Modem",
   "timeline_source_speedtest": "Speedtest",
   "timeline_source_event": "Evento",
-  "timeline_no_data": "Sin datos de senal para este periodo"
+  "timeline_no_data": "Sin datos de senal para este periodo",
+  "import_browse_file": "Seleccionar archivo CSV o Excel",
+  "import_validation_choose": "Seleccione un archivo CSV o Excel. DOCSight mostrara una vista previa antes de importar.",
+  "import_validation_unsupported": "Tipo de archivo no compatible. Use archivos CSV o Excel.",
+  "import_validation_parsing": "Analizando archivo y comprobando filas...",
+  "import_validation_none": "No hay filas seleccionadas. Seleccione al menos una fila valida.",
+  "import_validation_ready": "{0} listas",
+  "import_validation_duplicates": "{0} duplicado",
+  "import_validation_dates": "{0} necesita fecha",
+  "import_selected_one": "Importar 1 entrada seleccionada",
+  "import_selected_count": "Importar {0} entradas seleccionadas",
+  "import_validation_no_valid": "No hay filas validas seleccionadas. Seleccione al menos una fila lista para importar."
 }

--- a/app/modules/journal/i18n/fr.json
+++ b/app/modules/journal/i18n/fr.json
@@ -93,5 +93,16 @@
   "timeline_source_modem": "Modem",
   "timeline_source_speedtest": "Speedtest",
   "timeline_source_event": "Evenement",
-  "timeline_no_data": "Aucune donnee de signal pour cette periode"
+  "timeline_no_data": "Aucune donnee de signal pour cette periode",
+  "import_browse_file": "Choisir un fichier CSV ou Excel",
+  "import_validation_choose": "Selectionnez un fichier CSV ou Excel. DOCSight affiche les lignes avant import.",
+  "import_validation_unsupported": "Type de fichier non pris en charge. Utilisez un fichier CSV ou Excel.",
+  "import_validation_parsing": "Analyse du fichier et verification des lignes...",
+  "import_validation_none": "Aucune ligne selectionnee. Selectionnez au moins une ligne valide.",
+  "import_validation_ready": "{0} pretes",
+  "import_validation_duplicates": "{0} doublon",
+  "import_validation_dates": "{0} necessite une date",
+  "import_selected_one": "Importer 1 entree selectionnee",
+  "import_selected_count": "Importer {0} entrees selectionnees",
+  "import_validation_no_valid": "Aucune ligne valide selectionnee. Selectionnez au moins une ligne prete a importer."
 }

--- a/app/modules/journal/i18n/template.json
+++ b/app/modules/journal/i18n/template.json
@@ -93,5 +93,16 @@
   "timeline_source_modem": "",
   "timeline_source_speedtest": "",
   "timeline_source_event": "",
-  "timeline_no_data": ""
+  "timeline_no_data": "",
+  "import_browse_file": "",
+  "import_validation_choose": "",
+  "import_validation_unsupported": "",
+  "import_validation_parsing": "",
+  "import_validation_none": "",
+  "import_validation_ready": "",
+  "import_validation_duplicates": "",
+  "import_validation_dates": "",
+  "import_selected_one": "",
+  "import_selected_count": "",
+  "import_validation_no_valid": ""
 }

--- a/app/static/css/modals.css
+++ b/app/static/css/modals.css
@@ -361,6 +361,41 @@
     outline-offset: 2px;
 }
 
+.import-browse-btn {
+    margin-top: var(--space-sm, 8px);
+}
+
+.import-validation-state {
+    margin: 10px 0;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface-soft, rgba(255,255,255,0.04));
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.import-validation-state.is-success {
+    border-color: var(--accent-purple, var(--accent));
+    color: var(--fg);
+}
+
+.import-validation-state.is-warning {
+    border-color: #eab308;
+    color: var(--fg);
+}
+
+.import-validation-state.is-error {
+    border-color: #ef4444;
+    color: #fecaca;
+}
+
+.import-validation-state.is-progress,
+.import-validation-state.is-info {
+    border-color: var(--accent);
+    color: var(--fg);
+}
+
 /* ── Guided integration setup modals ── */
 .setup-guide-modal {
     max-width: 920px;

--- a/app/static/js/bqm.js
+++ b/app/static/js/bqm.js
@@ -466,14 +466,39 @@ function openBqmImportModal() {
     document.getElementById('bqm-import-overwrite').checked = false;
     document.getElementById('bqm-import-offset').value = '0';
     document.getElementById('bqm-import-tbody').innerHTML = '';
-    modal.classList.add('open');
+    setBqmImportValidationState(T.bqm_import_validation_choose || 'Choose PNG or JPEG BQM graph images. DOCSight will preview dates before importing.', 'info');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.open('bqm-import-modal');
+    } else {
+        modal.classList.add('open');
+    }
 }
 
 function closeBqmImportModal() {
-    document.getElementById('bqm-import-modal').classList.remove('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.close('bqm-import-modal');
+    } else {
+        document.getElementById('bqm-import-modal').classList.remove('open');
+    }
     // Revoke thumb URLs
     _bqmImportFiles.forEach(function(f) { if (f.thumbUrl) URL.revokeObjectURL(f.thumbUrl); });
     _bqmImportFiles = [];
+}
+
+function setBqmImportValidationState(message, tone) {
+    var el = document.getElementById('bqm-import-validation-state');
+    if (!el) return;
+    el.textContent = message || '';
+    el.className = 'import-validation-state' + (tone ? ' is-' + tone : '');
+}
+
+function updateBqmImportValidationState(datesDetected, datesMissing) {
+    var parts = [];
+    parts.push((T.bqm_import_validation_ready || '{0} ready').replace('{0}', datesDetected));
+    if (datesMissing) {
+        parts.push((T.bqm_import_validation_dates || '{0} needs a date').replace('{0}', datesMissing));
+    }
+    setBqmImportValidationState(parts.join(', '), datesMissing ? 'warning' : 'success');
 }
 
 function offsetDate(isoDate, days) {
@@ -506,7 +531,7 @@ function handleBqmImportFiles(fileList) {
         var thumbUrl = URL.createObjectURL(f);
         _bqmImportFiles.push({ file: f, date: date, originalDate: date, thumbUrl: thumbUrl });
     }
-    if (rejected > 0) showToast(T.bqm_import_invalid || 'Only PNG and JPEG images', 'error');
+    if (rejected > 0) setBqmImportValidationState(T.bqm_import_validation_unsupported || 'Unsupported file type. Only PNG and JPEG images are supported.', 'error');
     if (_bqmImportFiles.length > 0) {
         // Apply current offset to newly added files
         var days = parseInt(document.getElementById('bqm-import-offset').value) || 0;
@@ -570,6 +595,11 @@ function renderBqmImportPreview() {
             _bqmImportFiles[i].date = this.value;
             renderBqmImportPreview();
         });
+        dateInput.addEventListener('input', function() {
+            var i = parseInt(this.getAttribute('data-idx'));
+            _bqmImportFiles[i].date = this.value;
+            renderBqmImportPreview();
+        });
         tdDate.appendChild(dateInput);
         tr.appendChild(tdDate);
 
@@ -599,6 +629,7 @@ function renderBqmImportPreview() {
     var statusEl = document.getElementById('bqm-import-status');
     statusEl.textContent = datesDetected + ' dates detected' + (datesMissing > 0 ? ', ' + datesMissing + ' needs manual entry' : '');
     statusEl.style.display = 'block';
+    updateBqmImportValidationState(datesDetected, datesMissing);
 
     document.getElementById('bqm-import-dropzone').style.display = 'none';
     document.getElementById('bqm-import-options').style.display = 'block';

--- a/app/static/js/journal.js
+++ b/app/static/js/journal.js
@@ -545,12 +545,77 @@ function openImportModal() {
     document.getElementById('import-preview').style.display = 'none';
     document.getElementById('import-footer').style.display = 'none';
     document.getElementById('import-file-input').value = '';
+    setImportValidationState(T.import_validation_choose || 'Choose a CSV or Excel file. DOCSight will preview rows before importing.', 'info');
     _importPreviewData = null;
-    modal.classList.add('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.open('import-modal');
+    } else {
+        modal.classList.add('open');
+    }
 }
 
 function closeImportModal() {
-    document.getElementById('import-modal').classList.remove('open');
+    if (window.DOCSightModal) {
+        window.DOCSightModal.close('import-modal');
+    } else {
+        document.getElementById('import-modal').classList.remove('open');
+    }
+}
+
+function setImportValidationState(message, tone) {
+    var el = document.getElementById('import-validation-state');
+    if (!el) return;
+    el.textContent = message || '';
+    el.className = 'import-validation-state' + (tone ? ' is-' + tone : '');
+}
+
+function updateImportSelectionState() {
+    if (!_importPreviewData) return;
+    var cbs = document.querySelectorAll('.import-row-cb');
+    var selected = 0;
+    var selectedImportable = 0;
+    for (var i = 0; i < cbs.length; i++) {
+        if (!cbs[i].checked) continue;
+        selected++;
+        var idx = parseInt(cbs[i].getAttribute('data-idx'));
+        var row = _importPreviewData.rows[idx];
+        if (row && row.date) selectedImportable++;
+    }
+    var btn = document.getElementById('import-confirm-btn');
+    if (btn) {
+        btn.disabled = selectedImportable === 0;
+        btn.textContent = selectedImportable === 1 ? (T.import_selected_one || 'Import 1 selected entry') : (T.import_selected_count || 'Import {0} selected entries').replace('{0}', selectedImportable);
+    }
+    if (selectedImportable === 0) {
+        var noneMessage = selected > 0
+            ? (T.import_validation_no_valid || 'No valid rows selected. Add dates or select rows that are ready to import.')
+            : (T.import_validation_no_valid || 'No valid rows selected. Select at least one ready row to import.');
+        setImportValidationState(noneMessage, 'error');
+    } else {
+        updateImportValidationSummary();
+    }
+}
+
+function updateImportValidationSummary() {
+    if (!_importPreviewData) return;
+    var rows = _importPreviewData.rows || [];
+    var ready = 0;
+    var duplicates = 0;
+    var needsDate = 0;
+    rows.forEach(function(row) {
+        if (row.skipped || !row.date) {
+            needsDate++;
+        } else if (row.duplicate) {
+            duplicates++;
+        } else {
+            ready++;
+        }
+    });
+    var parts = [];
+    parts.push((T.import_validation_ready || '{0} ready').replace('{0}', ready));
+    if (duplicates) parts.push((T.import_validation_duplicates || '{0} duplicate').replace('{0}', duplicates));
+    if (needsDate) parts.push((T.import_validation_dates || '{0} needs a date').replace('{0}', needsDate));
+    setImportValidationState(parts.join(', '), needsDate ? 'warning' : 'success');
 }
 
 // Drag & drop support
@@ -584,16 +649,17 @@ function handleImportFile(input) {
     var file = input.files[0];
     var lower = file.name.toLowerCase();
     if (!lower.endsWith('.xlsx') && !lower.endsWith('.csv')) {
-        showToast(T.import_file_unsupported, 'error');
+        setImportValidationState(T.import_validation_unsupported || 'Unsupported file type. Use CSV or Excel files.', 'error');
         return;
     }
     if (file.size > 5 * 1024 * 1024) {
-        showToast(T.import_file_too_large, 'error');
+        setImportValidationState(T.import_file_too_large || 'File is too large. Maximum size is 5 MB.', 'error');
         return;
     }
 
     document.getElementById('import-upload-zone').style.display = 'none';
     document.getElementById('import-loading').style.display = '';
+    setImportValidationState(T.import_validation_parsing || 'Parsing file and checking rows...', 'progress');
 
     var formData = new FormData();
     formData.append('file', file);
@@ -603,7 +669,7 @@ function handleImportFile(input) {
         .then(function(res) {
             document.getElementById('import-loading').style.display = 'none';
             if (res.status >= 400) {
-                showToast(res.data.error || T.error_prefix, 'error');
+                setImportValidationState(res.data.error || T.error_prefix, 'error');
                 document.getElementById('import-upload-zone').style.display = '';
                 return;
             }
@@ -613,11 +679,12 @@ function handleImportFile(input) {
         .catch(function() {
             document.getElementById('import-loading').style.display = 'none';
             document.getElementById('import-upload-zone').style.display = '';
-            showToast(T.network_error || 'Error', 'error');
+            setImportValidationState(T.network_error || 'Error', 'error');
         });
 }
 
 function renderImportPreview(data) {
+    _importPreviewData = data;
     var tbody = document.getElementById('import-tbody');
     tbody.innerHTML = '';
 
@@ -651,7 +718,7 @@ function renderImportPreview(data) {
             dateCell = escapeHtml(row.date);
         }
         tr.innerHTML =
-            '<td><input type="checkbox" class="import-row-cb" data-idx="' + i + '" ' + checked + '></td>' +
+            '<td><input type="checkbox" class="import-row-cb" data-idx="' + i + '" ' + checked + ' onchange="updateImportSelectionState()"></td>' +
             '<td style="text-align:center;">' + iconHtml + '</td>' +
             '<td>' + dateCell + '</td>' +
             '<td>' + escapeHtml(row.title) + dupeBadge + '</td>' +
@@ -662,6 +729,7 @@ function renderImportPreview(data) {
     document.getElementById('import-select-all').checked = true;
     document.getElementById('import-preview').style.display = '';
     document.getElementById('import-footer').style.display = '';
+    updateImportSelectionState();
 }
 
 function fixImportDate(input, idx) {
@@ -678,6 +746,7 @@ function fixImportDate(input, idx) {
         }
         var badge = tr.querySelector('.import-skipped-badge');
         if (badge) badge.style.display = 'none';
+        updateImportSelectionState();
     }
 }
 
@@ -686,6 +755,7 @@ function toggleImportAll(checked) {
     for (var i = 0; i < cbs.length; i++) {
         cbs[i].checked = checked;
     }
+    updateImportSelectionState();
 }
 
 function confirmImport() {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1086,8 +1086,10 @@
                 </svg>
                 <p>{{ t.bqm_import_drop }}</p>
                 <p style="font-size:0.8em;color:var(--muted);">{{ t.bqm_import_formats }}</p>
+                <button type="button" class="btn btn-muted import-browse-btn" onclick="event.stopPropagation(); document.getElementById('bqm-import-file-input').click();">{{ t.get('bqm_import_browse', 'Browse BQM images') }}</button>
                 <input type="file" id="bqm-import-file-input" style="display:none;" accept="image/png,image/jpeg,.png,.jpg,.jpeg" multiple>
             </div>
+            <div id="bqm-import-validation-state" class="import-validation-state" role="status" aria-live="polite"></div>
             <!-- Options: overwrite + date offset -->
             <div id="bqm-import-options" style="display:none; margin:10px 0;">
                 <div style="display:flex;align-items:center;gap:16px;flex-wrap:wrap;">
@@ -1725,8 +1727,10 @@
                 </svg>
                 <p>{{ t.import_upload_hint }}</p>
                 <p style="font-size:0.8em;color:var(--muted);">{{ t.import_file_types }}</p>
+                <button type="button" class="btn btn-muted import-browse-btn" onclick="event.stopPropagation(); document.getElementById('import-file-input').click();">{{ t.get('import_browse_file', 'Browse CSV or Excel file') }}</button>
                 <input type="file" id="import-file-input" style="display:none;" accept=".xlsx,.csv" onchange="handleImportFile(this)">
             </div>
+            <div id="import-validation-state" class="import-validation-state" role="status" aria-live="polite"></div>
             <!-- Loading -->
             <div id="import-loading" style="display:none;text-align:center;padding:20px;">
                 <div class="spinner"></div>

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -325,6 +325,94 @@ def test_integration_setup_copy_actions_provide_feedback(demo_page):
     expect(modal).not_to_be_visible()
 
 
+def test_journal_import_modal_shows_preview_and_validation_states(demo_page):
+    """Journal import exposes accepted formats, inline validation, preview counts, and selection state."""
+    _open_journal(demo_page)
+    demo_page.evaluate("openImportModal()")
+    modal = demo_page.locator("#import-modal")
+
+    expect(modal).to_be_visible()
+    expect(modal.get_by_role("button", name="Browse CSV or Excel file")).to_be_visible()
+    expect(modal.locator("#import-validation-state")).to_contain_text("Choose a CSV or Excel file")
+
+    demo_page.evaluate(
+        """
+        () => {
+            const file = new File(['not supported'], 'notes.txt', { type: 'text/plain' });
+            handleImportFile({ files: [file] });
+        }
+        """
+    )
+    expect(modal.locator("#import-validation-state")).to_contain_text("Unsupported file type")
+
+    demo_page.evaluate(
+        """
+        () => renderImportPreview({
+            total: 3,
+            skipped: 1,
+            duplicates: 1,
+            rows: [
+                { date: '2026-05-01', title: 'Outage window', description: 'Cable modem offline', skipped: false, duplicate: false },
+                { date: '2026-05-02', title: 'Existing packet loss', description: 'Already imported earlier', skipped: false, duplicate: true },
+                { date: '', raw_date: 'May 3', title: 'Needs date review', description: 'No parseable date', skipped: true, duplicate: false }
+            ]
+        })
+        """
+    )
+    expect(modal.locator("#import-validation-state")).to_contain_text("1 ready")
+    expect(modal.locator("#import-validation-state")).to_contain_text("1 duplicate")
+    expect(modal.locator("#import-validation-state")).to_contain_text("1 needs a date")
+    expect(modal.locator("#import-confirm-btn")).to_contain_text("Import 1 selected entry")
+    expect(modal.locator("#import-confirm-btn")).to_be_enabled()
+
+    modal.locator(".import-row-cb").first.uncheck()
+    expect(modal.locator("#import-validation-state")).to_contain_text("No valid rows selected")
+    expect(modal.locator("#import-confirm-btn")).to_be_disabled()
+
+    modal.locator(".import-row-skipped .import-row-cb").check()
+    expect(modal.locator("#import-validation-state")).to_contain_text("No valid rows selected")
+    expect(modal.locator("#import-confirm-btn")).to_be_disabled()
+
+
+def test_bqm_import_modal_shows_preview_and_validation_states(demo_page):
+    """BQM image import explains accepted files, validates dates, and summarizes readiness in the modal."""
+    demo_page.evaluate("openBqmImportModal()")
+    modal = demo_page.locator("#bqm-import-modal")
+
+    expect(modal).to_be_visible()
+    expect(modal.get_by_role("button", name="Browse BQM images")).to_be_visible()
+    expect(modal.locator("#bqm-import-validation-state")).to_contain_text("Choose PNG or JPEG BQM graph images")
+
+    demo_page.evaluate(
+        """
+        () => {
+            const bad = new File(['bad'], 'notes.txt', { type: 'text/plain' });
+            handleBqmImportFiles([bad]);
+        }
+        """
+    )
+    expect(modal.locator("#bqm-import-validation-state")).to_contain_text("Unsupported file type")
+
+    demo_page.evaluate(
+        """
+        () => {
+            window._bqmImportFiles = [
+                { file: new File(['png'], 'bqm-2026-05-01.png', { type: 'image/png' }), date: '2026-05-01', originalDate: '2026-05-01', thumbUrl: '' },
+                { file: new File(['png'], 'bqm-no-date.png', { type: 'image/png' }), date: '', originalDate: '', thumbUrl: '' }
+            ];
+            renderBqmImportPreview();
+        }
+        """
+    )
+    expect(modal.locator("#bqm-import-validation-state")).to_contain_text("1 ready")
+    expect(modal.locator("#bqm-import-validation-state")).to_contain_text("1 needs a date")
+    expect(modal.locator("#bqm-import-confirm-btn")).to_be_disabled()
+
+    modal.locator(".bqm-import-date-missing").fill("2026-05-02")
+    expect(modal.locator("#bqm-import-validation-state")).to_contain_text("2 ready")
+    expect(modal.locator("#bqm-import-confirm-btn")).to_be_enabled()
+
+
 def test_ai_export_modal_previews_privacy_scope_and_size(demo_page):
     """AI export modal explains local scope, included/excluded data, and output size before copying."""
     demo_page.route(


### PR DESCRIPTION
## Summary
- add inline preview and validation guidance to the Journal CSV/XLSX import modal before entries can be committed
- make Journal selection state count only rows that are actually importable, keeping invalid or missing-date rows recoverable inside the modal
- add visible BQM image import guidance, browse action, validation state, and ready/error messaging before image import
- keep Import modal recovery states inside the modal and preserve shared modal behavior

## Tests
- `node --check app/static/js/journal.js`
- `node --check app/static/js/bqm.js`
- `TZ=UTC pytest -q tests/e2e/test_modals.py::test_journal_import_modal_shows_preview_and_validation_states tests/e2e/test_modals.py::test_bqm_import_modal_shows_preview_and_validation_states --tb=short`
- `TZ=UTC pytest -q tests/e2e/test_modals.py --tb=short`
- `git diff --check`
- i18n JSON parse checks for touched app and journal locale files
- native dialog scan: `native_dialog_matches 0`
- browser smoke for Journal and BQM import modal validation states with no console errors
- focused re-review: no remaining merge blockers
- `TZ=UTC pytest -q tests/e2e --tb=short` → `323 passed`
- `TZ=UTC pytest -q tests --ignore=tests/e2e --tb=short` → `2200 passed, 11 skipped, 1 warning`

Closes #385
