### PR TITLE
Align modal workflow docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -631,15 +631,15 @@ CREATE TABLE bnetz_measurements (
 | `/api/journal` | GET/POST | Journal entries (list, create) |
 | `/api/journal/<id>` | GET/PUT/DELETE | Single journal entry CRUD |
 | `/api/journal/<id>/attachments` | POST | Upload entry attachments |
-| `/api/journal/import/*` | POST | Excel/CSV import (preview + confirm) |
+| `/api/journal/import/*` | POST | Excel/CSV import preview + confirm; UI keeps invalid or skipped rows visible before import |
 | `/api/incidents` | GET/POST | Incident containers (list, create) |
 | `/api/incidents/<id>` | GET/PUT/DELETE | Single incident container CRUD |
 | `/api/incidents/<id>/assign` | POST | Assign entries to incident |
 | `/api/journal/export` | GET | Export journal entries (CSV, JSON, or Markdown) |
 | `/api/tokens` | GET/POST | List or create API tokens (POST requires session auth) |
 | `/api/tokens/<id>` | DELETE | Revoke an API token (requires session auth) |
-| `/api/export` | GET | LLM-optimized report |
-| `/api/report` | GET | PDF incident report |
+| `/api/export` | GET | AI/LLM-oriented markdown export; browser UI applies local preview, scope, and redaction controls |
+| `/api/report` | GET | PDF evidence package for complaint/report workflows |
 | `/api/bnetz/upload` | POST | Upload BNetzA measurement (PDF or CSV) |
 | `/api/bnetz/measurements` | GET | List BNetzA measurements |
 | `/api/bnetz/pdf/<id>` | GET | Download original measurement PDF |

--- a/README.md
+++ b/README.md
@@ -177,19 +177,19 @@ DOCSight is built around an evidence-first workflow, then extended with deeper a
 | **[Signal Trends](https://github.com/itsDNNS/docsight/wiki/Features-Signal-Trends)** | Turn intermittent instability into visible long-term patterns |
 | **[Connection Monitor](https://github.com/itsDNNS/docsight/wiki/Features-Connection-Monitor)** | Track latency, packet loss, outages, and traceroute evidence continuously |
 | **[Event Log](https://github.com/itsDNNS/docsight/wiki/Features-Event-Log)** | Automatically record anomalies like modulation drops and modem restarts |
-| **[Incident Journal](https://github.com/itsDNNS/docsight/wiki/Features-Incident-Journal)** | Add your own notes, imports, attachments, and incident groupings |
+| **[Incident Journal](https://github.com/itsDNNS/docsight/wiki/Features-Incident-Journal)** | Add notes, attachments, reviewed imports, and incident groupings |
 | **[Before/After Comparison](https://github.com/itsDNNS/docsight/wiki/Features-Before-After-Comparison)** | Show whether a technician visit or ISP change actually improved anything |
 | **[Correlation Analysis](https://github.com/itsDNNS/docsight/wiki/Features-Correlation-Analysis)** | Combine signal, speed, and event history in one timeline |
-| **[Complaint Generator](https://github.com/itsDNNS/docsight/wiki/Filing-a-Complaint)** | Turn your evidence trail into ISP-ready letters and technical PDFs |
+| **[Complaint Generator](https://github.com/itsDNNS/docsight/wiki/Filing-a-Complaint)** | Build ISP-ready evidence packages with letter text, checklist, and PDF output |
 
 ### Analysis, Integrations, and Power Features
 
 | Category | Includes |
 |---|---|
 | **Network analysis** | [Gaming Quality Index](https://github.com/itsDNNS/docsight/wiki/Features-Gaming-Quality), [Modulation Performance](https://github.com/itsDNNS/docsight/wiki/Features-Modulation-Performance), [Channel Timeline](https://github.com/itsDNNS/docsight/wiki/Features-Channel-Timeline), [Cable Segment Utilization](https://github.com/itsDNNS/docsight/wiki/Features-Segment-Utilization) |
-| **External data sources** | [Speedtest Integration](https://github.com/itsDNNS/docsight/wiki/Features-Speedtest), [Smart Capture](https://github.com/itsDNNS/docsight/wiki/Features-Smart-Capture), [BNetzA Measurements](https://github.com/itsDNNS/docsight/wiki/Features-BNetzA), [BQM Integration](https://github.com/itsDNNS/docsight/wiki/Features-BQM), [Smokeping Integration](https://github.com/itsDNNS/docsight/wiki/Features-Smokeping) |
+| **External data sources** | Guided setup for [Speedtest Integration](https://github.com/itsDNNS/docsight/wiki/Features-Speedtest), [BQM Integration](https://github.com/itsDNNS/docsight/wiki/Features-BQM), and [Smokeping Integration](https://github.com/itsDNNS/docsight/wiki/Features-Smokeping), plus [Smart Capture](https://github.com/itsDNNS/docsight/wiki/Features-Smart-Capture) and [BNetzA Measurements](https://github.com/itsDNNS/docsight/wiki/Features-BNetzA) |
 | **Platform features** | [Home Assistant](https://github.com/itsDNNS/docsight/wiki/Home-Assistant), [Backup & Restore](https://github.com/itsDNNS/docsight/wiki/Backup-and-Restore), notifications, setup wizard, optional authentication, API tokens |
-| **Usability and extensibility** | [Demo Mode](https://github.com/itsDNNS/docsight/wiki/Features-Demo-Mode), [Theme Engine](https://github.com/itsDNNS/docsight/wiki/Themes), [Community Modules](https://github.com/itsDNNS/docsight-modules), [In-App Glossary](https://github.com/itsDNNS/docsight/wiki/Features-Glossary), [LLM Export](https://github.com/itsDNNS/docsight/wiki/Features-LLM-Export) |
+| **Usability and extensibility** | [Demo Mode](https://github.com/itsDNNS/docsight/wiki/Features-Demo-Mode), [Theme Engine](https://github.com/itsDNNS/docsight/wiki/Themes), [Community Modules](https://github.com/itsDNNS/docsight-modules), [In-App Glossary](https://github.com/itsDNNS/docsight/wiki/Features-Glossary), [AI/LLM Export](https://github.com/itsDNNS/docsight/wiki/Features-LLM-Export) with local redaction controls |
 
 Also includes 4 languages (EN/DE/FR/ES), light/dark mode, PWA/offline support, and a system font toggle.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -183,9 +183,11 @@ Maintainers use this checklist when reviewing changes that touch integration or 
 - **Modem/router response parsing** — driver code parses untrusted modem firmware output and must tolerate missing, malformed, or unexpected fields without crashing the poller.
   - `tests/test_vodafone_station_tg.py`
   - `tests/test_driver_registry.py`
-- **Import/export paths** — backup, history import, and report export flows handle user-supplied files and produce shareable output.
+- **Import/export paths** — backup, history import, AI/LLM export, journal import, BQM image import, and report output handle user-supplied files or produce shareable evidence.
   - `tests/test_import_parser.py`
   - `tests/test_report.py`
+  - `tests/web/test_health_export.py`
+  - `tests/e2e/test_modals.py`
 - **Local authentication/session handling** — login, session cookies, the `require_auth` decorator, and Bearer token verification.
   - `tests/test_auth.py`
   - `tests/test_security_hardening.py`


### PR DESCRIPTION
## Summary
- align README and architecture notes with the updated evidence builder, AI export redaction, guided setup, and import preview flows
- expand the security review checklist for import/export paths touched by the modal updates

## Tests
- `git diff --check`
- `TZ=UTC pytest -q tests/test_defensive_review_docs.py --tb=short`

Refs #382
Refs #383
Refs #384
Refs #385
