### PR TITLE
Prevent guided setup modal footers covering mobile content

### DIFF
--- a/app/static/css/modals.css
+++ b/app/static/css/modals.css
@@ -400,6 +400,13 @@
 .setup-guide-modal {
     max-width: 920px;
 }
+.setup-guide-modal .modal-body {
+    padding-bottom: max(var(--space-md), env(safe-area-inset-bottom));
+}
+.setup-guide-modal .modal-footer {
+    flex-wrap: wrap;
+    align-items: stretch;
+}
 .setup-guide-body {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -451,4 +458,13 @@
 @media (max-width: 720px) {
     .setup-guide-body { grid-template-columns: 1fr; }
     .setup-guide-command code { white-space: pre-wrap; }
+    .setup-guide-modal .modal-footer {
+        justify-content: stretch;
+    }
+    .setup-guide-modal .modal-footer .btn {
+        flex: 1 1 100%;
+        min-width: 0;
+        white-space: normal;
+        text-align: center;
+    }
 }

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -299,6 +299,50 @@ def test_integration_setup_modals_are_guided_and_actionable(demo_page):
         expect(modal).not_to_be_visible()
 
 
+def test_guided_setup_modal_footers_do_not_cover_mobile_content(demo_page):
+    """Mobile setup modals should scroll their final content fully above footer actions."""
+    demo_page.set_viewport_size({"width": 393, "height": 852})
+    cases = [
+        ("openSpeedtestSetupModal()", "#speedtest-setup-modal"),
+        ("openBqmSetupModal()", "#bqm-setup-modal"),
+        ("openSmokepingSetupModal()", "#smokeping-setup-modal"),
+    ]
+
+    for opener, selector in cases:
+        demo_page.evaluate(opener)
+        modal = demo_page.locator(selector)
+        expect(modal).to_be_visible()
+        modal.locator(".modal-body").evaluate("el => { el.scrollTop = el.scrollHeight; }")
+        geometry = modal.evaluate(
+            """
+            (el) => {
+                const footer = el.querySelector('.modal-footer');
+                const body = el.querySelector('.modal-body');
+                const lastCard = body.querySelector('.setup-guide-card:last-child');
+                const footerRect = footer.getBoundingClientRect();
+                const bodyRect = body.getBoundingClientRect();
+                const lastRect = lastCard.getBoundingClientRect();
+                const footerStyle = getComputedStyle(footer);
+                return {
+                    lastCardBottom: lastRect.bottom,
+                    footerTop: footerRect.top,
+                    bodyBottom: bodyRect.bottom,
+                    footerWraps: footerRect.height >= 44,
+                    footerFlexWrap: footerStyle.flexWrap,
+                };
+            }
+            """
+        )
+
+        assert geometry["lastCardBottom"] <= geometry["footerTop"] - 8
+        assert geometry["bodyBottom"] <= geometry["footerTop"] - 8
+        assert geometry["footerWraps"] is True
+        assert geometry["footerFlexWrap"] == "wrap"
+
+        demo_page.keyboard.press("Escape")
+        expect(modal).not_to_be_visible()
+
+
 def test_integration_setup_copy_actions_provide_feedback(demo_page):
     """Copy actions in guided setup modals provide accessible feedback without native dialogs."""
     demo_page.evaluate("""


### PR DESCRIPTION
## Summary
- Adds a mobile Playwright regression for Speedtest, BQM, and SmokePing guided setup modal footer/content spacing
- Adds safe bottom padding for guided setup modal bodies so the final card can scroll clear of footer actions
- Allows guided setup footer actions to wrap/stack on narrow mobile widths and longer labels

Closes #397

## Test plan
- `TZ=UTC pytest -q tests/e2e/test_modals.py::test_guided_setup_modal_footers_do_not_cover_mobile_content tests/e2e/test_modals.py::test_integration_setup_modals_are_guided_and_actionable --tb=short`
- `TZ=UTC pytest -q tests/e2e/test_modals.py --tb=short`
- `TZ=UTC pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC pytest -q tests/e2e --tb=short`
- `git diff --check`
