### PR TITLE
Fix mobile evidence tables

### DIFF
--- a/app/modules/bnetz/static/style.css
+++ b/app/modules/bnetz/static/style.css
@@ -35,6 +35,7 @@
 /* Verdict icon */
 .bnetz-verdict { text-align: center; }
 .bnetz-verdict i { width: 18px; height: 18px; }
+.bnetz-verdict-text { display: none; }
 
 /* Detail expand cell */
 .bnetz-detail-cell { padding: 0 8px 12px 24px; }
@@ -67,4 +68,109 @@
 
 @media (max-width: 600px) {
     .bnetz-detail-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 768px) {
+    #bnetz-table-card {
+        overflow-x: hidden;
+    }
+
+    #bnetz-table,
+    #bnetz-table > tbody {
+        display: block;
+        width: 100%;
+    }
+
+    #bnetz-table > thead {
+        display: none;
+    }
+
+    #bnetz-table > tbody > tr[data-bnetz-idx] {
+        display: block;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--card-border, var(--input-border));
+    }
+
+    #bnetz-table > tbody > tr[data-bnetz-idx] > td {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+        width: 100%;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--border-tint, rgba(255,255,255,0.08));
+        white-space: normal;
+        overflow-wrap: anywhere;
+        text-align: right;
+    }
+
+    #bnetz-table > tbody > tr[data-bnetz-idx] > td:last-child {
+        border-bottom: none;
+    }
+
+    #bnetz-table > tbody > tr[data-bnetz-idx] > td::before {
+        content: attr(data-label);
+        flex: 0 0 min(46%, 150px);
+        color: var(--text-secondary, var(--text-muted));
+        font-size: 0.82em;
+        font-weight: 600;
+        text-align: left;
+    }
+
+    #bnetz-table > tbody > tr[data-bnetz-idx] > td:first-child {
+        align-items: center;
+    }
+
+    .bnetz-expand-btn {
+        min-width: 36px;
+        min-height: 36px;
+        margin-right: 4px;
+    }
+
+    #bnetz-table > tbody > tr[data-bnetz-idx] > .bnetz-verdict {
+        align-items: center;
+        justify-content: flex-end;
+        gap: 6px;
+    }
+
+    .bnetz-verdict-text {
+        display: inline;
+        overflow-wrap: anywhere;
+    }
+
+    .bnetz-actions-cell {
+        display: flex !important;
+        align-items: center;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+        gap: 8px;
+        white-space: normal;
+    }
+
+    .bnetz-actions-cell::before {
+        margin-right: auto;
+    }
+
+    .bnetz-action-btn {
+        min-width: 40px;
+        min-height: 40px;
+        margin-right: 0;
+    }
+
+    .bnetz-detail-cell {
+        display: block;
+        width: 100%;
+        padding: 10px 12px 14px;
+        overflow-x: hidden;
+    }
+
+    .bnetz-detail-table {
+        table-layout: fixed;
+    }
+
+    .bnetz-detail-table th,
+    .bnetz-detail-table td {
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
 }

--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -811,10 +811,61 @@
         border: 1px solid var(--glass-border, var(--card-border));
         border-radius: var(--radius-pill, 100px);
     }
-    #correlation-table thead th,
+    #correlation-table-card.table-card,
+    #correlation-table-wrap {
+        overflow-x: hidden;
+    }
+
+    #correlation-table-wrap {
+        max-height: none;
+    }
+
+    #correlation-table,
+    #correlation-table > tbody {
+        display: block;
+        width: 100%;
+    }
+
+    #correlation-table > thead {
+        display: none;
+    }
+
+    #correlation-table tbody tr {
+        display: block;
+        width: 100%;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--card-border, var(--input-border));
+    }
+
     #correlation-table tbody td {
-        padding: 8px 12px;
-        font-size: 0.8em;
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+        width: 100%;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--border-tint, rgba(255,255,255,0.08));
+        font-size: 0.82em;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
+
+    #correlation-table tbody td:last-child {
+        border-bottom: none;
+    }
+
+    #correlation-table tbody td::before {
+        content: attr(data-label);
+        flex: 0 0 min(38%, 120px);
+        color: var(--text-secondary, var(--text-muted));
+        font-weight: 600;
+        text-align: left;
+    }
+
+    #correlation-table .correlation-cell-message,
+    #correlation-table .correlation-cell-details {
+        min-width: 0;
     }
 }
 

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -1329,10 +1329,10 @@ function renderCorrelationTable(data) {
             details = typeLabels[e.event_type] || e.event_type || '';
         }
 
-        tr.innerHTML = '<td style="white-space:nowrap; font-size:0.82em;">' + ts + '</td>'
-            + '<td>' + src + '</td>'
-            + '<td>' + msg + '</td>'
-            + '<td style="font-size:0.82em; color:var(--muted);">' + details + '</td>';
+        tr.innerHTML = '<td data-label="' + escapeHtml(T.timestamp || 'Timestamp') + '" class="correlation-cell-timestamp">' + ts + '</td>'
+            + '<td data-label="' + escapeHtml(T.source || 'Source') + '" class="correlation-cell-source">' + src + '</td>'
+            + '<td data-label="' + escapeHtml(T.event_message || 'Message') + '" class="correlation-cell-message">' + msg + '</td>'
+            + '<td data-label="' + escapeHtml(T.event_details || 'Details') + '" class="correlation-cell-details">' + details + '</td>';
         tr.addEventListener('mouseenter', function() {
             if (_corrPinnedRow) return;
             var rowTs = this.getAttribute('data-ts');

--- a/app/static/js/integrations.js
+++ b/app/static/js/integrations.js
@@ -43,14 +43,14 @@ function loadBnetzData() {
                     'title="' + (T.bnetz_generate_complaint || 'Generate complaint') + '">' +
                     '<i data-lucide="file-pen"></i></a>';
             }
-            tr.innerHTML = '<td>' + (hasMeasurements ? '<button class="bnetz-expand-btn" id="bnetz-arrow-' + idx + '"><i data-lucide="chevron-right"></i></button> ' : '') + escapeHtml(m.date || '') + '</td>' +
-                '<td>' + escapeHtml(m.provider || '-') + '</td>' +
-                '<td>' + (m.download_max_tariff ? Math.round(m.download_max_tariff) + ' Mbit/s' : '-') + '</td>' +
-                '<td>' + Math.round(m.download_measured_avg || 0) + ' Mbit/s' + (dlPct ? ' (' + dlPct + '%)' : '') + '</td>' +
-                '<td>' + (m.upload_max_tariff ? Math.round(m.upload_max_tariff) + ' Mbit/s' : '-') + '</td>' +
-                '<td>' + Math.round(m.upload_measured_avg || 0) + ' Mbit/s' + (ulPct ? ' (' + ulPct + '%)' : '') + '</td>' +
-                '<td class="bnetz-verdict ' + verdictClass + '" title="' + verdictText + '">' + verdictIcon + '</td>' +
-                '<td class="bnetz-actions-cell" onclick="event.stopPropagation();">' +
+            tr.innerHTML = '<td data-label="' + escapeHtml(T.bnetz_date || 'Date') + '">' + (hasMeasurements ? '<button class="bnetz-expand-btn" id="bnetz-arrow-' + idx + '" aria-label="' + escapeHtml(T.expand || 'Expand') + '"><i data-lucide="chevron-right"></i></button> ' : '') + escapeHtml(m.date || '') + '</td>' +
+                '<td data-label="' + escapeHtml(T.bnetz_provider || 'Provider') + '">' + escapeHtml(m.provider || '-') + '</td>' +
+                '<td data-label="' + escapeHtml(T.bnetz_download_target || 'Download target') + '">' + (m.download_max_tariff ? Math.round(m.download_max_tariff) + ' Mbit/s' : '-') + '</td>' +
+                '<td data-label="' + escapeHtml(T.bnetz_download_actual || 'Download measured') + '">' + Math.round(m.download_measured_avg || 0) + ' Mbit/s' + (dlPct ? ' (' + dlPct + '%)' : '') + '</td>' +
+                '<td data-label="' + escapeHtml(T.bnetz_upload_target || 'Upload target') + '">' + (m.upload_max_tariff ? Math.round(m.upload_max_tariff) + ' Mbit/s' : '-') + '</td>' +
+                '<td data-label="' + escapeHtml(T.bnetz_upload_actual || 'Upload measured') + '">' + Math.round(m.upload_measured_avg || 0) + ' Mbit/s' + (ulPct ? ' (' + ulPct + '%)' : '') + '</td>' +
+                '<td data-label="' + escapeHtml(T.bnetz_verdict || 'Verdict') + '" class="bnetz-verdict ' + verdictClass + '" title="' + verdictText + '">' + verdictIcon + '<span class="bnetz-verdict-text">' + escapeHtml(verdictText) + '</span></td>' +
+                '<td data-label="' + escapeHtml(T.actions || 'Actions') + '" class="bnetz-actions-cell" onclick="event.stopPropagation();">' +
                     complaintBtn +
                     (m.source !== 'csv_import' ? '<a href="/api/bnetz/pdf/' + m.id + '" class="bnetz-action-btn" title="PDF"><i data-lucide="file-down"></i></a>' : '') +
                     '<a href="javascript:void(0)" class="bnetz-action-btn bnetz-action-delete" onclick="deleteBnetzFromView(' + m.id + ')" title="' + (T.delete_incident || 'Delete') + '"><i data-lucide="trash-2"></i></a>' +

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -93,3 +93,58 @@ class TestMobileLayout:
             mobile_page.wait_for_timeout(200)
             items = analysis.locator(".nav-section-items .nav-item")
             assert items.count() >= 1
+
+    def test_bnetz_measurements_are_readable_and_actionable_on_mobile(self, mobile_page):
+        """BNetzA evidence rows should not hide values or actions off-screen."""
+        mobile_page.evaluate("switchView('bnetz')")
+        mobile_page.wait_for_selector("#bnetz-table-card", state="visible")
+        mobile_page.wait_for_selector("#bnetz-tbody tr[data-bnetz-idx]")
+
+        overflow = mobile_page.locator("#bnetz-table-card").evaluate(
+            "el => el.scrollWidth - el.clientWidth"
+        )
+        assert overflow <= 1
+
+        action_rects = mobile_page.locator("#bnetz-tbody tr[data-bnetz-idx] .bnetz-action-btn").evaluate_all(
+            """
+            buttons => buttons.map((btn) => {
+                const rect = btn.getBoundingClientRect();
+                return {left: rect.left, right: rect.right, width: rect.width, visible: rect.width > 0 && rect.height > 0};
+            })
+            """
+        )
+        assert action_rects, "expected BNetzA row actions to be rendered"
+        viewport_width = mobile_page.evaluate("window.innerWidth")
+        assert all(rect["visible"] for rect in action_rects)
+        assert all(rect["left"] >= 0 and rect["right"] <= viewport_width for rect in action_rects)
+
+    def test_correlation_timeline_wraps_mobile_evidence_rows(self, mobile_page):
+        """Correlation timeline rows should expose details without hidden horizontal scrolling."""
+        mobile_page.evaluate("switchView('correlation')")
+        mobile_page.wait_for_selector("#correlation-table-card", state="visible")
+        mobile_page.wait_for_selector("#correlation-tbody tr[data-ts]")
+
+        overflow = mobile_page.locator("#correlation-table-wrap").evaluate(
+            "el => el.scrollWidth - el.clientWidth"
+        )
+        assert overflow <= 1
+
+        row_geometry = mobile_page.locator("#correlation-tbody tr[data-ts]").first.evaluate(
+            """
+            (row) => {
+                const rowRect = row.getBoundingClientRect();
+                const details = row.querySelector('td:last-child').getBoundingClientRect();
+                return {
+                    rowLeft: rowRect.left,
+                    rowRight: rowRect.right,
+                    detailsLeft: details.left,
+                    detailsRight: details.right,
+                    viewportWidth: window.innerWidth,
+                };
+            }
+            """
+        )
+        assert row_geometry["rowLeft"] >= 0
+        assert row_geometry["rowRight"] <= row_geometry["viewportWidth"]
+        assert row_geometry["detailsLeft"] >= 0
+        assert row_geometry["detailsRight"] <= row_geometry["viewportWidth"]


### PR DESCRIPTION
## Summary
- Converts BNetzA measurement rows into labeled mobile evidence cards so values and row actions stay within the viewport.
- Converts the unified correlation timeline into stacked mobile rows with visible message/details labels.
- Adds mobile regression coverage for BNetzA and correlation table overflow/action reachability.

Closes #395

## Test plan
- `./.venv/bin/python -m pytest tests/e2e/test_responsive.py -q --tb=short`
- `./.venv/bin/python -m pytest tests/e2e/_tmp_mobile_395_visual.py -q --tb=short` (temporary local visual smoke)
- `node --check app/static/js/integrations.js`
- `node --check app/static/js/correlation.js`
- `git diff --check`
