### PR TITLE
fix(journal): improve mobile incident layout

### DIFF
--- a/app/modules/journal/static/style.css
+++ b/app/modules/journal/static/style.css
@@ -1185,14 +1185,39 @@ mark.search-highlight {
     .journal-hide-mobile {
         display: none;
     }
+    .journal-header {
+        align-items: stretch;
+    }
+    .journal-header .trend-title {
+        text-align: center;
+    }
     .journal-header-actions {
         width: 100%;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
         justify-content: stretch;
+        align-items: stretch;
     }
-    .journal-header-actions .btn-new-entry {
-        flex: 1;
-        justify-content: center;
+    .journal-header-actions .btn-new-entry,
+    .journal-header-actions .btn-danger {
+        width: 100%;
+        min-width: 0;
         min-height: 44px;
+        justify-content: center;
+        white-space: normal;
+        text-align: center;
+    }
+    .journal-export-wrapper {
+        display: block !important;
+        min-width: 0;
+    }
+    .journal-export-dropdown {
+        left: 0;
+        right: auto;
+        width: 100%;
+    }
+    .journal-export-dropdown button {
+        min-height: 40px;
     }
     .incident-timeline-entry {
         flex-direction: column;
@@ -1204,28 +1229,116 @@ mark.search-highlight {
         gap: var(--space-xs);
     }
     .incident-filter-bar {
-        overflow-x: auto;
-        flex-wrap: nowrap;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: none;
+        overflow: visible;
+        flex-wrap: wrap;
+        align-items: stretch;
         padding-bottom: var(--space-sm);
-    }
-    .incident-filter-bar::-webkit-scrollbar {
-        display: none;
     }
     .incident-pill {
         min-height: 44px;
+        max-width: 100%;
+        white-space: normal;
+        text-align: left;
     }
     .incident-pill-add {
         min-width: 44px;
         min-height: 44px;
+    }
+    #journal-table {
+        display: block;
+        width: 100%;
+    }
+    #journal-table thead {
+        display: none;
+    }
+    #journal-table tbody {
+        display: block;
+    }
+    #journal-table tbody tr {
+        display: block;
+        width: 100%;
+        padding: var(--space-sm) var(--space-md);
+        margin-bottom: var(--space-sm);
+        border: 1px solid var(--card-border, var(--input-border));
+        border-radius: var(--radius-sm);
+        background: rgba(255,255,255,0.03);
+    }
+    #journal-table tbody tr:hover {
+        transform: none;
+        box-shadow: 0 0 0 1px rgba(168,85,247,0.25);
+    }
+    #journal-table tbody tr.journal-month-header {
+        padding: 0;
+        margin: var(--space-sm) 0;
+        border: none;
+        border-radius: 0;
+        background: transparent;
+    }
+    #journal-table tbody td {
+        display: block;
+        width: 100%;
+        padding: 0;
+        border-left: none;
+    }
+    #journal-table tbody .journal-icon-cell {
+        float: left;
+        width: 28px;
+        margin: 1px var(--space-sm) var(--space-xs) 0;
+        color: var(--accent-purple, var(--accent));
+    }
+    #journal-table tbody .journal-date-cell {
+        color: var(--muted);
+        font-size: 0.78rem;
+        line-height: 1.35;
+    }
+    #journal-table tbody .journal-title-cell {
+        color: var(--text);
+        font-size: 0.96rem;
+        font-weight: 650;
+        line-height: 1.35;
+        overflow-wrap: anywhere;
+        word-break: normal;
+    }
+    #journal-table tbody .journal-clip {
+        display: none;
+        margin-top: var(--space-xs);
+        text-align: left;
+        color: var(--text-secondary, var(--muted));
+        font-size: 0.8rem;
+    }
+    #journal-table tbody .journal-clip:not(:empty) {
+        display: inline-flex;
+        align-items: center;
+        width: auto;
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        background: rgba(168,85,247,0.12);
+        color: var(--accent-purple, var(--accent));
+    }
+    #journal-table tbody .journal-check-cell {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        min-height: 44px;
+        padding-bottom: var(--space-xs);
+    }
+    #journal-table tbody .journal-check-cell::after {
+        content: attr(data-label);
+        margin-left: var(--space-sm);
+        color: var(--text-secondary, var(--muted));
+        font-size: 0.82rem;
+        font-weight: 600;
+    }
+    #journal-table tbody .journal-check-cell input[type="checkbox"] {
+        width: 22px;
+        height: 22px;
     }
     .journal-bulk-bar {
         padding: var(--space-sm);
     }
     .journal-bulk-select {
         min-width: 0;
-        flex: 1;
+        flex: 1 1 100%;
     }
     .incident-timeline-card {
         padding: var(--space-md);

--- a/app/static/js/journal.js
+++ b/app/static/js/journal.js
@@ -179,6 +179,10 @@ function loadJournal(searchQuery) {
         });
 }
 
+function escapeHtmlAttribute(value) {
+    return escapeHtml(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 function highlightText(text, query) {
     if (!query || !text) return escapeHtml(text);
     var escaped = escapeHtml(text);
@@ -245,12 +249,12 @@ function renderJournalTable(data, searchQuery) {
         var descHtml = q ? highlightText(desc, q) : escapeHtml(desc);
         var dateHtml = q ? highlightText(formatDateDE(inc.date), q) : formatDateDE(inc.date);
         tr.innerHTML =
-            (_bulkMode ? '<td class="journal-check-cell"><input type="checkbox" class="journal-row-check" data-entry-id="' + inc.id + '"' + (isSelected ? ' checked' : '') + ' onclick="toggleEntrySelection(this, ' + inc.id + ')"></td>' : '') +
-            '<td class="journal-icon-cell">' + iconHtml + '</td>' +
-            '<td>' + dateHtml + '</td>' +
-            '<td>' + titleHtml + '</td>' +
-            '<td class="journal-desc journal-hide-mobile">' + descHtml + '</td>' +
-            '<td class="journal-clip">' + clipCell + '</td>';
+            (_bulkMode ? '<td class="journal-check-cell" data-label="' + escapeHtmlAttribute(T.bulk_select || 'Select') + '"><input type="checkbox" class="journal-row-check" data-entry-id="' + inc.id + '"' + (isSelected ? ' checked' : '') + ' onclick="toggleEntrySelection(this, ' + inc.id + ')"></td>' : '') +
+            '<td class="journal-icon-cell" aria-hidden="true">' + iconHtml + '</td>' +
+            '<td class="journal-date-cell" data-label="' + escapeHtmlAttribute(T.incident_date || 'Date') + '">' + dateHtml + '</td>' +
+            '<td class="journal-title-cell" data-label="' + escapeHtmlAttribute(T.incident_title || 'Title') + '">' + titleHtml + '</td>' +
+            '<td class="journal-desc journal-hide-mobile" data-label="' + escapeHtmlAttribute(T.incident_description || 'Description') + '">' + descHtml + '</td>' +
+            '<td class="journal-clip" data-label="' + escapeHtmlAttribute(T.attachments || 'Attachments') + '">' + clipCell + '</td>';
         tbody.appendChild(tr);
     });
     // Update sort indicators in header

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -148,3 +148,159 @@ class TestMobileLayout:
         assert row_geometry["rowRight"] <= row_geometry["viewportWidth"]
         assert row_geometry["detailsLeft"] >= 0
         assert row_geometry["detailsRight"] <= row_geometry["viewportWidth"]
+
+    def test_incident_journal_mobile_actions_chips_and_rows_are_scannable(self, mobile_page):
+        """Incident Journal should use mobile-first actions, wrapping chips, and card rows."""
+        mobile_page.evaluate("switchView('journal')")
+        mobile_page.wait_for_selector("#journal-table-card", state="visible")
+        mobile_page.wait_for_selector("#journal-tbody tr[data-id]")
+        mobile_page.evaluate(
+            """
+            () => {
+                window._incidentsData = [
+                    {id: 501, name: 'Upstream Noise Issue with very long mobile label', status: 'open', entry_count: 3},
+                    {id: 502, name: 'Firmware Update Issues and repeated support calls', status: 'escalated', entry_count: 1}
+                ];
+                window.renderIncidentBar(window._incidentsData);
+            }
+            """
+        )
+
+        geometry = mobile_page.evaluate(
+            """
+            () => {
+                const viewportWidth = window.innerWidth;
+                const visibleRows = Array.from(document.querySelectorAll('#journal-tbody tr[data-id]'));
+                const firstRow = visibleRows[0];
+                const titleCell = firstRow.querySelector('td:nth-child(3)');
+                const clipCell = firstRow.querySelector('.journal-clip');
+                const actionRects = Array.from(document.querySelectorAll('.journal-header-actions > button, .journal-export-wrapper > button')).map((button) => {
+                    const rect = button.getBoundingClientRect();
+                    return {left: rect.left, right: rect.right, height: rect.height, width: rect.width};
+                });
+                const chipRects = Array.from(document.querySelectorAll('#incident-filter-bar .incident-pill')).map((pill) => {
+                    const rect = pill.getBoundingClientRect();
+                    return {left: rect.left, right: rect.right, width: rect.width};
+                });
+                return {
+                    viewportWidth,
+                    viewOverflow: document.querySelector('#view-journal').scrollWidth - document.querySelector('#view-journal').clientWidth,
+                    actionsOverflow: document.querySelector('.journal-header-actions').scrollWidth - document.querySelector('.journal-header-actions').clientWidth,
+                    tableOverflow: document.querySelector('#journal-table-card').scrollWidth - document.querySelector('#journal-table-card').clientWidth,
+                    chipWrap: getComputedStyle(document.querySelector('#incident-filter-bar')).flexWrap,
+                    rowDisplay: getComputedStyle(firstRow).display,
+                    titleWidth: titleCell.getBoundingClientRect().width,
+                    clipDisplay: getComputedStyle(clipCell).display,
+                    actionRects,
+                    chipRects,
+                };
+            }
+            """
+        )
+
+        assert geometry["viewOverflow"] <= 1
+        assert geometry["actionsOverflow"] <= 1
+        assert geometry["tableOverflow"] <= 1
+        assert geometry["chipWrap"] == "wrap"
+        assert geometry["rowDisplay"] in {"block", "grid"}
+        assert geometry["titleWidth"] >= 220
+        assert geometry["clipDisplay"] == "none"
+        assert all(rect["height"] >= 44 for rect in geometry["actionRects"])
+        assert all(rect["left"] >= 0 and rect["right"] <= geometry["viewportWidth"] for rect in geometry["actionRects"])
+        assert all(rect["left"] >= 0 and rect["right"] <= geometry["viewportWidth"] for rect in geometry["chipRects"])
+
+    def test_incident_journal_mobile_bulk_selection_remains_accessible(self, mobile_page):
+        """Bulk mode controls should remain reachable in mobile card rows."""
+        mobile_page.evaluate("switchView('journal')")
+        mobile_page.wait_for_selector("#journal-table-card", state="visible")
+        mobile_page.wait_for_selector("#journal-tbody tr[data-id]")
+        mobile_page.locator("#btn-bulk-toggle").click()
+        mobile_page.wait_for_selector(".journal-row-check")
+
+        checkbox_geometry = mobile_page.locator("#journal-tbody tr[data-id] .journal-check-cell").first.evaluate(
+            """
+            (cell) => {
+                const rect = cell.getBoundingClientRect();
+                const inputRect = cell.querySelector('input').getBoundingClientRect();
+                return {
+                    cellLeft: rect.left,
+                    cellRight: rect.right,
+                    cellHeight: rect.height,
+                    inputLeft: inputRect.left,
+                    inputRight: inputRect.right,
+                    viewportWidth: window.innerWidth,
+                };
+            }
+            """
+        )
+
+        assert checkbox_geometry["cellLeft"] >= 0
+        assert checkbox_geometry["cellRight"] <= checkbox_geometry["viewportWidth"]
+        assert checkbox_geometry["cellHeight"] >= 44
+        assert checkbox_geometry["inputLeft"] >= 0
+        assert checkbox_geometry["inputRight"] <= checkbox_geometry["viewportWidth"]
+
+    def test_incident_journal_mobile_export_and_attachment_badges_fit_viewport(self, mobile_page):
+        """Export choices and attachment badges should remain usable in the mobile layout."""
+        mobile_page.evaluate("switchView('journal')")
+        mobile_page.wait_for_selector("#journal-table-card", state="visible")
+        mobile_page.evaluate(
+            """
+            () => {
+                window._journalSortCol = 'date';
+                window._journalSortAsc = false;
+                window.T = Object.assign({}, window.T, {
+                    attachments: 'Attachments "screenshots"',
+                    incident_date: 'Date "local"'
+                });
+                window.renderJournalTable([{
+                    id: 9001,
+                    date: '2026-05-02',
+                    title: 'Mobile evidence entry with attached screenshots and modem exports',
+                    description: 'Includes screenshots and diagnostics for the support case.',
+                    attachment_count: 2,
+                    icon: 'documentation'
+                }]);
+            }
+            """
+        )
+        mobile_page.locator(".journal-export-wrapper > button").click()
+
+        geometry = mobile_page.evaluate(
+            """
+            () => {
+                const viewportWidth = window.innerWidth;
+                const dropdown = document.querySelector('#journal-export-dropdown');
+                const dropdownRect = dropdown.getBoundingClientRect();
+                const optionRects = Array.from(dropdown.querySelectorAll('button')).map((button) => {
+                    const rect = button.getBoundingClientRect();
+                    return {left: rect.left, right: rect.right, height: rect.height};
+                });
+                const clip = document.querySelector('#journal-tbody tr[data-id] .journal-clip');
+                const clipRect = clip.getBoundingClientRect();
+                return {
+                    viewportWidth,
+                    dropdownLeft: dropdownRect.left,
+                    dropdownRight: dropdownRect.right,
+                    optionRects,
+                    clipDisplay: getComputedStyle(clip).display,
+                    clipText: clip.textContent.trim(),
+                    clipLeft: clipRect.left,
+                    clipRight: clipRect.right,
+                    clipLabel: clip.getAttribute('data-label'),
+                    dateLabel: document.querySelector('#journal-tbody tr[data-id] .journal-date-cell').getAttribute('data-label'),
+                };
+            }
+            """
+        )
+
+        assert geometry["dropdownLeft"] >= 0
+        assert geometry["dropdownRight"] <= geometry["viewportWidth"]
+        assert all(rect["left"] >= 0 and rect["right"] <= geometry["viewportWidth"] for rect in geometry["optionRects"])
+        assert all(rect["height"] >= 40 for rect in geometry["optionRects"])
+        assert geometry["clipDisplay"] == "inline-flex"
+        assert geometry["clipText"] == "📎 2"
+        assert geometry["clipLabel"] == 'Attachments "screenshots"'
+        assert geometry["dateLabel"] == 'Date "local"'
+        assert geometry["clipLeft"] >= 0
+        assert geometry["clipRight"] <= geometry["viewportWidth"]


### PR DESCRIPTION
## Summary
- Improves Incident Journal mobile actions, filter chips, and evidence rows so content stays readable within narrow viewports.
- Converts journal rows into mobile-friendly cards with localized labels and attachment badges.
- Adds mobile regression coverage for action sizing, chip wrapping, bulk selection, export menu fit, and attachment badges.

## Test plan
- `node --check app/static/js/journal.js`
- `./.venv/bin/python -m pytest tests/e2e/test_responsive.py -q`
- `./.venv/bin/python -m pytest tests/e2e/test_modals.py::test_journal_entry_modal_guides_evidence_capture tests/e2e/test_modals.py::test_incident_modal_and_summary_offer_report_path -q`
- `git diff --check`

Closes #396
