### PR TITLE
Add mobile viewport Playwright quality gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,28 @@ jobs:
       - name: Run tests
         run: python -m pytest tests/ -v --tb=short --ignore=tests/e2e
 
+  mobile-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --require-hashes -r requirements-test.txt
+          pip install pytest-playwright==0.7.2 playwright==1.58.0
+          python -m playwright install --with-deps chromium
+
+      - name: Run mobile viewport quality gate
+        run: TZ=UTC python -m pytest -q tests/e2e/test_mobile_quality_gate.py --tb=short
+
   audit:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,20 @@ For the full routing guide, see [SUPPORT.md](SUPPORT.md).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). **Please open an issue or start an Ideas discussion before working on new features.**
 
+### Mobile viewport quality gate
+
+DOCSight includes a focused Playwright gate for mobile regressions across the main blades and high-value modals. It uses an iPhone-sized `393x852` viewport and checks for horizontal overflow, off-screen controls, modal/footer overlap, console errors, and representative 44 px touch targets.
+
+To run the same gate locally:
+
+```bash
+python -m pip install pytest-playwright==0.7.2 playwright==1.58.0
+python -m playwright install chromium
+TZ=UTC python -m pytest -q tests/e2e/test_mobile_quality_gate.py --tb=short
+```
+
+The test does not commit screenshot artifacts by default. Use the broader E2E suite when changing shared modal, navigation, chart, or journal behavior.
+
 ## Roadmap
 
 See the **[full roadmap](https://github.com/itsDNNS/docsight/wiki/Roadmap)** in the wiki for long-term goals and modem support plans.

--- a/app/static/css/modals.css
+++ b/app/static/css/modals.css
@@ -74,6 +74,7 @@
     flex-direction: column;
     border: 1px solid var(--glass-border);
     box-shadow: var(--shadow-lg);
+    box-sizing: border-box;
 }
 
 .modal-header {
@@ -174,6 +175,18 @@
 }
 .report-builder-privacy strong { color: var(--text); }
 @media (max-width: 720px) {
+    .modal {
+        width: calc(100% - 24px);
+        max-height: calc(100vh - 24px);
+        padding: var(--space-md);
+    }
+    .modal-footer {
+        flex-wrap: wrap;
+    }
+    .modal-footer .btn {
+        min-width: 0;
+        white-space: normal;
+    }
     .report-builder-preview { grid-template-columns: 1fr; }
 }
 .modal-body textarea {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2194,52 +2194,52 @@
             <h2 id="export-modal-title">{{ t.export_title }}</h2>
             <button class="modal-close" onclick="closeExportModal()" aria-label="{{ t.close }}">&times;</button>
         </div>
-        <p class="modal-hint">{{ t.export_hint }}</p>
-        <div class="export-privacy-note">
-            <strong>{{ t.get('export_privacy_title', 'Generated locally') }}</strong>
-            <span>{{ t.get('export_privacy_text', 'DOCSight builds this export in your browser from local monitoring data. You decide where to paste or upload it.') }}</span>
-        </div>
-        <div class="export-mode-selector" role="radiogroup" aria-label="{{ t.get('export_scope_label', 'Export scope') }}">
-            <label>
-                <input type="radio" name="export-mode" value="full" checked onchange="exportForLLM()">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18"/><path d="M18.7 8l-5.1 5.2-2.8-2.7L7 14.3"/></svg>
-                {{ t.export_full }}
-            </label>
-            <label>
-                <input type="radio" name="export-mode" value="update" onchange="exportForLLM()">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-                {{ t.export_update }}
-            </label>
-        </div>
-        <div class="export-scope-grid">
-            <section class="export-scope-card">
-                <h3>{{ t.get('export_included_title', 'Included in this export') }}</h3>
-                <ul>
-                    <li>{{ t.get('export_included_signal', 'DOCSIS signal summary') }}</li>
-                    <li>{{ t.get('export_included_channels', 'Downstream and upstream channel tables') }}</li>
-                    <li>{{ t.get('export_included_history', 'Recent events, speedtests, incidents, and reference thresholds when available') }}</li>
-                </ul>
-            </section>
-            <section class="export-scope-card">
-                <h3>{{ t.get('export_excluded_title', 'Excluded by default') }}</h3>
-                <ul>
-                    <li>{{ t.get('export_excluded_remote', 'Remote upload to AI services') }}</li>
-                    <li>{{ t.get('export_excluded_credentials', 'Admin passwords, API tokens, and DOCSight credentials') }}</li>
-                    <li>{{ t.get('export_excluded_raw_logs', 'Raw logs or files outside the generated diagnostic summary') }}</li>
-                </ul>
-            </section>
-        </div>
-        <fieldset class="export-redaction-controls">
-            <legend>{{ t.get('export_redaction_title', 'Redaction controls') }}</legend>
-            <label><input type="checkbox" id="export-redact-ips" onchange="refreshExportPreview()"> {{ t.get('export_redact_ips', 'Redact IP addresses') }}</label>
-            <label><input type="checkbox" id="export-redact-hostnames" onchange="refreshExportPreview()"> {{ t.get('export_redact_hostnames', 'Redact hostnames') }}</label>
-            <label><input type="checkbox" id="export-redact-customers" onchange="refreshExportPreview()"> {{ t.get('export_redact_customers', 'Redact account or customer details') }}</label>
-        </fieldset>
-        <div class="export-output-meta">
-            <span id="export-size-indicator">0 {{ t.get('export_size_characters', 'characters') }}</span>
-            <span id="export-status" role="status" aria-live="polite"></span>
-        </div>
-        <div class="modal-body">
+        <div class="modal-body export-modal-body">
+            <p class="modal-hint">{{ t.export_hint }}</p>
+            <div class="export-privacy-note">
+                <strong>{{ t.get('export_privacy_title', 'Generated locally') }}</strong>
+                <span>{{ t.get('export_privacy_text', 'DOCSight builds this export in your browser from local monitoring data. You decide where to paste or upload it.') }}</span>
+            </div>
+            <div class="export-mode-selector" role="radiogroup" aria-label="{{ t.get('export_scope_label', 'Export scope') }}">
+                <label>
+                    <input type="radio" name="export-mode" value="full" checked onchange="exportForLLM()">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18"/><path d="M18.7 8l-5.1 5.2-2.8-2.7L7 14.3"/></svg>
+                    {{ t.export_full }}
+                </label>
+                <label>
+                    <input type="radio" name="export-mode" value="update" onchange="exportForLLM()">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                    {{ t.export_update }}
+                </label>
+            </div>
+            <div class="export-scope-grid">
+                <section class="export-scope-card">
+                    <h3>{{ t.get('export_included_title', 'Included in this export') }}</h3>
+                    <ul>
+                        <li>{{ t.get('export_included_signal', 'DOCSIS signal summary') }}</li>
+                        <li>{{ t.get('export_included_channels', 'Downstream and upstream channel tables') }}</li>
+                        <li>{{ t.get('export_included_history', 'Recent events, speedtests, incidents, and reference thresholds when available') }}</li>
+                    </ul>
+                </section>
+                <section class="export-scope-card">
+                    <h3>{{ t.get('export_excluded_title', 'Excluded by default') }}</h3>
+                    <ul>
+                        <li>{{ t.get('export_excluded_remote', 'Remote upload to AI services') }}</li>
+                        <li>{{ t.get('export_excluded_credentials', 'Admin passwords, API tokens, and DOCSight credentials') }}</li>
+                        <li>{{ t.get('export_excluded_raw_logs', 'Raw logs or files outside the generated diagnostic summary') }}</li>
+                    </ul>
+                </section>
+            </div>
+            <fieldset class="export-redaction-controls">
+                <legend>{{ t.get('export_redaction_title', 'Redaction controls') }}</legend>
+                <label><input type="checkbox" id="export-redact-ips" onchange="refreshExportPreview()"> {{ t.get('export_redact_ips', 'Redact IP addresses') }}</label>
+                <label><input type="checkbox" id="export-redact-hostnames" onchange="refreshExportPreview()"> {{ t.get('export_redact_hostnames', 'Redact hostnames') }}</label>
+                <label><input type="checkbox" id="export-redact-customers" onchange="refreshExportPreview()"> {{ t.get('export_redact_customers', 'Redact account or customer details') }}</label>
+            </fieldset>
+            <div class="export-output-meta">
+                <span id="export-size-indicator">0 {{ t.get('export_size_characters', 'characters') }}</span>
+                <span id="export-status" role="status" aria-live="polite"></span>
+            </div>
             <textarea id="export-text" readonly aria-label="{{ t.get('export_preview_label', 'Export preview') }}"></textarea>
         </div>
         <div class="modal-footer">

--- a/tests/e2e/test_mobile_quality_gate.py
+++ b/tests/e2e/test_mobile_quality_gate.py
@@ -1,0 +1,235 @@
+"""Focused mobile viewport quality gate for high-value DOCSight surfaces."""
+
+from playwright.sync_api import expect
+
+MOBILE_VIEWPORT = {"width": 393, "height": 852}
+MAX_HORIZONTAL_OVERFLOW = 1
+MIN_TOUCH_TARGET = 44
+
+
+MAIN_BLADES = [
+    ("Home", "live", "#view-dashboard"),
+    ("Event Log", "events", "#view-events"),
+    ("Channels", "channels", "#view-channels"),
+    ("Signal Trends", "trends", "#view-trends"),
+    ("Correlation", "correlation", "#view-correlation"),
+    ("Connection Monitor", "connection-monitor", "#view-connection-monitor"),
+    ("Segment Utilization", "segment-utilization", "#view-segment-utilization"),
+    ("Before/After Comparison", "comparison", "#view-comparison"),
+    ("Gaming Quality", "gaming", "#view-gaming"),
+    ("Modulation Performance", "modulation", "#view-modulation"),
+    ("Speedtest", "speedtest", "#view-speedtest"),
+    ("BQM", "bqm", "#view-bqm"),
+    ("SmokePing", "smokeping", "#view-smokeping"),
+    ("BNetzA", "bnetz", "#view-bnetz"),
+    ("Incident Journal", "journal", "#view-journal"),
+]
+
+MODALS = [
+    ("Report evidence builder", "openReportModal()", "#report-modal"),
+    ("AI export", "exportForLLM()", "#export-modal"),
+    ("Speedtest setup", "openSpeedtestSetupModal()", "#speedtest-setup-modal"),
+    ("BQM setup", "openBqmSetupModal()", "#bqm-setup-modal"),
+    ("SmokePing setup", "openSmokepingSetupModal()", "#smokeping-setup-modal"),
+    ("BQM image import", "openBqmImportModal()", "#bqm-import-modal"),
+    ("Journal entry", "openEntryModal()", "#entry-modal"),
+    ("Incident container", "openIncidentModal()", "#incident-container-modal"),
+    ("Journal import", "openImportModal()", "#import-modal"),
+]
+
+
+def _record_console_error(errors):
+    def _handler(msg):
+        if msg.type != "error":
+            return
+        # Chromium reports failed image/network resources as console errors without a
+        # stable URL in the message. The gate tracks JavaScript/page errors as
+        # blockers and lets surface geometry assertions catch visible breakage.
+        if msg.text.startswith("Failed to load resource:"):
+            return
+        errors.append(msg.text)
+    return _handler
+
+
+def _assert_no_browser_errors(page, console_errors, page_errors, surface):
+    assert console_errors == [], f"{surface} console errors: {console_errors}"
+    assert page_errors == [], f"{surface} page errors: {page_errors}"
+
+
+def _assert_no_horizontal_overflow(page, surface, root_selector=None):
+    geometry = page.evaluate(
+        """
+        (selector) => {
+            const root = selector ? document.querySelector(selector) : document.documentElement;
+            const activeView = document.querySelector('.view.active');
+            return {
+                documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+                bodyOverflow: document.body.scrollWidth - window.innerWidth,
+                rootOverflow: root ? root.scrollWidth - root.clientWidth : 0,
+                activeViewOverflow: activeView ? activeView.scrollWidth - activeView.clientWidth : 0,
+            };
+        }
+        """,
+        root_selector,
+    )
+    offenders = {key: value for key, value in geometry.items() if value > MAX_HORIZONTAL_OVERFLOW}
+    assert offenders == {}, f"{surface} horizontal overflow: {offenders}"
+
+
+def _assert_visible_controls_stay_in_view(page, surface, root_selector):
+    controls = page.locator(
+        f"{root_selector} button, {root_selector} a[href], {root_selector} input, "
+        f"{root_selector} select, {root_selector} textarea, {root_selector} [role='button']"
+    ).evaluate_all(
+        """
+        (nodes) => nodes.map((node) => {
+            const rect = node.getBoundingClientRect();
+            const style = getComputedStyle(node);
+            return {
+                text: (node.textContent || node.getAttribute('aria-label') || node.id || node.className || node.tagName).trim(),
+                left: rect.left,
+                right: rect.right,
+                width: rect.width,
+                height: rect.height,
+                visible: style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0,
+                viewportWidth: window.innerWidth,
+            };
+        }).filter((item) => item.visible)
+        """
+    )
+    offscreen = [
+        control for control in controls
+        if control["left"] < -MAX_HORIZONTAL_OVERFLOW
+        or control["right"] > control["viewportWidth"] + MAX_HORIZONTAL_OVERFLOW
+    ]
+    assert offscreen == [], f"{surface} off-screen controls: {offscreen}"
+
+
+def _assert_touch_targets(page, surface, selector):
+    targets = page.locator(selector).evaluate_all(
+        """
+        (nodes) => nodes.map((node) => {
+            const rect = node.getBoundingClientRect();
+            const style = getComputedStyle(node);
+            return {
+                text: (node.textContent || node.getAttribute('aria-label') || node.id || node.className || node.tagName).trim(),
+                width: rect.width,
+                height: rect.height,
+                left: rect.left,
+                right: rect.right,
+                visible: style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0,
+                bottom: rect.bottom,
+                viewportWidth: window.innerWidth,
+                viewportHeight: window.innerHeight,
+            };
+        }).filter((item) => item.visible)
+        """
+    )
+    assert targets, f"{surface} expected visible touch targets for {selector}"
+    too_small = [target for target in targets if target["width"] < MIN_TOUCH_TARGET or target["height"] < MIN_TOUCH_TARGET]
+    offscreen = [
+        target for target in targets
+        if target["left"] < -MAX_HORIZONTAL_OVERFLOW
+        or target["right"] > target["viewportWidth"] + MAX_HORIZONTAL_OVERFLOW
+        or target["bottom"] > target["viewportHeight"] + MAX_HORIZONTAL_OVERFLOW
+    ]
+    assert too_small == [], f"{surface} small touch targets: {too_small}"
+    assert offscreen == [], f"{surface} off-screen touch targets: {offscreen}"
+
+
+def _close_modal(page, selector):
+    page.keyboard.press("Escape")
+    expect(page.locator(selector)).not_to_be_visible()
+
+
+def test_mobile_main_blades_have_no_overflow_or_offscreen_controls(demo_page):
+    """Main mobile blades should fit a modern phone viewport without hidden horizontal controls."""
+    page = demo_page
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    console_errors = []
+    page_errors = []
+    page.on("console", _record_console_error(console_errors))
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+    page.reload()
+    page.wait_for_load_state("networkidle")
+
+    for label, view, selector in MAIN_BLADES:
+        if page.locator(f'.nav-item[data-view="{view}"]').count() == 0:
+            continue
+        page.evaluate("view => switchView(view)", view)
+        page.wait_for_selector(f"{selector}.active", state="visible")
+        _assert_no_browser_errors(page, console_errors, page_errors, label)
+        _assert_no_horizontal_overflow(page, label, selector)
+        _assert_visible_controls_stay_in_view(page, label, selector)
+
+
+def test_mobile_navigation_and_high_value_modals_pass_quality_gate(demo_page):
+    """Mobile nav and key modals should expose controls without footer overlap or off-screen targets."""
+    page = demo_page
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    console_errors = []
+    page_errors = []
+    page.on("console", _record_console_error(console_errors))
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+    page.reload()
+    page.wait_for_load_state("networkidle")
+
+    sidebar = page.locator("#sidebar")
+    hamburger = page.locator("#hamburger")
+    expect(sidebar).to_have_attribute("aria-hidden", "true")
+    hidden_focus_targets = page.evaluate(
+        """
+        () => Array.from(document.querySelectorAll(
+            '#sidebar a[href], #sidebar button, #sidebar input, #sidebar [role="button"], #sidebar [tabindex]'
+        )).filter((el) => !el.disabled && el.getAttribute('tabindex') !== '-1')
+          .map((el) => el.textContent.trim() || el.id || el.getAttribute('data-view'))
+        """
+    )
+    assert hidden_focus_targets == []
+    hamburger.focus()
+    hamburger.click()
+    page.wait_for_timeout(300)
+    expect(sidebar).to_have_attribute("aria-hidden", "false")
+    _assert_visible_controls_stay_in_view(page, "open mobile navigation", "#sidebar")
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(300)
+    expect(sidebar).to_have_attribute("aria-hidden", "true")
+    assert page.evaluate("document.activeElement && document.activeElement.id") == "hamburger"
+
+    page.evaluate("switchView('journal')")
+    page.wait_for_selector("#view-journal.active", state="visible")
+    for label, opener, selector in MODALS:
+        if page.locator(selector).count() == 0:
+            continue
+        page.evaluate(opener)
+        modal = page.locator(selector)
+        expect(modal).to_be_visible()
+        page.wait_for_timeout(100)
+        if modal.locator(".modal-body").count() > 0:
+            modal.locator(".modal-body").evaluate("el => { el.scrollTop = el.scrollHeight; }")
+            body_height = modal.locator(".modal-body").evaluate("el => el.getBoundingClientRect().height")
+            body_scroll_height = modal.locator(".modal-body").evaluate("el => el.scrollHeight")
+            if body_scroll_height > 0:
+                assert body_height >= 96, f"{label} modal body is crowded by surrounding content"
+        _assert_no_browser_errors(page, console_errors, page_errors, label)
+        _assert_no_horizontal_overflow(page, label, selector)
+        _assert_visible_controls_stay_in_view(page, label, selector)
+        _assert_touch_targets(page, label, f"{selector} .modal-close, {selector} .modal-footer .btn")
+        if modal.locator(".setup-guide-card:last-child").count() > 0:
+            spacing = modal.evaluate(
+                """
+                (el) => {
+                    const footer = el.querySelector('.modal-footer');
+                    const body = el.querySelector('.modal-body');
+                    const last = body.querySelector('.setup-guide-card:last-child');
+                    return {
+                        lastBottom: last.getBoundingClientRect().bottom,
+                        bodyBottom: body.getBoundingClientRect().bottom,
+                        footerTop: footer.getBoundingClientRect().top,
+                    };
+                }
+                """
+            )
+            assert spacing["lastBottom"] <= spacing["footerTop"] - 8, f"{label} footer covers content"
+            assert spacing["bodyBottom"] <= spacing["footerTop"] - 8, f"{label} body overlaps footer"
+        _close_modal(page, selector)

--- a/tests/test_mobile_quality_gate_ci.py
+++ b/tests/test_mobile_quality_gate_ci.py
@@ -1,0 +1,28 @@
+"""Regression checks for the mobile viewport quality gate wiring."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+README = ROOT / "README.md"
+
+
+def test_ci_runs_focused_mobile_viewport_quality_gate():
+    """CI should run the dedicated mobile Playwright gate on PRs and main pushes."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "mobile-e2e:" in workflow
+    assert "pytest-playwright==0.7.2" in workflow
+    assert "playwright==1.58.0" in workflow
+    assert "python -m playwright install --with-deps chromium" in workflow
+    assert "tests/e2e/test_mobile_quality_gate.py" in workflow
+
+
+def test_mobile_quality_gate_is_documented_for_local_runs():
+    """Developers should have a local command for the same mobile gate CI uses."""
+    readme = README.read_text(encoding="utf-8")
+
+    assert "Mobile viewport quality gate" in readme
+    assert "pytest-playwright==0.7.2 playwright==1.58.0" in readme
+    assert "pytest -q tests/e2e/test_mobile_quality_gate.py" in readme


### PR DESCRIPTION
## Summary
- Adds a dedicated mobile Playwright quality gate for primary blades, mobile navigation, high-value modals, touch targets, overflow, and console/page errors.
- Wires the gate into CI and documents the local reproduction command.
- Keeps export modal content in a scrollable mobile body so footer actions remain visible without squeezing the preview area.

## Validation
- `python -m pytest tests/test_mobile_quality_gate_ci.py tests/e2e/test_mobile_quality_gate.py tests/e2e/test_responsive.py::TestMobileLayout::test_closed_mobile_sidebar_removes_nav_from_tab_order tests/e2e/test_responsive.py::TestMobileLayout::test_mobile_sidebar_focus_moves_in_and_returns_on_escape tests/e2e/test_modals.py::test_guided_setup_modal_footers_do_not_cover_mobile_content -q --tb=short`
- `python -m pytest tests/ -q --tb=short --ignore=tests/e2e`
- `actionlint .github/workflows/test.yml`
- `git diff --check`

Closes #399
