### PR TITLE
Contain guided setup cards on mobile

### DIFF
--- a/app/static/css/modals.css
+++ b/app/static/css/modals.css
@@ -432,12 +432,16 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--space-sm);
     padding: var(--space-sm) 0;
+    min-width: 0;
+    max-width: 100%;
 }
 .setup-guide-card {
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     background: var(--surface);
     padding: var(--space-md);
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 .setup-guide-card h3 {
     margin: 0 0 var(--space-xs);
@@ -466,6 +470,7 @@
     font-family: var(--font-mono);
     font-size: 0.82em;
     white-space: nowrap;
+    max-width: 100%;
 }
 .setup-validation-status {
     min-height: 1.4em;
@@ -476,8 +481,12 @@
 .setup-validation-status.is-error { color: var(--danger, #ff6b6b); }
 .setup-validation-status.is-progress { color: var(--accent); }
 @media (max-width: 720px) {
-    .setup-guide-body { grid-template-columns: 1fr; }
-    .setup-guide-command code { white-space: pre-wrap; }
+    .setup-guide-body { grid-template-columns: minmax(0, 1fr); }
+    .setup-guide-command code {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
     .setup-guide-modal .modal-footer {
         justify-content: stretch;
     }

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -323,19 +323,32 @@ def test_guided_setup_modal_footers_do_not_cover_mobile_content(demo_page):
                 const bodyRect = body.getBoundingClientRect();
                 const lastRect = lastCard.getBoundingClientRect();
                 const footerStyle = getComputedStyle(footer);
+                const overflowingCards = Array.from(body.querySelectorAll('.setup-guide-card')).filter((card) => {
+                    const rect = card.getBoundingClientRect();
+                    return rect.left < -1 || rect.right > window.innerWidth + 1;
+                }).map((card) => card.querySelector('h3')?.textContent?.trim() || card.textContent.trim().slice(0, 40));
                 return {
                     lastCardBottom: lastRect.bottom,
                     footerTop: footerRect.top,
                     bodyBottom: bodyRect.bottom,
+                    bodyHeight: bodyRect.height,
+                    bodyOverflow: body.scrollWidth - body.clientWidth,
+                    overflowingCards,
+                    footerBottom: footerRect.bottom,
                     footerWraps: footerRect.height >= 44,
                     footerFlexWrap: footerStyle.flexWrap,
+                    viewportHeight: window.innerHeight,
                 };
             }
             """
         )
 
+        assert geometry["bodyHeight"] >= 96
+        assert geometry["bodyOverflow"] <= 1
+        assert geometry["overflowingCards"] == []
         assert geometry["lastCardBottom"] <= geometry["footerTop"] - 8
         assert geometry["bodyBottom"] <= geometry["footerTop"] - 8
+        assert geometry["footerBottom"] <= geometry["viewportHeight"]
         assert geometry["footerWraps"] is True
         assert geometry["footerFlexWrap"] == "wrap"
 


### PR DESCRIPTION
## Summary
- Keeps guided setup modal cards constrained to the mobile modal width
- Wraps long setup command/URL examples on narrow screens instead of expanding the grid
- Extends the mobile modal regression to catch body overflow, off-screen cards, footer viewport fit, and usable body height

Refs #397

## Test plan
- `TZ=UTC ./.venv/bin/python -m pytest -q tests/e2e/test_modals.py::test_guided_setup_modal_footers_do_not_cover_mobile_content --tb=short`
- `TZ=UTC ./.venv/bin/python -m pytest -q tests/e2e/test_modals.py::test_guided_setup_modal_footers_do_not_cover_mobile_content tests/e2e/test_modals.py::test_integration_setup_modals_are_guided_and_actionable --tb=short`
- `TZ=UTC ./.venv/bin/python -m pytest -q tests/e2e/test_responsive.py::TestMobileLayout::test_closed_mobile_sidebar_removes_nav_from_tab_order tests/e2e/test_responsive.py::TestMobileLayout::test_mobile_sidebar_focus_moves_in_and_returns_on_escape --tb=short`
- `TZ=UTC ./.venv/bin/python -m pytest -q tests/e2e/test_mobile_quality_gate.py --tb=short`
- `git diff --check`
