### PR TITLE
Polish mobile sidebar drawer

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -59,10 +59,10 @@
   top: 0; left: 0; bottom: 0;
   width: 260px;
   max-width: calc(100vw - 56px);
-  background:
+  background-color: var(--void-deep);
+  background-image:
     radial-gradient(ellipse at 20% 0%, color-mix(in srgb, var(--accent) 8%, transparent), transparent 60%),
-    radial-gradient(ellipse at 80% 100%, color-mix(in srgb, var(--info) 6%, transparent), transparent 60%),
-    color-mix(in srgb, var(--void-deep) 85%, transparent);
+    radial-gradient(ellipse at 80% 100%, color-mix(in srgb, var(--info) 6%, transparent), transparent 60%);
   border-right: 1px solid var(--glass-border);
   display: flex;
   flex-direction: column;
@@ -77,7 +77,8 @@
 .sidebar.open { transform: translateX(0); }
 
 .sidebar-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--space-xs);
   padding: var(--space-sm) var(--space-sm) var(--space-md);
@@ -96,8 +97,23 @@
   flex-shrink: 0;
 }
 .sidebar-logo img { width: 32px; height: 32px; }
+.sidebar-brand-text { min-width: 0; }
 .sidebar-title { font-size: 0.92rem; font-weight: 700; letter-spacing: -0.02em; }
 .sidebar-subtitle { font-size: 0.7rem; color: var(--text-muted); }
+.sidebar-close {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.sidebar-close svg { width: 18px; height: 18px; }
+.sidebar-close:focus-visible { outline: 2px solid var(--amethyst); outline-offset: 2px; }
 
 .sidebar-content {
   flex: 1;
@@ -834,6 +850,24 @@ body.is-offline .offline-banner { display: flex; }
 /* ══════════════════════════════════════════════════════════════════
    RESPONSIVE -- TABLET & DESKTOP
    ══════════════════════════════════════════════════════════════════ */
+
+@media (max-width: 1023px) {
+  .sidebar {
+    background-color: var(--void-deep);
+  }
+  .sidebar-close {
+    display: inline-flex;
+  }
+  .sidebar-content {
+    padding-bottom: calc(var(--space-xl) + var(--safe-bottom));
+  }
+  .nav-item {
+    min-height: 44px;
+    white-space: normal;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+  }
+}
 
 /* Tablet: 2 columns */
 @media (min-width: 640px) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -62,10 +62,13 @@
 <nav class="sidebar" id="sidebar" aria-label="Main navigation" aria-hidden="true">
     <div class="sidebar-header">
         <div class="sidebar-logo"><img src="/static/logo.svg" alt="DOCSight" width="18" height="18"></div>
-        <div>
+        <div class="sidebar-brand-text">
             <div class="sidebar-title">DOCSight</div>
             <div class="sidebar-subtitle">{{ t.sidebar_monitoring }}</div>
         </div>
+        <button type="button" class="sidebar-close" onclick="closeSidebar()" aria-label="{{ t.get('close_menu', 'Close menu') }}">
+            <i data-lucide="x"></i>
+        </button>
     </div>
     <div class="sidebar-content">
         <!-- Primary navigation -->
@@ -2464,6 +2467,8 @@ var TEMPERATURE_UNIT = {{ temperature_unit|tojson }};
 
     function focusFirstSidebarItem() {
         var first = getSidebarFocusables().find(function(el) {
+            return el.classList && el.classList.contains('nav-item') && !el.disabled && el.offsetParent !== null;
+        }) || getSidebarFocusables().find(function(el) {
             return !el.disabled && el.offsetParent !== null;
         });
         if (first) first.focus({ preventScroll: true });

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -73,6 +73,46 @@ class TestMobileLayout:
         assert mobile_page.locator("#sidebar").get_attribute("aria-hidden") == "true"
         assert mobile_page.evaluate("document.activeElement && document.activeElement.id") == "hamburger"
 
+    def test_mobile_sidebar_close_control_and_labels_are_touch_friendly(self, mobile_page):
+        """Mobile drawer should have an obvious close control and contained labels."""
+        hamburger = mobile_page.locator("#hamburger")
+        hamburger.focus()
+        hamburger.click()
+        mobile_page.wait_for_timeout(300)
+
+        close_button = mobile_page.get_by_role("button", name="Close menu")
+        assert close_button.is_visible()
+        close_box = close_button.bounding_box()
+        assert close_box is not None
+        assert close_box["width"] >= 44
+        assert close_box["height"] >= 44
+
+        sidebar_geometry = mobile_page.locator("#sidebar").evaluate(
+            """
+            (sidebar) => {
+                const sidebarRect = sidebar.getBoundingClientRect();
+                const items = Array.from(sidebar.querySelectorAll('.nav-item'));
+                const overflowingItems = items.filter((item) => item.scrollWidth - item.clientWidth > 1).map((item) => item.textContent.trim());
+                return {
+                    background: getComputedStyle(sidebar).backgroundColor,
+                    overflowingItems,
+                    outsideItems: items.filter((item) => {
+                        const rect = item.getBoundingClientRect();
+                        return rect.left < sidebarRect.left - 1 || rect.right > sidebarRect.right + 1;
+                    }).map((item) => item.textContent.trim()),
+                };
+            }
+            """
+        )
+        assert sidebar_geometry["overflowingItems"] == []
+        assert sidebar_geometry["outsideItems"] == []
+        assert "rgba" not in sidebar_geometry["background"]
+
+        close_button.click()
+        mobile_page.wait_for_timeout(300)
+        assert mobile_page.locator("#sidebar").get_attribute("aria-hidden") == "true"
+        assert mobile_page.evaluate("document.activeElement && document.activeElement.id") == "hamburger"
+
     def test_primary_nav_items_in_sidebar(self, mobile_page):
         mobile_page.locator("#hamburger").click()
         mobile_page.wait_for_timeout(300)


### PR DESCRIPTION
## Summary
- Adds a visible mobile drawer close control with a 44px touch target
- Keeps mobile sidebar labels contained and readable within the drawer
- Makes the mobile drawer panel more solid so dashboard content does not bleed through

## Test plan
- `python3 -m pytest tests/e2e/test_responsive.py::TestMobileLayout::test_mobile_sidebar_close_control_and_labels_are_touch_friendly -q --tb=short` (fails before fix)
- `.venv/bin/python -m pytest tests/e2e/test_responsive.py::TestMobileLayout::test_mobile_sidebar_close_control_and_labels_are_touch_friendly tests/e2e/test_responsive.py::TestMobileLayout::test_mobile_sidebar_focus_moves_in_and_returns_on_escape -q --tb=short`
- `.venv/bin/python -m pytest tests/e2e/test_responsive.py::TestMobileLayout::test_closed_mobile_sidebar_removes_nav_from_tab_order tests/e2e/test_responsive.py::TestMobileLayout::test_mobile_sidebar_focus_moves_in_and_returns_on_escape tests/e2e/test_responsive.py::TestMobileLayout::test_mobile_sidebar_close_control_and_labels_are_touch_friendly tests/e2e/test_modals.py::test_guided_setup_modal_footers_do_not_cover_mobile_content -q --tb=short`
- `.venv/bin/python -m pytest tests/e2e/test_responsive.py tests/e2e/test_modals.py::test_guided_setup_modal_footers_do_not_cover_mobile_content tests/e2e/test_mobile_quality_gate.py -q --tb=short`
- `node --check /tmp/docsight-inline-main.js`
- `git diff --check`
- iPhone-sized Playwright smoke for sidebar and guided setup modal geometry; browser console showed no errors

Refs #394
