### PR TITLE
Replace event log table mode with CSV export

### DIFF
--- a/app/blueprints/events_bp.py
+++ b/app/blueprints/events_bp.py
@@ -1,8 +1,12 @@
 """Event log routes."""
 
+import csv
+import io
+import json
 import logging
+from datetime import datetime, timezone
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, Response
 
 from app.web import (
     require_auth,
@@ -12,7 +16,71 @@ from app.web import (
 
 log = logging.getLogger("docsis.web")
 
+_EVENTS_EXPORT_LIMIT = 10000
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
 events_bp = Blueprint("events_bp", __name__)
+
+
+def _acknowledged_from_request():
+    ack_param = request.args.get("acknowledged")
+    if ack_param is None or ack_param == "":
+        return None
+    try:
+        acknowledged = int(ack_param)
+    except ValueError as exc:
+        raise ValueError("acknowledged must be 0 or 1") from exc
+    if acknowledged not in (0, 1):
+        raise ValueError("acknowledged must be 0 or 1")
+    return acknowledged
+
+
+def _event_filters_from_request():
+    return {
+        "severity": request.args.get("severity") or None,
+        "event_type": request.args.get("event_type") or None,
+        "event_prefix": request.args.get("event_prefix") or None,
+        "acknowledged": _acknowledged_from_request(),
+        "exclude_operational": request.args.get("exclude_operational", "false").lower() == "true",
+    }
+
+
+def _csv_cell(value):
+    if value is None:
+        return ""
+    text = str(value)
+    if text.startswith(_CSV_FORMULA_PREFIXES):
+        return "'" + text
+    return text
+
+
+def _events_csv_response(events, truncated=False):
+    output = io.StringIO(newline="")
+    fieldnames = ["timestamp", "severity", "event_type", "message", "acknowledged", "details"]
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    for event in events:
+        details = event.get("details")
+        details_text = json.dumps(details, ensure_ascii=False, sort_keys=True) if details else ""
+        writer.writerow({
+            "timestamp": _csv_cell(event.get("timestamp", "")),
+            "severity": _csv_cell(event.get("severity", "")),
+            "event_type": _csv_cell(event.get("event_type", "")),
+            "message": _csv_cell(event.get("message", "")),
+            "acknowledged": "true" if event.get("acknowledged") else "false",
+            "details": _csv_cell(details_text),
+        })
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%SZ")
+    return Response(
+        output.getvalue(),
+        mimetype="text/csv",
+        headers={
+            "Content-Disposition": f"attachment; filename=docsight-events-{stamp}.csv",
+            "X-DOCSight-Export-Limit": str(_EVENTS_EXPORT_LIMIT),
+            "X-DOCSight-Export-Truncated": "true" if truncated else "false",
+        },
+    )
 
 
 @events_bp.route("/api/events", methods=["GET"])
@@ -24,26 +92,48 @@ def api_events_list():
         return jsonify({"events": [], "unacknowledged_count": 0})
     limit = request.args.get("limit", 200, type=int)
     offset = request.args.get("offset", 0, type=int)
-    severity = request.args.get("severity") or None
-    event_type = request.args.get("event_type") or None
-    ack_param = request.args.get("acknowledged")
-    acknowledged = int(ack_param) if ack_param is not None and ack_param != "" else None
-    event_prefix = request.args.get("event_prefix") or None
-    exclude_operational = request.args.get("exclude_operational", "false").lower() == "true"
+    try:
+        filters = _event_filters_from_request()
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
     events = _storage.get_events(
-        limit=limit, offset=offset, severity=severity,
-        event_type=event_type, acknowledged=acknowledged,
-        exclude_operational=exclude_operational, event_prefix=event_prefix
+        limit=limit, offset=offset, severity=filters["severity"],
+        event_type=filters["event_type"], acknowledged=filters["acknowledged"],
+        exclude_operational=filters["exclude_operational"], event_prefix=filters["event_prefix"]
     )
     unack = _storage.get_event_count(
         acknowledged=0,
-        exclude_operational=exclude_operational,
-        event_prefix=event_prefix,
-        severity=severity
+        exclude_operational=filters["exclude_operational"],
+        event_prefix=filters["event_prefix"],
+        severity=filters["severity"]
     )
     _localize_timestamps(events)
     return jsonify({"events": events, "unacknowledged_count": unack})
+
+
+@events_bp.route("/api/events/export.csv", methods=["GET"])
+@require_auth
+def api_events_export_csv():
+    """Export all events matching the current event-log filters as CSV."""
+    _storage = get_storage()
+    if not _storage:
+        return _events_csv_response([])
+    try:
+        filters = _event_filters_from_request()
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    events = _storage.get_events(
+        limit=_EVENTS_EXPORT_LIMIT + 1,
+        offset=0,
+        severity=filters["severity"],
+        event_type=filters["event_type"],
+        acknowledged=filters["acknowledged"],
+        exclude_operational=filters["exclude_operational"],
+        event_prefix=filters["event_prefix"],
+    )
+    truncated = len(events) > _EVENTS_EXPORT_LIMIT
+    return _events_csv_response(events[:_EVENTS_EXPORT_LIMIT], truncated=truncated)
 
 
 @events_bp.route("/api/events/count", methods=["GET"])

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -321,9 +321,6 @@
   "event_type_modem_restart_detected": "Modem-Neustart erkannt",
   "event_type_error_spike": "Fehleranstieg",
   "event_acknowledged": "Bestätigt",
-  "event_view_mode": "Ereignisansicht",
-  "event_view_feed": "Feed",
-  "event_view_table": "Tabelle",
   "event_all_severities": "Alle Schweregrade",
   "event_all_types": "Alle Typen",
   "sidebar_monitoring": "Überwachung",
@@ -967,5 +964,6 @@
   "bqm_import_validation_choose": "Wähle PNG- oder JPEG-BQM-Grafiken. DOCSight zeigt die Daten vor dem Import als Vorschau.",
   "bqm_import_validation_unsupported": "Nicht unterstützter Dateityp. Nur PNG- und JPEG-Bilder werden unterstützt.",
   "bqm_import_validation_ready": "{0} bereit",
-  "bqm_import_validation_dates": "{0} benötigt ein Datum"
+  "bqm_import_validation_dates": "{0} benötigt ein Datum",
+  "event_export_csv": "CSV exportieren"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -321,9 +321,6 @@
   "event_type_modem_restart_detected": "Modem restart detected",
   "event_type_error_spike": "Error Spike",
   "event_acknowledged": "Acknowledged",
-  "event_view_mode": "Event view mode",
-  "event_view_feed": "Feed",
-  "event_view_table": "Table",
   "event_all_severities": "All Severities",
   "event_all_types": "All Types",
   "sidebar_monitoring": "Monitoring",
@@ -967,5 +964,6 @@
   "bqm_import_validation_choose": "Choose PNG or JPEG BQM graph images. DOCSight will preview dates before importing.",
   "bqm_import_validation_unsupported": "Unsupported file type. Only PNG and JPEG images are supported.",
   "bqm_import_validation_ready": "{0} ready",
-  "bqm_import_validation_dates": "{0} needs a date"
+  "bqm_import_validation_dates": "{0} needs a date",
+  "event_export_csv": "Export CSV"
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -316,9 +316,6 @@
   "event_type_device_reboot": "Reinicio",
   "event_type_device_ip_change": "Cambio de IP",
   "event_acknowledged": "Confirmado",
-  "event_view_mode": "Modo de vista de eventos",
-  "event_view_feed": "Feed",
-  "event_view_table": "Tabla",
   "event_all_severities": "Todas las severidades",
   "event_all_types": "Todos los tipos",
   "sidebar_monitoring": "Monitoreo",
@@ -962,5 +959,6 @@
   "bqm_import_validation_choose": "Seleccione imagenes BQM PNG o JPEG. DOCSight previsualizara las fechas antes de importar.",
   "bqm_import_validation_unsupported": "Tipo de archivo no compatible. Solo se admiten imagenes PNG y JPEG.",
   "bqm_import_validation_ready": "{0} listas",
-  "bqm_import_validation_dates": "{0} necesita fecha"
+  "bqm_import_validation_dates": "{0} necesita fecha",
+  "event_export_csv": "Exportar CSV"
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -313,9 +313,6 @@
   "event_type_device_reboot": "Redémarrage",
   "event_type_device_ip_change": "Changement d'IP",
   "event_acknowledged": "Confirme",
-  "event_view_mode": "Mode d'affichage des evenements",
-  "event_view_feed": "Flux",
-  "event_view_table": "Tableau",
   "event_all_severities": "Toutes les gravites",
   "event_all_types": "Tous les types",
   "sidebar_monitoring": "Surveillance",
@@ -959,5 +956,6 @@
   "bqm_import_validation_choose": "Selectionnez des images BQM PNG ou JPEG. DOCSight affiche les dates avant import.",
   "bqm_import_validation_unsupported": "Type de fichier non pris en charge. Seules les images PNG et JPEG sont acceptees.",
   "bqm_import_validation_ready": "{0} pretes",
-  "bqm_import_validation_dates": "{0} necessite une date"
+  "bqm_import_validation_dates": "{0} necessite une date",
+  "event_export_csv": "Exporter CSV"
 }

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -300,9 +300,6 @@
   "event_type_device_reboot": "",
   "event_type_device_ip_change": "",
   "event_acknowledged": "",
-  "event_view_mode": "",
-  "event_view_feed": "",
-  "event_view_table": "",
   "event_all_severities": "",
   "event_all_types": "",
   "sidebar_monitoring": "",
@@ -812,5 +809,6 @@
   "bqm_import_validation_choose": "",
   "bqm_import_validation_unsupported": "",
   "bqm_import_validation_ready": "",
-  "bqm_import_validation_dates": ""
+  "bqm_import_validation_dates": "",
+  "event_export_csv": ""
 }

--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -328,43 +328,6 @@
     flex-shrink: 0;
 }
 
-/* Phase 4.3: Events table styling */
-#events-table {
-    width: 100%;
-    margin: 0;
-}
-#events-table thead tr {
-    background: var(--surface-2, rgba(0,0,0,0.15));
-}
-#events-table thead th {
-    padding: 12px 16px;
-    text-align: left;
-    font-weight: 600;
-    font-size: 0.85em;
-    color: var(--text);
-    border-bottom: 1px solid var(--card-border, var(--input-border));
-}
-#events-table tbody tr {
-    transition: background 0.15s;
-    border-bottom: 1px solid var(--border-tint);
-}
-#events-table tbody tr:hover {
-    background: color-mix(in srgb, var(--amethyst) 8%, transparent);
-}
-#events-table tbody tr.event-acked {
-    opacity: 0.5;
-}
-#events-table tbody td {
-    padding: 12px 16px;
-    font-size: 0.85em;
-}
-#events-table td.event-msg {
-    word-break: break-word;
-}
-#events-table td.event-actions {
-    white-space: nowrap;
-}
-
 /* Event message formatting */
 .ev-val { font-family: var(--font-mono, monospace); font-weight: 600; white-space: nowrap; display: inline-block; }
 .ev-arrow-icon { display: inline-block; width: 14px; height: 14px; margin: 0 4px; vertical-align: middle; color: var(--muted); }
@@ -493,36 +456,29 @@
     gap: var(--space-sm, 12px);
     flex-wrap: wrap;
 }
-.events-view-toggle {
+.btn-export-events {
+    min-height: 36px;
     display: inline-flex;
-    gap: 4px;
-    padding: 4px;
+    align-items: center;
+    justify-content: center;
+    padding: 7px 14px;
     border: 1px solid var(--card-border, var(--input-border));
     border-radius: 999px;
     background: var(--surface-2, rgba(0,0,0,0.18));
-}
-.events-view-mode-btn {
-    min-height: 36px;
-    padding: 7px 14px;
-    border: 0;
-    border-radius: 999px;
-    background: transparent;
     color: var(--text-secondary, var(--muted));
     cursor: pointer;
     font-family: inherit;
     font-size: 0.85em;
     font-weight: 600;
+    text-decoration: none;
     transition: all 0.2s var(--ease-out-expo);
 }
-.events-view-mode-btn:hover {
-    color: var(--text);
-    background: var(--amethyst-muted);
-}
-.events-view-mode-btn.active {
+.btn-export-events:hover {
     color: var(--text-on-accent);
     background: var(--accent-purple, var(--accent));
+    border-color: var(--accent-purple, var(--accent));
 }
-.events-view-mode-btn:focus-visible { outline: 2px solid var(--amethyst); outline-offset: 2px; }
+.btn-export-events:focus-visible { outline: 2px solid var(--amethyst); outline-offset: 2px; }
 
 .events-feed {
     display: grid;
@@ -618,14 +574,13 @@
         align-items: flex-start;
     }
     .events-card-actions,
-    .events-view-toggle {
+    .btn-export-events {
         width: 100%;
     }
     .events-card-actions {
         justify-content: stretch;
     }
-    .events-view-mode-btn {
-        flex: 1;
+    .btn-export-events {
         min-height: 44px;
     }
     .events-feed {
@@ -643,25 +598,6 @@
     .event-feed-action .btn-ack {
         width: 100%;
         justify-content: center;
-    }
-    #events-table thead th,
-    #events-table tbody td {
-        padding: 8px 12px;
-        font-size: 0.8em;
-    }
-    /* Hide Type column on mobile — severity badge + message give enough context */
-    #events-table thead th:nth-child(3),
-    #events-table tbody td:nth-child(3) {
-        display: none;
-    }
-    /* Allow timestamp to wrap on mobile (date on one line, time below) */
-    #events-table tbody td:first-child {
-        white-space: normal !important;
-        min-width: 70px;
-        max-width: 90px;
-    }
-    #events-table td.event-msg {
-        max-width: 45vw;
     }
     /* Show severity icons instead of text on mobile */
     .sev-text { display: none; }

--- a/app/static/js/events.js
+++ b/app/static/js/events.js
@@ -27,7 +27,6 @@ var _sevLabels = {
 var _currentSeverityFilter = '';
 var _deviceOnlyFilter = false;
 var _hideOperational = true;
-var _eventsViewMode = 'feed';
 var _OPERATIONAL_EVENT_TYPES = { monitoring_started: true, monitoring_stopped: true };
 
 function _eventTypeLabel(eventType) {
@@ -64,28 +63,15 @@ function _eventAckMarkup(ev, compact) {
     return '<button class="btn-ack" type="button" aria-label="' + label + '" onclick="acknowledgeEvent(' + ev.id + ', event)">' + visible + '</button>';
 }
 
-function applyEventsViewMode() {
-    var feed = document.getElementById('events-feed');
-    var table = document.getElementById('events-table');
-    var feedBtn = document.getElementById('events-view-mode-feed');
-    var tableBtn = document.getElementById('events-view-mode-table');
-    var isTable = _eventsViewMode === 'table';
-
-    if (feed) feed.style.display = isTable ? 'none' : '';
-    if (table) table.style.display = isTable ? '' : 'none';
-    if (feedBtn) {
-        feedBtn.classList.toggle('active', !isTable);
-        feedBtn.setAttribute('aria-pressed', String(!isTable));
-    }
-    if (tableBtn) {
-        tableBtn.classList.toggle('active', isTable);
-        tableBtn.setAttribute('aria-pressed', String(isTable));
-    }
-}
-
-function setEventsViewMode(mode) {
-    _eventsViewMode = mode === 'table' ? 'table' : 'feed';
-    applyEventsViewMode();
+function updateEventsExportLink() {
+    var exportLink = document.getElementById('events-export-csv');
+    if (!exportLink) return;
+    var params = new URLSearchParams();
+    if (_currentSeverityFilter) params.set('severity', _currentSeverityFilter);
+    if (_hideOperational) params.set('exclude_operational', 'true');
+    if (_deviceOnlyFilter) params.set('event_prefix', 'device_');
+    var qs = params.toString();
+    exportLink.href = '/api/events/export.csv' + (qs ? '?' + qs : '');
 }
 
 /* ── Rich event message formatter ── */
@@ -253,7 +239,7 @@ function filterEventsByDevice() {
 
 function loadEvents(append) {
     if (!append) _eventsOffset = 0;
-    var tableRequestId = ++_eventsRequestCount;
+    var feedRequestId = ++_eventsRequestCount;
     var badgeRequestId = ++_badgeRequestCount;
     var severity = _currentSeverityFilter;
     var params = '?limit=' + _eventsPageSize + '&offset=' + _eventsOffset;
@@ -261,10 +247,10 @@ function loadEvents(append) {
     if (_hideOperational) params += '&exclude_operational=true';
     if (_deviceOnlyFilter) params += '&event_prefix=device_';
 
-    var tbody = document.getElementById('events-tbody');
+    updateEventsExportLink();
+
     var feed = document.getElementById('events-feed');
-    var tableCard = document.getElementById('events-table-card');
-    var table = document.getElementById('events-table');
+    var feedCard = document.getElementById('events-feed-card');
     var empty = document.getElementById('events-empty');
     var loading = document.getElementById('events-loading');
     var moreBtn = document.getElementById('events-show-more');
@@ -272,9 +258,8 @@ function loadEvents(append) {
 
     if (!append) {
         loading.style.display = '';
-        tbody.innerHTML = '';
         feed.innerHTML = '';
-        tableCard.style.display = 'none';
+        feedCard.style.display = 'none';
         empty.style.display = 'none';
         moreBtn.style.display = 'none';
     }
@@ -286,34 +271,23 @@ function loadEvents(append) {
             var events = data.events || [];
             var unack = data.unacknowledged_count || 0;
 
-            // Events and unack count are now natively filtered by the backend!
-            // Events and unack count are now natively filtered by the backend!
+            // Events and unack count are natively filtered by the backend.
             var eventsViewEl = document.getElementById('view-events');
             if (badgeRequestId === _badgeRequestCount && eventsViewEl && eventsViewEl.classList.contains('active')) {
                 updateEventBadge(unack);
                 ackAllBtn.style.display = unack > 0 ? '' : 'none';
             }
 
-            if (tableRequestId === _eventsRequestCount) {
+            if (feedRequestId === _eventsRequestCount) {
                 if (events.length === 0 && !append) {
+                    feedCard.style.display = '';
                     empty.textContent = T.event_no_events || 'No events detected yet.';
                     empty.style.display = '';
                     return;
                 }
                 events.forEach(function(ev) {
-                    var tr = document.createElement('tr');
-                    if (ev.acknowledged) tr.className = 'event-acked';
-                    tr.setAttribute('data-event-id', ev.id);
                     var sevMeta = _eventSeverityMeta(ev);
                     var typeLabel = _eventTypeLabel(ev.event_type);
-                    tr.innerHTML =
-                        '<td style="white-space:nowrap;">' + _eventTimestampLabel(ev.timestamp) + '</td>' +
-                        '<td>' + _eventSeverityBadge(sevMeta) + '</td>' +
-                        '<td>' + escapeHtml(typeLabel) + '</td>' +
-                        '<td class="event-msg">' + formatEventMessage(ev) + '</td>' +
-                        '<td class="event-actions">' + _eventAckMarkup(ev, true) + '</td>';
-                    tbody.appendChild(tr);
-
                     var card = document.createElement('article');
                     card.className = 'event-feed-item' + (ev.acknowledged ? ' event-acked' : '');
                     card.setAttribute('role', 'listitem');
@@ -334,8 +308,8 @@ function loadEvents(append) {
                         '<div class="event-feed-action">' + _eventAckMarkup(ev, false) + '</div>';
                     feed.appendChild(card);
                 });
-                tableCard.style.display = '';
-                applyEventsViewMode();
+                feedCard.style.display = '';
+                updateEventsExportLink();
                 moreBtn.style.display = events.length >= _eventsPageSize ? '' : 'none';
                 if (typeof lucide !== 'undefined') lucide.createIcons();
             }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1401,8 +1401,8 @@
     </div>
     <div id="events-empty" class="events-empty" style="display:none;"></div>
 
-    <!-- Phase 4.3: Card wrapper for events table -->
-    <div id="events-table-card" class="table-card" style="display:none;">
+    <!-- Phase 4.4: Card wrapper for events feed -->
+    <div id="events-feed-card" class="table-card" style="display:none;">
         <div class="table-card-header events-card-header">
             <div class="table-card-title">
                 <svg class="table-card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1411,24 +1411,11 @@
                 <span>{{ t.event_log }}</span>
             </div>
             <div class="events-card-actions">
-                <div class="events-view-toggle" role="group" aria-label="{{ t.event_view_mode }}">
-                    <button id="events-view-mode-feed" class="events-view-mode-btn active" type="button" onclick="setEventsViewMode('feed')" aria-pressed="true">{{ t.event_view_feed }}</button>
-                    <button id="events-view-mode-table" class="events-view-mode-btn" type="button" onclick="setEventsViewMode('table')" aria-pressed="false">{{ t.event_view_table }}</button>
-                </div>
+                <a class="btn-export-events" id="events-export-csv" href="/api/events/export.csv?exclude_operational=true" download>{{ t.event_export_csv }}</a>
                 <button class="btn-ack-all" id="btn-ack-all" onclick="acknowledgeAllEvents()" style="display:none;">&#10003; {{ t.event_acknowledge_all }}</button>
             </div>
         </div>
         <div id="events-feed" class="events-feed" role="list"></div>
-        <table id="events-table" class="events-table-mode">
-            <thead><tr>
-                <th scope="col">{{ t.timestamp }}</th>
-                <th scope="col">{{ t.event_severity }}</th>
-                <th scope="col">{{ t.event_type }}</th>
-                <th scope="col">{{ t.event_message }}</th>
-                <th scope="col"></th>
-            </tr></thead>
-            <tbody id="events-tbody"></tbody>
-        </table>
     </div>
 
     <div id="events-show-more" style="text-align:center; padding:16px; display:none;">

--- a/tests/e2e/test_event_log_redesign.py
+++ b/tests/e2e/test_event_log_redesign.py
@@ -1,6 +1,7 @@
-"""Regression coverage for the event log feed/table redesign."""
+"""Regression coverage for the event log feed-only redesign."""
 
 from playwright.sync_api import expect
+import re
 
 MOBILE_VIEWPORT = {"width": 393, "height": 852}
 DESKTOP_VIEWPORT = {"width": 1440, "height": 1000}
@@ -13,7 +14,7 @@ def _open_events(page, viewport):
     base_url = page.url.split("#", 1)[0].split("?", 1)[0].rstrip("/")
     page.goto(f"{base_url}/?lang=de#events", wait_until="networkidle")
     page.wait_for_selector("#view-events.active", state="visible")
-    page.wait_for_selector("#events-table-card", state="visible")
+    page.wait_for_selector("#events-feed-card", state="visible")
     page.wait_for_selector("#events-feed .event-feed-item", state="visible")
 
 
@@ -37,7 +38,7 @@ def _active_view_geometry(page):
                 documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
                 activeViewOverflow: activeView ? activeView.scrollWidth - activeView.clientWidth : 0,
                 feedDisplay: feed ? getComputedStyle(feed).display : null,
-                tableDisplay: table ? getComputedStyle(table).display : null,
+                hasTable: Boolean(table),
                 firstCard: rect(firstCard),
                 message: rect(message),
                 action: rect(action),
@@ -47,14 +48,17 @@ def _active_view_geometry(page):
     )
 
 
-def test_mobile_event_log_uses_feed_cards_instead_of_squeezed_table(demo_page):
-    """Mobile should render a scanable event feed, not a compressed desktop table."""
+def test_mobile_event_log_uses_feed_cards_without_table_mode(demo_page):
+    """Mobile should render a scanable event feed with no alternate table mode."""
     page = demo_page
     _open_events(page, MOBILE_VIEWPORT)
 
     feed_items = page.locator("#events-feed .event-feed-item")
     expect(feed_items).to_have_count(50)
-    expect(page.locator("#events-table")).to_be_hidden()
+    expect(page.locator("#events-table")).to_have_count(0)
+    expect(page.locator("#events-view-mode-table")).to_have_count(0)
+    expect(page.locator("#events-view-mode-feed")).to_have_count(0)
+    expect(page.locator("#events-export-csv")).to_be_visible()
     expect(feed_items.first.locator(".event-feed-title")).to_be_visible()
     expect(feed_items.first.locator(".event-feed-meta")).to_be_visible()
     expect(feed_items.first.locator(".event-feed-message")).to_be_visible()
@@ -67,7 +71,7 @@ def test_mobile_event_log_uses_feed_cards_instead_of_squeezed_table(demo_page):
     assert geometry["documentOverflow"] <= MAX_HORIZONTAL_OVERFLOW
     assert geometry["activeViewOverflow"] <= MAX_HORIZONTAL_OVERFLOW
     assert geometry["feedDisplay"] != "none"
-    assert geometry["tableDisplay"] == "none"
+    assert geometry["hasTable"] is False
     assert geometry["firstCard"]["left"] >= 0
     assert geometry["firstCard"]["right"] <= geometry["viewportWidth"] + MAX_HORIZONTAL_OVERFLOW
     assert geometry["message"]["width"] >= 240
@@ -76,27 +80,66 @@ def test_mobile_event_log_uses_feed_cards_instead_of_squeezed_table(demo_page):
         assert geometry["action"]["height"] >= MIN_TOUCH_TARGET
 
 
-def test_desktop_event_log_defaults_to_feed_with_optional_table_mode(demo_page):
-    """Desktop should favor a scanable feed while keeping table mode available."""
+def test_desktop_event_log_is_feed_only_with_export_and_acknowledge(demo_page):
+    """Desktop should keep the feed, expose export, and not render table mode."""
     page = demo_page
     _open_events(page, DESKTOP_VIEWPORT)
 
     expect(page.locator("#events-feed .event-feed-item").first).to_be_visible()
-    expect(page.locator("#events-table")).to_be_hidden()
-    expect(page.locator("#events-view-mode-feed")).to_have_attribute("aria-pressed", "true")
-    expect(page.locator("#events-view-mode-table")).to_have_attribute("aria-pressed", "false")
+    expect(page.locator("#events-table")).to_have_count(0)
+    expect(page.locator("#events-view-mode-table")).to_have_count(0)
+    expect(page.locator("#events-view-mode-feed")).to_have_count(0)
+    export = page.locator("#events-export-csv")
+    expect(export).to_be_visible()
+    expect(export).to_have_attribute("href", re.compile(r"/api/events/export\.csv\?.*exclude_operational=true"))
 
     first_card = page.locator("#events-feed .event-feed-item").first
     expect(first_card.locator(".event-feed-title")).to_be_visible()
     expect(first_card.locator(".event-feed-meta")).to_be_visible()
     expect(first_card.locator(".event-feed-message")).to_be_visible()
 
-    page.locator("#events-view-mode-table").click()
-    expect(page.locator("#events-view-mode-table")).to_have_attribute("aria-pressed", "true")
-    expect(page.locator("#events-feed")).to_be_hidden()
-    expect(page.locator("#events-table")).to_be_visible()
-    expect(page.locator("#events-table tbody tr").first).to_be_visible()
+    ack_button = first_card.locator(".event-feed-action .btn-ack")
+    if ack_button.count() > 0:
+        ack_button.click()
+        expect(page.locator("#events-feed .event-feed-item").first).to_be_visible()
 
-    page.locator("#events-view-mode-feed").click()
+
+def test_event_export_link_tracks_active_filters(demo_page):
+    page = demo_page
+    _open_events(page, DESKTOP_VIEWPORT)
+
+    page.locator("button[data-severity='warning']").click()
     expect(page.locator("#events-feed .event-feed-item").first).to_be_visible()
-    expect(page.locator("#events-table")).to_be_hidden()
+    expect(page.locator("#events-export-csv")).to_have_attribute(
+        "href",
+        re.compile(r"/api/events/export\.csv\?.*severity=warning.*exclude_operational=true"),
+    )
+
+    page.locator("#device-filter-pill").click()
+    expect(page.locator("#events-feed .event-feed-item").first).to_be_visible()
+    expect(page.locator("#events-export-csv")).to_have_attribute(
+        "href",
+        re.compile(r"/api/events/export\.csv\?.*(event_prefix=device_.*exclude_operational=true|exclude_operational=true.*event_prefix=device_)"),
+    )
+
+
+def test_event_export_stays_available_for_empty_filtered_feed(demo_page):
+    page = demo_page
+    _open_events(page, DESKTOP_VIEWPORT)
+    page.route(
+        re.compile(r".*/api/events\?.*severity=critical.*"),
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"events": [], "unacknowledged_count": 0}',
+        ),
+    )
+
+    page.locator("button[data-severity='critical']").click()
+
+    expect(page.locator("#events-empty")).to_be_visible()
+    expect(page.locator("#events-export-csv")).to_be_visible()
+    expect(page.locator("#events-export-csv")).to_have_attribute(
+        "href",
+        re.compile(r"/api/events/export\.csv\?.*severity=critical.*exclude_operational=true"),
+    )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,7 @@
 """Tests for event detection, storage, and API endpoints."""
 
+import csv
+import io
 import json
 import shutil
 import subprocess
@@ -20,6 +22,17 @@ from app.config import ConfigManager
 def storage(tmp_path):
     db_path = str(tmp_path / "test.db")
     return SnapshotStorage(db_path, max_days=7)
+
+
+@pytest.fixture
+def events_client(tmp_path, storage):
+    config_mgr = ConfigManager(str(tmp_path / "config"))
+    config_mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
+    init_config(config_mgr)
+    init_storage(storage)
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
 
 
 @pytest.fixture
@@ -173,6 +186,115 @@ class TestEventStorage:
         """Only considers error_spike events."""
         storage.save_event("2026-02-28T12:00:00Z", "warning", "power_change", "Power shifted")
         assert storage.get_latest_spike_timestamp() is None
+
+
+class TestEventExportApi:
+    def test_events_export_csv_respects_filters_and_serializes_details(self, events_client, storage):
+        storage.save_event(
+            "2026-04-29T22:23:26Z",
+            "warning",
+            "power_change",
+            "DS power changed",
+            {"direction": "downstream", "prev": 1.0, "current": 4.5},
+        )
+        storage.save_event(
+            "2026-04-29T22:24:26Z",
+            "info",
+            "device_reboot",
+            "Modem rebooted",
+            {"reason": "manual"},
+        )
+        storage.save_event(
+            "2026-04-29T22:25:26Z",
+            "warning",
+            "monitoring_started",
+            "Monitoring started",
+        )
+
+        resp = events_client.get("/api/events/export.csv?severity=warning&exclude_operational=true")
+
+        assert resp.status_code == 200
+        assert resp.content_type.startswith("text/csv")
+        assert "attachment" in resp.headers["Content-Disposition"]
+        assert "docsight-events" in resp.headers["Content-Disposition"]
+        assert resp.headers["X-DOCSight-Export-Limit"] == "10000"
+        assert resp.headers["X-DOCSight-Export-Truncated"] == "false"
+        rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+        assert [row["message"] for row in rows] == ["DS power changed"]
+        assert rows[0]["timestamp"] == "2026-04-29T22:23:26Z"
+        assert rows[0]["severity"] == "warning"
+        assert rows[0]["event_type"] == "power_change"
+        assert rows[0]["acknowledged"] == "false"
+        assert json.loads(rows[0]["details"])["current"] == 4.5
+
+    def test_events_export_csv_respects_device_filter(self, events_client, storage):
+        storage.save_event("2026-04-29T22:23:26Z", "info", "device_ip_change", "IP changed")
+        storage.save_event("2026-04-29T22:24:26Z", "info", "channel_change", "Channels changed")
+
+        resp = events_client.get("/api/events/export.csv?event_prefix=device_")
+
+        assert resp.status_code == 200
+        rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+        assert [row["event_type"] for row in rows] == ["device_ip_change"]
+
+    def test_events_export_csv_respects_acknowledged_filter(self, events_client, storage):
+        unacked_id = storage.save_event("2026-04-29T22:23:26Z", "warning", "power_change", "Unacked")
+        acked_id = storage.save_event("2026-04-29T22:24:26Z", "warning", "power_change", "Acked")
+        storage.acknowledge_event(acked_id)
+        assert unacked_id != acked_id
+
+        resp = events_client.get("/api/events/export.csv?acknowledged=0")
+
+        assert resp.status_code == 200
+        rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+        assert [row["message"] for row in rows] == ["Unacked"]
+        assert rows[0]["acknowledged"] == "false"
+
+    @pytest.mark.parametrize("prefix", ["=", "+", "-", "@", "\t", "\r"])
+    def test_events_export_csv_neutralizes_spreadsheet_formulas(self, events_client, storage, prefix):
+        storage.save_event("2026-04-29T22:23:26Z", "warning", "power_change", f"{prefix}payload")
+
+        resp = events_client.get("/api/events/export.csv")
+
+        assert resp.status_code == 200
+        rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+        assert rows[0]["message"].startswith(f"'{prefix}")
+
+    def test_events_export_csv_rejects_invalid_acknowledged_filter(self, events_client):
+        resp = events_client.get("/api/events/export.csv?acknowledged=maybe")
+
+        assert resp.status_code == 400
+        assert resp.get_json() == {"error": "acknowledged must be 0 or 1"}
+
+    def test_events_list_rejects_invalid_acknowledged_filter(self, events_client):
+        resp = events_client.get("/api/events?acknowledged=2")
+
+        assert resp.status_code == 400
+        assert resp.get_json() == {"error": "acknowledged must be 0 or 1"}
+
+    def test_events_export_csv_respects_auth_boundary(self, tmp_path, storage):
+        config_mgr = ConfigManager(str(tmp_path / "auth-config"))
+        config_mgr.save({"modem_password": "test", "modem_type": "fritzbox", "admin_password": "admin-secret"})
+        init_config(config_mgr)
+        init_storage(storage)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            resp = client.get("/api/events/export.csv")
+
+        assert resp.status_code == 401
+        assert resp.get_json() == {"error": "Authentication required"}
+
+    def test_events_export_csv_sets_truncation_header_when_limited(self, events_client, storage):
+        for index in range(10001):
+            storage.save_event(f"2026-04-29T22:{index % 60:02d}:26Z", "info", "channel_change", f"Event {index}")
+
+        resp = events_client.get("/api/events/export.csv")
+
+        assert resp.status_code == 200
+        assert resp.headers["X-DOCSight-Export-Limit"] == "10000"
+        assert resp.headers["X-DOCSight-Export-Truncated"] == "true"
+        rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+        assert len(rows) == 10000
 
 
 # ── EventDetector Tests ──


### PR DESCRIPTION
## Summary
- Removes the event log Table Mode so the page uses the feed as the single interactive event surface.
- Adds a filter-aware CSV export for audit and support workflows.
- Hardens the export with auth coverage, spreadsheet-formula neutralization, invalid-filter handling, and explicit truncation headers.

## Validation
- `git diff --check`
- `python3 -m py_compile app/blueprints/events_bp.py tests/test_events.py`
- `node --check app/static/js/events.js`
- `uv run --with-requirements requirements-test.txt --with pytest-playwright pytest tests/test_events.py::TestEventExportApi tests/e2e/test_event_log_redesign.py -q` — 17 passed
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e` — 2220 passed, 11 skipped
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e` — 341 passed
- Mobile and desktop visual smoke: feed-only layout, CSV export visible, no table/toggle artifacts, no obvious overflow or layout regression

Closes #417
