### PR TITLE
Avoid exposing event filter parsing details

### DIFF
--- a/app/blueprints/events_bp.py
+++ b/app/blueprints/events_bp.py
@@ -94,8 +94,8 @@ def api_events_list():
     offset = request.args.get("offset", 0, type=int)
     try:
         filters = _event_filters_from_request()
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
+    except ValueError:
+        return jsonify({"error": "Invalid acknowledged filter"}), 400
 
     events = _storage.get_events(
         limit=limit, offset=offset, severity=filters["severity"],
@@ -121,8 +121,8 @@ def api_events_export_csv():
         return _events_csv_response([])
     try:
         filters = _event_filters_from_request()
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
+    except ValueError:
+        return jsonify({"error": "Invalid acknowledged filter"}), 400
     events = _storage.get_events(
         limit=_EVENTS_EXPORT_LIMIT + 1,
         offset=0,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -264,13 +264,13 @@ class TestEventExportApi:
         resp = events_client.get("/api/events/export.csv?acknowledged=maybe")
 
         assert resp.status_code == 400
-        assert resp.get_json() == {"error": "acknowledged must be 0 or 1"}
+        assert resp.get_json() == {"error": "Invalid acknowledged filter"}
 
     def test_events_list_rejects_invalid_acknowledged_filter(self, events_client):
         resp = events_client.get("/api/events?acknowledged=2")
 
         assert resp.status_code == 400
-        assert resp.get_json() == {"error": "acknowledged must be 0 or 1"}
+        assert resp.get_json() == {"error": "Invalid acknowledged filter"}
 
     def test_events_export_csv_respects_auth_boundary(self, tmp_path, storage):
         config_mgr = ConfigManager(str(tmp_path / "auth-config"))


### PR DESCRIPTION
## Summary
- Returns a stable generic error for invalid event `acknowledged` filters.
- Avoids exposing exception-derived parsing details in event API responses.
- Updates export/list regression coverage for the generic error response.

## Validation
- `git diff --check`
- `python3 -m py_compile app/blueprints/events_bp.py tests/test_events.py`
- `uv run --with-requirements requirements-test.txt pytest tests/test_events.py::TestEventExportApi -q` — 13 passed

Refs #417
Refs #418
