### PR TITLE
Tighten BQM legacy PNG collection follow-up

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -298,6 +298,7 @@ Users can switch from demo to live mode via Settings UI or `POST /api/demo/migra
 **Collection behavior:**
 - Settings save with a new ThinkBroadband CSV share URL triggers an immediate authenticated initial fetch through `POST /api/bqm/fetch-now` / `run_bqm_initial_fetch()`.
 - Daily polling uses the CSV Yesterday share link and records collection metadata in `bqm_meta` (`last_success_target_date`, mode, rows, timestamp).
+- Legacy PNG collection also stores the previous day as the target date so restart skip logic stays consistent with daily BQM evidence.
 - A fresh collector instance checks persisted metadata before fetching so restarts after a successful collection do not duplicate the same target date.
 - DOCSight does not silently invent multi-day backfill from the daily collector. Longer gaps should be filled with the BQM CSV bulk import.
 - The UI labels cached PNG fallback separately from live refresh so cached evidence is not presented as live freshness.

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -975,5 +975,8 @@
   "bqm_setup_configure_text": "Erstelle oder öffne deinen BQM-Monitor, kopiere die CSV-Yesterday-Share-URL und speichere sie in den Einstellungen. CSV Live ist nur für Spot-Checks gedacht.",
   "bqm_setup_validate_text": "Nach dem Speichern einer CSV-Yesterday-URL führt DOCSight einen initialen Abruf aus. Nutze den CSV-Bulk-Import für bis zu 12 Monate Historie oder längere Lücken.",
   "bqm_setup_copy_url": "Beispiel-URL-Format kopieren",
-  "bqm_setup_open_settings": "BQM-Einstellungen öffnen"
+  "bqm_setup_open_settings": "BQM-Einstellungen öffnen",
+  "previous_month": "Vorheriger Monat",
+  "next_month": "Nächster Monat",
+  "bqm_csv_import": "BQM CSV-Import"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -975,5 +975,8 @@
   "bqm_setup_configure_text": "Create or open your BQM monitor, copy the CSV Yesterday share URL, then save it in Settings. CSV Live is for spot checks only.",
   "bqm_setup_validate_text": "After saving a CSV Yesterday URL, DOCSight performs one initial fetch. Use CSV bulk import for up to 12 months of history or longer gaps.",
   "bqm_setup_copy_url": "Copy example URL format",
-  "bqm_setup_open_settings": "Open BQM settings"
+  "bqm_setup_open_settings": "Open BQM settings",
+  "previous_month": "Previous month",
+  "next_month": "Next month",
+  "bqm_csv_import": "BQM CSV import"
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -970,5 +970,8 @@
   "bqm_setup_configure_text": "Crea o abre tu monitor BQM, copia la URL compartida CSV Yesterday y guárdala en Configuración. CSV Live es solo para comprobaciones puntuales.",
   "bqm_setup_validate_text": "Después de guardar una URL CSV Yesterday, DOCSight realiza una obtención inicial. Usa la importación masiva CSV para hasta 12 meses de historial o brechas más largas.",
   "bqm_setup_copy_url": "Copiar formato de URL de ejemplo",
-  "bqm_setup_open_settings": "Abrir configuración de BQM"
+  "bqm_setup_open_settings": "Abrir configuración de BQM",
+  "previous_month": "Mes anterior",
+  "next_month": "Mes siguiente",
+  "bqm_csv_import": "Importación CSV de BQM"
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -967,5 +967,8 @@
   "bqm_setup_configure_text": "Créez ou ouvrez votre moniteur BQM, copiez l’URL de partage CSV Yesterday, puis enregistrez-la dans les paramètres. CSV Live sert uniquement aux contrôles ponctuels.",
   "bqm_setup_validate_text": "Après l’enregistrement d’une URL CSV Yesterday, DOCSight effectue une récupération initiale. Utilisez l’import CSV en masse pour jusqu’à 12 mois d’historique ou les lacunes plus longues.",
   "bqm_setup_copy_url": "Copier le format d’URL d’exemple",
-  "bqm_setup_open_settings": "Ouvrir les paramètres BQM"
+  "bqm_setup_open_settings": "Ouvrir les paramètres BQM",
+  "previous_month": "Mois précédent",
+  "next_month": "Mois suivant",
+  "bqm_csv_import": "Import CSV BQM"
 }

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -820,5 +820,8 @@
   "bqm_setup_configure_text": "",
   "bqm_setup_validate_text": "",
   "bqm_setup_copy_url": "",
-  "bqm_setup_open_settings": ""
+  "bqm_setup_open_settings": "",
+  "previous_month": "",
+  "next_month": "",
+  "bqm_csv_import": ""
 }

--- a/app/modules/bqm/collector.py
+++ b/app/modules/bqm/collector.py
@@ -103,15 +103,11 @@ class BQMCollector(Collector):
             return CollectorResult.failure(self.name, f"Invalid BQM CSV: {exc}")
 
     def _collect_png(self, url):
-        """Legacy PNG collection: fetch graph image and store it."""
+        """Legacy PNG collection: fetch graph image and store it for the daily target."""
         today = time.strftime("%Y-%m-%d")
+        graph_date = (date.today() - timedelta(days=1)).isoformat()
         image = fetch_graph(url)
         if image:
-            collect_time = self._config_mgr.get("bqm_collect_time") or "02:00"
-            if collect_time < "12:00":
-                graph_date = (date.today() - timedelta(days=1)).isoformat()
-            else:
-                graph_date = date.today().isoformat()
             self._storage.save_bqm_graph(image, graph_date=graph_date)
             self._storage.record_collection_success(
                 collection_date=today,

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -293,6 +293,45 @@ class TestBQMCollector:
         assert result.data == {"skipped": True, "reason": "already_collected", "date": "2099-01-01"}
         mock_fetch.assert_not_called()
 
+    @patch("app.modules.bqm.collector.fetch_graph")
+    def test_png_collection_records_yesterday_target_for_restart_skip(self, mock_fetch, tmp_path, sample_png):
+        db_path = str(tmp_path / "collector-png.db")
+        storage = SnapshotStorage(db_path, max_days=7)
+        mgr = ConfigManager(str(tmp_path / "data"))
+        mgr.save({
+            "modem_password": "test",
+            "modem_type": "fritzbox",
+            "bqm_url": "https://www.thinkbroadband.com/broadband/monitoring/quality/share/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png",
+            "bqm_collect_time": "14:00",
+        })
+        mock_fetch.return_value = sample_png
+
+        class FixedDate(date):
+            @classmethod
+            def today(cls):
+                return cls(2099, 1, 2)
+
+        def fake_strftime(fmt, *args):
+            if fmt == "%Y-%m-%d":
+                return "2099-01-02"
+            if fmt == "%H:%M":
+                return "14:05"
+            if fmt == "%Y-%m-%dT%H:%M:%SZ":
+                return "2099-01-02T14:05:00Z"
+            raise AssertionError(f"unexpected strftime format: {fmt}")
+
+        with patch("app.modules.bqm.collector.date", FixedDate), patch(
+            "app.modules.bqm.collector.time.strftime",
+            side_effect=fake_strftime,
+        ):
+            result = BQMCollector(mgr, storage).collect()
+
+        assert result.success is True
+        assert result.data == {"date": "2099-01-01", "mode": "png"}
+        meta = BqmStorage(db_path).get_collection_metadata()
+        assert meta["last_success_target_date"] == "2099-01-01"
+        assert meta["last_success_mode"] == "png"
+
 
 # ── API Tests ──
 


### PR DESCRIPTION
## Summary
- Align legacy BQM PNG collection target dates with the CSV Yesterday/restart-skip contract.
- Add a regression test for afternoon PNG collection metadata.
- Add missing global BQM UI i18n keys and document the PNG target-date invariant.

## Verification
- Claude Code on dev30: PASS, no blockers.
- Review gate: PASS, no blockers.
- `git diff --check`
- `python3 -m py_compile app/modules/bqm/collector.py tests/test_bqm.py`
- `uv run --with-requirements requirements-test.txt pytest tests/test_bqm.py -q`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e`

Follow-up to #424 / #422.
