### PR TITLE
Fix Settings autofill dirty prompts

### DIFF
--- a/app/modules/mqtt/templates/mqtt_settings.html
+++ b/app/modules/mqtt/templates/mqtt_settings.html
@@ -31,7 +31,7 @@
             </div>
             <div class="form-field">
                 <label class="form-label" for="mqtt_password">{{ t['docsight.mqtt.password_opt'] or 'Password (optional)' }}</label>
-                <input class="form-input" type="password" id="mqtt_password" name="mqtt_password" value="" placeholder="{% if config.mqtt_password %}{{ t.saved_ph }}{% endif %}">
+                <input class="form-input" type="password" id="mqtt_password" name="mqtt_password" value="" placeholder="{% if config.mqtt_password %}{{ t.saved_ph }}{% endif %}"{% if config.mqtt_password %} data-saved-secret="true"{% endif %}>
             </div>
             <div class="form-field" style="grid-column: 1 / -1">
                 <label class="form-label" for="mqtt_topic_prefix">{{ t['docsight.mqtt.topic_prefix'] or 'Topic Prefix' }}</label>

--- a/app/modules/speedtest/templates/speedtest_settings.html
+++ b/app/modules/speedtest/templates/speedtest_settings.html
@@ -20,7 +20,7 @@
             </div>
             <div class="form-field" style="grid-column: 1 / -1">
                 <label class="form-label" for="speedtest_tracker_token">{{ t['docsight.speedtest.speedtest_token'] or 'API Token' }}</label>
-                <input class="form-input" type="password" id="speedtest_tracker_token" name="speedtest_tracker_token" value="" placeholder="{% if config.speedtest_tracker_token %}{{ t.saved_ph }}{% endif %}">
+                <input class="form-input" type="password" id="speedtest_tracker_token" name="speedtest_tracker_token" value="" placeholder="{% if config.speedtest_tracker_token %}{{ t.saved_ph }}{% endif %}"{% if config.speedtest_tracker_token %} data-saved-secret="true"{% endif %}>
                 <span class="form-hint">{{ t['docsight.speedtest.speedtest_token_hint'] or 'Bearer token from Speedtest Tracker settings' }}</span>
             </div>
             <div class="form-field" style="grid-column: 1 / -1; display: flex; gap: 12px; align-items: flex-start; flex-wrap: wrap;">

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -29,14 +29,7 @@ function switchSection(id) {
     if (mobileTitle) mobileTitle.textContent = SECTION_TITLES[id] || id;
 
     /* Save footer: hide on support/modules, otherwise respect dirty state */
-    var saveFooter = document.getElementById('save-footer');
-    if (saveFooter) {
-        if (_saveHiddenSections[id]) {
-            saveFooter.classList.remove('visible');
-        } else if (_formDirty) {
-            saveFooter.classList.add('visible');
-        }
-    }
+    _syncSaveFooter();
 
     /* Auto-load data for certain panels */
     if (id === 'security') loadApiTokens();
@@ -292,7 +285,11 @@ function getFormData() {
         }
         if (inp.type === 'hidden' && data[inp.name] !== undefined) return;
         if (SECRET_FIELDS.indexOf(inp.name) !== -1) {
-            data[inp.name] = inp.value || MASK;
+            if (_isSavedSecretField(inp) && !inp.dataset.userEditedSecret) {
+                data[inp.name] = MASK;
+            } else {
+                data[inp.name] = inp.value || MASK;
+            }
         } else {
             data[inp.name] = inp.value;
         }
@@ -592,17 +589,83 @@ function runDemoMigration() {
 
 /* ── Unsaved Changes ── */
 var _formDirty = false;
+var _formBaseline = null;
+
+function _isSavedSecretField(el) {
+    return !!(
+        el &&
+        el.name &&
+        el.tagName === 'INPUT' &&
+        el.type === 'password' &&
+        (
+            el.dataset.savedSecret === 'true' ||
+            (el.getAttribute('placeholder') || '').toLowerCase() === 'saved'
+        )
+    );
+}
+
+function _normalizedFormValue(el) {
+    if (_isSavedSecretField(el)) {
+        return el.dataset.userEditedSecret ? '__edited_secret__' : '';
+    }
+    if (el.type === 'checkbox' || el.type === 'radio') {
+        return el.checked ? '1' : '0';
+    }
+    if (el.tagName === 'SELECT' && el.multiple) {
+        return Array.prototype.map.call(el.selectedOptions, function(opt) { return opt.value; }).sort().join('\u0000');
+    }
+    return el.value || '';
+}
+
+function _serializeSettingsForm(form) {
+    if (!form) return '[]';
+    var fields = [];
+    Array.prototype.forEach.call(form.elements, function(el) {
+        if (!el.name || el.type === 'submit' || el.type === 'button' || el.type === 'file') return;
+        fields.push({ name: el.name, type: el.type || el.tagName, value: _normalizedFormValue(el) });
+    });
+    fields.sort(function(a, b) {
+        return (a.name + ':' + a.type).localeCompare(b.name + ':' + b.type);
+    });
+    return JSON.stringify(fields);
+}
+
+function _captureFormBaseline() {
+    var form = document.getElementById('settings-form');
+    _formBaseline = _serializeSettingsForm(form);
+}
+
+function _syncSaveFooter() {
+    var footer = document.getElementById('save-footer');
+    if (!footer) return;
+    if (_formDirty && !_saveHiddenSections[_currentSection]) {
+        footer.classList.add('visible');
+        footer.removeAttribute('aria-hidden');
+        footer.removeAttribute('inert');
+    } else {
+        footer.classList.remove('visible');
+        footer.setAttribute('aria-hidden', 'true');
+        footer.setAttribute('inert', '');
+    }
+}
+
+function _updateDirtyState() {
+    var form = document.getElementById('settings-form');
+    if (!form) return;
+    if (_formBaseline === null) _captureFormBaseline();
+    _formDirty = _serializeSettingsForm(form) !== _formBaseline;
+    _syncSaveFooter();
+}
 
 function initUnsavedDetection() {
     var form = document.getElementById('settings-form');
     if (!form) return;
-    function markDirty() {
-        if (_formDirty) return;
-        _formDirty = true;
-        var footer = document.getElementById('save-footer');
-        if (footer && !_saveHiddenSections[_currentSection]) {
-            footer.classList.add('visible');
+    _captureFormBaseline();
+    function markDirty(e) {
+        if (e && _isSavedSecretField(e.target) && e.isTrusted) {
+            e.target.dataset.userEditedSecret = 'true';
         }
+        _updateDirtyState();
     }
     form.addEventListener('input', markDirty);
     form.addEventListener('change', markDirty);
@@ -616,10 +679,22 @@ function initUnsavedDetection() {
     });
 }
 
+function _resetEditedSavedSecrets() {
+    var form = document.getElementById('settings-form');
+    if (!form) return;
+    Array.prototype.forEach.call(form.elements, function(el) {
+        if (!_isSavedSecretField(el) || !el.dataset.userEditedSecret) return;
+        el.value = '';
+        el.dataset.savedSecret = 'true';
+        delete el.dataset.userEditedSecret;
+    });
+}
+
 function clearDirty() {
+    _resetEditedSavedSecrets();
+    _captureFormBaseline();
     _formDirty = false;
-    var footer = document.getElementById('save-footer');
-    if (footer) footer.classList.remove('visible');
+    _syncSaveFooter();
 }
 
 /**
@@ -1148,6 +1223,9 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     } catch(e) {}
 
+    _captureFormBaseline();
+    _formDirty = false;
+
     /* Restore section from URL hash, default to connection */
     var hash = location.hash.replace('#', '');
     if (hash && document.getElementById('panel-' + hash)) {
@@ -1164,6 +1242,12 @@ function initModuleToggles() {
             var moduleId = this.getAttribute('data-module-id');
             var action = this.checked ? 'enable' : 'disable';
             var toggleEl = this;
+
+            if (_formDirty) {
+                toggleEl.checked = !toggleEl.checked;
+                _syncSaveFooter();
+                return;
+            }
 
             _guardUnsaved().then(function(proceed) {
                 if (!proceed) {

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -163,8 +163,8 @@
             {% endfor %}
 
             <!-- ═══ Save Footer ═══ -->
-            <div class="save-footer" id="save-footer">
-                <div class="unsaved-hint">
+            <div class="save-footer" id="save-footer" aria-hidden="true" inert>
+                <div class="unsaved-hint" role="status" aria-live="polite">
                     <span class="unsaved-dot"></span>
                     {{ t.unsaved_changes }}
                 </div>

--- a/app/templates/settings/connection.html
+++ b/app/templates/settings/connection.html
@@ -36,7 +36,7 @@
             </div>
             <div class="form-field">
                 <label class="form-label" for="modem_password">{{ t.password }}</label>
-                <input class="form-input" type="password" id="modem_password" name="modem_password" value="" placeholder="{% if config.modem_password %}{{ t.saved_ph }}{% endif %}">
+                <input class="form-input" type="password" id="modem_password" name="modem_password" value="" placeholder="{% if config.modem_password %}{{ t.saved_ph }}{% endif %}"{% if config.modem_password %} data-saved-secret="true"{% endif %}>
             </div>
         </div>
         <div style="margin-top: var(--space-lg);">

--- a/app/templates/settings/notifications.html
+++ b/app/templates/settings/notifications.html
@@ -21,7 +21,7 @@
             </div>
             <div class="form-field" style="grid-column: 1 / -1">
                 <label class="form-label" for="notify_webhook_token">{{ t.notify_webhook_token }}</label>
-                <input class="form-input" type="password" id="notify_webhook_token" name="notify_webhook_token" value="" placeholder="{% if config.notify_webhook_token %}{{ t.saved_ph }}{% endif %}">
+                <input class="form-input" type="password" id="notify_webhook_token" name="notify_webhook_token" value="" placeholder="{% if config.notify_webhook_token %}{{ t.saved_ph }}{% endif %}"{% if config.notify_webhook_token %} data-saved-secret="true"{% endif %}>
                 <span class="form-hint">{{ t.notify_webhook_token_hint }}</span>
             </div>
             <div class="form-field">

--- a/app/templates/settings/speedtest.html
+++ b/app/templates/settings/speedtest.html
@@ -16,7 +16,7 @@
             </div>
             <div class="form-row full">
                 <label for="speedtest_tracker_token">{{ t.speedtest_token }}</label>
-                <input type="password" id="speedtest_tracker_token" name="speedtest_tracker_token" value="" placeholder="{% if config.speedtest_tracker_token %}{{ t.saved_ph }}{% endif %}">
+                <input type="password" id="speedtest_tracker_token" name="speedtest_tracker_token" value="" placeholder="{% if config.speedtest_tracker_token %}{{ t.saved_ph }}{% endif %}"{% if config.speedtest_tracker_token %} data-saved-secret="true"{% endif %}>
                 <span class="hint">{{ t.speedtest_token_hint }}</span>
             </div>
             <div class="form-row">

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -1,5 +1,7 @@
 """E2E tests for the settings page."""
 
+import re
+
 import pytest
 from playwright.sync_api import expect
 
@@ -58,6 +60,100 @@ class TestSettingsFormElements:
     def test_back_to_dashboard_link(self, settings_page):
         link = settings_page.locator('a[href="/"]')
         assert link.count() > 0
+
+
+class TestSettingsDirtyState:
+    """Unsaved-change prompts only appear for deliberate settings edits."""
+
+    def test_modem_password_autofill_does_not_show_unsaved_footer(self, settings_page):
+        footer = settings_page.locator("#save-footer")
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+        settings_page.evaluate(
+            """
+            () => {
+              const input = document.querySelector('#modem_password');
+              input.dataset.savedSecret = 'true';
+              input.setAttribute('placeholder', 'Gespeichert');
+              input.value = 'autofilled-password';
+              input.dispatchEvent(new Event('input', {bubbles: true}));
+              input.dispatchEvent(new Event('change', {bubbles: true}));
+            }
+            """
+        )
+
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        expect(footer).to_have_attribute("aria-hidden", "true")
+        expect(footer).to_have_attribute("inert", "")
+        settings_page.locator('button[data-section="extensions"]').click()
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+    def test_autofilled_saved_secret_is_masked_when_unrelated_setting_is_saved(self, settings_page):
+        payloads = []
+
+        def capture_config(route):
+            payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        settings_page.route("**/api/config", capture_config)
+        settings_page.evaluate(
+            """
+            () => {
+              const input = document.querySelector('#modem_password');
+              input.dataset.savedSecret = 'true';
+              input.setAttribute('placeholder', 'Gespeichert');
+              input.value = 'autofilled-password';
+              input.dispatchEvent(new Event('input', {bubbles: true}));
+              input.dispatchEvent(new Event('change', {bubbles: true}));
+            }
+            """
+        )
+        settings_page.locator('#modem_url').fill('http://192.168.100.1')
+
+        settings_page.locator('#save-footer button[type="submit"]').click()
+        expect(settings_page.locator("#save-footer")).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+        assert payloads[-1]["modem_password"] == "••••••••"
+
+    def test_user_edited_saved_secret_is_submitted_and_cleared_after_save(self, settings_page):
+        payloads = []
+
+        def capture_config(route):
+            payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        settings_page.route("**/api/config", capture_config)
+        settings_page.evaluate(
+            """
+            () => {
+              const input = document.querySelector('#modem_password');
+              input.dataset.savedSecret = 'true';
+              input.setAttribute('placeholder', 'Gespeichert');
+            }
+            """
+        )
+
+        settings_page.locator('#modem_password').fill('new-secret-value')
+        settings_page.locator('#save-footer button[type="submit"]').click()
+        expect(settings_page.locator("#save-footer")).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+        assert payloads[-1]["modem_password"] == "new-secret-value"
+        assert settings_page.locator('#modem_password').input_value() == ""
+
+    def test_real_settings_edit_shows_only_footer_when_module_toggle_is_clicked(self, settings_page):
+        footer = settings_page.locator("#save-footer")
+        settings_page.locator('#modem_url').fill('http://192.168.100.1')
+        expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
+        expect(footer).not_to_have_attribute("aria-hidden", "true")
+        expect(footer).not_to_have_attribute("inert", "")
+
+        settings_page.locator('button[data-section="extensions"]').click()
+        toggle = settings_page.locator('.module-toggle-input').first
+        assert toggle.count() == 1
+        settings_page.locator('.module-toggle .toggle-slider').first.click()
+
+        expect(settings_page.locator('#docsight-confirm-modal')).to_have_count(0)
+        expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
 
 
 class TestSpeedtestModule:

--- a/tests/test_settings_secret_fields.py
+++ b/tests/test_settings_secret_fields.py
@@ -1,0 +1,62 @@
+"""Regression tests for saved secret settings fields."""
+
+import re
+from pathlib import Path
+
+from app.config import ConfigManager, PASSWORD_MASK
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_saved_secret_inputs_use_stable_marker():
+    """Saved secret fields must not depend on localized placeholder text."""
+    templates = list((ROOT / "app" / "templates" / "settings").glob("*.html"))
+    templates += list((ROOT / "app" / "modules").glob("*/templates/*settings*.html"))
+
+    offenders: list[str] = []
+    for template in templates:
+        html = template.read_text(encoding="utf-8")
+        for line_no, line in enumerate(html.splitlines(), start=1):
+            if 'type="password"' not in line:
+                continue
+            if "t.saved_ph" not in line:
+                continue
+            if "data-saved-secret" not in line:
+                offenders.append(f"{template.relative_to(ROOT)}:{line_no}")
+
+    assert offenders == []
+
+
+def test_frontend_secret_fields_cover_saved_secret_inputs():
+    """Every saved-secret input must be covered by the frontend masking list."""
+    js = (ROOT / "app" / "static" / "js" / "settings.js").read_text(encoding="utf-8")
+    match = re.search(r"SECRET_FIELDS\s*=\s*\[(?P<fields>[^\]]+)\]", js)
+    assert match is not None
+
+    secret_fields = set(re.findall(r"['\"]([^'\"]+)['\"]", match.group("fields")))
+    expected = {
+        "modem_password",
+        "mqtt_password",
+        "speedtest_tracker_token",
+        "notify_webhook_token",
+    }
+
+    assert expected <= secret_fields
+
+
+def test_config_save_preserves_masked_saved_secrets(tmp_path):
+    """Posting the mask must preserve existing secret values server-side."""
+    mgr = ConfigManager(str(tmp_path / "data"))
+    original = {
+        "modem_password": "modem-secret",
+        "mqtt_password": "mqtt-secret",
+        "speedtest_tracker_token": "speedtest-secret",
+        "notify_webhook_token": "notify-secret",
+    }
+    mgr.save(original.copy())
+
+    mgr.save({key: PASSWORD_MASK for key in original})
+
+    for key, value in original.items():
+        assert mgr.get(key) == value


### PR DESCRIPTION
## Summary
- Prevent saved-secret autofill from marking Settings as changed.
- Preserve masked saved secrets when unrelated settings are saved.
- Avoid stacking the module-toggle unsaved-changes dialog on top of the existing save footer.
- Keep the hidden save footer out of the accessibility tree until there are real unsaved changes.

## Tests
- `git diff --check`
- `python3 -m py_compile tests/test_settings_secret_fields.py tests/e2e/test_settings.py`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/test_settings_secret_fields.py tests/e2e/test_settings.py::TestSettingsDirtyState`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e/test_settings.py`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e`

Closes #426
Refs #423
