### PR TITLE
Fix extension module batch save

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -415,6 +415,12 @@ class ModemDriver(ABC):
 
 Drivers are loaded by name via `load_driver(modem_type, url, user, password)`. The registry maps type strings to fully qualified class paths for lazy importing.
 
+### Extension module state
+
+Installed non-theme modules are discovered by `ModuleLoader` and persisted through the comma-separated `disabled_modules` config key. The Settings Extensions panel treats installed module toggles as pending form state: users can change multiple modules and save them once through `POST /api/modules/batch`. Theme modules remain on the dedicated theme APIs because preview and active-theme handling are separate flows.
+
+Threshold-profile modules are mutually exclusive. The UI renders threshold modules as a single radio group, and the batch API validates the invariant server-side so exactly one threshold profile remains active after save.
+
 ### Vodafone Station Auto-Detection
 
 The Vodafone Station driver supports two hardware variants with different auth flows:

--- a/app/blueprints/modules_bp.py
+++ b/app/blueprints/modules_bp.py
@@ -143,6 +143,60 @@ def api_module_disable(module_id):
     return jsonify({"success": True, "restart_required": True})
 
 
+@modules_bp.route("/api/modules/batch", methods=["POST"])
+@require_auth
+def api_modules_batch():
+    """Apply multiple non-theme module enable/disable states in one save."""
+    loader = get_module_loader()
+    if not loader:
+        return jsonify({"success": False, "error": "Module system not initialized"}), 500
+
+    config_mgr = get_config_manager()
+    if not config_mgr:
+        return jsonify({"success": False, "error": "Config not initialized"}), 500
+
+    data = request.get_json(silent=True) or {}
+    requested = data.get("modules")
+    if not isinstance(requested, list):
+        return jsonify({"success": False, "error": "Missing modules list"}), 400
+
+    modules = {m.id: m for m in loader.get_modules()}
+    desired = {}
+    for item in requested:
+        if not isinstance(item, dict):
+            return jsonify({"success": False, "error": "Invalid module entry"}), 400
+        module_id = item.get("id")
+        enabled = item.get("enabled")
+        if not isinstance(module_id, str) or module_id not in modules:
+            return jsonify({"success": False, "error": f"Module '{module_id}' not found"}), 404
+        if not isinstance(enabled, bool):
+            return jsonify({"success": False, "error": "Module enabled state must be boolean"}), 400
+        if modules[module_id].type == "theme":
+            return jsonify({"success": False, "error": "Theme modules must be changed through theme settings"}), 400
+        desired[module_id] = enabled
+
+    disabled_raw = config_mgr.get("disabled_modules", "")
+    disabled_set = {s.strip() for s in disabled_raw.split(",") if s.strip()}
+    for module_id, enabled in desired.items():
+        if enabled:
+            disabled_set.discard(module_id)
+        else:
+            disabled_set.add(module_id)
+
+    threshold_ids = [m.id for m in loader.get_threshold_modules()]
+    if threshold_ids:
+        active_thresholds = [module_id for module_id in threshold_ids if module_id not in disabled_set]
+        if len(active_thresholds) != 1:
+            return jsonify({
+                "success": False,
+                "error": "Exactly one threshold profile must be active.",
+            }), 409
+
+    config_mgr.save({"disabled_modules": ",".join(sorted(disabled_set))})
+    log.info("Applied %d module state changes (restart required)", len(desired))
+    return jsonify({"success": True, "restart_required": bool(desired)})
+
+
 @modules_bp.route("/api/themes")
 @require_auth
 def api_themes_list():

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -216,6 +216,7 @@ html, body {
   flex: 1;
   margin-left: var(--sidebar-width);
   padding: var(--space-2xl);
+  padding-bottom: calc(var(--space-2xl) + 88px + env(safe-area-inset-bottom, 0px));
   max-width: 860px;
   overflow-y: auto;
   height: 100vh;
@@ -1156,7 +1157,7 @@ html, body {
 /* ─── Save Footer ─── */
 .save-footer {
   position: fixed;
-  bottom: 0;
+  bottom: env(safe-area-inset-bottom, 0px);
   left: var(--sidebar-width);
   right: 0;
   padding: 16px var(--space-2xl);
@@ -1404,7 +1405,7 @@ html, body {
     padding: var(--space-lg);
     height: calc(100vh - 56px);
     margin-top: 56px;
-    padding-bottom: 100px;
+    padding-bottom: calc(100px + env(safe-area-inset-bottom, 0px));
   }
   .form-grid.cols-2 { grid-template-columns: 1fr; }
   .support-grid { grid-template-columns: 1fr; }

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -622,10 +622,10 @@ function _serializeSettingsForm(form) {
     var fields = [];
     Array.prototype.forEach.call(form.elements, function(el) {
         if (!el.name || el.type === 'submit' || el.type === 'button' || el.type === 'file') return;
-        fields.push({ name: el.name, type: el.type || el.tagName, value: _normalizedFormValue(el) });
+        fields.push({ name: el.name, id: el.getAttribute('data-module-id') || '', type: el.type || el.tagName, value: _normalizedFormValue(el) });
     });
     fields.sort(function(a, b) {
-        return (a.name + ':' + a.type).localeCompare(b.name + ':' + b.type);
+        return (a.name + ':' + a.id + ':' + a.type).localeCompare(b.name + ':' + b.id + ':' + b.type);
     });
     return JSON.stringify(fields);
 }
@@ -697,14 +697,63 @@ function clearDirty() {
     _syncSaveFooter();
 }
 
-/**
- * Save the settings form via /api/config.
- * Uses the same error display and lang/tz reload logic as the normal submit.
- * Returns a Promise that resolves to true on success, false on failure.
- */
-function _saveForm() {
-    var errEl = document.getElementById('global-error');
-    if (errEl) errEl.style.display = 'none';
+function _getPendingModuleStates() {
+    var states = [];
+    document.querySelectorAll('.module-toggle-input').forEach(function(toggle) {
+        var moduleId = toggle.getAttribute('data-module-id');
+        if (!moduleId) return;
+        var initial = toggle.getAttribute('data-initial-enabled') === 'true';
+        if (toggle.checked !== initial) {
+            states.push({ id: moduleId, enabled: toggle.checked });
+        }
+    });
+    return states;
+}
+
+function _markModuleStatesSaved() {
+    document.querySelectorAll('.module-toggle-input').forEach(function(toggle) {
+        toggle.setAttribute('data-initial-enabled', toggle.checked ? 'true' : 'false');
+    });
+}
+
+function _saveModuleStatesIfNeeded() {
+    var states = _getPendingModuleStates();
+    if (states.length === 0) return Promise.resolve({ success: true, restart_required: false });
+    return fetch('/api/modules/batch', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ modules: states })
+    })
+    .then(function(r) {
+        return r.json().then(function(data) { return { ok: r.ok, data: data }; });
+    })
+    .then(function(res) {
+        if (!res.ok || !res.data.success) {
+            throw new Error(res.data.error || T.save_failed || 'Save failed');
+        }
+        _markModuleStatesSaved();
+        if (res.data.restart_required) {
+            var banner = document.getElementById('module-restart-banner');
+            if (banner) {
+                banner.style.display = 'flex';
+                if (typeof lucide !== 'undefined') lucide.createIcons({nodes: [banner]});
+            }
+        }
+        return res.data;
+    });
+}
+
+function _finishSettingsSave() {
+    clearDirty();
+    showToast(T.settings_saved || 'Settings saved', true);
+    var newLang = document.getElementById('language').value;
+    var newTz = document.getElementById('timezone').value;
+    if (newLang !== currentLang || newTz !== currentTz) {
+        setTimeout(function() { location.reload(); }, 800);
+    }
+}
+
+function _saveAllSettings() {
     var data = getFormData();
     return fetch('/api/config', {
         method: 'POST',
@@ -713,25 +762,29 @@ function _saveForm() {
     })
     .then(function(r) { return r.json(); })
     .then(function(res) {
-        if (res.success) {
-            clearDirty();
-            showToast(T.settings_saved || 'Settings saved', true);
-            var newLang = document.getElementById('language').value;
-            var newTz = document.getElementById('timezone').value;
-            if (newLang !== currentLang || newTz !== currentTz) {
-                setTimeout(function() { location.reload(); }, 800);
-            }
-            return true;
+        if (!res.success) {
+            throw new Error(res.error || T.save_failed || 'Save failed');
         }
-        if (errEl) {
-            errEl.textContent = res.error || T.save_failed;
-            errEl.style.display = 'block';
-        }
-        return false;
+        return _saveModuleStatesIfNeeded();
     })
-    .catch(function() {
+    .then(function() {
+        _finishSettingsSave();
+        return true;
+    });
+}
+
+/**
+ * Save the settings form via /api/config and pending module state.
+ * Uses the same error display and lang/tz reload logic as the normal submit.
+ * Returns a Promise that resolves to true on success, false on failure.
+ */
+function _saveForm() {
+    var errEl = document.getElementById('global-error');
+    if (errEl) errEl.style.display = 'none';
+    return _saveAllSettings()
+    .catch(function(err) {
         if (errEl) {
-            errEl.textContent = T.network_error;
+            errEl.textContent = err.message || T.network_error;
             errEl.style.display = 'block';
         }
         return false;
@@ -764,30 +817,9 @@ function initFormSubmit() {
         e.preventDefault();
         var errEl = document.getElementById('global-error');
         errEl.style.display = 'none';
-        var saveBtn = e.target.querySelector('button[type="submit"]');
-        var data = getFormData();
-        fetch('/api/config', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify(data)
-        })
-        .then(function(r) { return r.json(); })
-        .then(function(res) {
-            if (res.success) {
-                clearDirty();
-                showToast(T.settings_saved || 'Settings saved', true);
-                var newLang = document.getElementById('language').value;
-                var newTz = document.getElementById('timezone').value;
-                if (newLang !== currentLang || newTz !== currentTz) {
-                    setTimeout(function() { location.reload(); }, 800);
-                }
-            } else {
-                errEl.textContent = res.error || T.save_failed;
-                errEl.style.display = 'block';
-            }
-        })
-        .catch(function() {
-            errEl.textContent = T.network_error;
+        _saveAllSettings()
+        .catch(function(err) {
+            errEl.textContent = err.message || T.network_error;
             errEl.style.display = 'block';
         });
     });
@@ -1239,44 +1271,13 @@ document.addEventListener('DOMContentLoaded', function() {
 function initModuleToggles() {
     document.querySelectorAll('.module-toggle-input').forEach(function(toggle) {
         toggle.addEventListener('change', function() {
-            var moduleId = this.getAttribute('data-module-id');
-            var action = this.checked ? 'enable' : 'disable';
             var toggleEl = this;
-
-            if (_formDirty) {
-                toggleEl.checked = !toggleEl.checked;
-                _syncSaveFooter();
-                return;
-            }
-
-            _guardUnsaved().then(function(proceed) {
-                if (!proceed) {
-                    toggleEl.checked = !toggleEl.checked;
-                    return;
-                }
-                fetch('/api/modules/' + moduleId + '/' + action, {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                })
-                .then(function(r) { return r.json(); })
-                .then(function(res) {
-                    if (res.success) {
-                        showToast(T.settings_saved || 'Saved');
-                        var banner = document.getElementById('module-restart-banner');
-                        if (banner) {
-                            banner.style.display = 'flex';
-                            lucide.createIcons({nodes: [banner]});
-                        }
-                    } else {
-                        toggleEl.checked = !toggleEl.checked;
-                        showToast(res.error || 'Error', true);
-                    }
-                })
-                .catch(function() {
-                    toggleEl.checked = !toggleEl.checked;
-                    showToast(T.network_error || 'Network error', true);
+            if (toggleEl.getAttribute('data-is-threshold') === 'true' && toggleEl.checked) {
+                document.querySelectorAll('.module-toggle-input[data-is-threshold="true"]').forEach(function(other) {
+                    if (other !== toggleEl) other.checked = false;
                 });
-            });
+            }
+            _updateDirtyState();
         });
     });
 }

--- a/app/templates/settings/extensions.html
+++ b/app/templates/settings/extensions.html
@@ -30,7 +30,7 @@
         {% set modules_list = [] %}
         {% if all_modules %}
         {% for mod in all_modules|selectattr('type', 'ne', 'theme')|list %}
-        {% if modules_list.append({'name': mod.name, 'desc': mod.description, 'mod_id': mod.id, 'checked': mod.enabled, 'disabled': false, 'error': mod.error}) %}{% endif %}
+        {% if modules_list.append({'name': mod.name, 'desc': mod.description, 'mod_id': mod.id, 'checked': mod.enabled, 'disabled': false, 'error': mod.error, 'is_threshold': 'thresholds' in mod.contributes}) %}{% endif %}
         {% endfor %}
         {% endif %}
 
@@ -52,24 +52,33 @@
 
         {# ── Modules ── #}
         {% if modules_list %}
-        <div class="toggle-section-divider">{{ t.get('ext_modules', 'Modules') }}</div>
+        <div class="toggle-section-divider" id="extensions-modules-heading">{{ t.get('ext_modules', 'Modules') }}</div>
+        <div role="group" aria-labelledby="extensions-modules-heading">
         {% for ext in modules_list|sort(attribute='name') %}
+        {% set module_label_id = 'module-title-' ~ loop.index %}
+        {% set module_desc_id = 'module-desc-' ~ loop.index %}
         <div class="toggle-row{% if ext.disabled %} toggle-row-disabled{% endif %}" data-module-id="{{ ext.mod_id }}">
             <div class="toggle-info">
-                <span class="toggle-title">
+                <span class="toggle-title" id="{{ module_label_id }}">
                     {{ ext.name }}
                     {% if ext.error is defined and ext.error %}<span class="module-badge badge-error">{{ t.modules_error }}</span>{% endif %}
                 </span>
-                <span class="toggle-desc">{{ ext.desc }}</span>
+                <span class="toggle-desc" id="{{ module_desc_id }}">{{ ext.desc }}</span>
             </div>
             <label class="toggle module-toggle">
-                <input type="checkbox" class="module-toggle-input"
+                <input type="{{ 'radio' if ext.is_threshold else 'checkbox' }}" class="module-toggle-input"
                        data-module-id="{{ ext.mod_id }}"
+                       data-initial-enabled="{{ 'true' if ext.checked else 'false' }}"
+                       data-is-threshold="{{ 'true' if ext.is_threshold else 'false' }}"
+                       aria-labelledby="{{ module_label_id }}"
+                       aria-describedby="{{ module_desc_id }}"
+                       {% if ext.is_threshold %}name="threshold_profile_module" value="{{ ext.mod_id }}"{% else %}name="module_state_{{ ext.mod_id }}" value="true"{% endif %}
                        {% if ext.checked %}checked{% endif %}>
                 <span class="toggle-slider"></span>
             </label>
         </div>
         {% endfor %}
+        </div>
         {% endif %}
     </div>
 

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -156,6 +156,58 @@ class TestSettingsDirtyState:
         expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
 
 
+class TestSettingsExtensionsBatchSave:
+    """Installed module changes are saved with the Settings save flow."""
+
+    def test_module_toggles_batch_save_once_without_immediate_api_calls(self, settings_page):
+        config_payloads = []
+        batch_payloads = []
+        immediate_calls = []
+
+        def capture_config(route):
+            config_payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        def capture_batch(route):
+            batch_payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True, "restart_required": True})
+
+        def capture_immediate(route):
+            immediate_calls.append(route.request.url)
+            route.fulfill(status=500, json={"success": False})
+
+        settings_page.route("**/api/config", capture_config)
+        settings_page.route("**/api/modules/batch", capture_batch)
+        settings_page.route(re.compile(r".*/api/modules/.+/(enable|disable)$"), capture_immediate)
+
+        settings_page.locator('button[data-section="extensions"]').click()
+        toggles = settings_page.locator('.module-toggle-input[data-is-threshold="false"]')
+        assert toggles.count() >= 2
+        settings_page.locator('.module-toggle-input[data-is-threshold="false"] + .toggle-slider').nth(0).click()
+        settings_page.locator('.module-toggle-input[data-is-threshold="false"] + .toggle-slider').nth(1).click()
+
+        footer = settings_page.locator("#save-footer")
+        expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
+        settings_page.locator('#save-footer button[type="submit"]').click()
+
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        expect(settings_page.locator("#module-restart-banner")).to_be_visible()
+        assert len(config_payloads) == 1
+        assert len(batch_payloads) == 1
+        assert len(batch_payloads[0]["modules"]) == 2
+        assert immediate_calls == []
+
+    def test_threshold_profile_toggles_are_exclusive_radios(self, settings_page):
+        settings_page.locator('button[data-section="extensions"]').click()
+        threshold_toggles = settings_page.locator('.module-toggle-input[data-is-threshold="true"]')
+        assert threshold_toggles.count() >= 1
+        assert threshold_toggles.first.get_attribute("type") == "radio"
+        assert threshold_toggles.first.get_attribute("name") == "threshold_profile_module"
+        assert threshold_toggles.first.get_attribute("aria-labelledby")
+        assert threshold_toggles.first.get_attribute("aria-describedby")
+        expect(settings_page.locator('[role="group"][aria-labelledby="extensions-modules-heading"]')).to_be_visible()
+
+
 class TestSpeedtestModule:
     """Speedtest module settings interactions."""
 

--- a/tests/test_modules_api.py
+++ b/tests/test_modules_api.py
@@ -153,6 +153,101 @@ class TestEnableDisable:
             assert resp.status_code == 200
 
 
+class TestBatchModuleSettings:
+    """POST /api/modules/batch applies module settings in one save."""
+
+    @pytest.fixture(autouse=True)
+    def setup_app(self, tmp_path):
+        import json
+        from app.config import ConfigManager
+
+        threshold_data = {
+            "downstream_power": {"_default": "256QAM", "256QAM": {"good": [-4, 13], "warning": [-6, 18], "critical": [-8, 20]}},
+            "upstream_power": {"_default": "sc_qam", "sc_qam": {"good": [41, 47], "warning": [37, 51], "critical": [35, 53]}},
+            "snr": {"_default": "256QAM", "256QAM": {"good_min": 33, "warning_min": 31, "critical_min": 30}},
+        }
+        for dirname, module_id, contributes in [
+            ("regular", "test.integration", {}),
+            ("vfkd", "test.thresholds_vfkd", {"thresholds": "thresholds.json"}),
+            ("forum", "test.thresholds_forum", {"thresholds": "thresholds.json"}),
+        ]:
+            mod_dir = tmp_path / dirname
+            mod_dir.mkdir()
+            (mod_dir / "manifest.json").write_text(json.dumps({
+                "id": module_id,
+                "name": module_id,
+                "description": "d",
+                "version": "1.0.0",
+                "author": "a",
+                "minAppVersion": "2026.2",
+                "type": "driver",
+                "contributes": contributes,
+            }))
+            if contributes:
+                (mod_dir / "thresholds.json").write_text(json.dumps(threshold_data))
+
+        self.app = Flask(__name__)
+        self.app.config["TESTING"] = True
+        self.config_mgr = ConfigManager(str(tmp_path / "config"))
+        self.config_mgr.save({"disabled_modules": "test.thresholds_forum"})
+        self.loader = ModuleLoader(self.app, search_paths=[str(tmp_path)])
+        from app import analyzer
+        self._orig_thresholds = analyzer._thresholds.copy()
+        self.loader.load_all()
+
+        from app import web
+        self._orig_module_loader = web._module_loader
+        self._orig_config_manager = web._config_manager
+        web.init_modules(self.loader)
+        web.init_config(self.config_mgr)
+
+        from app.blueprints.modules_bp import modules_bp
+        self.app.register_blueprint(modules_bp)
+
+        yield
+
+        web._module_loader = self._orig_module_loader
+        web._config_manager = self._orig_config_manager
+        analyzer._thresholds = self._orig_thresholds
+
+    def test_batch_applies_multiple_modules_and_threshold_exclusivity(self):
+        with self.app.test_client() as c:
+            resp = c.post("/api/modules/batch", json={"modules": [
+                {"id": "test.integration", "enabled": False},
+                {"id": "test.thresholds_vfkd", "enabled": False},
+                {"id": "test.thresholds_forum", "enabled": True},
+            ]})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["restart_required"] is True
+        disabled = set(self.config_mgr.get("disabled_modules", "").split(","))
+        assert "test.integration" in disabled
+        assert "test.thresholds_vfkd" in disabled
+        assert "test.thresholds_forum" not in disabled
+
+    def test_batch_rejects_no_active_threshold_profile(self):
+        with self.app.test_client() as c:
+            resp = c.post("/api/modules/batch", json={"modules": [
+                {"id": "test.thresholds_vfkd", "enabled": False},
+                {"id": "test.thresholds_forum", "enabled": False},
+            ]})
+
+        assert resp.status_code == 409
+        assert resp.get_json()["success"] is False
+
+    def test_batch_rejects_multiple_active_threshold_profiles(self):
+        with self.app.test_client() as c:
+            resp = c.post("/api/modules/batch", json={"modules": [
+                {"id": "test.thresholds_vfkd", "enabled": True},
+                {"id": "test.thresholds_forum", "enabled": True},
+            ]})
+
+        assert resp.status_code == 409
+        assert resp.get_json()["success"] is False
+
+
 class TestThemeMutualExclusion:
     """Enabling a theme auto-disables others; cannot disable last theme."""
 


### PR DESCRIPTION
## Summary
- Moves installed module toggles into the normal Settings save flow so multiple extension changes can be saved once.
- Adds a batch module settings API with server-side validation for non-theme modules and threshold-profile exclusivity.
- Renders threshold profiles as exclusive radio controls and keeps the restart banner after saved module changes.
- Documents the extension module state flow in the architecture notes.

## Test plan
- `uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright pytest -q tests/test_modules_api.py::TestBatchModuleSettings tests/e2e/test_settings.py::TestSettingsExtensionsBatchSave`
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright pytest -q tests/e2e`

Closes #427
