### PR TITLE
Fix Settings saved-secret autofill dirty state

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -604,6 +604,16 @@ function _isSavedSecretField(el) {
     );
 }
 
+function _shouldTreatSavedSecretEventAsUserEdit(e) {
+    var target = e && e.target;
+    return !!(
+        e &&
+        e.isTrusted &&
+        _isSavedSecretField(target) &&
+        document.activeElement === target
+    );
+}
+
 function _normalizedFormValue(el) {
     if (_isSavedSecretField(el)) {
         return el.dataset.userEditedSecret ? '__edited_secret__' : '';
@@ -662,7 +672,7 @@ function initUnsavedDetection() {
     if (!form) return;
     _captureFormBaseline();
     function markDirty(e) {
-        if (e && _isSavedSecretField(e.target) && e.isTrusted) {
+        if (_shouldTreatSavedSecretEventAsUserEdit(e)) {
             e.target.dataset.userEditedSecret = 'true';
         }
         _updateDirtyState();

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -65,6 +65,32 @@ class TestSettingsFormElements:
 class TestSettingsDirtyState:
     """Unsaved-change prompts only appear for deliberate settings edits."""
 
+    def test_saved_secret_user_edit_guard_requires_active_field(self, settings_page):
+        result = settings_page.evaluate(
+            """
+            () => {
+              const input = document.querySelector('#modem_password');
+              input.dataset.savedSecret = 'true';
+              const inactive = window._shouldTreatSavedSecretEventAsUserEdit({
+                target: input,
+                isTrusted: true,
+              });
+              input.focus();
+              const active = window._shouldTreatSavedSecretEventAsUserEdit({
+                target: input,
+                isTrusted: true,
+              });
+              const untrusted = window._shouldTreatSavedSecretEventAsUserEdit({
+                target: input,
+                isTrusted: false,
+              });
+              return {inactive, active, untrusted};
+            }
+            """
+        )
+
+        assert result == {"inactive": False, "active": True, "untrusted": False}
+
     def test_modem_password_autofill_does_not_show_unsaved_footer(self, settings_page):
         footer = settings_page.locator("#save-footer")
         expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))

--- a/tests/test_settings_secret_fields.py
+++ b/tests/test_settings_secret_fields.py
@@ -45,6 +45,15 @@ def test_frontend_secret_fields_cover_saved_secret_inputs():
     assert expected <= secret_fields
 
 
+def test_saved_secret_dirty_detection_requires_active_field_before_user_edit():
+    """Password-manager autofill events on inactive saved secrets must stay clean."""
+    js = (ROOT / "app" / "static" / "js" / "settings.js").read_text(encoding="utf-8")
+
+    assert "function _shouldTreatSavedSecretEventAsUserEdit" in js
+    assert "document.activeElement === target" in js
+    assert "e && _isSavedSecretField(e.target) && e.isTrusted" not in js
+
+
 def test_config_save_preserves_masked_saved_secrets(tmp_path):
     """Posting the mask must preserve existing secret values server-side."""
     mgr = ConfigManager(str(tmp_path / "data"))


### PR DESCRIPTION
## Summary
- Prevent saved-secret autofill events from being treated as user edits unless the field is currently active.
- Keep saved secret values masked for background autofill while preserving normal focused edits.
- Add regression coverage for the saved-secret edit guard and Settings dirty-state behavior.

## Tests
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e`

Closes #426
