### PR TITLE
Fix BQM non-CSV response logging

### DIFF
--- a/app/modules/bqm/auth.py
+++ b/app/modules/bqm/auth.py
@@ -77,7 +77,7 @@ def fetch_share_csv(share_id: str, variant: str = "y") -> str:
         content_type = (response.headers.get("Content-Type") or "").lower()
         if "csv" in content_type or response.text.startswith('"Timestamp"'):
             return response.text
-        log.warning("ThinkBroadband response is not CSV (content-type: %s)", content_type)
+        log.warning("ThinkBroadband response is not CSV")
         return ""
     except ThinkBroadbandBatchAbort:
         raise

--- a/tests/test_bqm_auth.py
+++ b/tests/test_bqm_auth.py
@@ -88,6 +88,18 @@ class TestFetchShareCsv:
         mock_get.return_value = _response(200, "<html>not csv</html>", "text/html")
         assert fetch_share_csv("abc123-2", "y") == ""
 
+    @patch("app.modules.bqm.auth.requests.get")
+    def test_non_csv_content_type_is_not_logged(self, mock_get, caplog):
+        sensitive_content_type = "text/html; password=secret123"
+        mock_get.return_value = _response(200, "<html>not csv</html>", sensitive_content_type)
+
+        with caplog.at_level("WARNING", logger="docsis.bqm.auth"):
+            assert fetch_share_csv("abc123-2", "y") == ""
+
+        assert "ThinkBroadband response is not CSV" in caplog.text
+        assert sensitive_content_type not in caplog.text
+        assert "secret123" not in caplog.text
+
 
 class TestValidateShareId:
     @patch("app.modules.bqm.auth.fetch_share_csv")


### PR DESCRIPTION
## Summary
- Stop logging the externally supplied ThinkBroadband response `Content-Type` value on non-CSV responses.
- Keep the non-CSV warning generic while preserving CSV detection behavior.
- Add regression coverage to ensure sensitive header fragments do not appear in BQM auth logs.

## Tests
- `uv run --with-requirements requirements-test.txt pytest -q tests/test_bqm_auth.py::TestFetchShareCsv::test_non_csv_content_type_is_not_logged`
- `uv run --with-requirements requirements-test.txt pytest -q tests/test_bqm_auth.py`
- `git diff --check`
- `python3 -m py_compile app/modules/bqm/auth.py tests/test_bqm_auth.py`
- `uv run --with-requirements requirements-test.txt pytest -q tests/test_bqm_auth.py tests/test_bqm.py tests/web/test_config_api.py`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e`

Refs code scanning alert #77
