### PR TITLE
Hide unsupported DOCSIS error comparisons

### DIFF
--- a/app/modules/comparison/routes.py
+++ b/app/modules/comparison/routes.py
@@ -17,6 +17,9 @@ def _aggregate_period(snapshots):
             "snapshots": 0,
             "avg": {"ds_power": None, "ds_snr": None, "us_power": None},
             "total": {"corr_errors": 0, "uncorr_errors": 0},
+            "errors_supported": False,
+            "corr_errors_supported": False,
+            "uncorr_errors_supported": False,
             "health_distribution": {},
             "timeseries": [],
         }
@@ -26,6 +29,8 @@ def _aggregate_period(snapshots):
     us_power = []
     corr_total = 0
     uncorr_total = 0
+    corr_errors_supported = False
+    uncorr_errors_supported = False
     health_counts = {}
     timeseries = []
 
@@ -37,8 +42,14 @@ def _aggregate_period(snapshots):
             ds_snr.append(s["ds_snr_avg"])
         if s.get("us_power_avg") is not None:
             us_power.append(s["us_power_avg"])
-        corr_total += s.get("ds_correctable_errors", 0) or 0
-        uncorr_total += s.get("ds_uncorrectable_errors", 0) or 0
+        corr_errors = s.get("ds_correctable_errors")
+        uncorr_errors = s.get("ds_uncorrectable_errors")
+        if corr_errors is not None:
+            corr_errors_supported = True
+            corr_total += corr_errors
+        if uncorr_errors is not None:
+            uncorr_errors_supported = True
+            uncorr_total += uncorr_errors
         h = s.get("health", "unknown")
         health_counts[h] = health_counts.get(h, 0) + 1
         timeseries.append({
@@ -46,7 +57,7 @@ def _aggregate_period(snapshots):
             "ds_power_avg": s.get("ds_power_avg"),
             "ds_snr_avg": s.get("ds_snr_avg"),
             "us_power_avg": s.get("us_power_avg"),
-            "uncorr_errors": s.get("ds_uncorrectable_errors", 0),
+            "uncorr_errors": uncorr_errors,
             "health": h,
         })
 
@@ -60,7 +71,13 @@ def _aggregate_period(snapshots):
             "ds_snr": avg(ds_snr),
             "us_power": avg(us_power),
         },
-        "total": {"corr_errors": corr_total, "uncorr_errors": uncorr_total},
+        "total": {
+            "corr_errors": corr_total if corr_errors_supported else None,
+            "uncorr_errors": uncorr_total if uncorr_errors_supported else None,
+        },
+        "errors_supported": corr_errors_supported or uncorr_errors_supported,
+        "corr_errors_supported": corr_errors_supported,
+        "uncorr_errors_supported": uncorr_errors_supported,
         "health_distribution": health_counts,
         "timeseries": timeseries,
     }
@@ -81,7 +98,12 @@ def _compute_delta(period_a, period_b):
     ds_power_d = diff("ds_power")
     ds_snr_d = diff("ds_snr")
     us_power_d = diff("us_power")
-    uncorr_d = period_b["total"]["uncorr_errors"] - period_a["total"]["uncorr_errors"]
+    if period_a["total"].get("uncorr_errors") is not None and period_b["total"].get("uncorr_errors") is not None:
+        uncorr_d = period_b["total"]["uncorr_errors"] - period_a["total"]["uncorr_errors"]
+    elif period_a.get("snapshots", 0) == 0 and period_b.get("snapshots", 0) == 0:
+        uncorr_d = 0
+    else:
+        uncorr_d = None
 
     # Verdict: improved if SNR went up and errors went down (or stayed)
     # degraded if SNR went down or errors went up significantly
@@ -91,10 +113,11 @@ def _compute_delta(period_a, period_b):
             score += 1
         elif ds_snr_d < -1:
             score -= 1
-    if uncorr_d > 10:
-        score -= 1
-    elif uncorr_d < 0:
-        score += 1
+    if uncorr_d is not None:
+        if uncorr_d > 10:
+            score -= 1
+        elif uncorr_d < 0:
+            score += 1
 
     if score > 0:
         verdict = "improved"

--- a/app/modules/comparison/static/main.js
+++ b/app/modules/comparison/static/main.js
@@ -143,6 +143,23 @@ function _cmpMapToLabels(normalized, hourLabels) {
 }
 
 /* ── Chart Rendering ── */
+function _cmpPeriodSupportsDocsisErrors(period) {
+    if (!period) return false;
+    if (period.uncorr_errors_supported === true) return true;
+    return period.total && period.total.uncorr_errors != null || !!(period.timeseries && period.timeseries.some(function(pt) {
+        return pt && pt.uncorr_errors != null;
+    }));
+}
+
+function _cmpSetErrorsChartVisible(visible) {
+    var card = document.getElementById('comparison-errors-card');
+    if (card) card.style.display = visible ? '' : 'none';
+    if (!visible && charts['cmp-chart-errors']) {
+        charts['cmp-chart-errors'].destroy();
+        delete charts['cmp-chart-errors'];
+    }
+}
+
 function _cmpRenderCharts(data) {
     var pa = data.period_a;
     var pb = data.period_b;
@@ -186,10 +203,14 @@ function _cmpRenderCharts(data) {
         {label: labelB, data: extract(mappedB, 'us_power_avg'), color: '#ff9800', spanGaps: true}
     ], null, US_POWER_THRESHOLDS);
 
-    renderChart('cmp-chart-errors', xLabels, [
-        {label: labelA, data: extract(mappedA, 'uncorr_errors'), color: '#2196f3'},
-        {label: labelB, data: extract(mappedB, 'uncorr_errors'), color: '#ff9800'}
-    ], 'bar');
+    var showErrors = _cmpPeriodSupportsDocsisErrors(pa) || _cmpPeriodSupportsDocsisErrors(pb);
+    _cmpSetErrorsChartVisible(showErrors);
+    if (showErrors) {
+        renderChart('cmp-chart-errors', xLabels, [
+            {label: labelA, data: extract(mappedA, 'uncorr_errors'), color: '#2196f3'},
+            {label: labelB, data: extract(mappedB, 'uncorr_errors'), color: '#ff9800'}
+        ], 'bar');
+    }
 }
 
 /* ── Delta Table ── */

--- a/app/modules/comparison/templates/comparison_tab.html
+++ b/app/modules/comparison/templates/comparison_tab.html
@@ -80,7 +80,7 @@
             </div>
             <canvas id="cmp-chart-us-power"></canvas>
         </div>
-        <div class="chart-card">
+        <div class="chart-card" id="comparison-errors-card">
             <div class="chart-card-header">
                 <div class="chart-header-content">
                     <div class="chart-label">{{ t.get('docsight.comparison.uncorr_errors', 'Uncorr. Errors') }}</div>

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -1292,10 +1292,15 @@ function renderCorrelationTable(data) {
             var badge = '<span class="st-health-badge health-' + h + '">' + (healthLabels[h] || h) + '</span>';
             src = '<span style="color:var(--accent);">Modem</span>';
             msg = badge;
-            details = (T.correlation_tt_snr || 'SNR') + ' ' + (e.ds_snr_min != null ? e.ds_snr_min + ' dB' : '') +
-                      ' | ' + (T.event_power || 'Power') + ' ' + (e.ds_power_avg != null ? e.ds_power_avg + ' dBmV' : '') +
-                      ' | TX ' + (e.us_power_avg != null ? e.us_power_avg + ' dBmV' : '') +
-                      ' | ' + (T.correlation_tt_errors || 'Errors') + ' ' + (e.ds_uncorrectable_errors || 0);
+            var modemDetails = [
+                (T.correlation_tt_snr || 'SNR') + ' ' + (e.ds_snr_min != null ? e.ds_snr_min + ' dB' : ''),
+                (T.event_power || 'Power') + ' ' + (e.ds_power_avg != null ? e.ds_power_avg + ' dBmV' : ''),
+                'TX ' + (e.us_power_avg != null ? e.us_power_avg + ' dBmV' : '')
+            ];
+            if (e.ds_uncorrectable_errors != null) {
+                modemDetails.push((T.correlation_tt_errors || 'Errors') + ' ' + e.ds_uncorrectable_errors);
+            }
+            details = modemDetails.join(' | ');
         } else if (src === 'speedtest') {
             src = '<span style="color:var(--good);">Speedtest</span>';
             msg = (e.download_mbps ? e.download_mbps.toFixed(1) + ' / ' + (e.upload_mbps || 0).toFixed(1) + ' Mbps' : '');

--- a/app/static/js/journal.js
+++ b/app/static/js/journal.js
@@ -1429,6 +1429,9 @@ function _renderTimelineTable(data) {
             details = '<span class="st-health-badge health-' + (e.health || 'unknown') + '">' + hLabel + '</span>';
             details += ' SNR ' + (e.ds_snr_min != null ? e.ds_snr_min + ' dB' : '-');
             details += ' | Power ' + (e.ds_power_avg != null ? e.ds_power_avg + ' dBmV' : '-');
+            if (e.ds_uncorrectable_errors != null) {
+                details += ' | ' + (T.correlation_tt_errors || 'Errors') + ' ' + e.ds_uncorrectable_errors;
+            }
         } else if (e.source === 'speedtest') {
             srcBadge = '<span class="timeline-source-badge timeline-source-badge-speedtest">' + (T.timeline_source_speedtest || 'Speedtest') + '</span>';
             details = (e.download_mbps ? e.download_mbps.toFixed(1) + ' / ' + (e.upload_mbps || 0).toFixed(1) + ' Mbps' : '');

--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -35,8 +35,8 @@ class AnalysisMixin:
                     "ds_snr_min": s.get("ds_snr_min"),
                     "ds_snr_avg": s.get("ds_snr_avg"),
                     "us_power_avg": s.get("us_power_avg"),
-                    "ds_correctable_errors": s.get("ds_correctable_errors", 0),
-                    "ds_uncorrectable_errors": s.get("ds_uncorrectable_errors", 0),
+                    "ds_correctable_errors": s.get("ds_correctable_errors"),
+                    "ds_uncorrectable_errors": s.get("ds_uncorrectable_errors"),
                 })
 
         if "speedtest" in sources:

--- a/tests/e2e/test_comparison.py
+++ b/tests/e2e/test_comparison.py
@@ -3,6 +3,62 @@
 from playwright.sync_api import expect
 
 
+def _comparison_payload(errors_supported, uncorr_errors):
+    return {
+        "period_a": {
+            "from": "2026-03-01T00:00:00Z",
+            "to": "2026-03-01T23:59:00Z",
+            "snapshots": 1,
+            "avg": {"ds_power": 3.1, "ds_snr": 34.2, "us_power": 42.1},
+            "total": {
+                "corr_errors": 0 if errors_supported else None,
+                "uncorr_errors": uncorr_errors if errors_supported else None,
+            },
+            "errors_supported": errors_supported,
+            "corr_errors_supported": errors_supported,
+            "uncorr_errors_supported": errors_supported,
+            "health_distribution": {"good": 1},
+            "timeseries": [{
+                "timestamp": "2026-03-01T06:00:00Z",
+                "ds_power_avg": 3.1,
+                "ds_snr_avg": 34.2,
+                "us_power_avg": 42.1,
+                "uncorr_errors": uncorr_errors if errors_supported else None,
+                "health": "good",
+            }],
+        },
+        "period_b": {
+            "from": "2026-03-08T00:00:00Z",
+            "to": "2026-03-08T23:59:00Z",
+            "snapshots": 1,
+            "avg": {"ds_power": 3.2, "ds_snr": 34.3, "us_power": 42.2},
+            "total": {
+                "corr_errors": 0 if errors_supported else None,
+                "uncorr_errors": uncorr_errors if errors_supported else None,
+            },
+            "errors_supported": errors_supported,
+            "corr_errors_supported": errors_supported,
+            "uncorr_errors_supported": errors_supported,
+            "health_distribution": {"good": 1},
+            "timeseries": [{
+                "timestamp": "2026-03-08T06:00:00Z",
+                "ds_power_avg": 3.2,
+                "ds_snr_avg": 34.3,
+                "us_power_avg": 42.2,
+                "uncorr_errors": uncorr_errors if errors_supported else None,
+                "health": "good",
+            }],
+        },
+        "delta": {
+            "ds_power": 0.1,
+            "ds_snr": 0.1,
+            "us_power": 0.1,
+            "uncorr_errors": 0 if errors_supported else None,
+            "verdict": "unchanged",
+        },
+    }
+
+
 def navigate_to_comparison(page):
     """Open the comparison view and wait for the control bar."""
     page.locator('.nav-item[data-view="comparison"]').click()
@@ -21,6 +77,48 @@ class TestComparisonView:
         expect(demo_page.locator("#comparison-health")).to_be_visible()
         assert demo_page.locator("#comparison-health-bars-a .comparison-health-row").count() == 5
         assert demo_page.locator("#comparison-health-bars-b .comparison-health-row").count() == 5
+
+    def test_hides_error_chart_when_docsis_errors_are_unsupported(self, demo_page):
+        demo_page.route(
+            "**/api/comparison**",
+            lambda route: route.fulfill(json=_comparison_payload(False, None)),
+        )
+        navigate_to_comparison(demo_page)
+
+        demo_page.locator("#comparison-run-btn").click()
+
+        expect(demo_page.locator("#comparison-health")).to_be_visible()
+        expect(demo_page.locator("#comparison-errors-card")).to_be_hidden()
+        assert demo_page.locator("#cmp-chart-errors .uplot").count() == 0
+
+    def test_hides_uncorrectable_chart_when_only_correctable_errors_are_supported(self, demo_page):
+        payload = _comparison_payload(False, None)
+        for period_key in ("period_a", "period_b"):
+            period = payload[period_key]
+            period["errors_supported"] = True
+            period["corr_errors_supported"] = True
+            period["uncorr_errors_supported"] = False
+            period["total"]["corr_errors"] = 5
+        demo_page.route("**/api/comparison**", lambda route: route.fulfill(json=payload))
+        navigate_to_comparison(demo_page)
+
+        demo_page.locator("#comparison-run-btn").click()
+
+        expect(demo_page.locator("#comparison-health")).to_be_visible()
+        expect(demo_page.locator("#comparison-errors-card")).to_be_hidden()
+        assert demo_page.locator("#cmp-chart-errors .uplot").count() == 0
+
+    def test_keeps_zero_error_chart_when_docsis_errors_are_supported(self, demo_page):
+        demo_page.route(
+            "**/api/comparison**",
+            lambda route: route.fulfill(json=_comparison_payload(True, 0)),
+        )
+        navigate_to_comparison(demo_page)
+
+        demo_page.locator("#comparison-run-btn").click()
+
+        expect(demo_page.locator("#comparison-health")).to_be_visible()
+        expect(demo_page.locator("#comparison-errors-card")).to_be_visible()
 
     def test_comparison_can_open_report_modal_with_attached_evidence(self, demo_page):
         navigate_to_comparison(demo_page)

--- a/tests/test_comparison_module.py
+++ b/tests/test_comparison_module.py
@@ -44,6 +44,20 @@ SNAPSHOT_B = {
     "us_channels": [],
 }
 
+UNSUPPORTED_ERRORS_SNAPSHOT = {
+    "timestamp": "2026-03-01T06:00:00Z",
+    "summary": {
+        "ds_power_avg": 3.1,
+        "ds_snr_avg": 34.2,
+        "us_power_avg": 42.1,
+        "ds_correctable_errors": None,
+        "ds_uncorrectable_errors": None,
+        "health": "good",
+    },
+    "ds_channels": [],
+    "us_channels": [],
+}
+
 
 class TestCompareEndpoint:
     def test_missing_params_returns_400(self, app_client):
@@ -219,6 +233,49 @@ class TestAggregatePeriod:
         assert result["avg"]["ds_snr"] == pytest.approx(32.85)
         assert result["total"]["corr_errors"] == 300
 
+    def test_unsupported_error_counters_remain_none(self):
+        from app.modules.comparison.routes import _aggregate_period
+
+        result = _aggregate_period([UNSUPPORTED_ERRORS_SNAPSHOT])
+
+        assert result["errors_supported"] is False
+        assert result["corr_errors_supported"] is False
+        assert result["uncorr_errors_supported"] is False
+        assert result["total"]["corr_errors"] is None
+        assert result["total"]["uncorr_errors"] is None
+        assert result["timeseries"][0]["uncorr_errors"] is None
+
+    def test_zero_error_counters_stay_supported_zeroes(self):
+        from app.modules.comparison.routes import _aggregate_period
+
+        result = _aggregate_period([SNAPSHOT_A])
+
+        assert result["errors_supported"] is True
+        assert result["corr_errors_supported"] is True
+        assert result["uncorr_errors_supported"] is True
+        assert result["total"]["corr_errors"] == 100
+        assert result["total"]["uncorr_errors"] == 0
+
+    def test_partially_supported_error_counters_do_not_invent_zeroes(self):
+        from app.modules.comparison.routes import _aggregate_period
+
+        partial = {
+            **UNSUPPORTED_ERRORS_SNAPSHOT,
+            "summary": {
+                **UNSUPPORTED_ERRORS_SNAPSHOT["summary"],
+                "ds_correctable_errors": 5,
+                "ds_uncorrectable_errors": None,
+            },
+        }
+        result = _aggregate_period([partial])
+
+        assert result["errors_supported"] is True
+        assert result["corr_errors_supported"] is True
+        assert result["uncorr_errors_supported"] is False
+        assert result["total"]["corr_errors"] == 5
+        assert result["total"]["uncorr_errors"] is None
+        assert result["timeseries"][0]["uncorr_errors"] is None
+
     def test_compare_periods_helper(self):
         from app.modules.comparison.routes import compare_periods
 
@@ -270,6 +327,19 @@ class TestComputeDelta:
         delta = _compute_delta(pa, pb)
         assert delta["ds_power"] is None
         assert delta["uncorr_errors"] == 0
+        assert delta["verdict"] == "unchanged"
+
+    def test_delta_ignores_unsupported_error_counters(self):
+        from app.modules.comparison.routes import _aggregate_period, _compute_delta
+
+        unsupported_a = _aggregate_period([UNSUPPORTED_ERRORS_SNAPSHOT])
+        unsupported_b = _aggregate_period([
+            {**UNSUPPORTED_ERRORS_SNAPSHOT, "timestamp": "2026-03-08T06:00:00Z"}
+        ])
+
+        delta = _compute_delta(unsupported_a, unsupported_b)
+
+        assert delta["uncorr_errors"] is None
         assert delta["verdict"] == "unchanged"
 
     def test_extreme_snr_improvement(self):

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -184,6 +184,28 @@ class TestCorrelationTimeline:
         assert "ds_snr_min" in m
         assert "ds_power_avg" in m
 
+    @pytest.mark.parametrize("remove_keys", [False, True])
+    def test_modem_unsupported_error_counters_remain_none(self, storage, sample_analysis, remove_keys):
+        """Unsupported DOCSIS counters must not be normalized to zero in the timeline."""
+        unsupported = dict(sample_analysis["summary"])
+        if remove_keys:
+            unsupported.pop("ds_correctable_errors")
+            unsupported.pop("ds_uncorrectable_errors")
+        else:
+            unsupported["ds_correctable_errors"] = None
+            unsupported["ds_uncorrectable_errors"] = None
+        ts = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        with sqlite3.connect(storage.db_path) as conn:
+            conn.execute(
+                "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?,?,?,?)",
+                (ts, json.dumps(unsupported), "[]", "[]"),
+            )
+
+        timeline = storage.get_correlation_timeline(ts, ts, sources={"modem"})
+
+        assert timeline[0]["ds_correctable_errors"] is None
+        assert timeline[0]["ds_uncorrectable_errors"] is None
+
     def test_speedtest_fields_present(self, storage, speedtest_storage, sample_analysis):
         """Speedtest entries must contain download, upload, ping."""
         now = self._seed_data(storage, speedtest_storage, sample_analysis)


### PR DESCRIPTION
## Summary

- preserve unsupported DOCSIS error counters as `null` in Before/After Comparison and Unified Timeline data
- hide the Before/After uncorrectable error chart when uncorrectable DOCSIS counters are unsupported
- keep supported zero values visible so real `0` error counts are not hidden
- omit misleading `Errors 0` text from Unified Timeline rows when DOCSIS errors are unsupported

Fixes #433.

## Tests

- `.venv/bin/python -m pytest tests/test_comparison_module.py tests/test_correlation.py::TestCorrelationTimeline::test_modem_unsupported_error_counters_remain_none tests/e2e/test_comparison.py -q` — 34 passed
- `.venv/bin/python -m pytest --ignore=tests/e2e -q` — 2248 passed, 11 skipped, 1 warning
- `.venv/bin/python -m pytest tests/e2e -q` — 351 passed
- `git diff --check`
- static added-line secret scan

## Review

Independent review passed after correcting partial-support handling for correctable-only DOCSIS counters.
