### PR TITLE
fix: preserve unsupported DOCSIS error counters

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -171,7 +171,8 @@ def apply_spike_suppression(analysis: AnalysisResult, last_spike_ts: str | None)
         return  # Still in observation period
 
     summary = analysis["summary"]
-    summary["ds_uncorr_pct"] = 0.0
+    if summary.get("ds_uncorr_pct") is not None:
+        summary["ds_uncorr_pct"] = 0.0
     summary["health_issues"] = [i for i in summary["health_issues"] if "uncorr" not in i]
     summary["spike_suppression"] = {
         "active": True,
@@ -486,12 +487,19 @@ def analyze(data: DocsisData) -> AnalysisResult:
     us_powers = [c["power"] for c in us_channels if c["power"] is not None]
     ds_snrs = [c["snr"] for c in ds_channels if c["snr"] is not None]
 
-    has_error_data = any(
-        c["correctable_errors"] is not None or c["uncorrectable_errors"] is not None
-        for c in ds_channels
+    has_corr_data = any(c["correctable_errors"] is not None for c in ds_channels)
+    has_uncorr_data = any(c["uncorrectable_errors"] is not None for c in ds_channels)
+    has_error_data = has_corr_data or has_uncorr_data
+    total_corr = (
+        sum(c["correctable_errors"] for c in ds_channels if c["correctable_errors"] is not None)
+        if has_corr_data
+        else None
     )
-    total_corr = sum(c["correctable_errors"] for c in ds_channels if c["correctable_errors"] is not None)
-    total_uncorr = sum(c["uncorrectable_errors"] for c in ds_channels if c["uncorrectable_errors"] is not None)
+    total_uncorr = (
+        sum(c["uncorrectable_errors"] for c in ds_channels if c["uncorrectable_errors"] is not None)
+        if has_uncorr_data
+        else None
+    )
 
     us_bitrates = [c["theoretical_bitrate"] for c in us_channels if c["theoretical_bitrate"] is not None]
     us_capacity = round(sum(us_bitrates), 1) if us_bitrates else None
@@ -559,16 +567,19 @@ def analyze(data: DocsisData) -> AnalysisResult:
     elif any("snr tolerated" in c["health_detail"] for c in ds_channels):
         issues.append("snr_tolerated")
 
-    total_codewords = total_corr + total_uncorr
+    total_codewords = (total_corr or 0) + (total_uncorr or 0)
     et = _get_uncorr_thresholds()
-    if total_codewords >= et["min_codewords"]:
-        uncorr_pct = round((total_uncorr / total_codewords) * 100, 2)
-        if uncorr_pct >= et["critical"]:
-            issues.append("uncorr_errors_critical")
-        elif uncorr_pct >= et["warning"]:
-            issues.append("uncorr_errors_high")
+    if has_corr_data and has_uncorr_data:
+        if total_codewords >= et["min_codewords"]:
+            uncorr_pct = round(((total_uncorr or 0) / total_codewords) * 100, 2)
+            if uncorr_pct >= et["critical"]:
+                issues.append("uncorr_errors_critical")
+            elif uncorr_pct >= et["warning"]:
+                issues.append("uncorr_errors_high")
+        else:
+            uncorr_pct = 0.0
     else:
-        uncorr_pct = 0.0
+        uncorr_pct = None
     summary["ds_uncorr_pct"] = uncorr_pct
 
     if not issues:

--- a/app/blueprints/data_bp.py
+++ b/app/blueprints/data_bp.py
@@ -37,6 +37,18 @@ def _translate_issue(key: str) -> str:
     return _ISSUE_LABELS.get(key, key.replace("_", " ").title())
 
 
+def _summary_error_count(summary, key):
+    """Return a DOCSIS error counter only when the summary supports it."""
+    if summary.get("errors_supported") is False:
+        return None
+    return summary.get(key)
+
+
+def _format_error_count(value) -> str:
+    """Format DOCSIS error counters while preserving unsupported/null as N/A."""
+    return f"{value:,}" if value is not None else "N/A"
+
+
 data_bp = Blueprint("data_bp", __name__)
 
 
@@ -121,8 +133,8 @@ def api_export():
         f"| Downstream Channels | {s.get('ds_total', 0)} |",
         f"| DS Power (Min/Avg/Max) | {s.get('ds_power_min')} / {s.get('ds_power_avg')} / {s.get('ds_power_max')} dBmV |",
         f"| DS SNR (Min/Avg) | {s.get('ds_snr_min')} / {s.get('ds_snr_avg')} dB |",
-        f"| DS Correctable Errors | {s.get('ds_correctable_errors', 0):,} |",
-        f"| DS Uncorrectable Errors | {s.get('ds_uncorrectable_errors', 0):,} |",
+        f"| DS Correctable Errors | {_format_error_count(_summary_error_count(s, 'ds_correctable_errors'))} |",
+        f"| DS Uncorrectable Errors | {_format_error_count(_summary_error_count(s, 'ds_uncorrectable_errors'))} |",
         f"| Upstream Channels | {s.get('us_total', 0)} |",
         f"| US Power (Min/Avg/Max) | {s.get('us_power_min')} / {s.get('us_power_avg')} / {s.get('us_power_max')} dBmV |",
         "",
@@ -221,7 +233,7 @@ def api_export():
                         f"| {st['timestamp'][:16]} | {st.get('download_human', '')} "
                         f"| {ss.get('health', '')} | {ss.get('ds_snr_min', '')} dB "
                         f"| {ss.get('ds_power_avg', '')} dBmV "
-                        f"| {ss.get('ds_uncorrectable_errors', 0):,} |"
+                        f"| {_format_error_count(_summary_error_count(ss, 'ds_uncorrectable_errors'))} |"
                     )
             if corr_lines:
                 lines += [

--- a/app/event_detector.py
+++ b/app/event_detector.py
@@ -385,8 +385,12 @@ class EventDetector:
             })
 
     def _check_errors(self, events, ts, cur, prev):
+        if cur.get("errors_supported") is False or prev.get("errors_supported") is False:
+            return
         uncorr_cur = cur.get("ds_uncorrectable_errors", 0)
         uncorr_prev = prev.get("ds_uncorrectable_errors", 0)
+        if uncorr_cur is None or uncorr_prev is None:
+            return
         delta = uncorr_cur - uncorr_prev
 
         if delta > UNCORR_SPIKE_THRESHOLD:

--- a/app/modules/comparison/routes.py
+++ b/app/modules/comparison/routes.py
@@ -16,7 +16,7 @@ def _aggregate_period(snapshots):
         return {
             "snapshots": 0,
             "avg": {"ds_power": None, "ds_snr": None, "us_power": None},
-            "total": {"corr_errors": 0, "uncorr_errors": 0},
+            "total": {"corr_errors": None, "uncorr_errors": None},
             "errors_supported": False,
             "corr_errors_supported": False,
             "uncorr_errors_supported": False,
@@ -42,8 +42,9 @@ def _aggregate_period(snapshots):
             ds_snr.append(s["ds_snr_avg"])
         if s.get("us_power_avg") is not None:
             us_power.append(s["us_power_avg"])
-        corr_errors = s.get("ds_correctable_errors")
-        uncorr_errors = s.get("ds_uncorrectable_errors")
+        errors_supported = s.get("errors_supported", True)
+        corr_errors = s.get("ds_correctable_errors") if errors_supported else None
+        uncorr_errors = s.get("ds_uncorrectable_errors") if errors_supported else None
         if corr_errors is not None:
             corr_errors_supported = True
             corr_total += corr_errors
@@ -100,8 +101,6 @@ def _compute_delta(period_a, period_b):
     us_power_d = diff("us_power")
     if period_a["total"].get("uncorr_errors") is not None and period_b["total"].get("uncorr_errors") is not None:
         uncorr_d = period_b["total"]["uncorr_errors"] - period_a["total"]["uncorr_errors"]
-    elif period_a.get("snapshots", 0) == 0 and period_b.get("snapshots", 0) == 0:
-        uncorr_d = 0
     else:
         uncorr_d = None
 

--- a/app/modules/comparison/static/main.js
+++ b/app/modules/comparison/static/main.js
@@ -229,8 +229,10 @@ function _cmpRenderDeltaTable(data) {
         pa.avg.ds_snr, pb.avg.ds_snr, 'dB', delta.ds_snr, true, false);
     _cmpAppendDeltaRow(tbody, T['docsight.comparison.us_power'] || 'US Power',
         pa.avg.us_power, pb.avg.us_power, 'dBmV', delta.us_power, false, false);
-    _cmpAppendDeltaRow(tbody, T['docsight.comparison.uncorr_errors'] || 'Uncorr. Errors',
-        pa.total.uncorr_errors, pb.total.uncorr_errors, '', delta.uncorr_errors, false, true);
+    if (_cmpPeriodSupportsDocsisErrors(pa) || _cmpPeriodSupportsDocsisErrors(pb)) {
+        _cmpAppendDeltaRow(tbody, T['docsight.comparison.uncorr_errors'] || 'Uncorr. Errors',
+            pa.total.uncorr_errors, pb.total.uncorr_errors, '', delta.uncorr_errors, false, true);
+    }
 
     /* Health verdict row */
     var healthA = _cmpTopHealth(pa.health_distribution);

--- a/app/modules/reports/report.py
+++ b/app/modules/reports/report.py
@@ -354,6 +354,11 @@ class IncidentReport(FPDF):
         self.ln()
 
 
+def _format_optional_count(value):
+    """Format a counter value while preserving unsupported/null as N/A."""
+    return f"{value:,}" if value is not None else "N/A"
+
+
 def _compute_worst_values(snapshots):
     """Compute worst values across all snapshots in the range."""
     worst = {
@@ -361,8 +366,8 @@ def _compute_worst_values(snapshots):
         "ds_power_min": 0,
         "us_power_max": 0,
         "ds_snr_min": 999,
-        "ds_uncorrectable_max": 0,
-        "ds_correctable_max": 0,
+        "ds_uncorrectable_max": None,
+        "ds_correctable_max": None,
         "health_critical_count": 0,
         "health_marginal_count": 0,
         "health_tolerated_count": 0,
@@ -378,10 +383,17 @@ def _compute_worst_values(snapshots):
             worst["us_power_max"] = s.get("us_power_max", 0)
         if s.get("ds_snr_min", 999) < worst["ds_snr_min"]:
             worst["ds_snr_min"] = s.get("ds_snr_min", 999)
-        if s.get("ds_uncorrectable_errors", 0) > worst["ds_uncorrectable_max"]:
-            worst["ds_uncorrectable_max"] = s.get("ds_uncorrectable_errors", 0)
-        if s.get("ds_correctable_errors", 0) > worst["ds_correctable_max"]:
-            worst["ds_correctable_max"] = s.get("ds_correctable_errors", 0)
+        errors_supported = s.get("errors_supported", True)
+        uncorr_errors = s.get("ds_uncorrectable_errors") if errors_supported else None
+        corr_errors = s.get("ds_correctable_errors") if errors_supported else None
+        if uncorr_errors is not None and (
+            worst["ds_uncorrectable_max"] is None or uncorr_errors > worst["ds_uncorrectable_max"]
+        ):
+            worst["ds_uncorrectable_max"] = uncorr_errors
+        if corr_errors is not None and (
+            worst["ds_correctable_max"] is None or corr_errors > worst["ds_correctable_max"]
+        ):
+            worst["ds_correctable_max"] = corr_errors
         health = s.get("health", "good")
         if health == "critical":
             worst["health_critical_count"] += 1
@@ -549,8 +561,8 @@ def generate_report(snapshots, current_analysis, config=None, connection_info=No
                 f"{ch.get('power') or 0:.1f}",
                 f"{ch.get('snr') or 0:.1f}" if ch.get("snr") else "—",
                 str(ch.get("modulation") or "")[:10],
-                f"{ch.get('correctable_errors') or 0:,}",
-                f"{ch.get('uncorrectable_errors') or 0:,}",
+                _format_optional_count(ch.get('correctable_errors')),
+                _format_optional_count(ch.get('uncorrectable_errors')),
                 ch.get("health", ""),
             ], widths, health=ch.get("health"))
 
@@ -640,8 +652,8 @@ def generate_report(snapshots, current_analysis, config=None, connection_info=No
         pdf._key_value(s["ds_power_worst"], f"{worst['ds_power_max']} dBmV (threshold: {warn['ds_power']})")
         pdf._key_value(s["us_power_worst"], f"{worst['us_power_max']} dBmV (threshold: {warn['us_power']})")
         pdf._key_value(s["ds_snr_worst"], f"{worst['ds_snr_min']} dB (threshold: {warn['snr']})")
-        pdf._key_value(s["uncorr_err_max"], f"{worst['ds_uncorrectable_max']:,}")
-        pdf._key_value(s["corr_err_max"], f"{worst['ds_correctable_max']:,}")
+        pdf._key_value(s["uncorr_err_max"], _format_optional_count(worst["ds_uncorrectable_max"]))
+        pdf._key_value(s["corr_err_max"], _format_optional_count(worst["ds_correctable_max"]))
         pdf.ln(3)
 
         # Worst channels
@@ -699,7 +711,7 @@ def generate_report(snapshots, current_analysis, config=None, connection_info=No
             f"- {s['complaint_ds_power'].format(val=worst['ds_power_max'], thresh=warn['ds_power'])}\n"
             f"- {s['complaint_us_power'].format(val=worst['us_power_max'], thresh=warn['us_power'])}\n"
             f"- {s['complaint_snr'].format(val=worst['ds_snr_min'], thresh=warn['snr'])}\n"
-            f"- {s['complaint_uncorr'].format(val='{:,}'.format(worst['ds_uncorrectable_max']))}\n\n"
+            f"- {s['complaint_uncorr'].format(val=_format_optional_count(worst['ds_uncorrectable_max']))}\n\n"
             f"{diag_complaint}"
             f"{s['complaint_exceed']}\n\n"
             f"{s['complaint_request']}\n"
@@ -818,8 +830,8 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
         pdf._key_value(s["ds_power_worst"], f"{worst['ds_power_max']} dBmV (threshold: {warn['ds_power']})")
         pdf._key_value(s["us_power_worst"], f"{worst['us_power_max']} dBmV (threshold: {warn['us_power']})")
         pdf._key_value(s["ds_snr_worst"], f"{worst['ds_snr_min']} dB (threshold: {warn['snr']})")
-        pdf._key_value(s["uncorr_err_max"], f"{worst['ds_uncorrectable_max']:,}")
-        pdf._key_value(s["corr_err_max"], f"{worst['ds_correctable_max']:,}")
+        pdf._key_value(s["uncorr_err_max"], _format_optional_count(worst["ds_uncorrectable_max"]))
+        pdf._key_value(s["corr_err_max"], _format_optional_count(worst["ds_correctable_max"]))
         pdf.ln(3)
 
         # Worst channels
@@ -988,7 +1000,7 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
             f"- {s['complaint_ds_power'].format(val=worst['ds_power_max'], thresh=warn['ds_power'])}\n"
             f"- {s['complaint_us_power'].format(val=worst['us_power_max'], thresh=warn['us_power'])}\n"
             f"- {s['complaint_snr'].format(val=worst['ds_snr_min'], thresh=warn['snr'])}\n"
-            f"- {s['complaint_uncorr'].format(val='{:,}'.format(worst['ds_uncorrectable_max']))}\n\n"
+            f"- {s['complaint_uncorr'].format(val=_format_optional_count(worst['ds_uncorrectable_max']))}\n\n"
             f"{s['complaint_exceed']}\n\n"
             f"{s['complaint_request']}\n"
             f"1. {s['complaint_req1']}\n"
@@ -1129,7 +1141,7 @@ def generate_complaint_text(snapshots, config=None, connection_info=None, lang="
             f"- {s['complaint_ds_power'].format(val=worst['ds_power_max'], thresh=warn['ds_power'])}\n"
             f"- {s['complaint_us_power'].format(val=worst['us_power_max'], thresh=warn['us_power'])}\n"
             f"- {s['complaint_snr'].format(val=worst['ds_snr_min'], thresh=warn['snr'])}\n"
-            f"- {s['complaint_uncorr'].format(val='{:,}'.format(worst['ds_uncorrectable_max']))}\n\n"
+            f"- {s['complaint_uncorr'].format(val=_format_optional_count(worst['ds_uncorrectable_max']))}\n\n"
             f"{diag_complaint}"
             f"{comparison_section}"
             f"{bnetz_section}"

--- a/app/modules/speedtest/routes.py
+++ b/app/modules/speedtest/routes.py
@@ -192,6 +192,9 @@ def api_speedtest_signal(result_id):
             "message": t.get("signal_no_snapshot", "No signal snapshot found within 2 hours of this speedtest."),
         })
     s = snap["summary"]
+    errors_supported = s.get("errors_supported", True)
+    corr_errors = s.get("ds_correctable_errors") if errors_supported else None
+    uncorr_errors = s.get("ds_uncorrectable_errors") if errors_supported else None
     us_channels = []
     for ch in snap.get("us_channels", []):
         us_channels.append({
@@ -211,8 +214,8 @@ def api_speedtest_signal(result_id):
         "us_power_avg": s.get("us_power_avg"),
         "us_power_min": s.get("us_power_min"),
         "us_power_max": s.get("us_power_max"),
-        "ds_uncorrectable_errors": s.get("ds_uncorrectable_errors", 0),
-        "ds_correctable_errors": s.get("ds_correctable_errors", 0),
+        "ds_uncorrectable_errors": uncorr_errors,
+        "ds_correctable_errors": corr_errors,
         "ds_total": s.get("ds_total", 0),
         "us_total": s.get("us_total", 0),
         "us_channels": us_channels,

--- a/app/static/js/speedtest.js
+++ b/app/static/js/speedtest.js
@@ -202,15 +202,23 @@ function _renderSignalDetail(data, container) {
     var healthClass = 'health-' + (data.health || 'unknown');
     var healthLabels = {good: T.health_good || 'Good', tolerated: T.health_tolerated || 'Tolerated', marginal: T.health_marginal || 'Marginal', critical: T.health_critical || 'Critical'};
     var healthLabel = healthLabels[data.health] || data.health;
+    var errorParts = [];
+    if (data.ds_correctable_errors != null) {
+        errorParts.push(Number(data.ds_correctable_errors).toLocaleString() + ' ' + (T.signal_corr || 'corr.'));
+    }
+    if (data.ds_uncorrectable_errors != null) {
+        errorParts.push(Number(data.ds_uncorrectable_errors).toLocaleString() + ' ' + (T.signal_uncorr || 'uncorr.'));
+    }
     var items = [
         {label: T.signal_health || 'Health', value: healthLabel, badge: healthClass},
         {label: T.signal_ds_power || 'DS Power', value: data.ds_power_min + ' / ' + data.ds_power_avg + ' / ' + data.ds_power_max + ' dBmV'},
         {label: T.signal_ds_snr || 'DS SNR', value: data.ds_snr_min + ' / ' + data.ds_snr_avg + ' dB'},
         {label: T.signal_us_power || 'US Power', value: data.us_power_min + ' / ' + data.us_power_avg + ' / ' + data.us_power_max + ' dBmV'},
-        {label: T.signal_errors || 'Errors', value: (data.ds_correctable_errors || 0).toLocaleString() + ' ' + (T.signal_corr || 'corr.') + ' / ' + (data.ds_uncorrectable_errors || 0).toLocaleString() + ' ' + (T.signal_uncorr || 'uncorr.')},
+        {label: T.signal_errors || 'Errors', value: errorParts.length ? errorParts.join(' / ') : null},
         {label: (T.signal_ds_channels || 'DS') + ' / ' + (T.signal_us_channels || 'US'), value: (data.ds_total || 0) + ' / ' + (data.us_total || 0)}
     ];
     items.forEach(function(item) {
+        if (item.value == null) return;
         var div = document.createElement('div');
         div.className = 'st-sig-item';
         var lbl = document.createElement('span');

--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -26,6 +26,9 @@ class AnalysisMixin:
         if "modem" in sources:
             for snap in self.get_range_data(start_ts, end_ts):
                 s = snap["summary"]
+                errors_supported = s.get("errors_supported", True)
+                corr_errors = s.get("ds_correctable_errors") if errors_supported else None
+                uncorr_errors = s.get("ds_uncorrectable_errors") if errors_supported else None
                 timeline.append({
                     "timestamp": snap["timestamp"],
                     "source": "modem",
@@ -35,8 +38,8 @@ class AnalysisMixin:
                     "ds_snr_min": s.get("ds_snr_min"),
                     "ds_snr_avg": s.get("ds_snr_avg"),
                     "us_power_avg": s.get("us_power_avg"),
-                    "ds_correctable_errors": s.get("ds_correctable_errors"),
-                    "ds_uncorrectable_errors": s.get("ds_uncorrectable_errors"),
+                    "ds_correctable_errors": corr_errors,
+                    "ds_uncorrectable_errors": uncorr_errors,
                 })
 
         if "speedtest" in sources:

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -12,6 +12,15 @@ from ..tz import local_date_to_utc_range, utc_now
 log = logging.getLogger("docsis.storage")
 
 
+def _normalize_summary_errors(summary):
+    """Return summary with unsupported DOCSIS error counters normalized to null."""
+    if summary.get("errors_supported") is False:
+        summary = dict(summary)
+        summary["ds_correctable_errors"] = None
+        summary["ds_uncorrectable_errors"] = None
+    return summary
+
+
 class SnapshotMixin:
 
     def save_snapshot(self, analysis: AnalysisResult) -> None:
@@ -52,7 +61,7 @@ class SnapshotMixin:
         if not row:
             return None
         return {
-            "summary": json.loads(row[0]),
+            "summary": _normalize_summary_errors(json.loads(row[0])),
             "ds_channels": json.loads(row[1]),
             "us_channels": json.loads(row[2]),
         }
@@ -69,7 +78,7 @@ class SnapshotMixin:
         for row in rows:
             entry = {
                 "timestamp": row[0],
-                "summary": json.loads(row[1]),
+                "summary": _normalize_summary_errors(json.loads(row[1])),
                 "ds_channels": json.loads(row[2]),
                 "us_channels": json.loads(row[3]),
             }
@@ -91,7 +100,7 @@ class SnapshotMixin:
         results = []
         for row in rows:
             entry = {"timestamp": row[0]}
-            entry.update(json.loads(row[1]))
+            entry.update(_normalize_summary_errors(json.loads(row[1])))
             results.append(entry)
         return results
 
@@ -112,7 +121,7 @@ class SnapshotMixin:
         results = []
         for row in rows:
             entry = {"timestamp": row[0]}
-            entry.update(json.loads(row[1]))
+            entry.update(_normalize_summary_errors(json.loads(row[1])))
             results.append(entry)
         return results
 
@@ -136,7 +145,7 @@ class SnapshotMixin:
             return None
         return {
             "timestamp": row[0],
-            "summary": json.loads(row[1]),
+            "summary": _normalize_summary_errors(json.loads(row[1])),
             "ds_channels": json.loads(row[2]),
             "us_channels": json.loads(row[3]),
         }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -608,7 +608,7 @@
         </div>
 
         {# Card 4: Errors #}
-        {% if s.errors_supported is not defined or s.errors_supported %}
+        {% if (s.errors_supported is not defined or s.errors_supported) and s.ds_uncorr_pct is not none %}
         <div class="metric-card glass" id="metric-errors-card">
             <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_errors }}</div></span>
             <div class="metric-header">
@@ -621,7 +621,11 @@
             </div>
             <div class="metric-sub">
                 <span class="badge badge-{{ error_health }}">{{ health_labels[error_health] }}</span>
-                <span class="range">{{ s.ds_correctable_errors|fmt_k }} {{ t.corr }} / {{ s.ds_uncorrectable_errors|fmt_k }} {{ t.uncorr }}</span>
+                <span class="range">
+                    {% if s.ds_correctable_errors is not none %}{{ s.ds_correctable_errors|fmt_k }} {{ t.corr }}{% endif %}
+                    {% if s.ds_correctable_errors is not none and s.ds_uncorrectable_errors is not none %} / {% endif %}
+                    {% if s.ds_uncorrectable_errors is not none %}{{ s.ds_uncorrectable_errors|fmt_k }} {{ t.uncorr }}{% endif %}
+                </span>
             </div>
         </div>
         {% endif %}

--- a/app/types.py
+++ b/app/types.py
@@ -134,11 +134,11 @@ class AnalysisSummary(TypedDict):
     ds_snr_min: float
     ds_snr_max: float
     ds_snr_avg: float
-    ds_correctable_errors: int
-    ds_uncorrectable_errors: int
+    ds_correctable_errors: int | None
+    ds_uncorrectable_errors: int | None
     errors_supported: bool
     us_capacity_mbps: float | None
-    ds_uncorr_pct: float
+    ds_uncorr_pct: float | None
     health: str
     health_issues: list[str]
     # Set by apply_spike_suppression() when active

--- a/app/web.py
+++ b/app/web.py
@@ -810,7 +810,7 @@ def index():
         """Compute log-scale percentage for uncorrectable errors gauge."""
         if not analysis:
             return 0
-        uncorr = analysis.get("summary", {}).get("ds_uncorrectable_errors", 0)
+        uncorr = analysis.get("summary", {}).get("ds_uncorrectable_errors") or 0
         return min(100, math.log10(max(1, uncorr)) / 5 * 100)
 
     def _has_us_ofdma(analysis):

--- a/tests/analyzer/test_health.py
+++ b/tests/analyzer/test_health.py
@@ -264,6 +264,21 @@ class TestHealthCritical:
         assert "uncorr_errors_high" in result["summary"]["health_issues"]
         assert result["summary"]["health"] in ("tolerated", "marginal", "critical")
 
+    def test_uncorrectable_percent_requires_both_error_counter_types(self):
+        """Partial counter support must not be scored as 100% uncorrectable."""
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35", corr=None, uncorr=1000)],
+            us30=[_make_us30(1, power=42.0)],
+        )
+
+        result = analyze(data)
+
+        assert result["summary"]["ds_correctable_errors"] is None
+        assert result["summary"]["ds_uncorrectable_errors"] == 1000
+        assert result["summary"]["ds_uncorr_pct"] is None
+        assert "uncorr_errors_critical" not in result["summary"]["health_issues"]
+        assert "uncorr_errors_high" not in result["summary"]["health_issues"]
+
     def test_multiple_issues(self):
         """Multiple issues can coexist."""
         data = _make_data(

--- a/tests/analyzer/test_spike_and_fields.py
+++ b/tests/analyzer/test_spike_and_fields.py
@@ -160,6 +160,21 @@ class TestSpikeSuppression:
         apply_spike_suppression(analysis, "2026-02-27T14:00:00Z")
         assert analysis["summary"]["ds_uncorr_pct"] == 0.0
         assert analysis["summary"]["spike_suppression"]["active"] is True
+    @patch("app.analyzer.utc_now")
+    def test_expired_spike_preserves_uncomputable_uncorr_pct(self, mock_now):
+        """Spike expiry must not turn partial/unsupported error rates into fake 0%."""
+        from app.analyzer import apply_spike_suppression
+        mock_now.return_value = "2026-03-01T15:00:00Z"
+        analysis = self._make_analysis_with_uncorr(uncorr_pct=None)
+        analysis["summary"]["ds_correctable_errors"] = None
+        analysis["summary"]["ds_uncorrectable_errors"] = 1000000
+        analysis["summary"]["errors_supported"] = True
+
+        apply_spike_suppression(analysis, "2026-02-27T14:00:00Z")
+
+        assert analysis["summary"]["ds_uncorr_pct"] is None
+        assert "uncorr_errors_critical" not in analysis["summary"]["health_issues"]
+        assert analysis["summary"]["spike_suppression"]["active"] is True
 
 
 # -- Per-metric health extraction --

--- a/tests/analyzer/test_thresholds.py
+++ b/tests/analyzer/test_thresholds.py
@@ -216,7 +216,7 @@ class TestPercentErrors:
                 "label": "zero codewords",
                 "corr": 0,
                 "uncorr": 0,
-                "expected_pct": None,
+                "expected_pct": 0.0,
             },
             {
                 "label": "below minimum codewords",

--- a/tests/e2e/test_comparison.py
+++ b/tests/e2e/test_comparison.py
@@ -91,6 +91,18 @@ class TestComparisonView:
         expect(demo_page.locator("#comparison-errors-card")).to_be_hidden()
         assert demo_page.locator("#cmp-chart-errors .uplot").count() == 0
 
+    def test_hides_uncorrectable_delta_row_when_docsis_errors_are_unsupported(self, demo_page):
+        demo_page.route(
+            "**/api/comparison**",
+            lambda route: route.fulfill(json=_comparison_payload(False, None)),
+        )
+        navigate_to_comparison(demo_page)
+
+        demo_page.locator("#comparison-run-btn").click()
+
+        expect(demo_page.locator("#comparison-delta")).to_be_visible()
+        expect(demo_page.locator("#comparison-delta")).not_to_contain_text("Uncorr. Errors")
+
     def test_hides_uncorrectable_chart_when_only_correctable_errors_are_supported(self, demo_page):
         payload = _comparison_payload(False, None)
         for period_key in ("period_a", "period_b"):

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -206,6 +206,36 @@ class TestSpeedtestTableEscaping:
             text = cells.nth(i).inner_html()
             assert "<script" not in text.lower(), f"Script tag found in speedtest cell {i}"
 
+    def test_speedtest_signal_detail_hides_unsupported_error_counters(self, demo_page):
+        """Unsupported signal counters must not be rendered as fake zeroes."""
+        detail_text = demo_page.evaluate("""
+            () => {
+                const div = document.createElement('div');
+                _renderSignalDetail({
+                    found: true,
+                    health: 'good',
+                    ds_power_min: 1.0,
+                    ds_power_avg: 1.5,
+                    ds_power_max: 2.0,
+                    ds_snr_min: 37.0,
+                    ds_snr_avg: 38.0,
+                    us_power_min: 41.0,
+                    us_power_avg: 42.0,
+                    us_power_max: 43.0,
+                    ds_correctable_errors: null,
+                    ds_uncorrectable_errors: null,
+                    ds_total: 32,
+                    us_total: 4,
+                    snapshot_timestamp: '2026-05-01T12:00:00Z'
+                }, div);
+                return div.textContent;
+            }
+        """)
+
+        assert "0 corr" not in detail_text
+        assert "0 uncorr" not in detail_text
+        assert "Errors" not in detail_text
+
 
 class TestCorrelationTooltipEscaping:
     """Correlation chart tooltip should escape event messages."""

--- a/tests/test_analyzer_error_support.py
+++ b/tests/test_analyzer_error_support.py
@@ -1,0 +1,45 @@
+"""Regression tests for DOCSIS error-counter support semantics."""
+
+from app.analyzer import analyze
+
+
+def test_unsupported_downstream_error_counters_remain_none_in_summary():
+    result = analyze({
+        "channelDs": {
+            "docsis30": [{
+                "channelID": "1",
+                "frequency": "114 MHz",
+                "powerLevel": "0.1",
+                "mse": "-37.0",
+                "modulation": "256QAM",
+            }],
+            "docsis31": [],
+        },
+        "channelUs": {"docsis30": [], "docsis31": []},
+    })
+
+    assert result["summary"]["errors_supported"] is False
+    assert result["summary"]["ds_correctable_errors"] is None
+    assert result["summary"]["ds_uncorrectable_errors"] is None
+
+
+def test_supported_zero_downstream_error_counters_remain_zero_in_summary():
+    result = analyze({
+        "channelDs": {
+            "docsis30": [{
+                "channelID": "1",
+                "frequency": "114 MHz",
+                "powerLevel": "0.1",
+                "mse": "-37.0",
+                "modulation": "256QAM",
+                "corrErrors": 0,
+                "nonCorrErrors": 0,
+            }],
+            "docsis31": [],
+        },
+        "channelUs": {"docsis30": [], "docsis31": []},
+    })
+
+    assert result["summary"]["errors_supported"] is True
+    assert result["summary"]["ds_correctable_errors"] == 0
+    assert result["summary"]["ds_uncorrectable_errors"] == 0

--- a/tests/test_comparison_module.py
+++ b/tests/test_comparison_module.py
@@ -212,7 +212,9 @@ class TestAggregatePeriod:
         result = _aggregate_period([])
         assert result["snapshots"] == 0
         assert result["avg"]["ds_power"] is None
-        assert result["total"]["uncorr_errors"] == 0
+        assert result["errors_supported"] is False
+        assert result["total"]["corr_errors"] is None
+        assert result["total"]["uncorr_errors"] is None
 
     def test_single_snapshot(self):
         from app.modules.comparison.routes import _aggregate_period
@@ -237,6 +239,27 @@ class TestAggregatePeriod:
         from app.modules.comparison.routes import _aggregate_period
 
         result = _aggregate_period([UNSUPPORTED_ERRORS_SNAPSHOT])
+
+        assert result["errors_supported"] is False
+        assert result["corr_errors_supported"] is False
+        assert result["uncorr_errors_supported"] is False
+        assert result["total"]["corr_errors"] is None
+        assert result["total"]["uncorr_errors"] is None
+        assert result["timeseries"][0]["uncorr_errors"] is None
+
+    def test_errors_supported_false_zero_counters_remain_unsupported(self):
+        from app.modules.comparison.routes import _aggregate_period
+
+        legacy_zero_snapshot = {
+            **UNSUPPORTED_ERRORS_SNAPSHOT,
+            "summary": {
+                **UNSUPPORTED_ERRORS_SNAPSHOT["summary"],
+                "errors_supported": False,
+                "ds_correctable_errors": 0,
+                "ds_uncorrectable_errors": 0,
+            },
+        }
+        result = _aggregate_period([legacy_zero_snapshot])
 
         assert result["errors_supported"] is False
         assert result["corr_errors_supported"] is False
@@ -326,7 +349,7 @@ class TestComputeDelta:
         pb = _aggregate_period([])
         delta = _compute_delta(pa, pb)
         assert delta["ds_power"] is None
-        assert delta["uncorr_errors"] == 0
+        assert delta["uncorr_errors"] is None
         assert delta["verdict"] == "unchanged"
 
     def test_delta_ignores_unsupported_error_counters(self):

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -206,6 +206,24 @@ class TestCorrelationTimeline:
         assert timeline[0]["ds_correctable_errors"] is None
         assert timeline[0]["ds_uncorrectable_errors"] is None
 
+    def test_modem_errors_supported_false_zero_counters_remain_none(self, storage, sample_analysis):
+        """Legacy unsupported snapshots with zero counters must not display fake zeroes."""
+        unsupported = dict(sample_analysis["summary"])
+        unsupported["errors_supported"] = False
+        unsupported["ds_correctable_errors"] = 0
+        unsupported["ds_uncorrectable_errors"] = 0
+        ts = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        with sqlite3.connect(storage.db_path) as conn:
+            conn.execute(
+                "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?,?,?,?)",
+                (ts, json.dumps(unsupported), "[]", "[]"),
+            )
+
+        timeline = storage.get_correlation_timeline(ts, ts, sources={"modem"})
+
+        assert timeline[0]["ds_correctable_errors"] is None
+        assert timeline[0]["ds_uncorrectable_errors"] is None
+
     def test_speedtest_fields_present(self, storage, speedtest_storage, sample_analysis):
         """Speedtest entries must contain download, upload, ping."""
         now = self._seed_data(storage, speedtest_storage, sample_analysis)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1155,6 +1155,17 @@ class TestRestartDetection:
         restart_events = [e for e in events if e["event_type"] == "modem_restart_detected"]
         assert len(restart_events) == 0
 
+    def test_error_spike_ignores_unsupported_summary_counter(self, detector):
+        """Unsupported summary counters must not crash or create fake spikes."""
+        prev = _make_analysis(ds_uncorrectable_errors=0)
+        cur = _make_analysis(ds_uncorrectable_errors=99999)
+        prev["summary"]["errors_supported"] = False
+
+        detector.check(prev)
+        events = detector.check(cur)
+
+        assert [e for e in events if e["event_type"] == "error_spike"] == []
+
     def test_restart_with_some_channel_change(self, detector):
         """12/16 overlap and declining — detected despite channel churn."""
         prev_channels = [

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -308,6 +308,68 @@ class TestSpeedtestAPI:
         assert data["success"] is False
         assert "ConnectionError" in data["error"]
 
+    def test_signal_api_treats_legacy_unsupported_zero_error_counters_as_unavailable(self, speedtest_client, monkeypatch):
+        import app.modules.speedtest.routes as speedtest_routes
+
+        class SpeedtestStorage:
+            def get_speedtest_by_id(self, result_id):
+                return {"id": result_id, "timestamp": "2025-01-15T10:30:00Z"}
+
+        class CoreStorage:
+            def get_closest_snapshot(self, timestamp):
+                return {
+                    "timestamp": timestamp,
+                    "summary": {
+                        "errors_supported": False,
+                        "health": "good",
+                        "ds_correctable_errors": 0,
+                        "ds_uncorrectable_errors": 0,
+                    },
+                    "us_channels": [],
+                }
+
+        monkeypatch.setattr(speedtest_routes, "_get_speedtest_storage", lambda: SpeedtestStorage())
+        monkeypatch.setattr(speedtest_routes, "get_storage", lambda: CoreStorage())
+
+        resp = speedtest_client.get("/api/speedtest/1/signal")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["found"] is True
+        assert data["ds_correctable_errors"] is None
+        assert data["ds_uncorrectable_errors"] is None
+
+    def test_signal_api_preserves_supported_zero_error_counters(self, speedtest_client, monkeypatch):
+        import app.modules.speedtest.routes as speedtest_routes
+
+        class SpeedtestStorage:
+            def get_speedtest_by_id(self, result_id):
+                return {"id": result_id, "timestamp": "2025-01-15T10:30:00Z"}
+
+        class CoreStorage:
+            def get_closest_snapshot(self, timestamp):
+                return {
+                    "timestamp": timestamp,
+                    "summary": {
+                        "errors_supported": True,
+                        "health": "good",
+                        "ds_correctable_errors": 0,
+                        "ds_uncorrectable_errors": 0,
+                    },
+                    "us_channels": [],
+                }
+
+        monkeypatch.setattr(speedtest_routes, "_get_speedtest_storage", lambda: SpeedtestStorage())
+        monkeypatch.setattr(speedtest_routes, "get_storage", lambda: CoreStorage())
+
+        resp = speedtest_client.get("/api/speedtest/1/signal")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["found"] is True
+        assert data["ds_correctable_errors"] == 0
+        assert data["ds_uncorrectable_errors"] == 0
+
     def test_api_speedtest_not_configured(self, tmp_path):
         data_dir = str(tmp_path / "data2")
         mgr = ConfigManager(data_dir)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -49,6 +49,49 @@ class TestSnapshotStorage:
         assert len(intraday) >= 1
         assert "health" in intraday[0]
 
+    def test_trend_data_normalizes_unsupported_zero_error_counters(self, storage, sample_analysis):
+        sample_analysis["summary"].update({
+            "errors_supported": False,
+            "ds_correctable_errors": 0,
+            "ds_uncorrectable_errors": 0,
+        })
+        storage.save_snapshot(sample_analysis)
+        ts = storage.get_snapshot_list()[0]
+        date = ts[:10]
+
+        intraday = storage.get_intraday_data(date)
+        summary_range = storage.get_summary_range(date, date)
+
+        snapshot = storage.get_snapshot(ts)
+        range_data = storage.get_range_data(ts, ts)
+        closest = storage.get_closest_snapshot(ts)
+
+        assert intraday[0]["ds_correctable_errors"] is None
+        assert intraday[0]["ds_uncorrectable_errors"] is None
+        assert summary_range[0]["ds_correctable_errors"] is None
+        assert summary_range[0]["ds_uncorrectable_errors"] is None
+        assert snapshot["summary"]["ds_correctable_errors"] is None
+        assert snapshot["summary"]["ds_uncorrectable_errors"] is None
+        assert range_data[0]["summary"]["ds_correctable_errors"] is None
+        assert range_data[0]["summary"]["ds_uncorrectable_errors"] is None
+        assert closest["summary"]["ds_correctable_errors"] is None
+        assert closest["summary"]["ds_uncorrectable_errors"] is None
+
+    def test_trend_data_preserves_supported_zero_error_counters(self, storage, sample_analysis):
+        sample_analysis["summary"].update({
+            "errors_supported": True,
+            "ds_correctable_errors": 0,
+            "ds_uncorrectable_errors": 0,
+        })
+        storage.save_snapshot(sample_analysis)
+        ts = storage.get_snapshot_list()[0]
+        date = ts[:10]
+
+        intraday = storage.get_intraday_data(date)
+
+        assert intraday[0]["ds_correctable_errors"] == 0
+        assert intraday[0]["ds_uncorrectable_errors"] == 0
+
     def test_empty_storage(self, storage):
         assert storage.get_snapshot_list() == []
 

--- a/tests/web/test_health_export.py
+++ b/tests/web/test_health_export.py
@@ -55,3 +55,35 @@ class TestExportEndpoint:
         assert "DOCSight" in data["text"]
         assert "DOCSIS" in data["text"]
         assert "Vodafone" in data["text"]
+
+    def test_export_handles_unsupported_error_counters(self, client, sample_analysis):
+        sample_analysis["summary"].update({
+            "errors_supported": False,
+            "ds_correctable_errors": None,
+            "ds_uncorrectable_errors": None,
+        })
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/api/export")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert "| DS Correctable Errors | N/A |" in data["text"]
+        assert "| DS Uncorrectable Errors | N/A |" in data["text"]
+        assert "DOCSight" in data["text"]
+        assert "DOCSIS" in data["text"]
+        assert "Vodafone" in data["text"]
+
+
+class TestExportUnsupportedLegacyCounters:
+    def test_export_treats_legacy_unsupported_zero_error_counters_as_unavailable(self):
+        from app.blueprints.data_bp import _format_error_count, _summary_error_count
+
+        summary = {
+            "errors_supported": False,
+            "ds_correctable_errors": 0,
+            "ds_uncorrectable_errors": 0,
+        }
+
+        assert _format_error_count(_summary_error_count(summary, "ds_correctable_errors")) == "N/A"
+        assert _format_error_count(_summary_error_count(summary, "ds_uncorrectable_errors")) == "N/A"

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -41,6 +41,31 @@ class TestIndexRoute:
         assert b'id="metric-errors-card"' not in resp.data
         assert b"N/A</div>" not in resp.data
 
+    def test_index_accepts_unsupported_none_error_counter(self, client, sample_analysis):
+        sample_analysis["summary"]["errors_supported"] = False
+        sample_analysis["summary"]["ds_correctable_errors"] = None
+        sample_analysis["summary"]["ds_uncorrectable_errors"] = None
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/")
+
+        assert resp.status_code == 200
+        assert b'id="metric-errors-card"' not in resp.data
+
+    def test_index_partial_error_support_hides_uncomputable_error_card(self, client, sample_analysis):
+        sample_analysis["summary"]["errors_supported"] = True
+        sample_analysis["summary"]["ds_correctable_errors"] = None
+        sample_analysis["summary"]["ds_uncorrectable_errors"] = 1000
+        sample_analysis["summary"]["ds_uncorr_pct"] = None
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/")
+
+        assert resp.status_code == 200
+        assert b'id="metric-errors-card"' not in resp.data
+        assert b">None<" not in resp.data
+        assert b"None Corr" not in resp.data
+
     def test_index_with_incomplete_bnetz(self, tmp_path, sample_analysis):
         """Dashboard hides BNetzA card when entry has NULL fields (#148)."""
         mgr = ConfigManager(str(tmp_path / "data_bnetz"))

--- a/tests/web/test_reports.py
+++ b/tests/web/test_reports.py
@@ -3,6 +3,73 @@
 from unittest.mock import patch
 from app.web import app
 
+
+class TestReportHelpers:
+    def test_compute_worst_values_preserves_unsupported_error_counters(self):
+        from app.modules.reports.report import _compute_worst_values
+
+        snapshots = [
+            {"summary": {
+                "errors_supported": False,
+                "ds_correctable_errors": None,
+                "ds_uncorrectable_errors": None,
+                "health": "good",
+            }},
+        ]
+
+        worst = _compute_worst_values(snapshots)
+
+        assert worst["ds_correctable_max"] is None
+        assert worst["ds_uncorrectable_max"] is None
+
+    def test_compute_worst_values_treats_legacy_unsupported_zeroes_as_unavailable(self):
+        from app.modules.reports.report import _compute_worst_values
+
+        snapshots = [
+            {"summary": {
+                "errors_supported": False,
+                "ds_correctable_errors": 0,
+                "ds_uncorrectable_errors": 0,
+                "health": "good",
+            }},
+        ]
+
+        worst = _compute_worst_values(snapshots)
+
+        assert worst["ds_correctable_max"] is None
+        assert worst["ds_uncorrectable_max"] is None
+
+    def test_compute_worst_values_keeps_supported_zero_error_counters(self):
+        from app.modules.reports.report import _compute_worst_values
+
+        snapshots = [
+            {"summary": {
+                "errors_supported": False,
+                "ds_correctable_errors": None,
+                "ds_uncorrectable_errors": None,
+                "health": "good",
+            }},
+            {"summary": {
+                "errors_supported": True,
+                "ds_correctable_errors": 0,
+                "ds_uncorrectable_errors": 0,
+                "health": "good",
+            }},
+        ]
+
+        worst = _compute_worst_values(snapshots)
+
+        assert worst["ds_correctable_max"] == 0
+        assert worst["ds_uncorrectable_max"] == 0
+
+    def test_report_count_formatter_preserves_unsupported_values(self):
+        from app.modules.reports.report import _format_optional_count
+
+        assert _format_optional_count(None) == "N/A"
+        assert _format_optional_count(0) == "0"
+        assert _format_optional_count(1234) == "1,234"
+
+
 class TestComplaintRoutes:
     def test_get_comparison_data_helper(self):
         from app.modules.reports.routes import _get_comparison_data


### PR DESCRIPTION
## Summary
- Preserve unsupported DOCSIS error counters as null across analyzer, storage, API, dashboard, export, report, speedtest, and comparison paths
- Treat legacy snapshots with `errors_supported: false` and zero error counters as unsupported
- Keep supported zero counters visible as real values

## Test plan
- `git diff --check`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m pytest tests/analyzer/test_health.py tests/analyzer/test_thresholds.py tests/analyzer/test_spike_and_fields.py tests/test_events.py tests/test_speedtest.py tests/web/test_index.py tests/e2e/test_security.py tests/e2e/test_charts.py tests/e2e/test_comparison.py tests/test_storage.py tests/test_comparison_module.py tests/web/test_health_export.py tests/web/test_reports.py -q`

Closes #433
