### PR TITLE
fix: align US DOCSIS 3.1 Low-QAM exposure

### DIFF
--- a/app/modules/modulation/engine.py
+++ b/app/modules/modulation/engine.py
@@ -21,7 +21,7 @@ MAX_QAM = {
 }
 
 DEGRADED_QAM_THRESHOLDS = {
-    ("us", "3.1"): 256,
+    ("us", "3.1"): 64,
 }
 
 DISCLAIMER = (
@@ -183,11 +183,11 @@ def _group_channels_by_protocol(channels):
 
 
 def _degraded_qam_threshold(direction, docsis_version, default_threshold):
-    """Return the modulation threshold that counts as degraded.
+    """Return the DOCSight Low-QAM Exposure threshold for a protocol group.
 
-    Most protocol groups keep the legacy threshold. US DOCSIS 3.1 is stricter
-    because 128QAM already represents a substantial drop from the normal
-    1024QAM operating point.
+    Low-QAM Exposure is a product heuristic, not a DOCSIS standard metric.
+    Most groups keep the legacy <=16QAM threshold. US DOCSIS 3.1 counts 64QAM
+    as Low-QAM but excludes 128QAM; 128QAM is reflected through Health Index.
     """
     return DEGRADED_QAM_THRESHOLDS.get((direction, docsis_version), default_threshold)
 

--- a/app/modules/modulation/i18n/de.json
+++ b/app/modules/modulation/i18n/de.json
@@ -33,6 +33,6 @@
     "channel_summary": "Kanalzusammenfassung",
     "protocol_group_label": "Protokollgruppe",
     "glossary_health_index": "Gesundheitsindex: ein Gesamtwert (0-100), der die Modulationsqualität aller Kanäle widerspiegelt. Höher bedeutet weniger Signaldegradation.",
-    "glossary_low_qam": "Low-QAM-Anteil: Anteil der Zeit, in der Kanäle auf niedrige Modulationsstufen (QPSK, 16QAM) fallen. Hoher Anteil deutet auf anhaltende Signalprobleme hin.",
+    "glossary_low_qam": "Low-QAM-Anteil: DOCSight-Heuristik für den Anteil der Samples auf niedrigen Modulationsstufen. Bei US DOCSIS 3.1 zählt 64QAM und darunter; 128QAM fließt in den Gesundheitsindex ein, zählt aber nicht als Low-QAM. Hoher Anteil deutet auf anhaltende Signalprobleme hin.",
     "glossary_sample_density": "Messabdeckung: Anzahl der gesammelten Polling-Messungen im gewählten Zeitraum. Mehr Messungen bedeuten genauere Statistiken."
 }

--- a/app/modules/modulation/i18n/en.json
+++ b/app/modules/modulation/i18n/en.json
@@ -33,6 +33,6 @@
     "channel_summary": "Channel Summary",
     "protocol_group_label": "Protocol Group",
     "glossary_health_index": "Health Index: an aggregate score (0-100) reflecting overall modulation quality across all channels. Higher means less signal degradation.",
-    "glossary_low_qam": "Low-QAM Exposure: percentage of time channels drop to low modulation levels (QPSK, 16QAM). High exposure indicates persistent signal problems.",
+    "glossary_low_qam": "Low-QAM Exposure: DOCSight heuristic for the percentage of samples at low modulation levels. For US DOCSIS 3.1 this counts 64QAM and below; 128QAM is reflected by Health Index but not counted as Low-QAM. High exposure indicates persistent signal problems.",
     "glossary_sample_density": "Sample Density: number of polling samples collected for the selected period. More samples mean more accurate statistics."
 }

--- a/app/modules/modulation/i18n/es.json
+++ b/app/modules/modulation/i18n/es.json
@@ -33,6 +33,6 @@
     "channel_summary": "Resumen de canales",
     "protocol_group_label": "Grupo de protocolo",
     "glossary_health_index": "Índice de salud: puntuación global (0-100) que refleja la calidad de modulación en todos los canales. Mayor significa menos degradación.",
-    "glossary_low_qam": "Exposición Low-QAM: porcentaje de tiempo en que los canales caen a niveles bajos de modulación (QPSK, 16QAM). Alta exposición indica problemas de señal persistentes.",
+    "glossary_low_qam": "Exposición Low-QAM: heurística de DOCSight para el porcentaje de muestras en niveles bajos de modulación. Para US DOCSIS 3.1 cuenta 64QAM e inferiores; 128QAM se refleja en el índice de salud, pero no cuenta como Low-QAM. Una exposición alta indica problemas de señal persistentes.",
     "glossary_sample_density": "Densidad de muestras: número de mediciones recopiladas para el período seleccionado. Más muestras significan estadísticas más precisas."
 }

--- a/app/modules/modulation/i18n/fr.json
+++ b/app/modules/modulation/i18n/fr.json
@@ -33,6 +33,6 @@
     "channel_summary": "Résumé des canaux",
     "protocol_group_label": "Groupe de protocole",
     "glossary_health_index": "Indice de santé : score global (0-100) reflétant la qualité de modulation sur tous les canaux. Plus élevé signifie moins de dégradation.",
-    "glossary_low_qam": "Exposition Low-QAM : pourcentage de temps où les canaux passent en modulation basse (QPSK, 16QAM). Une exposition élevée indique des problèmes de signal persistants.",
+    "glossary_low_qam": "Exposition Low-QAM : heuristique DOCSight pour le pourcentage d’échantillons à de faibles niveaux de modulation. Pour l’US DOCSIS 3.1, 64QAM et moins sont comptés ; 128QAM est reflété par l’indice de santé, mais n’est pas compté comme Low-QAM. Une exposition élevée indique des problèmes de signal persistants.",
     "glossary_sample_density": "Densité d'échantillons : nombre de mesures collectées pour la période sélectionnée. Plus de mesures signifie des statistiques plus précises."
 }

--- a/tests/modulation/test_distribution.py
+++ b/tests/modulation/test_distribution.py
@@ -60,7 +60,7 @@ class TestComputeDistributionV2:
         assert "3.0" in versions
         assert "3.1" in versions
 
-    def test_us31_128qam_counts_as_degraded(self):
+    def test_us31_128qam_does_not_count_as_low_qam(self):
         us_channels = [
             {"channel_id": 41, "modulation": "128QAM", "docsis_version": "3.1"},
         ]
@@ -68,8 +68,8 @@ class TestComputeDistributionV2:
         result = compute_distribution_v2(snaps, "us", "UTC")
         pg = result["protocol_groups"][0]
         assert pg["docsis_version"] == "3.1"
-        assert pg["degraded_channel_count"] == 1
-        assert pg["low_qam_pct"] == 100.0
+        assert pg["degraded_channel_count"] == 0
+        assert pg["low_qam_pct"] == 0.0
 
     def test_us31_512qam_not_counted_as_degraded(self):
         us_channels = [
@@ -81,14 +81,14 @@ class TestComputeDistributionV2:
         assert pg["docsis_version"] == "3.1"
         assert pg["degraded_channel_count"] == 0
 
-    def test_us31_low_qam_pct_tracks_protocol_threshold(self):
+    def test_us31_low_qam_pct_counts_64qam_but_excludes_128qam(self):
         snaps = [
             _make_snapshot("2026-03-01T10:00:00Z",
                            us_channels=[{"channel_id": 41, "modulation": "1024QAM", "docsis_version": "3.1"}]),
             _make_snapshot("2026-03-01T14:00:00Z",
                            us_channels=[{"channel_id": 41, "modulation": "128QAM", "docsis_version": "3.1"}]),
             _make_snapshot("2026-03-01T18:00:00Z",
-                           us_channels=[{"channel_id": 41, "modulation": "512QAM", "docsis_version": "3.1"}]),
+                           us_channels=[{"channel_id": 41, "modulation": "64QAM", "docsis_version": "3.1"}]),
         ]
         result = compute_distribution_v2(snaps, "us", "UTC")
         pg = result["protocol_groups"][0]
@@ -111,7 +111,8 @@ class TestComputeDistributionV2:
         pg = result["protocol_groups"][0]
         assert pg["docsis_version"] == "3.1"
         assert pg["dominant_modulation"] == "128QAM"
-        assert pg["degraded_channel_count"] == 1
+        assert pg["degraded_channel_count"] == 0
+        assert pg["low_qam_pct"] == 0.0
         assert pg["distribution"]["128QAM"] == 100.0
 
     def test_per_day_data(self):
@@ -318,7 +319,7 @@ class TestComputeIntraday:
         result = compute_intraday(snaps, "us", "UTC", "2026-03-01")
         assert len(result["protocol_groups"]) == 2
 
-    def test_us31_channel_summary_shows_128qam_degradation(self):
+    def test_us31_channel_summary_does_not_treat_128qam_as_low_qam(self):
         snaps = [
             _make_snapshot("2026-03-01T10:00:00Z",
                            us_channels=[{"channel_id": 41, "modulation": "1024QAM",
@@ -333,13 +334,11 @@ class TestComputeIntraday:
         result = compute_intraday(snaps, "us", "UTC", "2026-03-01")
         pg = next(pg for pg in result["protocol_groups"] if pg["docsis_version"] == "3.1")
         ch = pg["channels"][0]
-        assert ch["degraded"] is True
-        assert "128QAM" in ch["summary"]
-        assert ch["worst_modulation"] == "128QAM"
-        assert ch["degraded_sample_pct"] == 33
-        assert len(ch["degraded_events"]) == 1
-        assert ch["degraded_events"][0]["label"] == "128QAM"
-        assert ch["degraded_events"][0]["duration_minutes"] == 0
+        assert ch["degraded"] is False
+        assert ch["summary"] == ""
+        assert ch["worst_modulation"] == ""
+        assert ch["degraded_sample_pct"] == 0
+        assert ch["degraded_events"] == []
 
     def test_intraday_prefers_profile_modulation_for_ofdma(self):
         snaps = [
@@ -356,8 +355,9 @@ class TestComputeIntraday:
         result = compute_intraday(snaps, "us", "UTC", "2026-03-01")
         pg = next(pg for pg in result["protocol_groups"] if pg["docsis_version"] == "3.1")
         ch = pg["channels"][0]
-        assert ch["degraded"] is True
-        assert ch["worst_modulation"] == "128QAM"
+        assert ch["degraded"] is False
+        assert ch["worst_modulation"] == ""
+        assert ch["degraded_events"] == []
         assert ch["timeline"] == [
             {"time": "10:00", "modulation": "1024QAM"},
             {"time": "14:00", "modulation": "128QAM"},

--- a/tests/modulation/test_health.py
+++ b/tests/modulation/test_health.py
@@ -249,8 +249,8 @@ class TestDegradedThresholds:
         assert _degraded_qam_threshold("us", "3.0", 16) == 16
         assert _degraded_qam_threshold("ds", "3.0", 16) == 16
 
-    def test_us31_uses_higher_threshold(self):
-        assert _degraded_qam_threshold("us", "3.1", 16) == 256
+    def test_us31_uses_64qam_threshold(self):
+        assert _degraded_qam_threshold("us", "3.1", 16) == 64
 
 
 # ── _low_qam_pct ──
@@ -274,6 +274,11 @@ class TestLowQamPct:
     def test_threshold_boundary(self):
         obs = [("16QAM", 16)] * 5 + [("64QAM", 64)] * 5
         assert _low_qam_pct(obs, 16) == 50.0
+
+
+    def test_threshold_64_excludes_128qam(self):
+        obs = [("64QAM", 64)] * 4 + [("128QAM", 128)] * 6
+        assert _low_qam_pct(obs, 64) == 40.0
 
     def test_ignores_ofdm(self):
         obs = [("4QAM", 4)] * 1 + [("64QAM", 64)] * 1 + [("OFDM", None)] * 8

--- a/tests/test_modulation_api.py
+++ b/tests/test_modulation_api.py
@@ -152,6 +152,38 @@ class TestDistributionEndpoint:
         assert data["aggregate"]["low_qam_pct"] == 1.0
         assert data["aggregate"]["low_qam_pct"] != 50.0
 
+
+    def test_us_docsis31_128qam_does_not_count_as_low_qam_in_distribution_trend(self, client_with_storage):
+        client, storage = client_with_storage
+        day = _ts_days_ago(1)[:10]
+        for minute in range(4):
+            _store_snapshot(
+                storage,
+                f"{day}T10:{minute:02d}:00Z",
+                us_channels=[
+                    {"modulation": "64QAM", "channel_id": 1, "docsis_version": "3.1"},
+                ],
+            )
+        for minute in range(4, 10):
+            _store_snapshot(
+                storage,
+                f"{day}T10:{minute:02d}:00Z",
+                us_channels=[
+                    {"modulation": "128QAM", "channel_id": 1, "docsis_version": "3.1"},
+                ],
+            )
+
+        resp = client.get("/api/modulation/distribution?days=7&direction=us")
+        data = resp.get_json()
+        pg = data["protocol_groups"][0]
+
+        assert pg["docsis_version"] == "3.1"
+        assert pg["distribution"] == {"128QAM": 60.0, "64QAM": 40.0}
+        assert pg["days"][0]["low_qam_pct"] == 40.0
+        assert pg["low_qam_pct"] == 40.0
+        assert data["aggregate"]["low_qam_pct"] == 40.0
+        assert pg["low_qam_pct"] != 100.0
+
     def test_protocol_group_structure(self, client_with_storage):
         client, storage = client_with_storage
         _store_snapshot(storage, _ts_days_ago(1),
@@ -292,6 +324,36 @@ class TestTrendEndpoint:
         assert len(data) == 1
         assert data[0]["low_qam_pct"] == 10.0
         assert data[0]["low_qam_pct"] != 100.0
+
+
+    def test_trend_us_docsis31_128qam_does_not_count_as_low_qam(self, client_with_storage):
+        client, storage = client_with_storage
+        day = _ts_days_ago(1)[:10]
+        for minute in range(4):
+            _store_snapshot(
+                storage,
+                f"{day}T10:{minute:02d}:00Z",
+                us_channels=[
+                    {"modulation": "64QAM", "channel_id": 1, "docsis_version": "3.1"},
+                ],
+            )
+        for minute in range(4, 10):
+            _store_snapshot(
+                storage,
+                f"{day}T10:{minute:02d}:00Z",
+                us_channels=[
+                    {"modulation": "128QAM", "channel_id": 1, "docsis_version": "3.1"},
+                ],
+            )
+
+        resp = client.get("/api/modulation/trend?days=7&direction=us")
+        data = resp.get_json()
+
+        assert len(data) == 1
+        assert data[0]["low_qam_pct"] == 40.0
+        assert data[0]["low_qam_pct"] != 100.0
+        assert data[0]["health_index"] < 100.0
+
 
 
 


### PR DESCRIPTION
## Summary
- Define US DOCSIS 3.1 Low-QAM Exposure as 64QAM and below, so 128QAM no longer inflates Low-QAM percentages
- Keep Health Index sensitive to 128QAM as reduced modulation quality versus the US DOCSIS 3.1 baseline
- Update modulation glossary copy and regression coverage for distribution, trend, aggregate, and intraday semantics

## Tests
- `.venv/bin/python -m pytest tests/test_glossary_i18n.py tests/test_modulation_api.py tests/modulation/test_health.py tests/modulation/test_distribution.py tests/modulation/test_grouping_timeline.py tests/test_modulation_static_contract.py tests/e2e/test_modulation.py -q`
- `.venv/bin/python -m pytest -q`
