### PR TITLE
fix: make correlation timeline header opaque

### DIFF
--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -818,7 +818,7 @@
     margin: 0;
 }
 #correlation-table thead tr {
-    background: var(--surface-2, rgba(0,0,0,0.15));
+    background: var(--card-bg, var(--card, var(--surface)));
 }
 #correlation-table thead th {
     padding: 12px 16px;
@@ -829,8 +829,9 @@
     border-bottom: 1px solid var(--card-border, var(--input-border));
     position: sticky;
     top: 0;
-    z-index: 2;
-    background: var(--surface-2, rgba(0,0,0,0.15));
+    z-index: 3;
+    background: var(--card-bg, var(--card, var(--surface)));
+    box-shadow: 0 1px 0 var(--card-border, var(--input-border));
 }
 #correlation-table tbody tr {
     transition: background 0.15s;

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -460,3 +460,51 @@ class TestMobileLayout:
         assert all(rect["opacity"] > 0 for rect in trends_targets["glossary"])
         assert all(rect["visibility"] == "visible" for rect in trends_targets["glossary"])
         assert all(rect["pointerEvents"] != "none" for rect in trends_targets["glossary"])
+
+class TestDesktopCorrelationLayout:
+    """Desktop correlation timeline layout behavior."""
+
+    def test_correlation_timeline_sticky_header_uses_opaque_backdrop(self, page, live_server):
+        """Sticky Unified Timeline headers should mask rows while scrolling."""
+        page.set_viewport_size({"width": 1366, "height": 768})
+        page.goto(live_server)
+        page.wait_for_load_state("networkidle")
+        page.evaluate("switchView('correlation')")
+        page.wait_for_selector("#correlation-table-card", state="visible")
+        page.wait_for_selector("#correlation-tbody tr[data-ts]")
+        page.locator("#correlation-table-wrap").evaluate("wrap => { wrap.style.maxHeight = '96px'; }")
+
+        header_state = page.locator("#correlation-table thead th").first.evaluate(
+            r"""
+            (th) => {
+                const wrap = document.querySelector('#correlation-table-wrap');
+                const canScroll = wrap.scrollHeight > wrap.clientHeight;
+                wrap.scrollTop = 80;
+                const style = getComputedStyle(th);
+                const bg = style.backgroundColor;
+                const match = bg.match(/rgba?\(([^)]+)\)/);
+                let alpha = 1;
+                if (match) {
+                    const parts = match[1].split(',').map((part) => part.trim());
+                    if (parts.length === 4) alpha = Number(parts[3]);
+                }
+                const rect = th.getBoundingClientRect();
+                const topElement = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+                return {
+                    backgroundColor: bg,
+                    alpha,
+                    canScroll,
+                    position: style.position,
+                    scrollTop: wrap.scrollTop,
+                    zIndex: Number(style.zIndex) || 0,
+                    topElementTag: topElement ? topElement.tagName : null,
+                };
+            }
+            """
+        )
+
+        assert header_state["canScroll"] is True
+        assert header_state["scrollTop"] > 0
+        assert header_state["position"] == "sticky"
+        assert header_state["topElementTag"] == "TH"
+        assert header_state["alpha"] >= 0.98, header_state["backgroundColor"]

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -1,0 +1,16 @@
+"""Static UI/CSS contract tests."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWS_CSS = ROOT / "app" / "static" / "css" / "views.css"
+
+
+def test_correlation_timeline_sticky_header_uses_opaque_surface():
+    css = VIEWS_CSS.read_text(encoding="utf-8")
+    header_block = css[css.index("#correlation-table thead th") : css.index("#correlation-table tbody tr")]
+
+    assert "position: sticky" in header_block
+    assert "background: var(--card-bg" in header_block
+    assert "rgba(0,0,0,0.15)" not in header_block
+    assert "z-index: 3" in header_block


### PR DESCRIPTION
## Summary
- make the Unified Timeline sticky table header use an opaque theme-backed surface
- keep the header above scrolling rows with a stable z-index and divider
- add regression coverage for scroll overlap and the CSS contract

## Tests
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `TZ=UTC .venv/bin/python -m pytest tests/e2e -q`
- `.venv/bin/python -m pytest -q`

Fixes #439
