### PR TITLE
fix: align Low-QAM percentages with visible samples

### DIFF
--- a/app/modules/modulation/engine.py
+++ b/app/modules/modulation/engine.py
@@ -161,12 +161,15 @@ def _low_qam_counts(observations, threshold):
     return low_count, len(numeric)
 
 
-def _low_qam_pct(observations, threshold):
-    """Compute % of numeric-QAM observations where qam_order <= threshold."""
+def _numeric_low_qam_pct(observations, threshold):
+    """Compute % of numeric-QAM observations where qam_order <= threshold.
+
+    This helper is intentionally numeric-only for health-facing internals. Visible
+    Low-QAM exposure uses raw low-QAM counts over total sample counts so Unknown
+    samples stay in the same denominator as the distribution chart.
+    """
     low_count, numeric_count = _low_qam_counts(observations, threshold)
-    if numeric_count == 0:
-        return 0
-    return round(low_count / numeric_count * 100, 1)
+    return round(low_count / numeric_count * 100, 1) if numeric_count else 0
 
 
 def _group_channels_by_protocol(channels):
@@ -292,10 +295,10 @@ def compute_distribution_v2(snapshots, direction, tz_name, low_qam_threshold=16)
     total_low_qam_samples = sum(
         group.get("low_qam_sample_count", 0) or 0 for group in protocol_groups
     )
-    total_numeric_samples = sum(
-        group.get("numeric_sample_count", 0) or 0 for group in protocol_groups
+    total_sample_exposure = sum(
+        group.get("sample_count", 0) or 0 for group in protocol_groups
     )
-    agg_lq = _weighted_pct_from_counts(total_low_qam_samples, total_numeric_samples)
+    agg_lq = _weighted_pct_from_counts(total_low_qam_samples, total_sample_exposure)
 
     return {
         "direction": direction,
@@ -356,7 +359,10 @@ def _build_protocol_group(version, direction, by_date, sorted_dates, threshold):
         else:
             hi = _health_index_for_group(day_observations, direction, version)
         low_qam_count, numeric_sample_count = _low_qam_counts(day_observations, effective_threshold)
-        lq = round(low_qam_count / numeric_sample_count * 100, 1) if numeric_sample_count else 0
+        # Keep the Low-QAM percentage on the same visible denominator as the
+        # distribution chart. Unknown/non-numeric samples remain in the total
+        # instead of turning one low numeric sample into 100% exposure.
+        lq = _weighted_pct_from_counts(low_qam_count, len(day_observations))
 
         # Count degraded channels for this day
         degraded = _count_degraded_channels_day(
@@ -386,10 +392,7 @@ def _build_protocol_group(version, direction, by_date, sorted_dates, threshold):
     overall_low_qam_count, overall_numeric_sample_count = _low_qam_counts(
         all_observations, effective_threshold
     )
-    overall_lq = (
-        round(overall_low_qam_count / overall_numeric_sample_count * 100, 1)
-        if overall_numeric_sample_count else 0
-    )
+    overall_lq = _weighted_pct_from_counts(overall_low_qam_count, len(all_observations))
     overall_dist = _distribution_pct(all_observations)
     dominant = max(overall_dist, key=overall_dist.get) if overall_dist else None
 
@@ -755,7 +758,7 @@ def compute_distribution(snapshots, direction, tz_name, low_qam_threshold=16):
             "distribution": distribution,
             "health_index": _weighted_avg(entry["health_values"]),
             "low_qam_pct": _weighted_pct_from_counts(
-                entry["low_qam_sample_count"], entry["numeric_sample_count"]
+                entry["low_qam_sample_count"], entry["sample_count"]
             ),
         })
 

--- a/app/modules/modulation/i18n/de.json
+++ b/app/modules/modulation/i18n/de.json
@@ -15,7 +15,7 @@
     "back_to_overview": "Zurück zur Übersicht",
     "intraday_title": "Kanaldetails",
     "channel_label": "Kanal",
-  "channels_label": "Kanäle",
+    "channels_label": "Kanäle",
     "dominant_modulation": "Dominant",
     "degraded_channels": "degradiert",
     "disclaimer": "Gesundheitsindizes und Modulationsstatistiken sind Schätzungen basierend auf periodischen Polling-Messungen.",
@@ -34,5 +34,6 @@
     "protocol_group_label": "Protokollgruppe",
     "glossary_health_index": "Gesundheitsindex: ein Gesamtwert (0-100), der die Modulationsqualität aller Kanäle widerspiegelt. Höher bedeutet weniger Signaldegradation.",
     "glossary_low_qam": "Low-QAM-Anteil: DOCSight-Heuristik für den Anteil der Samples auf niedrigen Modulationsstufen. Bei US DOCSIS 3.1 zählt 64QAM und darunter; 128QAM fließt in den Gesundheitsindex ein, zählt aber nicht als Low-QAM. Hoher Anteil deutet auf anhaltende Signalprobleme hin.",
-    "glossary_sample_density": "Messabdeckung: Anzahl der gesammelten Polling-Messungen im gewählten Zeitraum. Mehr Messungen bedeuten genauere Statistiken."
+    "glossary_sample_density": "Messabdeckung: Anzahl der gesammelten Polling-Messungen im gewählten Zeitraum. Mehr Messungen bedeuten genauere Statistiken.",
+    "low_qam_denominator_hint": "Unknown-Samples bleiben im Gesamtwert"
 }

--- a/app/modules/modulation/i18n/en.json
+++ b/app/modules/modulation/i18n/en.json
@@ -15,7 +15,7 @@
     "back_to_overview": "Back to Overview",
     "intraday_title": "Channel Detail",
     "channel_label": "Channel",
-  "channels_label": "Channels",
+    "channels_label": "Channels",
     "dominant_modulation": "Dominant",
     "degraded_channels": "degraded",
     "disclaimer": "Health indices and modulation statistics are estimates based on periodic polling samples.",
@@ -34,5 +34,6 @@
     "protocol_group_label": "Protocol Group",
     "glossary_health_index": "Health Index: an aggregate score (0-100) reflecting overall modulation quality across all channels. Higher means less signal degradation.",
     "glossary_low_qam": "Low-QAM Exposure: DOCSight heuristic for the percentage of samples at low modulation levels. For US DOCSIS 3.1 this counts 64QAM and below; 128QAM is reflected by Health Index but not counted as Low-QAM. High exposure indicates persistent signal problems.",
-    "glossary_sample_density": "Sample Density: number of polling samples collected for the selected period. More samples mean more accurate statistics."
+    "glossary_sample_density": "Sample Density: number of polling samples collected for the selected period. More samples mean more accurate statistics.",
+    "low_qam_denominator_hint": "Unknown samples stay in the total"
 }

--- a/app/modules/modulation/i18n/es.json
+++ b/app/modules/modulation/i18n/es.json
@@ -15,7 +15,7 @@
     "back_to_overview": "Volver al resumen",
     "intraday_title": "Detalle del canal",
     "channel_label": "Canal",
-  "channels_label": "Canales",
+    "channels_label": "Canales",
     "dominant_modulation": "Dominante",
     "degraded_channels": "degradados",
     "disclaimer": "Los índices de salud y las estadísticas de modulación son estimaciones basadas en muestras periódicas.",
@@ -34,5 +34,6 @@
     "protocol_group_label": "Grupo de protocolo",
     "glossary_health_index": "Índice de salud: puntuación global (0-100) que refleja la calidad de modulación en todos los canales. Mayor significa menos degradación.",
     "glossary_low_qam": "Exposición Low-QAM: heurística de DOCSight para el porcentaje de muestras en niveles bajos de modulación. Para US DOCSIS 3.1 cuenta 64QAM e inferiores; 128QAM se refleja en el índice de salud, pero no cuenta como Low-QAM. Una exposición alta indica problemas de señal persistentes.",
-    "glossary_sample_density": "Densidad de muestras: número de mediciones recopiladas para el período seleccionado. Más muestras significan estadísticas más precisas."
+    "glossary_sample_density": "Densidad de muestras: número de mediciones recopiladas para el período seleccionado. Más muestras significan estadísticas más precisas.",
+    "low_qam_denominator_hint": "Las muestras Unknown permanecen en el total"
 }

--- a/app/modules/modulation/i18n/fr.json
+++ b/app/modules/modulation/i18n/fr.json
@@ -15,7 +15,7 @@
     "back_to_overview": "Retour à l'aperçu",
     "intraday_title": "Détail du canal",
     "channel_label": "Canal",
-  "channels_label": "Canaux",
+    "channels_label": "Canaux",
     "dominant_modulation": "Dominante",
     "degraded_channels": "dégradés",
     "disclaimer": "Les indices de santé et les statistiques de modulation sont des estimations basées sur des échantillons périodiques.",
@@ -34,5 +34,6 @@
     "protocol_group_label": "Groupe de protocole",
     "glossary_health_index": "Indice de santé : score global (0-100) reflétant la qualité de modulation sur tous les canaux. Plus élevé signifie moins de dégradation.",
     "glossary_low_qam": "Exposition Low-QAM : heuristique DOCSight pour le pourcentage d’échantillons à de faibles niveaux de modulation. Pour l’US DOCSIS 3.1, 64QAM et moins sont comptés ; 128QAM est reflété par l’indice de santé, mais n’est pas compté comme Low-QAM. Une exposition élevée indique des problèmes de signal persistants.",
-    "glossary_sample_density": "Densité d'échantillons : nombre de mesures collectées pour la période sélectionnée. Plus de mesures signifie des statistiques plus précises."
+    "glossary_sample_density": "Densité d'échantillons : nombre de mesures collectées pour la période sélectionnée. Plus de mesures signifie des statistiques plus précises.",
+    "low_qam_denominator_hint": "Les échantillons Unknown restent dans le total"
 }

--- a/app/modules/modulation/static/main.js
+++ b/app/modules/modulation/static/main.js
@@ -144,7 +144,10 @@ function updateOverviewKPIs(data) {
         lqEl.className = 'mod-kpi-item-value ' + lowQamClass(lq);
     }
     var lqHint = document.getElementById('mod-kpi-lowqam-hint');
-    if (lqHint) lqHint.textContent = '\u2264 16QAM';
+    if (lqHint) {
+        lqHint.textContent = T['docsight.modulation.low_qam_denominator_hint'] ||
+            'Unknown samples stay in the total';
+    }
 
     var dEl = document.getElementById('mod-kpi-density');
     if (dEl) {

--- a/tests/modulation/test_distribution.py
+++ b/tests/modulation/test_distribution.py
@@ -95,6 +95,100 @@ class TestComputeDistributionV2:
         assert pg["low_qam_pct"] == 33.3
         assert pg["days"][0]["low_qam_pct"] == 33.3
 
+    def test_us31_low_qam_pct_keeps_unknown_in_visible_denominator(self):
+        snaps = [
+            _make_snapshot(
+                f"2026-05-01T{hour:02d}:00:00Z",
+                us_channels=[{
+                    "channel_id": 41,
+                    "modulation": "Unknown",
+                    "docsis_version": "3.1",
+                }],
+            )
+            for hour in range(19)
+        ]
+        snaps.append(_make_snapshot(
+            "2026-05-01T20:00:00Z",
+            us_channels=[{
+                "channel_id": 41,
+                "modulation": "64QAM",
+                "docsis_version": "3.1",
+            }],
+        ))
+
+        result = compute_distribution_v2(snaps, "us", "UTC")
+        pg = result["protocol_groups"][0]
+        day = pg["days"][0]
+
+        assert day["distribution"] == {"64QAM": 5.0, "Unknown": 95.0}
+        assert day["sample_count"] == 20
+        assert day["numeric_sample_count"] == 1
+        assert day["low_qam_sample_count"] == 1
+        assert day["low_qam_pct"] == 5.0
+        assert pg["low_qam_pct"] == 5.0
+        assert result["aggregate"]["low_qam_pct"] == 5.0
+
+    def test_us31_low_qam_pct_counts_64qam_excludes_128qam_and_keeps_unknown_denominator(self):
+        snaps = []
+        for hour in range(10):
+            snaps.append(_make_snapshot(
+                f"2026-05-06T{hour:02d}:00:00Z",
+                us_channels=[{"channel_id": 41, "modulation": "Unknown", "docsis_version": "3.1"}],
+            ))
+        for hour in range(10, 15):
+            snaps.append(_make_snapshot(
+                f"2026-05-06T{hour:02d}:00:00Z",
+                us_channels=[{"channel_id": 41, "modulation": "128QAM", "docsis_version": "3.1"}],
+            ))
+        for hour in range(15, 20):
+            snaps.append(_make_snapshot(
+                f"2026-05-06T{hour:02d}:00:00Z",
+                us_channels=[{"channel_id": 41, "modulation": "64QAM", "docsis_version": "3.1"}],
+            ))
+
+        result = compute_distribution_v2(snaps, "us", "UTC")
+        pg = result["protocol_groups"][0]
+        day = pg["days"][0]
+
+        assert day["distribution"] == {"128QAM": 25.0, "64QAM": 25.0, "Unknown": 50.0}
+        assert day["low_qam_pct"] == 25.0
+        assert pg["low_qam_pct"] == 25.0
+        assert result["aggregate"]["low_qam_pct"] == 25.0
+
+    def test_low_qam_pct_unknown_denominator_weighted_across_days_and_protocols(self):
+        snaps = []
+        # Day 1 / DOCSIS 3.1: 1 low sample, 19 Unknown => 5% for that day/group.
+        for hour in range(19):
+            snaps.append(_make_snapshot(
+                f"2026-05-01T{hour:02d}:00:00Z",
+                us_channels=[{"channel_id": 41, "modulation": "Unknown", "docsis_version": "3.1"}],
+            ))
+        snaps.append(_make_snapshot(
+            "2026-05-01T20:00:00Z",
+            us_channels=[{"channel_id": 41, "modulation": "64QAM", "docsis_version": "3.1"}],
+        ))
+        # Day 2 / DOCSIS 3.0: 1 low sample, 99 non-low samples. This guards the
+        # global aggregate against protocol averaging and numeric-only denominators.
+        snaps.append(_make_snapshot(
+            "2026-05-02T00:00:00Z",
+            us_channels=[{"channel_id": 1, "modulation": "16QAM", "docsis_version": "3.0"}],
+        ))
+        for minute in range(99):
+            snaps.append(_make_snapshot(
+                f"2026-05-02T01:{minute % 60:02d}:00Z",
+                us_channels=[{"channel_id": 1, "modulation": "64QAM", "docsis_version": "3.0"}],
+            ))
+
+        result = compute_distribution_v2(snaps, "us", "UTC")
+        groups = {pg["docsis_version"]: pg for pg in result["protocol_groups"]}
+
+        assert groups["3.1"]["low_qam_pct"] == 5.0
+        assert groups["3.0"]["low_qam_pct"] == 1.0
+        assert result["aggregate"]["low_qam_pct"] == 1.7
+        assert result["aggregate"]["low_qam_pct"] != 3.0
+        assert result["aggregate"]["low_qam_pct"] != 100.0
+
+
     def test_prefers_profile_modulation_for_ofdma_distribution(self):
         snaps = [
             _make_snapshot(
@@ -318,6 +412,29 @@ class TestComputeIntraday:
         snaps = [_make_snapshot("2026-03-01T10:00:00Z", us_channels=us_channels)]
         result = compute_intraday(snaps, "us", "UTC", "2026-03-01")
         assert len(result["protocol_groups"]) == 2
+
+    def test_us31_intraday_treats_64qam_as_degraded_event(self):
+        snaps = [
+            _make_snapshot("2026-03-01T10:00:00Z",
+                           us_channels=[{"channel_id": 41, "modulation": "1024QAM",
+                                         "docsis_version": "3.1", "frequency": "29.775 - 64.775"}]),
+            _make_snapshot("2026-03-01T14:00:00Z",
+                           us_channels=[{"channel_id": 41, "modulation": "64QAM",
+                                         "docsis_version": "3.1", "frequency": "29.775 - 64.775"}]),
+            _make_snapshot("2026-03-01T18:00:00Z",
+                           us_channels=[{"channel_id": 41, "modulation": "1024QAM",
+                                         "docsis_version": "3.1", "frequency": "29.775 - 64.775"}]),
+        ]
+
+        result = compute_intraday(snaps, "us", "UTC", "2026-03-01")
+        pg = next(pg for pg in result["protocol_groups"] if pg["docsis_version"] == "3.1")
+        ch = pg["channels"][0]
+
+        assert ch["degraded"] is True
+        assert ch["worst_modulation"] == "64QAM"
+        assert ch["degraded_sample_pct"] == 33
+        assert ch["degraded_events"][0]["label"] == "64QAM"
+        assert "64QAM" in ch["summary"]
 
     def test_us31_channel_summary_does_not_treat_128qam_as_low_qam(self):
         snaps = [

--- a/tests/modulation/test_grouping_timeline.py
+++ b/tests/modulation/test_grouping_timeline.py
@@ -13,7 +13,7 @@ from app.modules.modulation.engine import (
     _degraded_qam_threshold,
     _health_index,
     _health_index_for_group,
-    _low_qam_pct,
+    _numeric_low_qam_pct,
     _group_channels_by_protocol,
     _modulation_periods,
     _simplify_timeline,

--- a/tests/modulation/test_health.py
+++ b/tests/modulation/test_health.py
@@ -13,7 +13,7 @@ from app.modules.modulation.engine import (
     _degraded_qam_threshold,
     _health_index,
     _health_index_for_group,
-    _low_qam_pct,
+    _numeric_low_qam_pct,
     _group_channels_by_protocol,
     _modulation_periods,
     _simplify_timeline,
@@ -253,44 +253,44 @@ class TestDegradedThresholds:
         assert _degraded_qam_threshold("us", "3.1", 16) == 64
 
 
-# ── _low_qam_pct ──
+# ── _numeric_low_qam_pct ──
 
-class TestLowQamPct:
+class TestNumericLowQamPct:
     def test_no_observations(self):
-        assert _low_qam_pct([], 16) == 0
+        assert _numeric_low_qam_pct([], 16) == 0
 
     def test_all_low(self):
         obs = [("4QAM", 4)] * 10
-        assert _low_qam_pct(obs, 16) == 100.0
+        assert _numeric_low_qam_pct(obs, 16) == 100.0
 
     def test_none_low(self):
         obs = [("256QAM", 256)] * 10
-        assert _low_qam_pct(obs, 16) == 0.0
+        assert _numeric_low_qam_pct(obs, 16) == 0.0
 
     def test_mixed(self):
         obs = [("4QAM", 4)] * 2 + [("256QAM", 256)] * 8
-        assert _low_qam_pct(obs, 16) == 20.0
+        assert _numeric_low_qam_pct(obs, 16) == 20.0
 
     def test_threshold_boundary(self):
         obs = [("16QAM", 16)] * 5 + [("64QAM", 64)] * 5
-        assert _low_qam_pct(obs, 16) == 50.0
+        assert _numeric_low_qam_pct(obs, 16) == 50.0
 
 
     def test_threshold_64_excludes_128qam(self):
         obs = [("64QAM", 64)] * 4 + [("128QAM", 128)] * 6
-        assert _low_qam_pct(obs, 64) == 40.0
+        assert _numeric_low_qam_pct(obs, 64) == 40.0
 
     def test_ignores_ofdm(self):
         obs = [("4QAM", 4)] * 1 + [("64QAM", 64)] * 1 + [("OFDM", None)] * 8
-        assert _low_qam_pct(obs, 16) == 50.0
+        assert _numeric_low_qam_pct(obs, 16) == 50.0
 
     def test_custom_threshold_64(self):
         obs = [("16QAM", 16)] * 3 + [("64QAM", 64)] * 2 + [("256QAM", 256)] * 5
-        assert _low_qam_pct(obs, 64) == 50.0
+        assert _numeric_low_qam_pct(obs, 64) == 50.0
 
     def test_ofdm_only_returns_zero(self):
         obs = [("OFDM", None)] * 10
-        assert _low_qam_pct(obs, 16) == 0
+        assert _numeric_low_qam_pct(obs, 16) == 0
 
 
 # ── _group_channels_by_protocol ──

--- a/tests/test_modulation_api.py
+++ b/tests/test_modulation_api.py
@@ -326,6 +326,33 @@ class TestTrendEndpoint:
         assert data[0]["low_qam_pct"] != 100.0
 
 
+    def test_trend_keeps_unknown_in_visible_low_qam_denominator(self, client_with_storage):
+        client, storage = client_with_storage
+        day = _ts_days_ago(1)[:10]
+        for hour in range(19):
+            _store_snapshot(
+                storage,
+                f"{day}T{hour:02d}:00:00Z",
+                us_channels=[
+                    {"modulation": "Unknown", "channel_id": 1, "docsis_version": "3.1"},
+                ],
+            )
+        _store_snapshot(
+            storage,
+            f"{day}T20:00:00Z",
+            us_channels=[
+                {"modulation": "64QAM", "channel_id": 1, "docsis_version": "3.1"},
+            ],
+        )
+
+        resp = client.get("/api/modulation/trend?days=7&direction=us")
+        data = resp.get_json()
+
+        assert len(data) == 1
+        assert data[0]["low_qam_pct"] == 5.0
+        assert data[0]["low_qam_pct"] != 100.0
+        assert data[0]["dominant_modulation"] == "Unknown"
+
     def test_trend_us_docsis31_128qam_does_not_count_as_low_qam(self, client_with_storage):
         client, storage = client_with_storage
         day = _ts_days_ago(1)[:10]

--- a/tests/test_modulation_static_contract.py
+++ b/tests/test_modulation_static_contract.py
@@ -5,6 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 MODULATION_JS = ROOT / "app" / "modules" / "modulation" / "static" / "main.js"
 MODULATION_CSS = ROOT / "app" / "modules" / "modulation" / "static" / "style.css"
+I18N_DIR = ROOT / "app" / "modules" / "modulation" / "i18n"
 
 
 def test_distribution_day_bars_drill_into_intraday_detail():
@@ -27,3 +28,17 @@ def test_clickable_distribution_chart_has_pointer_cursor():
 
     assert ".modulation-clickable-chart" in css
     assert "cursor: pointer" in css
+
+
+def test_low_qam_hint_does_not_use_stale_global_16qam_threshold():
+    js = MODULATION_JS.read_text(encoding="utf-8")
+
+    assert "low_qam_denominator_hint" in js
+    assert "\u2264 16QAM" not in js
+    assert "\\u2264 16QAM" not in js
+
+
+def test_low_qam_denominator_hint_is_localized_for_all_modulation_languages():
+    for path in I18N_DIR.glob("*.json"):
+        text = path.read_text(encoding="utf-8")
+        assert "low_qam_denominator_hint" in text, path.name


### PR DESCRIPTION
## Summary
- Align visible Low-QAM percentages with the same total-sample denominator used by the modulation distribution.
- Keep Unknown samples in the denominator while excluding them from the Low-QAM count.
- Preserve US DOCSIS 3.1 semantics: 64QAM and below count as Low-QAM, 128QAM does not.
- Replace the stale Low-QAM hint with localized denominator copy.

## Tests
- `.venv/bin/python -m pytest tests/modulation/test_distribution.py::TestComputeIntraday::test_us31_intraday_treats_64qam_as_degraded_event tests/modulation/test_distribution.py::TestComputeIntraday::test_us31_channel_summary_does_not_treat_128qam_as_low_qam -q`
- `.venv/bin/python -m pytest tests/test_modulation_api.py tests/modulation/test_health.py tests/modulation/test_distribution.py tests/modulation/test_grouping_timeline.py tests/test_modulation_static_contract.py tests/test_glossary_i18n.py -q`
- `.venv/bin/python -m pytest tests/modulation tests/test_modulation_api.py tests/test_modulation_static_contract.py -q`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `.venv/bin/python -m pytest -q`

Fixes #436
