### PR TITLE
Clarify DOCSIS 3.1 Low-QAM distribution colors

### DIFF
--- a/app/modules/modulation/i18n/de.json
+++ b/app/modules/modulation/i18n/de.json
@@ -35,5 +35,6 @@
     "glossary_health_index": "Gesundheitsindex: ein Gesamtwert (0-100), der die Modulationsqualität aller Kanäle widerspiegelt. Höher bedeutet weniger Signaldegradation.",
     "glossary_low_qam": "Low-QAM-Anteil: DOCSight-Heuristik für den Anteil der Samples auf niedrigen Modulationsstufen. Bei US DOCSIS 3.1 zählt 64QAM und darunter; 128QAM fließt in den Gesundheitsindex ein, zählt aber nicht als Low-QAM. Hoher Anteil deutet auf anhaltende Signalprobleme hin.",
     "glossary_sample_density": "Messabdeckung: Anzahl der gesammelten Polling-Messungen im gewählten Zeitraum. Mehr Messungen bedeuten genauere Statistiken.",
-    "low_qam_denominator_hint": "Unknown-Samples bleiben im Gesamtwert"
+    "low_qam_denominator_hint": "Unknown-Samples bleiben im Gesamtwert",
+    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 Upstream: 64QAM und darunter zählen als Low-QAM (rot). 128QAM ist grenzwertig (orange). 256QAM und höher gelten als gesund."
 }

--- a/app/modules/modulation/i18n/en.json
+++ b/app/modules/modulation/i18n/en.json
@@ -35,5 +35,6 @@
     "glossary_health_index": "Health Index: an aggregate score (0-100) reflecting overall modulation quality across all channels. Higher means less signal degradation.",
     "glossary_low_qam": "Low-QAM Exposure: DOCSight heuristic for the percentage of samples at low modulation levels. For US DOCSIS 3.1 this counts 64QAM and below; 128QAM is reflected by Health Index but not counted as Low-QAM. High exposure indicates persistent signal problems.",
     "glossary_sample_density": "Sample Density: number of polling samples collected for the selected period. More samples mean more accurate statistics.",
-    "low_qam_denominator_hint": "Unknown samples stay in the total"
+    "low_qam_denominator_hint": "Unknown samples stay in the total",
+    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 upstream: 64QAM and below are Low-QAM (red). 128QAM is borderline (amber). 256QAM and above read as healthy."
 }

--- a/app/modules/modulation/i18n/es.json
+++ b/app/modules/modulation/i18n/es.json
@@ -35,5 +35,6 @@
     "glossary_health_index": "Índice de salud: puntuación global (0-100) que refleja la calidad de modulación en todos los canales. Mayor significa menos degradación.",
     "glossary_low_qam": "Exposición Low-QAM: heurística de DOCSight para el porcentaje de muestras en niveles bajos de modulación. Para US DOCSIS 3.1 cuenta 64QAM e inferiores; 128QAM se refleja en el índice de salud, pero no cuenta como Low-QAM. Una exposición alta indica problemas de señal persistentes.",
     "glossary_sample_density": "Densidad de muestras: número de mediciones recopiladas para el período seleccionado. Más muestras significan estadísticas más precisas.",
-    "low_qam_denominator_hint": "Las muestras Unknown permanecen en el total"
+    "low_qam_denominator_hint": "Las muestras Unknown permanecen en el total",
+    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 upstream: 64QAM y por debajo cuentan como Low-QAM (rojo). 128QAM es limítrofe (ámbar). 256QAM y superiores se muestran como saludables."
 }

--- a/app/modules/modulation/i18n/fr.json
+++ b/app/modules/modulation/i18n/fr.json
@@ -35,5 +35,6 @@
     "glossary_health_index": "Indice de santé : score global (0-100) reflétant la qualité de modulation sur tous les canaux. Plus élevé signifie moins de dégradation.",
     "glossary_low_qam": "Exposition Low-QAM : heuristique DOCSight pour le pourcentage d’échantillons à de faibles niveaux de modulation. Pour l’US DOCSIS 3.1, 64QAM et moins sont comptés ; 128QAM est reflété par l’indice de santé, mais n’est pas compté comme Low-QAM. Une exposition élevée indique des problèmes de signal persistants.",
     "glossary_sample_density": "Densité d'échantillons : nombre de mesures collectées pour la période sélectionnée. Plus de mesures signifie des statistiques plus précises.",
-    "low_qam_denominator_hint": "Les échantillons Unknown restent dans le total"
+    "low_qam_denominator_hint": "Les échantillons Unknown restent dans le total",
+    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 amont : 64QAM et moins comptent comme Low-QAM (rouge). 128QAM est limite (ambre). 256QAM et plus apparaissent comme sains."
 }

--- a/app/modules/modulation/static/main.js
+++ b/app/modules/modulation/static/main.js
@@ -22,6 +22,52 @@ var QAM_COLORS = {
     'Unknown': '#6b7280'
 };
 
+/* US DOCSIS 3.1 upstream context coloring.
+   In a max 1024QAM upstream group, 64QAM and below are Low-QAM (red family),
+   128QAM is not Low-QAM but is not unambiguously healthy (amber/warning),
+   256QAM and above read as healthy (green family).
+   Other contexts keep the global QAM_COLORS palette unchanged. */
+var QAM_COLORS_US_DOCSIS_31 = {
+    'QPSK':    '#b91c1c',
+    '4QAM':    '#b91c1c',
+    '8QAM':    '#dc2626',
+    '16QAM':   '#ef4444',
+    '32QAM':   '#f87171',
+    '64QAM':   '#fb7185',
+    '128QAM':  '#f59e0b',
+    '256QAM':  '#86efac',
+    '512QAM':  '#22c55e',
+    '1024QAM': '#16a34a',
+    '4096QAM': '#15803d',
+    'OFDM':    '#22c55e',
+    'OFDMA':   '#22c55e',
+    'Unknown': '#6b7280'
+};
+
+function isUsDocsis31Upstream(pg) {
+    if (!pg) return false;
+    var direction = pg._direction || pg.direction || '';
+    return direction === 'us' && String(pg.docsis_version || '') === '3.1';
+}
+
+function qamColorForContext(mod, pg) {
+    if (isUsDocsis31Upstream(pg)) {
+        if (Object.prototype.hasOwnProperty.call(QAM_COLORS_US_DOCSIS_31, mod)) {
+            return QAM_COLORS_US_DOCSIS_31[mod];
+        }
+    }
+    return QAM_COLORS[mod] || '#6b7280';
+}
+
+function lowQamLegendHintForContext(pg) {
+    if (isUsDocsis31Upstream(pg)) {
+        return T['docsight.modulation.low_qam_legend_hint_d31_us'] ||
+            T['low_qam_legend_hint_d31_us'] ||
+            'US DOCSIS 3.1: 64QAM and below count as Low-QAM; 128QAM is borderline.';
+    }
+    return '';
+}
+
 var MODULATION_LEVELS = [
     '4QAM',
     '8QAM',
@@ -168,8 +214,12 @@ function renderProtocolGroups(data) {
     container.textContent = '';
 
     var groups = data.protocol_groups || [];
+    var renderDirection = data.direction || _modDirection;
     groups.forEach(function(pg, idx) {
+        pg._direction = renderDirection;
         var section = _el('div', 'mod-protocol-group');
+        section.setAttribute('data-direction', renderDirection);
+        section.setAttribute('data-docsis-version', String(pg.docsis_version || ''));
 
         // Header
         var header = _el('div', 'mod-protocol-group-header');
@@ -310,11 +360,12 @@ function renderGroupDistChart(pg, idx) {
     var uSeries = [{ label: 'X', value: function(u, v) { return labels[v] || ''; } }];
     for (var li = layerData.length - 1; li >= 0; li--) {
         var layer = layerData[li];
+        var layerColor = qamColorForContext(layer.mod, pg);
         uData.push(layer.data);
         uSeries.push({
             label: layer.mod,
-            stroke: QAM_COLORS[layer.mod] || '#6b7280',
-            fill: QAM_COLORS[layer.mod] || '#6b7280',
+            stroke: layerColor,
+            fill: layerColor,
             width: 0,
             paths: barPaths,
             points: { show: false }
@@ -322,7 +373,7 @@ function renderGroupDistChart(pg, idx) {
     }
 
     if (legendContainer) {
-        renderDistributionLegend(legendContainer, modKeys);
+        renderDistributionLegend(legendContainer, modKeys, pg);
     }
 
     var w = container.offsetWidth || 400;
@@ -793,15 +844,21 @@ function modSortOrder(mod) {
     return order[mod] !== undefined ? order[mod] : (MODULATION_LEVELS.length - 1);
 }
 
-function renderDistributionLegend(container, modKeys) {
+function renderDistributionLegend(container, modKeys, pg) {
     modKeys.forEach(function(mod) {
         var item = _el('div', 'modulation-custom-legend-item');
         var swatch = _el('span', 'modulation-custom-legend-swatch');
-        swatch.style.background = QAM_COLORS[mod] || '#6b7280';
+        swatch.style.background = qamColorForContext(mod, pg);
         item.appendChild(swatch);
         item.appendChild(_el('span', 'modulation-custom-legend-label', mod));
         container.appendChild(item);
     });
+
+    var hintText = lowQamLegendHintForContext(pg);
+    if (hintText) {
+        var hint = _el('div', 'modulation-custom-legend-hint', hintText);
+        container.appendChild(hint);
+    }
 }
 
 function destroyCharts() {

--- a/app/modules/modulation/static/style.css
+++ b/app/modules/modulation/static/style.css
@@ -372,6 +372,15 @@
     flex-shrink: 0;
 }
 
+.modulation-custom-legend-hint {
+    flex-basis: 100%;
+    margin-top: 4px;
+    font-size: 0.72em;
+    line-height: 1.35;
+    color: var(--text-secondary, var(--muted));
+    opacity: 0.85;
+}
+
 /* ── Responsive ── */
 @media (max-width: 768px) {
     .mod-controls {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v5';
+var CACHE_VERSION = 'v6';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -269,6 +269,32 @@ class TestProtocolGroups:
         disclaimer = self.page.locator("#mod-disclaimer")
         expect(disclaimer).to_be_visible()
 
+    def test_us_docsis31_low_qam_legend_hint_visible_when_group_exists(self, live_server):
+        resp = self.page.request.get(f"{live_server}/api/modulation/distribution?direction=us&days=7")
+        groups = resp.json().get("protocol_groups", [])
+        has_us_docsis31 = any(str(group.get("docsis_version")) == "3.1" for group in groups)
+        if not has_us_docsis31:
+            pytest.skip("Demo data has no US DOCSIS 3.1 protocol group")
+
+        us_d31_group = self.page.locator(
+            '.mod-protocol-group[data-direction="us"][data-docsis-version="3.1"]'
+        ).first
+        expect(
+            us_d31_group.locator(".modulation-custom-legend-hint").filter(
+                has_text="US DOCSIS 3.1 upstream"
+            )
+        ).to_be_visible()
+
+        us_d30_groups = self.page.locator(
+            '.mod-protocol-group[data-direction="us"][data-docsis-version="3.0"]'
+        )
+        if us_d30_groups.count() > 0:
+            expect(us_d30_groups.first.locator(".modulation-custom-legend-hint")).to_have_count(0)
+
+        self.page.locator('#modulation-direction-tabs .trend-tab[data-dir="ds"]').click()
+        self.page.wait_for_timeout(1500)
+        expect(self.page.locator(".modulation-custom-legend-hint")).to_have_count(0)
+
 
 # ── No Console Errors ──
 

--- a/tests/test_modulation_static_contract.py
+++ b/tests/test_modulation_static_contract.py
@@ -1,5 +1,6 @@
 """Static UI contracts for the modulation performance module."""
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -42,3 +43,113 @@ def test_low_qam_denominator_hint_is_localized_for_all_modulation_languages():
     for path in I18N_DIR.glob("*.json"):
         text = path.read_text(encoding="utf-8")
         assert "low_qam_denominator_hint" in text, path.name
+
+
+def test_distribution_chart_uses_context_aware_qam_color_helper():
+    """Distribution chart color selection must be context-aware (per protocol group),
+    not a global-only QAM_COLORS lookup. Issue #444."""
+    js = MODULATION_JS.read_text(encoding="utf-8")
+
+    assert "function qamColorForContext" in js, (
+        "Expected helper qamColorForContext(mod, pg) for protocol-aware coloring"
+    )
+
+    render_match = re.search(
+        r"function renderGroupDistChart\([^)]*\)\s*\{(.*?)\n\}\s*\n",
+        js,
+        re.DOTALL,
+    )
+    assert render_match, "Could not locate renderGroupDistChart body"
+    body = render_match.group(1)
+
+    assert "qamColorForContext(" in body, (
+        "renderGroupDistChart must use the context-aware helper"
+    )
+    assert "QAM_COLORS[layer.mod]" not in body, (
+        "renderGroupDistChart must not use the global QAM_COLORS map directly"
+    )
+
+
+def test_us_docsis_31_64qam_is_critical_and_128qam_is_warning():
+    """US DOCSIS 3.1 upstream context: 64QAM and below in red family,
+    128QAM amber/warning, 256QAM and above green/healthy. Issue #444."""
+    js = MODULATION_JS.read_text(encoding="utf-8")
+
+    assert "function qamColorForContext" in js, "qamColorForContext must be defined"
+
+    map_match = re.search(
+        r"(QAM_COLORS_US_DOCSIS_31|US_DOCSIS_31[A-Z_]*)\s*=\s*\{([^}]+)\}",
+        js,
+    )
+    assert map_match, (
+        "Expected a US DOCSIS 3.1 context color map (e.g. QAM_COLORS_US_DOCSIS_31)"
+    )
+    ctx_map = map_match.group(2)
+
+    def color_for(level):
+        m = re.search(r"'" + re.escape(level) + r"'\s*:\s*'(#[0-9a-fA-F]{6})'", ctx_map)
+        assert m, f"US DOCSIS 3.1 context map missing entry for {level}"
+        return m.group(1).lower()
+
+    red_family = {"#ef4444", "#dc2626", "#b91c1c", "#f87171", "#fb7185"}
+    amber_family = {"#f59e0b", "#fbbf24", "#d97706", "#f97316"}
+    green_family = {"#22c55e", "#16a34a", "#15803d", "#86efac", "#14b8a6"}
+
+    assert color_for("64QAM") in red_family, (
+        "US DOCSIS 3.1 context: 64QAM must use a red-family hex"
+    )
+    assert color_for("128QAM") in amber_family, (
+        "US DOCSIS 3.1 context: 128QAM must use an amber/warning hex"
+    )
+    assert color_for("256QAM") in green_family, (
+        "US DOCSIS 3.1 context: 256QAM must use a green/healthy hex"
+    )
+
+
+def test_global_us_docsis_30_64qam_color_is_unchanged():
+    """The global QAM_COLORS map must keep 64QAM at its existing yellow value
+    so US DOCSIS 3.0 upstream is not painted red by default. Issue #444."""
+    js = MODULATION_JS.read_text(encoding="utf-8")
+
+    qam_colors_match = re.search(
+        r"var QAM_COLORS\s*=\s*\{(.*?)\};",
+        js,
+        re.DOTALL,
+    )
+    assert qam_colors_match, "QAM_COLORS map must remain defined"
+    qam_block = qam_colors_match.group(1)
+
+    assert re.search(r"'64QAM'\s*:\s*'#eab308'", qam_block), (
+        "Global QAM_COLORS['64QAM'] must remain '#eab308' for US DOCSIS 3.0"
+    )
+
+
+def test_low_qam_legend_hint_helper_is_context_aware():
+    """A context-aware legend/helper text helper must exist so US DOCSIS 3.1
+    upstream charts can explain why 64QAM is shown as Low-QAM. Issue #444."""
+    js = MODULATION_JS.read_text(encoding="utf-8")
+
+    assert "function lowQamLegendHintForContext" in js, (
+        "Expected helper lowQamLegendHintForContext(pg)"
+    )
+
+    helper_match = re.search(
+        r"function isUsDocsis31Upstream\([^)]*\)\s*\{(.*?)\n\}",
+        js,
+        re.DOTALL,
+    )
+    assert helper_match, "isUsDocsis31Upstream must be defined"
+    assert "_modDirection" not in helper_match.group(1), (
+        "Context classification must use the response render context, not mutable global direction"
+    )
+    assert "data-direction" in js and "data-docsis-version" in js, (
+        "Protocol group markup should expose render context for scoped browser assertions"
+    )
+
+
+def test_low_qam_legend_hint_key_is_localized_for_all_modulation_languages():
+    """Every modulation locale must define the DOCSIS 3.1 Low-QAM legend hint
+    so the new context-aware copy is translatable. Issue #444."""
+    for path in I18N_DIR.glob("*.json"):
+        text = path.read_text(encoding="utf-8")
+        assert "low_qam_legend_hint_d31_us" in text, path.name


### PR DESCRIPTION
## Summary

- Add context-aware Modulation Distribution colors for US DOCSIS 3.1 upstream groups.
- Show `64QAM` and below as Low-QAM aligned, `128QAM` as warning, and `256QAM+` as healthy only in that DOCSIS 3.1 upstream context.
- Add a localized legend hint and keep the existing global palette intact for other groups, including US DOCSIS 3.0 `64QAM`.
- Bump the service-worker cache version so updated module assets are fetched.

Closes #444

## Verification

- `python3 -m pytest tests/test_modulation_static_contract.py -q`
- `node --check app/modules/modulation/static/main.js`
- `node --check app/static/sw.js`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `python3 -m pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright --with playwright python -m pytest -q tests/e2e`
- `git diff --check`
