### PR TITLE
fix(modulation): use upstream-aware DOCSIS 3.0 colors

### DIFF
--- a/app/modules/modulation/i18n/de.json
+++ b/app/modules/modulation/i18n/de.json
@@ -36,5 +36,6 @@
     "glossary_low_qam": "Low-QAM-Anteil: DOCSight-Heuristik für den Anteil der Samples auf niedrigen Modulationsstufen. Bei US DOCSIS 3.1 zählt 64QAM und darunter; 128QAM fließt in den Gesundheitsindex ein, zählt aber nicht als Low-QAM. Hoher Anteil deutet auf anhaltende Signalprobleme hin.",
     "glossary_sample_density": "Messabdeckung: Anzahl der gesammelten Polling-Messungen im gewählten Zeitraum. Mehr Messungen bedeuten genauere Statistiken.",
     "low_qam_denominator_hint": "Unknown-Samples bleiben im Gesamtwert",
-    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 Upstream: 64QAM und darunter zählen als Low-QAM (rot). 128QAM ist grenzwertig (orange). 256QAM und höher gelten als gesund."
+    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 Upstream: 64QAM und darunter zählen als Low-QAM (rot). 128QAM ist grenzwertig (orange). 256QAM und höher gelten als gesund.",
+    "low_qam_legend_hint_d30_us": "US DOCSIS 3.0 Upstream: 64QAM ist der gesunde Maximalwert (grün). 32QAM ist reduziert (orange); 16QAM und darunter sind niedrig (rot)."
 }

--- a/app/modules/modulation/i18n/en.json
+++ b/app/modules/modulation/i18n/en.json
@@ -36,5 +36,6 @@
     "glossary_low_qam": "Low-QAM Exposure: DOCSight heuristic for the percentage of samples at low modulation levels. For US DOCSIS 3.1 this counts 64QAM and below; 128QAM is reflected by Health Index but not counted as Low-QAM. High exposure indicates persistent signal problems.",
     "glossary_sample_density": "Sample Density: number of polling samples collected for the selected period. More samples mean more accurate statistics.",
     "low_qam_denominator_hint": "Unknown samples stay in the total",
-    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 upstream: 64QAM and below are Low-QAM (red). 128QAM is borderline (amber). 256QAM and above read as healthy."
+    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 upstream: 64QAM and below are Low-QAM (red). 128QAM is borderline (amber). 256QAM and above read as healthy.",
+    "low_qam_legend_hint_d30_us": "US DOCSIS 3.0 upstream: 64QAM is the healthy maximum (green). 32QAM is reduced (amber); 16QAM and below are low (red)."
 }

--- a/app/modules/modulation/i18n/es.json
+++ b/app/modules/modulation/i18n/es.json
@@ -36,5 +36,6 @@
     "glossary_low_qam": "Exposición Low-QAM: heurística de DOCSight para el porcentaje de muestras en niveles bajos de modulación. Para US DOCSIS 3.1 cuenta 64QAM e inferiores; 128QAM se refleja en el índice de salud, pero no cuenta como Low-QAM. Una exposición alta indica problemas de señal persistentes.",
     "glossary_sample_density": "Densidad de muestras: número de mediciones recopiladas para el período seleccionado. Más muestras significan estadísticas más precisas.",
     "low_qam_denominator_hint": "Las muestras Unknown permanecen en el total",
-    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 upstream: 64QAM y por debajo cuentan como Low-QAM (rojo). 128QAM es limítrofe (ámbar). 256QAM y superiores se muestran como saludables."
+    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 upstream: 64QAM y por debajo cuentan como Low-QAM (rojo). 128QAM es limítrofe (ámbar). 256QAM y superiores se muestran como saludables.",
+    "low_qam_legend_hint_d30_us": "US DOCSIS 3.0 upstream: 64QAM es el máximo saludable (verde). 32QAM está reducido (ámbar); 16QAM e inferiores son bajos (rojo)."
 }

--- a/app/modules/modulation/i18n/fr.json
+++ b/app/modules/modulation/i18n/fr.json
@@ -36,5 +36,6 @@
     "glossary_low_qam": "Exposition Low-QAM : heuristique DOCSight pour le pourcentage d’échantillons à de faibles niveaux de modulation. Pour l’US DOCSIS 3.1, 64QAM et moins sont comptés ; 128QAM est reflété par l’indice de santé, mais n’est pas compté comme Low-QAM. Une exposition élevée indique des problèmes de signal persistants.",
     "glossary_sample_density": "Densité d'échantillons : nombre de mesures collectées pour la période sélectionnée. Plus de mesures signifie des statistiques plus précises.",
     "low_qam_denominator_hint": "Les échantillons Unknown restent dans le total",
-    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 amont : 64QAM et moins comptent comme Low-QAM (rouge). 128QAM est limite (ambre). 256QAM et plus apparaissent comme sains."
+    "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 amont : 64QAM et moins comptent comme Low-QAM (rouge). 128QAM est limite (ambre). 256QAM et plus apparaissent comme sains.",
+    "low_qam_legend_hint_d30_us": "US DOCSIS 3.0 amont : 64QAM est le maximum sain (vert). 32QAM est réduit (ambre) ; 16QAM et moins sont bas (rouge)."
 }

--- a/app/modules/modulation/static/main.js
+++ b/app/modules/modulation/static/main.js
@@ -32,7 +32,7 @@ var QAM_COLORS_US_DOCSIS_31 = {
     '4QAM':    '#b91c1c',
     '8QAM':    '#dc2626',
     '16QAM':   '#ef4444',
-    '32QAM':   '#f87171',
+    '32QAM':   '#dc2626',
     '64QAM':   '#fb7185',
     '128QAM':  '#f59e0b',
     '256QAM':  '#86efac',
@@ -44,16 +44,48 @@ var QAM_COLORS_US_DOCSIS_31 = {
     'Unknown': '#6b7280'
 };
 
+/* US DOCSIS 3.0 upstream context coloring.
+   In DOCSIS 3.0 upstream charts, 64QAM is the expected healthy maximum,
+   32QAM is reduced/warning, and 16QAM and below are degraded.
+   Downstream and non-DOCSIS 3.0 contexts keep the global palette unchanged. */
+var QAM_COLORS_US_DOCSIS_30 = {
+    'QPSK':    '#b91c1c',
+    '4QAM':    '#b91c1c',
+    '8QAM':    '#dc2626',
+    '16QAM':   '#ef4444',
+    '32QAM':   '#f59e0b',
+    '64QAM':   '#22c55e',
+    '128QAM':  '#84cc16',
+    '256QAM':  '#22c55e',
+    '512QAM':  '#14b8a6',
+    '1024QAM': '#06b6d4',
+    '4096QAM': '#3b82f6',
+    'OFDM':    '#8b5cf6',
+    'OFDMA':   '#8b5cf6',
+    'Unknown': '#6b7280'
+};
+
 function isUsDocsis31Upstream(pg) {
     if (!pg) return false;
     var direction = pg._direction || pg.direction || '';
     return direction === 'us' && String(pg.docsis_version || '') === '3.1';
 }
 
+function isUsDocsis30Upstream(pg) {
+    if (!pg) return false;
+    var direction = pg._direction || pg.direction || '';
+    return direction === 'us' && String(pg.docsis_version || '') === '3.0';
+}
+
 function qamColorForContext(mod, pg) {
     if (isUsDocsis31Upstream(pg)) {
         if (Object.prototype.hasOwnProperty.call(QAM_COLORS_US_DOCSIS_31, mod)) {
             return QAM_COLORS_US_DOCSIS_31[mod];
+        }
+    }
+    if (isUsDocsis30Upstream(pg)) {
+        if (Object.prototype.hasOwnProperty.call(QAM_COLORS_US_DOCSIS_30, mod)) {
+            return QAM_COLORS_US_DOCSIS_30[mod];
         }
     }
     return QAM_COLORS[mod] || '#6b7280';
@@ -64,6 +96,11 @@ function lowQamLegendHintForContext(pg) {
         return T['docsight.modulation.low_qam_legend_hint_d31_us'] ||
             T['low_qam_legend_hint_d31_us'] ||
             'US DOCSIS 3.1: 64QAM and below count as Low-QAM; 128QAM is borderline.';
+    }
+    if (isUsDocsis30Upstream(pg)) {
+        return T['docsight.modulation.low_qam_legend_hint_d30_us'] ||
+            T['low_qam_legend_hint_d30_us'] ||
+            'US DOCSIS 3.0 upstream: 64QAM is the healthy maximum; 32QAM is reduced.';
     }
     return '';
 }

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v6';
+var CACHE_VERSION = 'v7';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -269,27 +269,33 @@ class TestProtocolGroups:
         disclaimer = self.page.locator("#mod-disclaimer")
         expect(disclaimer).to_be_visible()
 
-    def test_us_docsis31_low_qam_legend_hint_visible_when_group_exists(self, live_server):
+    def test_upstream_protocol_groups_have_context_specific_legend_hints(self, live_server):
         resp = self.page.request.get(f"{live_server}/api/modulation/distribution?direction=us&days=7")
         groups = resp.json().get("protocol_groups", [])
         has_us_docsis31 = any(str(group.get("docsis_version")) == "3.1" for group in groups)
-        if not has_us_docsis31:
-            pytest.skip("Demo data has no US DOCSIS 3.1 protocol group")
+        has_us_docsis30 = any(str(group.get("docsis_version")) == "3.0" for group in groups)
+        if not (has_us_docsis31 or has_us_docsis30):
+            pytest.skip("Demo data has no US DOCSIS 3.0 or 3.1 protocol group")
 
-        us_d31_group = self.page.locator(
-            '.mod-protocol-group[data-direction="us"][data-docsis-version="3.1"]'
-        ).first
-        expect(
-            us_d31_group.locator(".modulation-custom-legend-hint").filter(
-                has_text="US DOCSIS 3.1 upstream"
-            )
-        ).to_be_visible()
+        if has_us_docsis31:
+            us_d31_group = self.page.locator(
+                '.mod-protocol-group[data-direction="us"][data-docsis-version="3.1"]'
+            ).first
+            expect(
+                us_d31_group.locator(".modulation-custom-legend-hint").filter(
+                    has_text="US DOCSIS 3.1 upstream"
+                )
+            ).to_be_visible()
 
-        us_d30_groups = self.page.locator(
-            '.mod-protocol-group[data-direction="us"][data-docsis-version="3.0"]'
-        )
-        if us_d30_groups.count() > 0:
-            expect(us_d30_groups.first.locator(".modulation-custom-legend-hint")).to_have_count(0)
+        if has_us_docsis30:
+            us_d30_group = self.page.locator(
+                '.mod-protocol-group[data-direction="us"][data-docsis-version="3.0"]'
+            ).first
+            expect(
+                us_d30_group.locator(".modulation-custom-legend-hint").filter(
+                    has_text="US DOCSIS 3.0 upstream"
+                )
+            ).to_be_visible()
 
         self.page.locator('#modulation-direction-tabs .trend-tab[data-dir="ds"]').click()
         self.page.wait_for_timeout(1500)

--- a/tests/test_modulation_static_contract.py
+++ b/tests/test_modulation_static_contract.py
@@ -106,9 +106,87 @@ def test_us_docsis_31_64qam_is_critical_and_128qam_is_warning():
     )
 
 
+def test_us_docsis_31_low_qam_colors_are_easy_to_distinguish():
+    """Adjacent low-QAM levels need enough palette separation for screenshots.
+    Issue #447."""
+    js = MODULATION_JS.read_text(encoding="utf-8")
+    map_match = re.search(
+        r"QAM_COLORS_US_DOCSIS_31\s*=\s*\{([^}]+)\}",
+        js,
+    )
+    assert map_match, "Expected US DOCSIS 3.1 context color map"
+    ctx_map = map_match.group(1)
+
+    def color_for(level):
+        m = re.search(r"'" + re.escape(level) + r"'\s*:\s*'(#[0-9a-fA-F]{6})'", ctx_map)
+        assert m, f"US DOCSIS 3.1 context map missing entry for {level}"
+        return m.group(1).lower()
+
+    assert color_for("32QAM") in {"#dc2626", "#b91c1c"}, (
+        "US DOCSIS 3.1 context: 32QAM should use a darker red than 64QAM"
+    )
+    assert color_for("64QAM") in {"#fb7185", "#f87171", "#ef4444"}, (
+        "US DOCSIS 3.1 context: 64QAM should remain red-family but distinct from 32QAM"
+    )
+    assert color_for("32QAM") != color_for("64QAM"), (
+        "US DOCSIS 3.1 context: 32QAM and 64QAM must not share a color"
+    )
+
+
+def test_us_docsis_30_upstream_uses_own_healthy_64qam_palette():
+    """US DOCSIS 3.0 upstream has a different visual semantic: 64QAM is
+    the healthy maximum, 32QAM is reduced/warning, and 16QAM and below are low.
+    Issue #447."""
+    js = MODULATION_JS.read_text(encoding="utf-8")
+
+    assert "function isUsDocsis30Upstream" in js, (
+        "Expected explicit US DOCSIS 3.0 upstream context helper"
+    )
+    map_match = re.search(
+        r"QAM_COLORS_US_DOCSIS_30\s*=\s*\{([^}]+)\}",
+        js,
+    )
+    assert map_match, "Expected US DOCSIS 3.0 upstream context color map"
+    ctx_map = map_match.group(1)
+
+    def color_for(level):
+        m = re.search(r"'" + re.escape(level) + r"'\s*:\s*'(#[0-9a-fA-F]{6})'", ctx_map)
+        assert m, f"US DOCSIS 3.0 context map missing entry for {level}"
+        return m.group(1).lower()
+
+    assert color_for("64QAM") in {"#22c55e", "#16a34a", "#15803d", "#86efac"}, (
+        "US DOCSIS 3.0 upstream: 64QAM must read as healthy/green"
+    )
+    assert color_for("32QAM") in {"#f59e0b", "#f97316", "#d97706", "#fbbf24"}, (
+        "US DOCSIS 3.0 upstream: 32QAM must read as warning/reduced modulation"
+    )
+    assert color_for("16QAM") in {"#ef4444", "#dc2626", "#b91c1c", "#f87171"}, (
+        "US DOCSIS 3.0 upstream: 16QAM and below must read as low/degraded"
+    )
+
+
+def test_us_docsis_30_upstream_context_does_not_match_downstream():
+    """The DOCSIS 3.0 upstream palette must stay scoped to upstream groups.
+    Downstream DOCSIS 3.0 keeps the default/global chart colors. Issue #447."""
+    js = MODULATION_JS.read_text(encoding="utf-8")
+    helper_match = re.search(
+        r"function isUsDocsis30Upstream\([^)]*\)\s*\{(.*?)\n\}",
+        js,
+        re.DOTALL,
+    )
+    assert helper_match, "isUsDocsis30Upstream must be defined"
+    helper_body = helper_match.group(1)
+    assert "direction === 'us'" in helper_body, (
+        "DOCSIS 3.0 context coloring must be scoped to upstream only"
+    )
+    assert "String(pg.docsis_version || '') === '3.0'" in helper_body, (
+        "DOCSIS 3.0 context coloring must require the 3.0 protocol group"
+    )
+
+
 def test_global_us_docsis_30_64qam_color_is_unchanged():
     """The global QAM_COLORS map must keep 64QAM at its existing yellow value
-    so US DOCSIS 3.0 upstream is not painted red by default. Issue #444."""
+    so non-contextual/default charts are unchanged. Issue #444/#447."""
     js = MODULATION_JS.read_text(encoding="utf-8")
 
     qam_colors_match = re.search(
@@ -153,3 +231,11 @@ def test_low_qam_legend_hint_key_is_localized_for_all_modulation_languages():
     for path in I18N_DIR.glob("*.json"):
         text = path.read_text(encoding="utf-8")
         assert "low_qam_legend_hint_d31_us" in text, path.name
+
+
+def test_docsis_30_upstream_legend_hint_key_is_localized_for_all_modulation_languages():
+    """Every modulation locale must define the DOCSIS 3.0 upstream legend hint.
+    Issue #447."""
+    for path in I18N_DIR.glob("*.json"):
+        text = path.read_text(encoding="utf-8")
+        assert "low_qam_legend_hint_d30_us" in text, path.name


### PR DESCRIPTION
## Summary
- Adds a DOCSIS 3.0 upstream-specific modulation palette so 64QAM reads healthy, 32QAM reads reduced, and 16QAM and below read low.
- Keeps the existing DOCSIS 3.1 upstream Low-QAM semantics from #436/#444, with clearer separation between 32QAM and 64QAM.
- Adds localized legend hints and bumps the service-worker cache version for the updated module asset.

## Validation
- `git diff --check`
- `python scripts/i18n_check.py --validate`
- `python -m pytest -q tests --ignore=tests/e2e`
- `TZ=UTC python -m pytest -q tests/e2e`

Closes #447
