### PR TITLE
fix: improve Event Log channel metadata

### DIFF
--- a/app/event_detector.py
+++ b/app/event_detector.py
@@ -68,6 +68,33 @@ def _coerce_float(value):
     return f
 
 
+def _channel_type_label(direction: str, channel: dict, fallback: dict | None = None) -> str:
+    """Return a concise DOCSIS channel type label for event details."""
+    fallback = fallback or {}
+    raw_values = [
+        channel.get("channel_type"),
+        channel.get("multiplex"),
+        channel.get("modulation"),
+        fallback.get("channel_type"),
+        fallback.get("multiplex"),
+        fallback.get("modulation"),
+    ]
+    raw = " ".join(str(v) for v in raw_values if v).upper()
+    if "OFDMA" in raw:
+        return "OFDMA"
+    if "OFDM" in raw:
+        return "OFDM" if direction == "DS" else "OFDMA"
+    if "SC-QAM" in raw or "ATDMA" in raw or "TDMA" in raw:
+        return "SC-QAM"
+
+    docsis_version = str(channel.get("docsis_version") or fallback.get("docsis_version") or "").strip()
+    if docsis_version in {"3.1", "4.0"}:
+        return "OFDM" if direction == "DS" else "OFDMA"
+    if docsis_version == "3.0":
+        return "SC-QAM"
+    return ""
+
+
 class EventDetector:
     """Compare consecutive analyses and emit event dicts."""
 
@@ -299,6 +326,7 @@ class EventDetector:
                 "channel": ch_id,
                 "frequency": cur_ch.get("frequency") or prev_ch.get("frequency") or "",
                 "docsis_version": cur_ch.get("docsis_version") or prev_ch.get("docsis_version") or "",
+                "channel_type": _channel_type_label("DS", cur_ch, prev_ch),
                 "modulation": cur_ch.get("modulation") or prev_ch.get("modulation") or "",
                 "prev": prev_snr,
                 "current": cur_snr,
@@ -333,34 +361,58 @@ class EventDetector:
             })
 
     def _check_modulation(self, events, ts, cur_analysis, prev_analysis):
-        cur_ds = {ch["channel_id"]: ch.get("modulation", "") for ch in cur_analysis.get("ds_channels", [])}
-        prev_ds = {ch["channel_id"]: ch.get("modulation", "") for ch in prev_analysis.get("ds_channels", [])}
-        cur_us = {ch["channel_id"]: ch.get("modulation", "") for ch in cur_analysis.get("us_channels", [])}
-        prev_us = {ch["channel_id"]: ch.get("modulation", "") for ch in prev_analysis.get("us_channels", [])}
+        def channel_map(analysis, direction):
+            source = "ds_channels" if direction == "DS" else "us_channels"
+            mapped = {}
+            for ch in analysis.get(source, []):
+                key = _normalize_channel_id(ch.get("channel_id"))
+                if key is not None:
+                    mapped[key] = ch
+            return mapped
+
+        def change_entry(direction, cur_ch, prev_ch):
+            cur_mod = cur_ch.get("modulation", "")
+            prev_mod = prev_ch.get("modulation", "")
+            cur_rank = _qam_rank(cur_mod)
+            prev_rank = _qam_rank(prev_mod)
+            docsis_version = cur_ch.get("docsis_version") or prev_ch.get("docsis_version") or ""
+            entry = {
+                "channel": cur_ch.get("channel_id", prev_ch.get("channel_id")),
+                "direction": direction,
+                "prev": prev_mod,
+                "current": cur_mod,
+                "prev_rank": prev_rank,
+                "current_rank": cur_rank,
+                "rank_drop": prev_rank - cur_rank,
+            }
+            if docsis_version:
+                entry["docsis_version"] = docsis_version
+            channel_type = _channel_type_label(direction, cur_ch, prev_ch)
+            if channel_type:
+                entry["channel_type"] = channel_type
+            frequency = cur_ch.get("frequency") or prev_ch.get("frequency") or ""
+            if frequency:
+                entry["frequency"] = frequency
+            return entry
+
+        cur_ds = channel_map(cur_analysis, "DS")
+        prev_ds = channel_map(prev_analysis, "DS")
+        cur_us = channel_map(cur_analysis, "US")
+        prev_us = channel_map(prev_analysis, "US")
 
         downgrades = []
         upgrades = []
-        for ch_id in set(cur_ds) & set(prev_ds):
-            if cur_ds[ch_id] != prev_ds[ch_id]:
-                entry = {"channel": ch_id, "direction": "DS", "prev": prev_ds[ch_id], "current": cur_ds[ch_id]}
-                cur_rank = _qam_rank(cur_ds[ch_id])
-                prev_rank = _qam_rank(prev_ds[ch_id])
-                entry["prev_rank"] = prev_rank
-                entry["current_rank"] = cur_rank
-                entry["rank_drop"] = prev_rank - cur_rank
-                if cur_rank < prev_rank:
+        for key in set(cur_ds) & set(prev_ds):
+            if cur_ds[key].get("modulation", "") != prev_ds[key].get("modulation", ""):
+                entry = change_entry("DS", cur_ds[key], prev_ds[key])
+                if entry["current_rank"] < entry["prev_rank"]:
                     downgrades.append(entry)
                 else:
                     upgrades.append(entry)
-        for ch_id in set(cur_us) & set(prev_us):
-            if cur_us[ch_id] != prev_us[ch_id]:
-                entry = {"channel": ch_id, "direction": "US", "prev": prev_us[ch_id], "current": cur_us[ch_id]}
-                cur_rank = _qam_rank(cur_us[ch_id])
-                prev_rank = _qam_rank(prev_us[ch_id])
-                entry["prev_rank"] = prev_rank
-                entry["current_rank"] = cur_rank
-                entry["rank_drop"] = prev_rank - cur_rank
-                if cur_rank < prev_rank:
+        for key in set(cur_us) & set(prev_us):
+            if cur_us[key].get("modulation", "") != prev_us[key].get("modulation", ""):
+                entry = change_entry("US", cur_us[key], prev_us[key])
+                if entry["current_rank"] < entry["prev_rank"]:
                     downgrades.append(entry)
                 else:
                     upgrades.append(entry)

--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -509,22 +509,15 @@
     flex-direction: column;
     gap: 8px;
 }
-.event-feed-topline,
-.event-feed-meta {
+.event-feed-topline {
     display: flex;
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
 }
-.event-feed-time,
-.event-feed-meta {
+.event-feed-time {
     color: var(--text-secondary, var(--muted));
     font-size: 0.82em;
-}
-.event-feed-meta span + span::before {
-    content: "•";
-    margin-right: 8px;
-    color: var(--text-muted, var(--muted));
 }
 .event-feed-title {
     color: var(--text);

--- a/app/static/js/events.js
+++ b/app/static/js/events.js
@@ -86,6 +86,15 @@ function _healthDot(h) {
     return '<span class="health-dot ' + cls + '"></span>' + escapeHtml(labels[h] || h);
 }
 
+function _eventChannelMeta(c) {
+    var meta = [];
+    if (c.frequency) meta.push(escapeHtml(String(c.frequency)));
+    if (c.channel_type) meta.push(escapeHtml(String(c.channel_type)));
+    if (c.docsis_version) meta.push('DOCSIS ' + escapeHtml(String(c.docsis_version)));
+    if (c.modulation) meta.push(escapeHtml(String(c.modulation)));
+    return meta;
+}
+
 function formatEventMessage(ev) {
     var d = ev.details;
     if (!d) return escapeHtml(ev.message);
@@ -121,9 +130,7 @@ function formatEventMessage(ev) {
                 var delta = typeof c.delta === 'number' ? c.delta : (c.current - c.prev);
                 var sign = delta >= 0 ? '+' : '';
                 var channelLabel = (T.event_ds || 'DS') + ' Ch ' + escapeHtml(String(c.channel));
-                var meta = [];
-                if (c.frequency) meta.push(escapeHtml(String(c.frequency)));
-                if (c.modulation) meta.push(escapeHtml(String(c.modulation)));
+                var meta = _eventChannelMeta(c);
                 html += '<span class="ev-sub">' + channelLabel +
                     (meta.length ? ' · ' + meta.join(' · ') : '') + ': ' +
                     '<span class="ev-val">' + _fmtNum(c.prev) + '</span>' +
@@ -158,8 +165,10 @@ function formatEventMessage(ev) {
                 var arrow = isDown ? '\u25BC' : '\u25B2';
                 var cls = isDown ? 'ev-down' : 'ev-up';
                 var ranks = Math.abs(c.rank_drop || 0);
+                var channelMeta = _eventChannelMeta(c);
                 html += '<span class="ev-sub">' +
-                    escapeHtml(c.direction) + ' Ch ' + escapeHtml(String(c.channel)) + ': ' +
+                    escapeHtml(c.direction) + ' Ch ' + escapeHtml(String(c.channel)) +
+                    (channelMeta.length ? ' · ' + channelMeta.join(' · ') : '') + ': ' +
                     '<span class="ev-val">' + escapeHtml(c.prev) + '</span>' +
                     '<i data-lucide="arrow-right" class="ev-arrow-icon"></i>' +
                     '<span class="ev-val">' + escapeHtml(c.current) + '</span> ' +
@@ -300,10 +309,6 @@ function loadEvents(append) {
                             '</div>' +
                             '<div class="event-feed-title">' + escapeHtml(typeLabel) + '</div>' +
                             '<div class="event-feed-message">' + formatEventMessage(ev) + '</div>' +
-                            '<div class="event-feed-meta">' +
-                                '<span>' + escapeHtml(sevMeta.label) + '</span>' +
-                                '<span>' + escapeHtml(typeLabel) + '</span>' +
-                            '</div>' +
                         '</div>' +
                         '<div class="event-feed-action">' + _eventAckMarkup(ev, false) + '</div>';
                     feed.appendChild(card);

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v7';
+var CACHE_VERSION = 'v8';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_event_log_redesign.py
+++ b/tests/e2e/test_event_log_redesign.py
@@ -60,7 +60,7 @@ def test_mobile_event_log_uses_feed_cards_without_table_mode(demo_page):
     expect(page.locator("#events-view-mode-feed")).to_have_count(0)
     expect(page.locator("#events-export-csv")).to_be_visible()
     expect(feed_items.first.locator(".event-feed-title")).to_be_visible()
-    expect(feed_items.first.locator(".event-feed-meta")).to_be_visible()
+    expect(feed_items.first.locator(".event-feed-meta")).to_have_count(0)
     expect(feed_items.first.locator(".event-feed-message")).to_be_visible()
 
     ack_button = feed_items.first.locator(".event-feed-action .btn-ack")
@@ -95,7 +95,7 @@ def test_desktop_event_log_is_feed_only_with_export_and_acknowledge(demo_page):
 
     first_card = page.locator("#events-feed .event-feed-item").first
     expect(first_card.locator(".event-feed-title")).to_be_visible()
-    expect(first_card.locator(".event-feed-meta")).to_be_visible()
+    expect(first_card.locator(".event-feed-meta")).to_have_count(0)
     expect(first_card.locator(".event-feed-message")).to_be_visible()
 
     ack_button = first_card.locator(".event-feed-action .btn-ack")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -391,6 +391,7 @@ class TestEventDetector:
             "channel": 11,
             "frequency": "794 MHz",
             "docsis_version": "3.0",
+            "channel_type": "SC-QAM",
             "modulation": "256QAM",
             "prev": 36.2,
             "current": 31.0,
@@ -713,6 +714,26 @@ class TestEventDetector:
         assert "dropped" in mod_events[0]["message"]
         assert mod_events[0]["details"]["direction"] == "downgrade"
         assert mod_events[0]["details"]["changes"][0]["rank_drop"] == 2
+
+    def test_modulation_change_includes_channel_docsis_metadata(self, detector):
+        """DOCSIS channel events carry enough metadata for useful Event Log labels."""
+        us1 = [{"channel_id": 5, "modulation": "qam_64", "power": 42.0,
+                "multiplex": "SC-QAM", "docsis_version": "3.0",
+                "health": "good", "health_detail": "", "frequency": "37 MHz"}]
+        us2 = [{"channel_id": 5, "modulation": "qam_8", "power": 42.0,
+                "multiplex": "SC-QAM", "docsis_version": "3.0",
+                "health": "good", "health_detail": "", "frequency": "37 MHz"}]
+
+        detector.check(_make_analysis(us_total=1, us_channels=us1))
+        events = detector.check(_make_analysis(us_total=1, us_channels=us2))
+
+        mod_event = next(e for e in events if e["event_type"] == "modulation_change")
+        change = mod_event["details"]["changes"][0]
+        assert change["channel"] == 5
+        assert change["direction"] == "US"
+        assert change["docsis_version"] == "3.0"
+        assert change["channel_type"] == "SC-QAM"
+        assert change["frequency"] == "37 MHz"
 
     def test_modulation_upgrade_qam_underscore_format(self, detector):
         """qam_64 → qam_256 = upgrade (Vodafone Station format)"""
@@ -1287,22 +1308,9 @@ class TestEventsJsRendering:
         if shutil.which("node") is None:
             pytest.skip("node runtime not available")
 
-    def _run_format(self, affected_channels):
+    def _run_format_event(self, ev):
         repo_root = Path(__file__).resolve().parent.parent
         events_js = repo_root / "app" / "static" / "js" / "events.js"
-        ev = {
-            "id": 1,
-            "timestamp": "2026-01-01T00:00:00",
-            "severity": "warning",
-            "event_type": "snr_change",
-            "message": "snr drop",
-            "details": {
-                "threshold": "warning",
-                "prev": 36.0,
-                "current": 31.0,
-                "affected_channels": affected_channels,
-            },
-        }
         harness = textwrap.dedent(
             """
             const fs = require('fs');
@@ -1339,6 +1347,53 @@ class TestEventsJsRendering:
             timeout=15,
         )
         return result
+
+    def _run_format(self, affected_channels):
+        return self._run_format_event({
+            "id": 1,
+            "timestamp": "2026-01-01T00:00:00",
+            "severity": "warning",
+            "event_type": "snr_change",
+            "message": "snr drop",
+            "details": {
+                "threshold": "warning",
+                "prev": 36.0,
+                "current": 31.0,
+                "affected_channels": affected_channels,
+            },
+        })
+
+    def test_modulation_render_includes_docsis_channel_type(self):
+        result = self._run_format_event({
+            "id": 1,
+            "timestamp": "2026-01-01T00:00:00",
+            "severity": "critical",
+            "event_type": "modulation_change",
+            "message": "Modulation dropped on 1 channel(s)",
+            "details": {
+                "direction": "downgrade",
+                "changes": [{
+                    "channel": 5,
+                    "direction": "US",
+                    "prev": "qam_64",
+                    "current": "qam_8",
+                    "rank_drop": 3,
+                    "docsis_version": "3.0",
+                    "channel_type": "SC-QAM",
+                    "frequency": "37 MHz",
+                }],
+            },
+        })
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.startswith("OK::"), result.stdout
+        html = result.stdout[len("OK::"):]
+        assert "US Ch 5" in html
+        assert "SC-QAM" in html
+        assert "DOCSIS 3.0" in html
+        assert "37 MHz" in html
+        assert "qam_64" in html
+        assert "qam_8" in html
 
     def test_snr_render_handles_malformed_affected_entries(self):
         """null/undefined/non-object entries must not break rendering."""


### PR DESCRIPTION
## Summary
- Remove the duplicate severity/type meta row from Event Log feed cards.
- Add DOCSIS channel metadata to SNR and modulation event details so the feed can show channel type, DOCSIS version, frequency, and modulation context.
- Bump the service worker cache version so updated Event Log assets are picked up after deploy.

## Validation
- `python -m pytest tests/test_events.py -q`
- `python -m pytest tests --ignore=tests/e2e -q`
- `TZ=UTC python -m pytest -q tests/e2e --tb=short`
- `python scripts/i18n_check.py --validate`
- `git diff --check`

Closes #450
