### PR TITLE
fix: align correlation timeline UI

### DIFF
--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -4,9 +4,9 @@
 :root {
     --corr-color-download: #0ea5e9;
     --corr-color-upload: #06b6d4;
-    --corr-color-snr: #a855f7;
+    --corr-color-snr: #3b82f6;
     --corr-color-tx-power: #f59e0b;
-    --corr-color-ds-power: #ec4899;
+    --corr-color-ds-power: #a855f7;
     --corr-color-errors: rgba(239,68,68,0.6);
     --corr-color-temperature: #f97316;
     --corr-color-seg-ds: #0ea5e9;
@@ -809,6 +809,7 @@
 #correlation-table {
     width: 100%;
     margin: 0;
+    table-layout: fixed;
 }
 #correlation-table thead tr {
     background: var(--card-bg, var(--card, var(--surface)));
@@ -825,6 +826,15 @@
     z-index: 3;
     background: var(--card-bg, var(--card, var(--surface)));
     box-shadow: 0 1px 0 var(--card-border, var(--input-border));
+}
+#correlation-table thead th:nth-child(1) {
+    width: 180px;
+}
+#correlation-table thead th:nth-child(2) {
+    width: 110px;
+}
+#correlation-table thead th:nth-child(3) {
+    width: 24%;
 }
 #correlation-table tbody tr {
     transition: background 0.15s;
@@ -855,6 +865,26 @@
 #correlation-table tbody td {
     padding: 12px 16px;
     font-size: 0.85em;
+    vertical-align: top;
+}
+#correlation-table .correlation-cell-timestamp {
+    width: 180px;
+    white-space: nowrap;
+}
+#correlation-table .correlation-cell-source {
+    width: 110px;
+    white-space: nowrap;
+}
+#correlation-table .correlation-cell-message {
+    width: 24%;
+}
+#correlation-table .correlation-cell-details {
+    width: auto;
+}
+#correlation-table .correlation-cell-message,
+#correlation-table .correlation-cell-details {
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 #correlation-table .source-badge {
     display: inline-block;
@@ -926,6 +956,7 @@
     #correlation-table tbody tr {
         display: block;
         width: 100%;
+        box-sizing: border-box;
         padding: 10px 12px;
         border-bottom: 1px solid var(--card-border, var(--input-border));
     }
@@ -956,8 +987,11 @@
         text-align: left;
     }
 
+    #correlation-table .correlation-cell-timestamp,
+    #correlation-table .correlation-cell-source,
     #correlation-table .correlation-cell-message,
     #correlation-table .correlation-cell-details {
+        width: 100%;
         min-width: 0;
     }
 }

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -11,12 +11,15 @@ var _corrZoom = null; // { tMin, tMax } when zoomed in
 // Event type sub-filter: operational events hidden by default
 var _corrEventFilter = {};
 var _OPERATIONAL_EVENTS = { monitoring_started: true, monitoring_stopped: true };
+function _corrEventTypeAllowed(e) {
+    var t = e.event_type || 'unknown';
+    if (!(t in _corrEventFilter)) _corrEventFilter[t] = !_OPERATIONAL_EVENTS[t];
+    return _corrEventFilter[t];
+}
 function _corrFilteredEvents(events) {
     if (!_corrVisible.events) return [];
     return events.filter(function(e) {
-        var t = e.event_type || 'unknown';
-        if (!(t in _corrEventFilter)) _corrEventFilter[t] = !_OPERATIONAL_EVENTS[t];
-        return _corrEventFilter[t];
+        return _corrEventTypeAllowed(e);
     });
 }
 
@@ -187,9 +190,9 @@ function renderCorrelationChart(data) {
 
     var downloadColor = _cssColor('--corr-color-download', '#0ea5e9');
     var uploadColor = _cssColor('--corr-color-upload', '#06b6d4');
-    var snrColor = _cssColor('--corr-color-snr', 'rgba(168,85,247,1)');
+    var snrColor = _cssColor('--corr-color-snr', '#3b82f6');
     var txColor = _cssColor('--corr-color-tx-power', '#f59e0b');
-    var dsPowerColor = _cssColor('--corr-color-ds-power', '#ec4899');
+    var dsPowerColor = _cssColor('--corr-color-ds-power', '#a855f7');
     var errorColor = _cssColor('--corr-color-errors', 'rgba(239,68,68,0.6)');
     var tempColor = _cssColor('--corr-color-temperature', '#f97316');
 
@@ -244,22 +247,6 @@ function renderCorrelationChart(data) {
             label = String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
         }
         ctx.fillText(label, xScale(t), H - pad.bottom + 18);
-    }
-
-    // Left axis labels (SNR) — only if SNR visible
-    if (_corrVisible.snr && modem.length > 0) {
-        ctx.textAlign = 'right';
-        ctx.fillStyle = accentColor;
-        for (var s = Math.ceil(snrMin); s <= snrMax; s += 5) {
-            ctx.fillText(s + ' dB', pad.left - 6, ySnr(s) + 3);
-        }
-        ctx.save();
-        ctx.translate(12, pad.top + plotH / 2);
-        ctx.rotate(-Math.PI / 2);
-        ctx.textAlign = 'center';
-        ctx.font = '11px system-ui, sans-serif';
-        ctx.fillText(T.chart_snr_axis || 'SNR (dB)', 0, 0);
-        ctx.restore();
     }
 
     // Right axis labels (Speed) — only if download or upload visible
@@ -544,13 +531,13 @@ function renderCorrelationChart(data) {
     var legend = document.getElementById('correlation-legend');
     var legendItems = [];
     if (modem.length > 0) {
-        legendItems.push({ metric: 'snr', color: snrColor, label: '&#9644; ' + (T.chart_snr || 'SNR (dB)') });
-        if (txValues.length > 0) {
-            legendItems.push({ metric: 'txPower', color: txColor, label: '&#9476; ' + (T.correlation_tx_power || 'TX Power (dBmV)') });
-        }
         if (dsPowerValues.length > 0) {
-            legendItems.push({ metric: 'dsPower', color: dsPowerColor, label: '&#183;&#183; ' + (T.correlation_ds_power || 'DS Power (dBmV)') });
+            legendItems.push({ metric: 'dsPower', color: dsPowerColor, label: '&#183;&#183; ' + (T.chart_ds_power || 'DS Power (dBmV)') });
         }
+        if (txValues.length > 0) {
+            legendItems.push({ metric: 'txPower', color: txColor, label: '&#9476; ' + (T.chart_us_power || 'US Power (dBmV)') });
+        }
+        legendItems.push({ metric: 'snr', color: snrColor, label: '&#9644; ' + (T.chart_snr || 'SNR (dB)') });
         if (errorMax > 0) {
             legendItems.push({ metric: 'errors', color: 'rgba(239,68,68,0.8)', label: '&#9612; ' + (T.correlation_errors || 'Errors') });
         }
@@ -626,6 +613,7 @@ function renderCorrelationChart(data) {
                 cb.addEventListener('change', function() {
                     _corrEventFilter[this.getAttribute('data-event-type')] = this.checked;
                     renderCorrelationChart(data);
+                    renderCorrelationTable(data);
                 });
             });
             // Close on outside click
@@ -1276,6 +1264,8 @@ function renderCorrelationTable(data) {
 
         // Skip modem entries that are not health transitions
         if (e.source === 'modem' && !modemTransitionTs[e.timestamp]) continue;
+        // Keep table rows aligned with the event type filter used by chart markers.
+        if (e.source === 'event' && !_corrEventTypeAllowed(e)) continue;
 
         var tr = document.createElement('tr');
         tr.setAttribute('data-ts', e.timestamp);

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v8';
+var CACHE_VERSION = 'v9';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_correlation_ui.py
+++ b/tests/e2e/test_correlation_ui.py
@@ -1,0 +1,191 @@
+"""Browser coverage for the correlation timeline UI."""
+
+from datetime import datetime, timedelta, timezone
+
+from playwright.sync_api import expect
+
+DESKTOP_VIEWPORT = {"width": 1440, "height": 1000}
+MOBILE_VIEWPORT = {"width": 393, "height": 852}
+MAX_HORIZONTAL_OVERFLOW = 1
+
+
+def _sample_correlation_data():
+    base = datetime.now(timezone.utc).replace(microsecond=0)
+
+    def ts(minutes_ago):
+        return (base - timedelta(minutes=minutes_ago)).isoformat().replace("+00:00", "Z")
+
+    return [
+        {
+            "source": "modem",
+            "timestamp": ts(45),
+            "health": "good",
+            "ds_snr_min": 38.2,
+            "ds_power_avg": 1.3,
+            "us_power_avg": 42.1,
+            "ds_uncorrectable_errors": 0,
+        },
+        {
+            "source": "speedtest",
+            "timestamp": ts(35),
+            "download_mbps": 280.4,
+            "upload_mbps": 48.2,
+            "ping_ms": 12.5,
+            "jitter_ms": 1.7,
+            "modem_health": "good",
+        },
+        {
+            "source": "event",
+            "timestamp": ts(25),
+            "event_type": "health_change",
+            "severity": "warning",
+            "message": "Health changed from good to warning",
+        },
+        {
+            "source": "event",
+            "timestamp": ts(15),
+            "event_type": "monitoring_started",
+            "severity": "info",
+            "message": "Monitoring started",
+        },
+    ]
+
+
+def _route_sample_correlation(page):
+    page.route("**/api/correlation?**", lambda route: route.fulfill(json=_sample_correlation_data()))
+    page.route("**/api/weather/range?**", lambda route: route.fulfill(json=[]))
+    page.route("**/api/fritzbox/segment-utilization/range?**", lambda route: route.fulfill(json=[]))
+
+
+def _open_correlation(page):
+    page.set_viewport_size(DESKTOP_VIEWPORT)
+    base_url = page.url.split("#", 1)[0].split("?", 1)[0].rstrip("/")
+    page.goto(f"{base_url}/?lang=en#correlation", wait_until="networkidle")
+    page.wait_for_selector("#view-correlation.active", state="visible")
+    page.wait_for_selector("#correlation-chart-container", state="visible")
+    page.wait_for_selector("#correlation-table-card", state="visible")
+
+
+def test_correlation_signal_legend_matches_home_chart_order(demo_page):
+    page = demo_page
+    _open_correlation(page)
+
+    legend_metrics = page.locator("#correlation-legend span[data-metric]").evaluate_all(
+        """
+        (items) => items
+            .map((item) => ({ metric: item.dataset.metric, text: item.textContent.trim() }))
+            .filter((item) => ['dsPower', 'txPower', 'snr'].includes(item.metric))
+        """
+    )
+
+    assert [item["metric"] for item in legend_metrics[:3]] == ["dsPower", "txPower", "snr"]
+    assert "DS Power (dBmV)" in legend_metrics[0]["text"]
+    assert "US Power (dBmV)" in legend_metrics[1]["text"]
+    assert "SNR (dB)" in legend_metrics[2]["text"]
+
+
+def test_correlation_table_keeps_stable_desktop_columns(demo_page):
+    page = demo_page
+    _open_correlation(page)
+
+    table = page.locator("#correlation-table")
+    expect(table).to_be_visible()
+    expect(page.locator("#correlation-tbody tr").first).to_be_visible()
+
+    geometry = page.evaluate(
+        """
+        () => {
+            const table = document.querySelector('#correlation-table');
+            const wrap = document.querySelector('#correlation-table-wrap');
+            const firstRow = document.querySelector('#correlation-tbody tr');
+            const cell = (selector) => {
+                const node = firstRow.querySelector(selector);
+                const rect = node.getBoundingClientRect();
+                return { width: rect.width, whiteSpace: getComputedStyle(node).whiteSpace };
+            };
+            return {
+                tableLayout: getComputedStyle(table).tableLayout,
+                documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+                wrapOverflow: wrap.scrollWidth - wrap.clientWidth,
+                timestamp: cell('.correlation-cell-timestamp'),
+                source: cell('.correlation-cell-source'),
+                message: cell('.correlation-cell-message'),
+                details: cell('.correlation-cell-details'),
+            };
+        }
+        """
+    )
+
+    assert geometry["tableLayout"] == "fixed"
+    assert geometry["documentOverflow"] <= MAX_HORIZONTAL_OVERFLOW
+    assert geometry["wrapOverflow"] <= MAX_HORIZONTAL_OVERFLOW
+    assert 150 <= geometry["timestamp"]["width"] <= 220
+    assert 90 <= geometry["source"]["width"] <= 140
+    assert geometry["message"]["width"] >= 180
+    assert geometry["details"]["width"] >= geometry["message"]["width"]
+
+
+def test_correlation_event_type_filter_updates_table_in_browser(demo_page):
+    page = demo_page
+    _route_sample_correlation(page)
+    _open_correlation(page)
+
+    event_rows = page.locator('#correlation-tbody tr[data-src="event"]')
+    expect(event_rows).to_have_count(1)
+    expect(event_rows.first.locator(".correlation-cell-details")).to_contain_text("Health Change")
+    expect(page.locator("#correlation-legend .corr-legend-events")).to_contain_text("(1/2)")
+
+    page.locator("#correlation-legend .corr-event-filter-btn").click()
+    page.locator('#corr-event-popover input[data-event-type="health_change"]').evaluate(
+        """
+        (checkbox) => {
+            checkbox.checked = false;
+            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        """
+    )
+
+    expect(event_rows).to_have_count(0)
+    expect(page.locator("#correlation-legend .corr-legend-events")).to_contain_text("(0/2)")
+
+
+def test_correlation_table_uses_card_layout_without_mobile_overflow(demo_page):
+    page = demo_page
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    _route_sample_correlation(page)
+    base_url = page.url.split("#", 1)[0].split("?", 1)[0].rstrip("/")
+    page.goto(f"{base_url}/?lang=en#correlation", wait_until="networkidle")
+    page.wait_for_selector("#view-correlation.active", state="visible")
+    page.wait_for_selector("#correlation-tbody tr", state="visible")
+
+    geometry = page.evaluate(
+        """
+        () => {
+            const wrap = document.querySelector('#correlation-table-wrap');
+            const row = document.querySelector('#correlation-tbody tr');
+            const timestamp = row.querySelector('.correlation-cell-timestamp');
+            const before = getComputedStyle(timestamp, '::before');
+            const rect = (node) => {
+                const box = node.getBoundingClientRect();
+                return { left: box.left, right: box.right, width: box.width, display: getComputedStyle(node).display };
+            };
+            return {
+                viewportWidth: window.innerWidth,
+                documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+                wrapOverflow: wrap.scrollWidth - wrap.clientWidth,
+                row: rect(row),
+                timestamp: rect(timestamp),
+                timestampLabel: before.content,
+            };
+        }
+        """
+    )
+
+    assert geometry["documentOverflow"] <= MAX_HORIZONTAL_OVERFLOW
+    assert geometry["wrapOverflow"] <= MAX_HORIZONTAL_OVERFLOW
+    assert geometry["row"]["display"] == "block"
+    assert geometry["row"]["left"] >= 0
+    assert geometry["row"]["right"] <= geometry["viewportWidth"] + MAX_HORIZONTAL_OVERFLOW
+    assert geometry["timestamp"]["display"] == "flex"
+    assert geometry["timestamp"]["width"] >= 300
+    assert "Timestamp" in geometry["timestampLabel"]

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 VIEWS_CSS = ROOT / "app" / "static" / "css" / "views.css"
+CORRELATION_JS = ROOT / "app" / "static" / "js" / "correlation.js"
+SW_JS = ROOT / "app" / "static" / "sw.js"
 
 
 def test_correlation_timeline_sticky_header_uses_opaque_surface():
@@ -14,3 +16,53 @@ def test_correlation_timeline_sticky_header_uses_opaque_surface():
     assert "background: var(--card-bg" in header_block
     assert "rgba(0,0,0,0.15)" not in header_block
     assert "z-index: 3" in header_block
+
+
+def test_correlation_table_uses_stable_desktop_columns():
+    css = VIEWS_CSS.read_text(encoding="utf-8")
+    table_block = css[css.index("#correlation-table {") : css.index("#correlation-table thead tr")]
+
+    assert "table-layout: fixed" in table_block
+    assert ".correlation-cell-timestamp" in css
+    assert ".correlation-cell-source" in css
+    assert ".correlation-cell-message" in css
+    assert ".correlation-cell-details" in css
+
+
+def test_correlation_legend_matches_home_signal_order_and_labels():
+    js = CORRELATION_JS.read_text(encoding="utf-8")
+
+    ds_idx = js.index("metric: 'dsPower'")
+    us_idx = js.index("metric: 'txPower'")
+    snr_idx = js.index("metric: 'snr'")
+
+    assert ds_idx < us_idx < snr_idx
+    assert "T.chart_ds_power || 'DS Power (dBmV)'" in js
+    assert "T.chart_us_power || 'US Power (dBmV)'" in js
+    assert "T.chart_snr || 'SNR (dB)'" in js
+
+
+def test_correlation_chart_omits_standalone_snr_axis_labels():
+    js = CORRELATION_JS.read_text(encoding="utf-8")
+
+    assert "ctx.fillText(s + ' dB'" not in js
+    assert "T.chart_snr_axis || 'SNR (dB)'" not in js
+
+
+def test_correlation_event_type_filter_applies_to_table_and_chart():
+    js = CORRELATION_JS.read_text(encoding="utf-8")
+
+    assert "function _corrEventTypeAllowed" in js
+    assert "_corrFilteredEvents(events)" in js
+    table_block = js[js.index("function renderCorrelationTable") :]
+    assert "_corrEventTypeAllowed(e)" in table_block
+
+    popover_block = js[js.index("cb.addEventListener('change'") : js.index("// Close on outside click")]
+    assert "renderCorrelationChart(data)" in popover_block
+    assert "renderCorrelationTable(data)" in popover_block
+
+
+def test_static_cache_version_was_bumped_for_correlation_assets():
+    sw_js = SW_JS.read_text(encoding="utf-8")
+
+    assert "var CACHE_VERSION = 'v9';" in sw_js


### PR DESCRIPTION
## Summary
- Aligns the correlation signal legend order, labels, and colors with the main charts.
- Keeps event-type filtering consistent between chart markers and timeline rows.
- Stabilizes the correlation table layout on desktop and mobile, including long content wrapping.
- Bumps the service worker cache for the changed static assets.

## Validation
- `git diff --check`
- `python scripts/i18n_check.py --validate`
- `pytest tests --ignore=tests/e2e -q --tb=short`
- `TZ=UTC pytest tests/e2e -q --tb=short`

Closes #451
