### PR TITLE
fix(settings): save toggles instantly

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -590,6 +590,7 @@ function runDemoMigration() {
 /* ── Unsaved Changes ── */
 var _formDirty = false;
 var _formBaseline = null;
+var _secretEditVersionCounter = 0;
 
 function _isSavedSecretField(el) {
     return !!(
@@ -632,7 +633,23 @@ function _serializeSettingsForm(form) {
     var fields = [];
     Array.prototype.forEach.call(form.elements, function(el) {
         if (!el.name || el.type === 'submit' || el.type === 'button' || el.type === 'file') return;
-        fields.push({ name: el.name, id: el.getAttribute('data-module-id') || '', type: el.type || el.tagName, value: _normalizedFormValue(el) });
+        var field = { name: el.name, id: el.getAttribute('data-module-id') || '', type: el.type || el.tagName, value: _normalizedFormValue(el) };
+        if (_isSavedSecretField(el) && el.dataset.userEditedSecret) {
+            field.secretEditVersion = el.dataset.secretEditVersion || '';
+        }
+        fields.push(field);
+    });
+    document.querySelectorAll('.notify-event-row').forEach(function(row) {
+        var key = row.getAttribute('data-event');
+        var toggle = row.querySelector('.notify-toggle');
+        var inp = row.querySelector('.notify-cooldown-input');
+        if (!key || !toggle || !inp) return;
+        fields.push({
+            name: 'notify_cooldown:' + key,
+            id: key,
+            type: 'notification-cooldown',
+            value: toggle.checked ? (inp.value || '') : '0'
+        });
     });
     fields.sort(function(a, b) {
         return (a.name + ':' + a.id + ':' + a.type).localeCompare(b.name + ':' + b.id + ':' + b.type);
@@ -674,6 +691,7 @@ function initUnsavedDetection() {
     function markDirty(e) {
         if (_shouldTreatSavedSecretEventAsUserEdit(e)) {
             e.target.dataset.userEditedSecret = 'true';
+            e.target.dataset.secretEditVersion = String(++_secretEditVersionCounter);
         }
         _updateDirtyState();
     }
@@ -689,14 +707,16 @@ function initUnsavedDetection() {
     });
 }
 
-function _resetEditedSavedSecrets() {
+function _resetEditedSavedSecrets(savedSecretVersions) {
     var form = document.getElementById('settings-form');
     if (!form) return;
     Array.prototype.forEach.call(form.elements, function(el) {
         if (!_isSavedSecretField(el) || !el.dataset.userEditedSecret) return;
+        if (savedSecretVersions && savedSecretVersions[el.name] !== el.dataset.secretEditVersion) return;
         el.value = '';
         el.dataset.savedSecret = 'true';
         delete el.dataset.userEditedSecret;
+        delete el.dataset.secretEditVersion;
     });
 }
 
@@ -720,14 +740,24 @@ function _getPendingModuleStates() {
     return states;
 }
 
-function _markModuleStatesSaved() {
+function _markModuleStatesSaved(states) {
+    var savedById = null;
+    if (states) {
+        savedById = {};
+        states.forEach(function(state) {
+            savedById[state.id] = state.enabled;
+        });
+    }
     document.querySelectorAll('.module-toggle-input').forEach(function(toggle) {
-        toggle.setAttribute('data-initial-enabled', toggle.checked ? 'true' : 'false');
+        var moduleId = toggle.getAttribute('data-module-id');
+        if (savedById && savedById[moduleId] === undefined) return;
+        var savedEnabled = savedById ? savedById[moduleId] : toggle.checked;
+        toggle.setAttribute('data-initial-enabled', savedEnabled ? 'true' : 'false');
     });
 }
 
-function _saveModuleStatesIfNeeded() {
-    var states = _getPendingModuleStates();
+function _saveModuleStatesIfNeeded(states) {
+    states = states || _getPendingModuleStates();
     if (states.length === 0) return Promise.resolve({ success: true, restart_required: false });
     return fetch('/api/modules/batch', {
         method: 'POST',
@@ -741,7 +771,7 @@ function _saveModuleStatesIfNeeded() {
         if (!res.ok || !res.data.success) {
             throw new Error(res.data.error || T.save_failed || 'Save failed');
         }
-        _markModuleStatesSaved();
+        _markModuleStatesSaved(states);
         if (res.data.restart_required) {
             var banner = document.getElementById('module-restart-banner');
             if (banner) {
@@ -753,8 +783,51 @@ function _saveModuleStatesIfNeeded() {
     });
 }
 
-function _finishSettingsSave() {
-    clearDirty();
+function _savedBaselineAfterSecretReset(serializedBaseline) {
+    try {
+        var fields = JSON.parse(serializedBaseline || '[]');
+        fields.forEach(function(field) {
+            if (field && field.value === '__edited_secret__') {
+                field.value = '';
+                delete field.secretEditVersion;
+            }
+        });
+        return JSON.stringify(fields);
+    } catch(e) {
+        return serializedBaseline;
+    }
+}
+
+function _savedSecretVersionsFromBaseline(serializedBaseline) {
+    var versions = {};
+    try {
+        var fields = JSON.parse(serializedBaseline || '[]');
+        fields.forEach(function(field) {
+            if (field && field.value === '__edited_secret__') {
+                versions[field.name] = field.secretEditVersion || '';
+            }
+        });
+    } catch(e) {}
+    return versions;
+}
+
+function _finishSettingsSave(savedFormBaseline) {
+    var form = document.getElementById('settings-form');
+    if (!savedFormBaseline || !form) {
+        clearDirty();
+    } else {
+        var savedBaseline = _savedBaselineAfterSecretReset(savedFormBaseline);
+        var savedSecretVersions = _savedSecretVersionsFromBaseline(savedFormBaseline);
+        _resetEditedSavedSecrets(savedSecretVersions);
+        if (_serializeSettingsForm(form) === savedBaseline) {
+            _formBaseline = savedBaseline;
+            _formDirty = false;
+            _syncSaveFooter();
+        } else {
+            _formBaseline = savedBaseline;
+            _updateDirtyState();
+        }
+    }
     showToast(T.settings_saved || 'Settings saved', true);
     var newLang = document.getElementById('language').value;
     var newTz = document.getElementById('timezone').value;
@@ -764,7 +837,10 @@ function _finishSettingsSave() {
 }
 
 function _saveAllSettings() {
+    var form = document.getElementById('settings-form');
     var data = getFormData();
+    var savedFormBaseline = _serializeSettingsForm(form);
+    var moduleStates = _getPendingModuleStates();
     return fetch('/api/config', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
@@ -775,10 +851,10 @@ function _saveAllSettings() {
         if (!res.success) {
             throw new Error(res.error || T.save_failed || 'Save failed');
         }
-        return _saveModuleStatesIfNeeded();
+        return _saveModuleStatesIfNeeded(moduleStates);
     })
     .then(function() {
-        _finishSettingsSave();
+        _finishSettingsSave(savedFormBaseline);
         return true;
     });
 }
@@ -791,12 +867,34 @@ function _saveAllSettings() {
 function _saveForm() {
     var errEl = document.getElementById('global-error');
     if (errEl) errEl.style.display = 'none';
-    return _saveAllSettings()
+    return _enqueueSettingsSave()
     .catch(function(err) {
         if (errEl) {
             errEl.textContent = err.message || T.network_error;
             errEl.style.display = 'block';
         }
+        return false;
+    });
+}
+
+var _settingsSaveQueue = Promise.resolve();
+
+function _enqueueSettingsSave() {
+    _settingsSaveQueue = _settingsSaveQueue.catch(function() { return true; }).then(function() {
+        return _saveAllSettings();
+    });
+    return _settingsSaveQueue;
+}
+
+function _saveSettingsInstantly() {
+    var errEl = document.getElementById('global-error');
+    if (errEl) errEl.style.display = 'none';
+    return _enqueueSettingsSave().catch(function(err) {
+        if (errEl) {
+            errEl.textContent = err.message || T.network_error;
+            errEl.style.display = 'block';
+        }
+        _updateDirtyState();
         return false;
     });
 }
@@ -827,7 +925,7 @@ function initFormSubmit() {
         e.preventDefault();
         var errEl = document.getElementById('global-error');
         errEl.style.display = 'none';
-        _saveAllSettings()
+        _enqueueSettingsSave()
         .catch(function(err) {
             errEl.textContent = err.message || T.network_error;
             errEl.style.display = 'block';
@@ -1210,6 +1308,52 @@ function toggleUsernameField() {
     }
 }
 
+function initInstantSettingsToggles() {
+    var form = document.getElementById('settings-form');
+    if (!form) return;
+    var selector = [
+        'label.toggle input[type="checkbox"]:not(#theme-toggle-appearance):not(.module-toggle-input):not(.notify-toggle)',
+        'label.switch input[type="checkbox"]'
+    ].join(',');
+    form.querySelectorAll(selector).forEach(function(toggle) {
+        toggle.addEventListener('change', function() {
+            if (toggle.id === 'font-toggle') {
+                applyFontToggle(toggle.checked);
+            }
+            _saveSettingsInstantly();
+        });
+    });
+}
+
+function initNotificationCooldownControls() {
+    try {
+        var saved = typeof savedCooldowns !== 'undefined' ? savedCooldowns : {};
+        document.querySelectorAll('.notify-event-row').forEach(function(row) {
+            var key = row.getAttribute('data-event');
+            var toggle = row.querySelector('.notify-toggle');
+            var inp = row.querySelector('.notify-cooldown-input');
+            if (!toggle || !inp) return;
+            if (saved[key] !== undefined) {
+                if (saved[key] === 0) {
+                    toggle.checked = false;
+                    inp.disabled = true;
+                    inp.style.opacity = '0.4';
+                } else {
+                    inp.value = saved[key];
+                }
+            }
+            toggle.addEventListener('change', function() {
+                inp.disabled = !toggle.checked;
+                inp.style.opacity = toggle.checked ? '1' : '0.4';
+                _saveSettingsInstantly();
+            });
+            inp.addEventListener('change', function() {
+                _saveSettingsInstantly();
+            });
+        });
+    } catch(e) {}
+}
+
 /* ── Init ── */
 document.addEventListener('DOMContentLoaded', function() {
     if (typeof lucide !== 'undefined') lucide.createIcons();
@@ -1217,6 +1361,8 @@ document.addEventListener('DOMContentLoaded', function() {
     initThemeToggle();
     initFormSubmit();
     initUnsavedDetection();
+    initInstantSettingsToggles();
+    initNotificationCooldownControls();
     initTimezoneHint();
     onIspChange();
     toggleUsernameField();
@@ -1242,29 +1388,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    /* Populate per-event notification toggles + cooldown inputs */
-    try {
-        var saved = typeof savedCooldowns !== 'undefined' ? savedCooldowns : {};
-        document.querySelectorAll('.notify-event-row').forEach(function(row) {
-            var key = row.getAttribute('data-event');
-            var toggle = row.querySelector('.notify-toggle');
-            var inp = row.querySelector('.notify-cooldown-input');
-            if (saved[key] !== undefined) {
-                if (saved[key] === 0) {
-                    toggle.checked = false;
-                    inp.disabled = true;
-                    inp.style.opacity = '0.4';
-                } else {
-                    inp.value = saved[key];
-                }
-            }
-            toggle.addEventListener('change', function() {
-                inp.disabled = !toggle.checked;
-                inp.style.opacity = toggle.checked ? '1' : '0.4';
-            });
-        });
-    } catch(e) {}
-
     _captureFormBaseline();
     _formDirty = false;
 
@@ -1287,7 +1410,7 @@ function initModuleToggles() {
                     if (other !== toggleEl) other.checked = false;
                 });
             }
-            _updateDirtyState();
+            _saveSettingsInstantly();
         });
     });
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -356,9 +356,9 @@ fpdf2==2.8.7 \
     --hash=sha256:7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9 \
     --hash=sha256:d391fc508a3ce02fc43a577c830cda4fe6f37646f2d143d489839940932fbc19
     # via -r requirements.in
-idna==3.11 \
-    --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
-    --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via requests
 itsdangerous==2.2.0 \
     --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef \

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -166,7 +166,21 @@ class TestSettingsDirtyState:
         assert payloads[-1]["modem_password"] == "new-secret-value"
         assert settings_page.locator('#modem_password').input_value() == ""
 
-    def test_real_settings_edit_shows_only_footer_when_module_toggle_is_clicked(self, settings_page):
+    def test_real_settings_edit_is_saved_when_module_toggle_is_clicked(self, settings_page):
+        config_payloads = []
+        batch_payloads = []
+
+        def capture_config(route):
+            config_payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        def capture_batch(route):
+            batch_payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True, "restart_required": False})
+
+        settings_page.route("**/api/config", capture_config)
+        settings_page.route("**/api/modules/batch", capture_batch)
+
         footer = settings_page.locator("#save-footer")
         settings_page.locator('#modem_url').fill('http://192.168.100.1')
         expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
@@ -176,16 +190,20 @@ class TestSettingsDirtyState:
         settings_page.locator('button[data-section="extensions"]').click()
         toggle = settings_page.locator('.module-toggle-input').first
         assert toggle.count() == 1
-        settings_page.locator('.module-toggle .toggle-slider').first.click()
+        with settings_page.expect_request("**/api/config"):
+            with settings_page.expect_request("**/api/modules/batch"):
+                settings_page.locator('.module-toggle .toggle-slider').first.click()
 
         expect(settings_page.locator('#docsight-confirm-modal')).to_have_count(0)
-        expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        assert config_payloads[-1]["modem_url"] == "http://192.168.100.1"
+        assert len(batch_payloads[-1]["modules"]) == 1
 
 
-class TestSettingsExtensionsBatchSave:
-    """Installed module changes are saved with the Settings save flow."""
+class TestSettingsInstantToggleSave:
+    """Settings toggles persist immediately without the global save footer."""
 
-    def test_module_toggles_batch_save_once_without_immediate_api_calls(self, settings_page):
+    def test_module_toggle_saves_immediately_without_direct_enable_disable_calls(self, settings_page):
         config_payloads = []
         batch_payloads = []
         immediate_calls = []
@@ -207,21 +225,149 @@ class TestSettingsExtensionsBatchSave:
         settings_page.route(re.compile(r".*/api/modules/.+/(enable|disable)$"), capture_immediate)
 
         settings_page.locator('button[data-section="extensions"]').click()
-        toggles = settings_page.locator('.module-toggle-input[data-is-threshold="false"]')
-        assert toggles.count() >= 2
-        settings_page.locator('.module-toggle-input[data-is-threshold="false"] + .toggle-slider').nth(0).click()
-        settings_page.locator('.module-toggle-input[data-is-threshold="false"] + .toggle-slider').nth(1).click()
+        toggle_slider = settings_page.locator('.module-toggle-input[data-is-threshold="false"] + .toggle-slider').first
+        assert toggle_slider.count() == 1
+        with settings_page.expect_request("**/api/config"):
+            with settings_page.expect_request("**/api/modules/batch"):
+                toggle_slider.click()
 
         footer = settings_page.locator("#save-footer")
-        expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
-        settings_page.locator('#save-footer button[type="submit"]').click()
-
         expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
         expect(settings_page.locator("#module-restart-banner")).to_be_visible()
         assert len(config_payloads) == 1
         assert len(batch_payloads) == 1
-        assert len(batch_payloads[0]["modules"]) == 2
+        assert len(batch_payloads[0]["modules"]) == 1
         assert immediate_calls == []
+
+    def test_notification_event_toggle_saves_cooldowns_immediately(self, settings_page):
+        config_payloads = []
+
+        def capture_config(route):
+            config_payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        settings_page.route("**/api/config", capture_config)
+        settings_page.locator('button[data-section="notifications"]').click()
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('.notify-event-row[data-event="health_change"] .toggle-slider').click()
+
+        footer = settings_page.locator("#save-footer")
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        assert len(config_payloads) == 1
+        cooldowns = config_payloads[0]["notify_cooldowns"]
+        assert '"health_change":0' in cooldowns.replace(" ", "")
+
+    def test_notification_cooldown_value_saves_immediately(self, settings_page):
+        config_payloads = []
+
+        def capture_config(route):
+            config_payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        settings_page.route("**/api/config", capture_config)
+        settings_page.locator('button[data-section="notifications"]').click()
+        settings_page.locator('.notify-event-row[data-event="power_change"] .notify-cooldown-input').fill('42')
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('.notify-event-row[data-event="power_change"] .notify-cooldown-input').blur()
+
+        footer = settings_page.locator("#save-footer")
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        assert len(config_payloads) == 1
+        cooldowns = config_payloads[0]["notify_cooldowns"]
+        assert '"power_change":42' in cooldowns.replace(" ", "")
+
+    def test_notification_event_toggle_stays_dirty_when_instant_save_fails(self, settings_page):
+        def fail_config(route):
+            route.fulfill(status=500, json={"success": False, "error": "Save failed"})
+
+        settings_page.route("**/api/config", fail_config)
+        settings_page.locator('button[data-section="notifications"]').click()
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('.notify-event-row[data-event="health_change"] .toggle-slider').click()
+
+        footer = settings_page.locator("#save-footer")
+        expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
+        expect(settings_page.locator('#global-error')).to_be_visible()
+
+    def test_edit_made_during_instant_save_remains_dirty(self, settings_page):
+        config_payloads = []
+
+        def capture_config(route):
+            config_payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        settings_page.route("**/api/config", capture_config)
+        settings_page.locator('button[data-section="notifications"]').click()
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('.notify-event-row[data-event="health_change"] .toggle-slider').click()
+        settings_page.locator('button[data-section="connection"]').click()
+        settings_page.locator('#modem_url').fill('http://192.168.100.1')
+
+        footer = settings_page.locator("#save-footer")
+        expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
+        assert config_payloads[0]["modem_url"] != "http://192.168.100.1"
+
+    def test_saved_secret_clears_when_concurrent_edit_remains_dirty(self, settings_page):
+        settings_page.evaluate(
+            """
+            () => {
+              const input = document.querySelector('#modem_password');
+              input.dataset.savedSecret = 'true';
+              input.setAttribute('placeholder', 'Saved');
+            }
+            """
+        )
+        settings_page.locator('#modem_password').fill('new-secret-value')
+        saved_baseline = settings_page.evaluate(
+            "() => _serializeSettingsForm(document.getElementById('settings-form'))"
+        )
+        settings_page.locator('#modem_url').fill('http://192.168.100.1')
+
+        settings_page.evaluate("baseline => _finishSettingsSave(baseline)", saved_baseline)
+
+        assert settings_page.locator('#modem_password').input_value() == ""
+        expect(settings_page.locator("#save-footer")).to_have_class(re.compile(r".*\bvisible\b.*"))
+
+    def test_saved_secret_edited_after_save_snapshot_is_not_cleared(self, settings_page):
+        settings_page.evaluate(
+            """
+            () => {
+              const input = document.querySelector('#modem_password');
+              input.dataset.savedSecret = 'true';
+              input.setAttribute('placeholder', 'Saved');
+            }
+            """
+        )
+        saved_baseline = settings_page.evaluate(
+            "() => _serializeSettingsForm(document.getElementById('settings-form'))"
+        )
+        settings_page.locator('#modem_password').fill('new-secret-value')
+
+        settings_page.evaluate("baseline => _finishSettingsSave(baseline)", saved_baseline)
+
+        assert settings_page.locator('#modem_password').input_value() == "new-secret-value"
+        expect(settings_page.locator("#save-footer")).to_have_class(re.compile(r".*\bvisible\b.*"))
+
+    def test_saved_secret_reedited_after_save_snapshot_is_not_cleared(self, settings_page):
+        settings_page.evaluate(
+            """
+            () => {
+              const input = document.querySelector('#modem_password');
+              input.dataset.savedSecret = 'true';
+              input.setAttribute('placeholder', 'Saved');
+            }
+            """
+        )
+        settings_page.locator('#modem_password').fill('first-secret-value')
+        saved_baseline = settings_page.evaluate(
+            "() => _serializeSettingsForm(document.getElementById('settings-form'))"
+        )
+        settings_page.locator('#modem_password').fill('second-secret-value')
+
+        settings_page.evaluate("baseline => _finishSettingsSave(baseline)", saved_baseline)
+
+        assert settings_page.locator('#modem_password').input_value() == "second-secret-value"
+        expect(settings_page.locator("#save-footer")).to_have_class(re.compile(r".*\bvisible\b.*"))
 
     def test_threshold_profile_toggles_are_exclusive_radios(self, settings_page):
         settings_page.locator('button[data-section="extensions"]').click()


### PR DESCRIPTION
## Summary
- Saves Settings toggles immediately for a consistent Settings experience.
- Persists notification per-event toggles and cooldown edits right away while keeping failed saves dirty.
- Keeps extension module changes on the batch API and preserves unsaved concurrent edits, including saved-secret fields.
- Bumps `idna` to 3.15 so the dependency audit gate stays green.

## Testing
- `git diff --check origin/main...HEAD`
- Static diff scan: no findings
- `python3 -m pip install --dry-run --require-hashes -r requirements.txt`
- `uvx pip-audit -r requirements.txt`
- `.venv/bin/pytest -q tests --ignore=tests/e2e`
- `TZ=UTC .venv/bin/pytest -q tests/e2e`

Closes #469