### PR TITLE
Fix Channels modulation chart labels

### DIFF
--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -406,6 +406,8 @@ function loadChannelTimeline() {
                     tooltipLabelCallback: function(ctx) { return (T.modulation || 'Modulation') + ': ' + (qamLabel[qamSteps[ctx.raw]] || ctx.raw); },
                     yMin: -0.5,
                     yMax: qamSteps.length - 0.5,
+                    yAxisSize: 72,
+                    zoomYAxisSize: 80,
                     yAfterBuildTicks: function(axis) {
                         axis.ticks = tickValues.map(function(v) { return {value: v}; });
                     }
@@ -799,6 +801,8 @@ function loadCompareCharts() {
                     tooltipLabelCallback: function(ctx) { return ctx.dataset.label + ': ' + (qamLabel[ctx.raw] || ctx.raw); },
                     yMin: -0.5,
                     yMax: qamNames.length - 0.5,
+                    yAxisSize: 72,
+                    zoomYAxisSize: 80,
                     yAfterBuildTicks: function(axis) {
                         axis.ticks = tickValues.map(function(v) { return {value: v}; });
                     }

--- a/app/static/js/chart-engine.js
+++ b/app/static/js/chart-engine.js
@@ -5,6 +5,9 @@
 var charts = {};
 var _tempOverlayVisible = true;
 var currentView = 'live';
+var DEFAULT_Y_AXIS_SIZE = 58;
+var DEFAULT_ZOOM_Y_AXIS_SIZE = 64;
+var DEFAULT_X_EDGE_PADDING = 1.5;
 
 /* ── Shared Helpers ── */
 // TEMPERATURE_UNIT is set by index.html; default to celsius if not present
@@ -44,8 +47,72 @@ function formatDateDE(str) {
 
 function chartXRange(u) {
     var xData = u && u.data && u.data[0] ? u.data[0] : [];
+    var edgePadding = u && u._docsightXEdgePadding ? u._docsightXEdgePadding : DEFAULT_X_EDGE_PADDING;
     if (!xData.length) return { min: 0, max: 0 };
-    return { min: xData[0], max: xData[xData.length - 1] };
+    if (xData.length === 1) return { min: xData[0] - edgePadding, max: xData[0] + edgePadding };
+    return { min: xData[0] - edgePadding, max: xData[xData.length - 1] + edgePadding };
+}
+
+function buildEvenIndexTicks(count, maxTicks) {
+    if (count <= 0) return [];
+    if (!maxTicks || maxTicks < 2) maxTicks = 2;
+    if (count <= maxTicks) {
+        var all = [];
+        for (var ai = 0; ai < count; ai++) all.push(ai);
+        return all;
+    }
+    var ticks = [];
+    var seen = {};
+    var gap = (count - 1) / (maxTicks - 1);
+    for (var ti = 0; ti < maxTicks; ti++) {
+        var idx = Math.round(ti * gap);
+        if (idx < 0) idx = 0;
+        if (idx >= count) idx = count - 1;
+        if (!seen[idx]) {
+            ticks.push(idx);
+            seen[idx] = true;
+        }
+    }
+    if (!seen[count - 1]) ticks.push(count - 1);
+    return ticks;
+}
+
+function estimateLongestLabelWidth(labels, minWidth) {
+    var longest = '';
+    labels.forEach(function(label) {
+        var text = label === null || label === undefined ? '' : String(label);
+        if (text.length > longest.length) longest = text;
+    });
+    return Math.max(longest.length * 7, minWidth || 40);
+}
+
+function calculateXEdgePadding(labels, xValues, chartWidth, yAxisSize, explicitPadding) {
+    if (explicitPadding !== undefined && explicitPadding !== null) return explicitPadding;
+    if (!labels || labels.length <= 1) return DEFAULT_X_EDGE_PADDING;
+    var labelWidth = estimateLongestLabelWidth(labels, 40);
+    var plotWidth = Math.max((chartWidth || 400) - (yAxisSize || DEFAULT_Y_AXIS_SIZE) - 24, 1);
+    var span = labels.length - 1;
+    if (xValues && xValues.length > 1) {
+        var first = Number(xValues[0]);
+        var last = Number(xValues[xValues.length - 1]);
+        if (isFinite(first) && isFinite(last) && Math.abs(last - first) > 0) {
+            span = Math.abs(last - first);
+        }
+    }
+    var labelHalfWidthWithBreathingRoom = (labelWidth / 2) + 10;
+    var padding = (labelHalfWidthWithBreathingRoom / plotWidth) * span;
+    return Math.max(DEFAULT_X_EDGE_PADDING, Math.ceil(padding * 10) / 10);
+}
+
+function calculateMaxXTicks(labels, chartWidth, yAxisSize, hardMax) {
+    var labelWidth = estimateLongestLabelWidth(labels, 40) + 18;
+    var plotWidth = Math.max((chartWidth || 400) - (yAxisSize || DEFAULT_Y_AXIS_SIZE) - 24, 1);
+    var byWidth = Math.floor(plotWidth / labelWidth);
+    var cap = hardMax || 6;
+    if (cap < 2) cap = 2;
+    if (byWidth < 2) byWidth = 2;
+    if (byWidth > cap) byWidth = cap;
+    return byWidth;
 }
 
 /* ── Shared uPlot Plugins ── */
@@ -310,12 +377,15 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
     var textColor = isDark ? '#888' : '#666';
     var isBar = type === 'bar';
     var n = labels.length;
+    var yAxisSize = opts && opts.yAxisSize ? opts.yAxisSize : DEFAULT_Y_AXIS_SIZE;
+    var width = container.offsetWidth || 400;
 
     /* Build columnar data: [xIndices, series1, series2, ...] */
     var xData = opts && opts.xData ? opts.xData.slice() : [];
     if (!xData.length) {
         for (var xi = 0; xi < n; xi++) xData.push(xi);
     }
+    var xEdgePadding = calculateXEdgePadding(labels, xData, width, yAxisSize, opts && opts.xEdgePadding);
     var uData = [xData];
     var allDatasets = datasets.slice();
 
@@ -412,8 +482,8 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
         };
     } else {
         scales.x.range = function() {
-            if (xData.length <= 1) return [-0.5, 0.5];
-            return [xData[0], xData[xData.length - 1]];
+            if (xData.length <= 1) return [-xEdgePadding, xEdgePadding];
+            return [xData[0] - xEdgePadding, xData[xData.length - 1] + xEdgePadding];
         };
     }
     if (yRange[0] !== null && yRange[1] !== null) {
@@ -436,7 +506,7 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
 
     /* Axes — pick evenly spaced label positions */
     var xSplits = [];
-    var wantTicks = 6;
+    var wantTicks = calculateMaxXTicks(labels, width, yAxisSize, opts && opts.maxXTicks ? opts.maxXTicks : 6);
     if (n <= wantTicks) {
         for (var li = 0; li < n; li++) xSplits.push(xData[li]);
     } else {
@@ -469,7 +539,7 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
             grid: { stroke: gridColor, width: 1 },
             ticks: { stroke: gridColor, width: 1 },
             font: '10px system-ui',
-            size: 50,
+            size: yAxisSize,
             gap: 4
         }
     ];
@@ -544,7 +614,6 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
     if (opts && opts.plugins) { opts.plugins.forEach(function(p) { plugins.push(p); }); }
 
     /* Build options */
-    var width = container.offsetWidth || 400;
     var heightRatio = opts && opts.heightRatio ? opts.heightRatio : 0.55;
     var minHeight = opts && opts.minHeight ? opts.minHeight : 180;
     var maxHeight = opts && opts.maxHeight ? opts.maxHeight : 350;
@@ -565,6 +634,7 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
 
     var chart = new uPlot(uOpts, uData, container);
     charts[canvasId] = chart;
+    chart._docsightXEdgePadding = xEdgePadding;
     chart._docsightParams = {labels: labels, datasets: datasets, type: type, zones: zones, opts: opts};
 
     /* Restore zoom state from previous chart instance (survives destroy/recreate) */
@@ -631,10 +701,15 @@ function openChartZoom(canvasId) {
         var isBar = params.type === 'bar';
         var n = params.labels.length;
         var isMulti = params.datasets.length > 1;
+        var zoomYAxisSize = params.opts && params.opts.zoomYAxisSize ? params.opts.zoomYAxisSize : DEFAULT_ZOOM_Y_AXIS_SIZE;
+        var w = zoomContainer.offsetWidth || 800;
+        var h = zoomContainer.offsetHeight || 500;
+        if (h < 300) h = 300;
 
         /* Build data */
         var xData = [];
         for (var xi = 0; xi < n; xi++) xData.push(xi);
+        var zoomXEdgePadding = calculateXEdgePadding(params.labels, xData, w, zoomYAxisSize, params.opts && params.opts.zoomXEdgePadding);
         var uData = [xData];
         params.datasets.forEach(function(ds) { uData.push(ds.data); });
 
@@ -697,7 +772,7 @@ function openChartZoom(canvasId) {
         if (params.opts && params.opts.yMax !== undefined) yRange[1] = params.opts.yMax;
 
         var scales = {
-            x: { time: false, range: function() { return [-0.5, n - 0.5]; } },
+            x: { time: false, range: function() { return [-zoomXEdgePadding, n - 1 + zoomXEdgePadding]; } },
             y: {}
         };
         if (yRange[0] !== null && yRange[1] !== null) {
@@ -712,24 +787,15 @@ function openChartZoom(canvasId) {
         if (zoomHasTemp) { scales.temp = {}; }
 
         /* Axes */
-        var zLongest = '';
-        for (var zi = 0; zi < params.labels.length; zi++) {
-            if (params.labels[zi] && params.labels[zi].length > zLongest.length) zLongest = params.labels[zi];
-        }
-        var zLabelWidth = Math.max(zLongest.length * 7, 60);
+        var zLabelWidth = estimateLongestLabelWidth(params.labels, 60);
 
-        var xTickValues = function(u, splits) {
-            var maxTicks = Math.floor(zoomContainer.offsetWidth / zLabelWidth);
-            if (maxTicks < 2) maxTicks = 2;
-            var step = Math.ceil(n / maxTicks);
-            return splits.filter(function(v) { return v >= 0 && v < n && v % step === 0; });
-        };
+        var zoomMaxTicks = calculateMaxXTicks(params.labels, w, zoomYAxisSize, 10);
+        var zoomXSplits = buildEvenIndexTicks(n, zoomMaxTicks);
         var axes = [
             {
                 scale: 'x',
                 space: zLabelWidth,
-                splits: function() { var o = []; for (var i = 0; i < n; i++) o.push(i); return o; },
-                filter: xTickValues,
+                splits: function() { return zoomXSplits; },
                 values: function(u, vals) { return vals.map(function(v) { return params.labels[v] || ''; }); },
                 stroke: textColor,
                 grid: { stroke: gridColor, width: 1 },
@@ -743,7 +809,7 @@ function openChartZoom(canvasId) {
                 grid: { stroke: gridColor, width: 1 },
                 ticks: { stroke: gridColor, width: 1 },
                 font: '11px system-ui',
-                size: 55,
+                size: zoomYAxisSize,
                 gap: 4
             }
         ];
@@ -774,10 +840,6 @@ function openChartZoom(canvasId) {
         /* Plugins */
         var plugins = [tooltipPlugin(params.labels, zoomTooltipCb)];
         if (params.zones) plugins.push(zonesPlugin(params.zones));
-
-        var w = zoomContainer.offsetWidth || 800;
-        var h = zoomContainer.offsetHeight || 500;
-        if (h < 300) h = 300;
 
         var uOpts = {
             width: w,

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v10';
+var CACHE_VERSION = 'v11';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -213,6 +213,85 @@ class TestChartZoom:
 class TestChannelCharts:
     """Charts in the Channels > Timeline view."""
 
+    def test_channel_modulation_layout_preserves_long_labels_and_bounded_zoom_ticks(self, demo_page):
+        """Long QAM labels and dense 7-day timestamps should get enough axis space."""
+        history = []
+        for idx in range(60):
+            day = 1 + (idx // 10)
+            hour = idx % 10
+            history.append({
+                "timestamp": f"2026-05-{day:02d}T{hour:02d}:30:00",
+                "power": 1.2,
+                "snr": 39.1,
+                "modulation": "1024QAM" if idx % 2 else "4096QAM",
+                "correctable_errors": None,
+                "uncorrectable_errors": None,
+            })
+
+        demo_page.route(
+            "**/api/channels",
+            lambda route: route.fulfill(json={
+                "ds_channels": [{
+                    "channel_id": 1,
+                    "frequency": "690 MHz",
+                    "docsis_version": "3.1",
+                    "power": 1.2,
+                    "snr": 39.1,
+                    "health": "good",
+                }],
+                "us_channels": [],
+            }),
+        )
+        demo_page.route("**/api/channel-history**", lambda route: route.fulfill(json=history))
+
+        navigate_to_channels(demo_page)
+        demo_page.set_viewport_size({"width": 640, "height": 760})
+        demo_page.locator("#channel-select").select_option("ds-1")
+        wait_for_uplot(demo_page, "chart-ch-modulation")
+
+        layout = demo_page.evaluate(
+            """
+            () => {
+                const chart = window.charts['chart-ch-modulation'];
+                const xData = chart.data[0];
+                const xSplits = chart.axes[0].splits();
+                return {
+                    yAxisSize: chart._docsightParams.opts && chart._docsightParams.opts.yAxisSize,
+                    xMin: chart.scales.x.min,
+                    xMax: chart.scales.x.max,
+                    firstX: xData[0],
+                    lastX: xData[xData.length - 1],
+                    splitCount: xSplits.length,
+                    samples: xData.length,
+                };
+            }
+            """
+        )
+        assert layout["yAxisSize"] >= 72
+        assert layout["firstX"] - layout["xMin"] >= 4
+        assert layout["xMax"] - layout["lastX"] >= 4
+        assert layout["splitCount"] <= 4
+        assert layout["splitCount"] < layout["samples"]
+
+        demo_page.locator('.chart-expand-btn[data-chart="chart-ch-modulation"]').click()
+        demo_page.wait_for_selector("#chart-zoom-canvas .uplot", timeout=5000)
+        zoom_layout = demo_page.evaluate(
+            """
+            () => {
+                const chart = window.zoomChart;
+                const splits = chart.axes[0].splits();
+                return {
+                    yAxisSize: chart.bbox.left,
+                    splitCount: splits.length,
+                    samples: chart.data[0].length,
+                };
+            }
+            """
+        )
+        assert zoom_layout["yAxisSize"] >= 80
+        assert zoom_layout["splitCount"] <= 10
+        assert zoom_layout["splitCount"] < zoom_layout["samples"]
+
     def test_channel_selection_renders_charts(self, demo_page):
         """Selecting a channel should render Power and Errors charts."""
         navigate_to_channels(demo_page)

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -6,6 +6,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 VIEWS_CSS = ROOT / "app" / "static" / "css" / "views.css"
 CORRELATION_JS = ROOT / "app" / "static" / "js" / "correlation.js"
+CHART_ENGINE_JS = ROOT / "app" / "static" / "js" / "chart-engine.js"
+CHANNELS_JS = ROOT / "app" / "static" / "js" / "channels.js"
 SW_JS = ROOT / "app" / "static" / "sw.js"
 MAIN_CSS = ROOT / "app" / "static" / "css" / "main.css"
 INDEX_HTML = ROOT / "app" / "templates" / "index.html"
@@ -72,10 +74,39 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v10';" in sw_js
+    assert "var CACHE_VERSION = 'v11';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js
+
+
+def test_chart_engine_has_configurable_axis_padding_for_long_qam_labels():
+    js = CHART_ENGINE_JS.read_text(encoding="utf-8")
+    channels_js = CHANNELS_JS.read_text(encoding="utf-8")
+
+    assert "DEFAULT_Y_AXIS_SIZE" in js
+    assert "DEFAULT_ZOOM_Y_AXIS_SIZE" in js
+    assert "DEFAULT_X_EDGE_PADDING" in js
+    assert "function calculateXEdgePadding" in js
+    assert "function calculateMaxXTicks" in js
+    assert "opts.yAxisSize" in js
+    assert "params.opts.zoomYAxisSize" in js
+    assert "xData[0] - xEdgePadding" in js
+    assert "xData[xData.length - 1] + xEdgePadding" in js
+    assert "calculateMaxXTicks(labels, width, yAxisSize" in js
+    assert "yAxisSize: 72" in channels_js
+    assert "zoomYAxisSize: 80" in channels_js
+
+
+def test_chart_zoom_uses_bounded_index_ticks_instead_of_all_samples():
+    js = CHART_ENGINE_JS.read_text(encoding="utf-8")
+    zoom_block = js[js.index("function openChartZoom") :]
+
+    assert "function buildEvenIndexTicks" in js
+    assert "calculateMaxXTicks(params.labels, w, zoomYAxisSize, 10)" in zoom_block
+    assert "var zoomXSplits = buildEvenIndexTicks(n, zoomMaxTicks);" in zoom_block
+    assert "for (var i = 0; i < n; i++) o.push(i); return o;" not in zoom_block
+    assert "filter: xTickValues" not in zoom_block
 
 
 def test_dashboard_i18n_keys_exist_in_all_language_files():


### PR DESCRIPTION
## Summary
- Fixes clipped long QAM labels in Channels modulation charts.
- Adds label-aware X-axis padding so edge timestamps stay visible.
- Bounds dense timestamp ticks in the chart zoom view.
- Bumps the service-worker cache version for the updated static assets.

## Validation
- `git diff --check`
- `node --check app/static/js/chart-engine.js`
- `node --check app/static/js/channels.js`
- `node --check app/static/sw.js`
- `pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC pytest -q tests/e2e --tb=short`
- Visual smoke for Channels modulation card and zoom chart

Closes #466
