### PR TITLE
Fix dashboard meta truncation

### DIFF
--- a/app/static/css/glossary.css
+++ b/app/static/css/glossary.css
@@ -111,6 +111,12 @@ body > .glossary-popover.above::before {
     margin-left: 0;
     border-radius: var(--radius-sm, 6px);
   }
+  .dashboard-view .insights-meta .hero-meta-item.glossary-hint {
+    width: auto;
+    height: auto;
+    justify-content: flex-start;
+  }
+
   .metric-card .glossary-hint {
     top: 4px;
     left: 4px;

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1050,7 +1050,7 @@ body:has(#view-dashboard.active) .app-main {
 .dashboard-view .insights-meta .hero-meta-item {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   flex: 0 1 auto;
   gap: 6px;
   min-width: 0;
@@ -1063,6 +1063,17 @@ body:has(#view-dashboard.active) .app-main {
   border-radius: 0;
   background: transparent;
   color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-view .insights-meta .hero-meta-item.glossary-hint {
+  margin-left: 0;
+}
+
+.dashboard-view .insights-meta .hero-meta-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1083,7 +1094,8 @@ body:has(#view-dashboard.active) .app-main {
   border-right: 0;
 }
 
-.dashboard-view .insights-meta .hero-meta-item i {
+.dashboard-view .insights-meta .hero-meta-item i,
+.dashboard-view .insights-meta .hero-meta-item svg {
   flex: 0 0 auto;
 }
 

--- a/app/static/js/glossary.js
+++ b/app/static/js/glossary.js
@@ -11,13 +11,16 @@
   document.body.appendChild(overlay);
 
   var activeHint = null;
+  var activeOpenedByFocus = false;
 
   function closeAll() {
     overlay.style.display = 'none';
     overlay.classList.remove('above');
+    activeOpenedByFocus = false;
     if (activeHint) {
       activeHint.classList.remove('open');
       activeHint.removeAttribute('aria-describedby');
+      activeHint.setAttribute('aria-expanded', 'false');
       activeHint = null;
     }
   }
@@ -29,6 +32,7 @@
     overlay.style.display = 'block';
     overlay.classList.remove('above');
     hint.setAttribute('aria-describedby', 'glossary-popover-overlay');
+    hint.setAttribute('aria-expanded', 'true');
 
     var r = hint.getBoundingClientRect();
     var top = r.bottom + 8;
@@ -62,7 +66,8 @@
         hint.removeAttribute('role');
         return;
       }
-      hint.setAttribute('aria-label', label.substring(0, 60));
+      hint.setAttribute('aria-label', label);
+      hint.setAttribute('aria-expanded', 'false');
     });
   }
   initHints();
@@ -91,6 +96,10 @@
       e.preventDefault();
       e.stopPropagation();
       var wasOpen = hint === activeHint;
+      if (wasOpen && activeOpenedByFocus) {
+        activeOpenedByFocus = false;
+        return;
+      }
       closeAll();
       if (!wasOpen) {
         activeHint = hint;
@@ -100,6 +109,23 @@
       return;
     }
     closeAll();
+  });
+
+  document.addEventListener('focusin', function (e) {
+    var hint = e.target.closest('.glossary-hint');
+    if (!hint) return;
+    var source = hint.querySelector('.glossary-popover');
+    if (!source || !source.textContent.trim()) return;
+    closeAll();
+    activeHint = hint;
+    activeOpenedByFocus = true;
+    hint.classList.add('open');
+    showPopover(hint);
+  });
+
+  document.addEventListener('focusout', function (e) {
+    var hint = e.target.closest('.glossary-hint');
+    if (hint && hint === activeHint) closeAll();
   });
 
   document.addEventListener('keydown', function (e) {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v11';
+var CACHE_VERSION = 'v12';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -406,9 +406,11 @@
                         </span>
                         {% endif %}
                         {% if device_info and device_info.model %}
-                        <span class="hero-meta-item" style="cursor:help;"
-                            title="{{ t.device_model_tooltip }}">
-                            <i data-lucide="router"></i> {{ device_info.model }}
+                        <span class="hero-meta-item hero-meta-truncate glossary-hint" style="cursor:help;"
+                            title="{{ device_info.model }}">
+                            <i data-lucide="router"></i>
+                            <span class="hero-meta-label">{{ device_info.model }}</span>
+                            <span class="glossary-popover">{{ device_info.model }}</span>
                         </span>
                         {% endif %}
                         {% if device_info and device_info.hw_version %}
@@ -418,9 +420,11 @@
                         </span>
                         {% endif %}
                         {% if device_info and device_info.sw_version %}
-                        <span class="hero-meta-item" style="cursor:help;"
-                            title="{{ t.sw_version_tooltip }}">
-                            <i data-lucide="package"></i> {{ device_info.sw_version }}
+                        <span class="hero-meta-item hero-meta-truncate glossary-hint" style="cursor:help;"
+                            title="{{ device_info.sw_version }}">
+                            <i data-lucide="package"></i>
+                            <span class="hero-meta-label">{{ device_info.sw_version }}</span>
+                            <span class="glossary-popover">{{ device_info.sw_version }}</span>
                         </span>
                         {% endif %}
                         {% if device_info and device_info.get('uptime_seconds') is not none %}

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -68,6 +68,77 @@ class TestDashboardSections:
         us = demo_page.locator(".dashboard-channel-panel .channel-title", has_text="Upstream")
         assert us.is_visible()
 
+    def test_long_device_meta_values_keep_icons_visible_when_truncated(self, demo_page):
+        demo_page.set_viewport_size({"width": 768, "height": 900})
+        cases = [
+            ("lucide-router", "Vodafone Station (TG6442VF/TG3442DE) with intentionally long vendor model label"),
+            ("lucide-package", "AR01.04.046.25_072922_7244.PC20.10-X1-GA-RDKB-INT intentionally long firmware label"),
+        ]
+
+        for viewport_width in (768, 390):
+            demo_page.set_viewport_size({"width": viewport_width, "height": 900})
+            for icon_class, long_value in cases:
+                metrics = demo_page.evaluate(
+                    """({ iconClass, longValue }) => {
+                        const item = Array.from(document.querySelectorAll('.dashboard-view .insights-meta .hero-meta-item'))
+                            .find((el) => el.querySelector('svg.' + iconClass));
+                        if (!item) throw new Error(iconClass + ' meta item not found');
+
+                        const icon = item.querySelector('svg.' + iconClass);
+                        const label = item.querySelector('.hero-meta-label');
+                        if (!label) throw new Error(iconClass + ' label not found');
+                        label.textContent = longValue;
+                        const popover = item.querySelector('.glossary-popover');
+                        if (popover) popover.textContent = longValue;
+                        item.setAttribute('title', longValue);
+                        item.setAttribute('aria-label', longValue);
+
+                        const itemRect = item.getBoundingClientRect();
+                        const iconRect = icon.getBoundingClientRect();
+                        return {
+                            itemLeft: itemRect.left,
+                            itemRight: itemRect.right,
+                            itemWidth: itemRect.width,
+                            textScrollWidth: label.scrollWidth,
+                            textClientWidth: label.clientWidth,
+                            iconLeft: iconRect.left,
+                            iconRight: iconRect.right,
+                            iconWidth: iconRect.width,
+                        };
+                    }""",
+                    {"iconClass": icon_class, "longValue": long_value},
+                )
+
+                assert metrics["itemWidth"] > 44
+                assert metrics["textScrollWidth"] > metrics["textClientWidth"]
+                assert metrics["iconWidth"] > 0
+                assert metrics["iconLeft"] >= metrics["itemLeft"]
+                assert metrics["iconRight"] <= metrics["itemRight"]
+
+    def test_device_meta_value_reveals_full_value_on_focus_and_click(self, demo_page):
+        item = demo_page.locator(".dashboard-view .insights-meta .hero-meta-item", has=demo_page.locator("svg.lucide-router")).first
+        assert item.is_visible()
+        assert item.get_attribute("role") == "button"
+        assert item.get_attribute("tabindex") == "0"
+        assert item.get_attribute("aria-expanded") == "false"
+        assert item.locator(".hero-meta-label").text_content().strip() == "Demo Router"
+        assert "Demo Router" in item.locator(".glossary-popover").text_content()
+
+        item.focus()
+        overlay = demo_page.locator("body > #glossary-popover-overlay")
+        assert overlay.is_visible()
+        assert item.get_attribute("aria-expanded") == "true"
+        assert "Demo Router" in overlay.text_content()
+
+        demo_page.keyboard.press("Escape")
+        assert not overlay.is_visible()
+        assert item.get_attribute("aria-expanded") == "false"
+
+        item.click()
+        assert overlay.is_visible()
+        assert item.get_attribute("aria-expanded") == "true"
+        assert "Demo Router" in overlay.text_content()
+
     def test_dashboard_refresh_control_is_keyboard_focusable(self, demo_page):
         refresh = demo_page.locator(".hero-refresh-button")
         assert refresh.first.is_visible()

--- a/tests/e2e/test_glossary.py
+++ b/tests/e2e/test_glossary.py
@@ -16,11 +16,11 @@ class TestGlossaryPresence:
         expect(hint).to_be_visible()
 
     def test_glossary_hint_has_info_icon(self, demo_page):
-        icon = demo_page.locator('#view-dashboard .glossary-hint svg').first
+        icon = demo_page.locator('#view-dashboard .metric-card .glossary-hint svg').first
         expect(icon).to_be_visible()
 
     def test_multiple_glossary_hints_on_dashboard(self, demo_page):
-        hints = demo_page.locator('#view-dashboard .glossary-hint')
+        hints = demo_page.locator('#view-dashboard .metric-card .glossary-hint')
         assert hints.count() >= 4, f"Expected at least 4 glossary hints, got {hints.count()}"
 
 
@@ -32,19 +32,19 @@ class TestGlossaryPopover:
         expect(popover).not_to_be_visible()
 
     def test_click_opens_popover(self, demo_page):
-        hint = demo_page.locator('#view-dashboard .glossary-hint').first
+        hint = demo_page.locator('#view-dashboard .metric-card .glossary-hint').first
         hint.click()
         expect(demo_page.locator(POPOVER)).to_be_visible()
 
     def test_popover_has_text_content(self, demo_page):
-        hint = demo_page.locator('#view-dashboard .glossary-hint').first
+        hint = demo_page.locator('#view-dashboard .metric-card .glossary-hint').first
         hint.click()
         popover = demo_page.locator(POPOVER)
         text = popover.text_content()
         assert len(text) > 20, f"Popover text too short: {text}"
 
     def test_click_outside_closes_popover(self, demo_page):
-        hint = demo_page.locator('#view-dashboard .glossary-hint').first
+        hint = demo_page.locator('#view-dashboard .metric-card .glossary-hint').first
         hint.click()
         popover = demo_page.locator(POPOVER)
         expect(popover).to_be_visible()
@@ -52,7 +52,7 @@ class TestGlossaryPopover:
         expect(popover).not_to_be_visible()
 
     def test_escape_closes_popover(self, demo_page):
-        hint = demo_page.locator('#view-dashboard .glossary-hint').first
+        hint = demo_page.locator('#view-dashboard .metric-card .glossary-hint').first
         hint.click()
         popover = demo_page.locator(POPOVER)
         expect(popover).to_be_visible()
@@ -60,7 +60,7 @@ class TestGlossaryPopover:
         expect(popover).not_to_be_visible()
 
     def test_clicking_second_hint_closes_first(self, demo_page):
-        hints = demo_page.locator('#view-dashboard .glossary-hint')
+        hints = demo_page.locator('#view-dashboard .metric-card .glossary-hint')
         first = hints.nth(0)
         second = hints.nth(2)  # skip nth(1) — same glossary_power text as nth(0)
         popover = demo_page.locator(POPOVER)

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -74,7 +74,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v11';" in sw_js
+    assert "var CACHE_VERSION = 'v12';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js


### PR DESCRIPTION
## Summary
- Keep dashboard modem and firmware icons visible while long values truncate cleanly on the right
- Expose full model and firmware values through native hover text and the existing accessible popover on focus/click/tap
- Scope glossary mobile sizing so dashboard meta items stay readable at tablet and phone widths
- Bump the PWA cache version for the changed static assets

Closes #465

## Tests
- `git diff --check`
- `pytest -q tests/test_static_contracts.py`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest --collect-only -q tests/e2e`
- `TZ=UTC pytest -q tests/e2e`
