### PR TITLE
Fix mobile dashboard meta popover position

### DIFF
--- a/app/static/css/glossary.css
+++ b/app/static/css/glossary.css
@@ -60,7 +60,7 @@ body > .glossary-popover {
   display: none;
   position: fixed;
   width: max-content;
-  max-width: 320px;
+  max-width: min(320px, calc(100vw - 24px));
   padding: 12px 16px;
   background: var(--surface);
   border: 1px solid var(--glass-border);
@@ -82,7 +82,7 @@ body > .glossary-popover {
 body > .glossary-popover::before {
   content: '';
   position: absolute;
-  left: 50%;
+  left: var(--glossary-arrow-left, 50%);
   top: -5px;
   transform: translateX(-50%) rotate(45deg);
   width: 8px;
@@ -125,7 +125,7 @@ body > .glossary-popover.above::before {
   .mod-kpi-item .glossary-hint {
     flex: 0 0 44px;
   }
-  body > .glossary-popover {
+  body > .glossary-popover:not(.dashboard-meta-popover) {
     left: 16px !important;
     right: 16px;
     top: auto !important;
@@ -133,7 +133,7 @@ body > .glossary-popover.above::before {
     width: auto;
     max-width: none;
   }
-  body > .glossary-popover::before {
+  body > .glossary-popover:not(.dashboard-meta-popover)::before {
     display: none;
   }
 }

--- a/app/static/js/glossary.js
+++ b/app/static/js/glossary.js
@@ -15,7 +15,8 @@
 
   function closeAll() {
     overlay.style.display = 'none';
-    overlay.classList.remove('above');
+    overlay.classList.remove('above', 'dashboard-meta-popover');
+    overlay.style.removeProperty('--glossary-arrow-left');
     activeOpenedByFocus = false;
     if (activeHint) {
       activeHint.classList.remove('open');
@@ -28,25 +29,44 @@
   function showPopover(hint) {
     var source = hint.querySelector('.glossary-popover');
     if (!source) return;
+    var isDashboardMeta = hint.matches('.dashboard-view .insights-meta .hero-meta-item');
     overlay.textContent = source.textContent;
     overlay.style.display = 'block';
     overlay.classList.remove('above');
+    overlay.classList.toggle('dashboard-meta-popover', isDashboardMeta);
+    overlay.style.removeProperty('--glossary-arrow-left');
     hint.setAttribute('aria-describedby', 'glossary-popover-overlay');
     hint.setAttribute('aria-expanded', 'true');
 
+    function clamp(value, min, max) {
+      return Math.min(Math.max(value, min), max);
+    }
+
     var r = hint.getBoundingClientRect();
-    var top = r.bottom + 8;
-    var left = r.left + r.width / 2;
+    var viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+    var viewportHeight = window.innerHeight;
+    var margin = 12;
+    var gap = 8;
+    var top = r.bottom + gap;
+    var center = r.left + r.width / 2;
+    var popRect = overlay.getBoundingClientRect();
+    var maxLeft = Math.max(margin, viewportWidth - popRect.width - margin);
+    var left = clamp(center - popRect.width / 2, margin, maxLeft);
     overlay.style.left = left + 'px';
     overlay.style.top = top + 'px';
-    overlay.style.transform = 'translateX(-50%)';
+    overlay.style.removeProperty('right');
+    overlay.style.removeProperty('bottom');
+    overlay.style.transform = 'none';
+    overlay.style.setProperty(
+      '--glossary-arrow-left',
+      clamp(center - left, 16, Math.max(16, popRect.width - 16)) + 'px'
+    );
 
     // Flip above if near bottom
-    var popRect = overlay.getBoundingClientRect();
-    if (popRect.bottom > window.innerHeight - 20) {
+    popRect = overlay.getBoundingClientRect();
+    if (popRect.bottom > viewportHeight - 20) {
       overlay.classList.add('above');
-      overlay.style.top = (r.top - 8) + 'px';
-      overlay.style.transform = 'translateX(-50%) translateY(-100%)';
+      overlay.style.top = Math.max(margin, r.top - gap - popRect.height) + 'px';
     }
   }
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v12';
+var CACHE_VERSION = 'v13';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -139,6 +139,41 @@ class TestDashboardSections:
         assert item.get_attribute("aria-expanded") == "true"
         assert "Demo Router" in overlay.text_content()
 
+    def test_device_meta_value_popover_stays_near_tapped_mobile_item(self, demo_page):
+        demo_page.set_viewport_size({"width": 390, "height": 900})
+        item = demo_page.locator(".dashboard-view .insights-meta .hero-meta-item", has=demo_page.locator("svg.lucide-router")).first
+        item.click()
+
+        overlay = demo_page.locator("body > #glossary-popover-overlay")
+        assert overlay.is_visible()
+
+        metrics = demo_page.evaluate(
+            """() => {
+                const item = Array.from(document.querySelectorAll('.dashboard-view .insights-meta .hero-meta-item'))
+                    .find((el) => el.querySelector('svg.lucide-router'));
+                const overlay = document.querySelector('body > #glossary-popover-overlay');
+                if (!item || !overlay) throw new Error('meta item or overlay missing');
+                const itemRect = item.getBoundingClientRect();
+                const overlayRect = overlay.getBoundingClientRect();
+                const viewportWidth = document.documentElement.clientWidth;
+                return {
+                    itemTop: itemRect.top,
+                    itemBottom: itemRect.bottom,
+                    overlayTop: overlayRect.top,
+                    overlayBottom: overlayRect.bottom,
+                    overlayLeft: overlayRect.left,
+                    overlayRight: overlayRect.right,
+                    viewportWidth,
+                };
+            }"""
+        )
+
+        below_gap = abs(metrics["overlayTop"] - metrics["itemBottom"])
+        above_gap = abs(metrics["itemTop"] - metrics["overlayBottom"])
+        assert min(below_gap, above_gap) <= 24
+        assert metrics["overlayLeft"] >= 8
+        assert metrics["overlayRight"] <= metrics["viewportWidth"] - 8
+
     def test_dashboard_refresh_control_is_keyboard_focusable(self, demo_page):
         refresh = demo_page.locator(".hero-refresh-button")
         assert refresh.first.is_visible()

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -74,7 +74,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v12';" in sw_js
+    assert "var CACHE_VERSION = 'v13';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js


### PR DESCRIPTION
## Summary
- Keep dashboard modem and firmware value popovers anchored near the tapped meta row on mobile/PWA screens
- Preserve the bottom-sheet behavior for regular glossary help popovers
- Clamp anchored popovers inside the viewport and keep the arrow aligned with the source item
- Bump the PWA cache version for the updated static assets

Refs #465

## Tests
- `git diff --check`
- `pytest -q tests/e2e/test_dashboard.py::TestDashboardSections::test_device_meta_value_popover_stays_near_tapped_mobile_item tests/e2e/test_dashboard.py::TestDashboardSections::test_device_meta_value_reveals_full_value_on_focus_and_click tests/e2e/test_glossary.py tests/test_static_contracts.py -q`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest --collect-only -q tests/e2e`
- `TZ=UTC pytest -q tests/e2e`
