### PR TITLE
test: tighten Apprise notification acceptance coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The value is not another chart. The value is putting the pieces of the cable pro
 - **Speed tests:** download, upload, ping, and jitter history
 - **Latency:** packet loss, outages, and route checks
 - **Modem events:** restarts, drops, and signal anomalies
+- **Alerts:** severity-filtered notifications through direct webhooks, Discord, or an optional Apprise sidecar
 - **Incident notes:** what you saw, when it happened, and what changed
 - **Before/after:** compare technician visits or ISP changes
 - **Reports:** PDF output and complaint-ready text
@@ -217,7 +218,7 @@ DOCSight is built around an evidence-first workflow, then extended with deeper a
 |---|---|
 | **Network analysis** | [Gaming Quality Index](https://github.com/itsDNNS/docsight/wiki/Features-Gaming-Quality), [Modulation Performance](https://github.com/itsDNNS/docsight/wiki/Features-Modulation-Performance), [Channel Timeline](https://github.com/itsDNNS/docsight/wiki/Features-Channel-Timeline), [Cable Segment Utilization](https://github.com/itsDNNS/docsight/wiki/Features-Segment-Utilization) |
 | **External data sources** | Guided setup for [Speedtest Integration](https://github.com/itsDNNS/docsight/wiki/Features-Speedtest), [BQM Integration](https://github.com/itsDNNS/docsight/wiki/Features-BQM), and [Smokeping Integration](https://github.com/itsDNNS/docsight/wiki/Features-Smokeping), plus [Smart Capture](https://github.com/itsDNNS/docsight/wiki/Features-Smart-Capture) and [BNetzA Measurements](https://github.com/itsDNNS/docsight/wiki/Features-BNetzA) |
-| **Platform features** | [Home Assistant](https://github.com/itsDNNS/docsight/wiki/Home-Assistant), [Backup & Restore](https://github.com/itsDNNS/docsight/wiki/Backup-and-Restore), notifications, setup wizard, optional authentication, API tokens |
+| **Platform features** | [Home Assistant](https://github.com/itsDNNS/docsight/wiki/Home-Assistant), [Notifications](https://github.com/itsDNNS/docsight/wiki/Notifications), [Backup & Restore](https://github.com/itsDNNS/docsight/wiki/Backup-and-Restore), setup wizard, optional authentication, API tokens |
 | **Usability and extensibility** | [Demo Mode](https://github.com/itsDNNS/docsight/wiki/Features-Demo-Mode), [Theme Engine](https://github.com/itsDNNS/docsight/wiki/Themes), [Community Modules](https://github.com/itsDNNS/docsight-modules), [In-App Glossary](https://github.com/itsDNNS/docsight/wiki/Features-Glossary), [AI/LLM Export](https://github.com/itsDNNS/docsight/wiki/Features-LLM-Export) with local redaction controls |
 
 Also includes 4 languages (EN/DE/FR/ES), light/dark mode, PWA/offline support, and a system font toggle.
@@ -400,6 +401,7 @@ See [TRADEMARKS.md](TRADEMARKS.md) for the full brand and trademark policy.
 |---|---|
 | [Wiki](https://github.com/itsDNNS/docsight/wiki) | User guides, feature docs, setup instructions |
 | [Proof pack](docs/proof-pack.md) | Demo-safe public screenshots, sample report, and claim-proof notes |
+| [Apprise notification sidecar](docs/notifications-apprise.md) | Optional alert fan-out through an Apprise API sidecar |
 | [Community proof templates](docs/community-proof-templates.md) | Public-safe templates for setup stories, modem reports, and ISP evidence outcomes |
 | [GitHub Releases](https://github.com/itsDNNS/docsight/releases) | Versioned builds and release notes |
 | [SUPPORT.md](SUPPORT.md) | Support routing, community channels, and issue guidance |

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -83,6 +83,7 @@ class AppriseChannel(NotificationChannel):
         self._tag = (tag or "").strip()
         self._token = (token or "").strip()
         self._log_label = "Apprise API"
+        self._last_error = ""
 
     @staticmethod
     def _format_body(payload: NotificationPayload) -> str:
@@ -130,15 +131,19 @@ class AppriseChannel(NotificationChannel):
                 timeout=10,
             )
             r.raise_for_status()
+            self._last_error = ""
             return True
         except requests.HTTPError as e:
+            status = e.response.status_code if e.response is not None else "unknown"
+            self._last_error = f"HTTP {status}"
             log.warning(
                 "Apprise POST failed (%s): HTTP %s",
                 self._log_label,
-                e.response.status_code if e.response is not None else "unknown",
+                status,
             )
             return False
         except Exception as e:
+            self._last_error = type(e).__name__
             log.warning("Apprise POST failed (%s): %s", self._log_label, type(e).__name__)
             return False
 
@@ -337,7 +342,10 @@ class NotificationDispatcher:
         for channel in channels:
             try:
                 if not channel.send(payload):
-                    errors.append(f"{type(channel).__name__}: send returned false")
+                    detail = getattr(channel, "_last_error", "")
+                    errors.append(
+                        f"{type(channel).__name__}: {detail or 'send returned false'}",
+                    )
             except Exception as e:
                 errors.append(f"{type(channel).__name__}: {e}")
         if errors:

--- a/docs/notifications-apprise.md
+++ b/docs/notifications-apprise.md
@@ -24,7 +24,7 @@ services:
     container_name: docsight-apprise
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     volumes:
       - apprise_config:/config
 
@@ -33,10 +33,10 @@ volumes:
   apprise_config:
 ```
 
-Open the Apprise API UI at `http://HOST:8000`, create a persistent configuration, and add one or more notification targets. Then open DOCSight Settings → Notifications and configure:
+Open the Apprise API UI at `http://localhost:8000` on the Docker host, create a persistent configuration, and add one or more notification targets. If you publish the Apprise port beyond a trusted host, bind it to localhost behind a reverse proxy or protect it with an API token. Then open DOCSight Settings → Notifications and configure:
 
 - Enable Apprise: on
-- Apprise API URL: `http://apprise:8000` when both services share the Compose network, or `http://HOST:8000` from another host
+- Apprise API URL: `http://apprise:8000` when both services share the Compose network. If DOCSight runs outside that Compose network, publish Apprise deliberately, protect the endpoint, and use that protected host URL.
 - Config key: the Apprise persistent configuration key, if you created one
 - API token: optional Bearer token if your Apprise API deployment requires one
 - Tags: optional comma-separated Apprise tags for route selection

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -426,3 +426,64 @@ class TestDispatcherChannelSetup:
     def test_apprise_enabled_without_url_is_ignored(self):
         dispatcher = NotificationDispatcher(self._make_config(None, apprise_enabled=True))
         assert len(dispatcher._get_channels()) == 0
+
+    @patch("app.notifier.requests.post")
+    def test_apprise_dispatch_keeps_severity_and_cooldown_controls(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+        config = self._make_config(
+            None,
+            apprise_enabled=True,
+            apprise_url="http://apprise:8000",
+        )
+        config.get.side_effect = lambda key, default=None: {
+            "notify_webhook_url": None,
+            "notify_apprise_enabled": True,
+            "notify_apprise_url": "http://apprise:8000",
+            "notify_apprise_key": "",
+            "notify_apprise_tag": "",
+            "notify_apprise_token": "",
+            "notify_cooldown": "3600",
+            "notify_cooldowns": json.dumps({"disabled_event": 0}),
+            "notify_min_severity": "warning",
+        }.get(key, default)
+        dispatcher = NotificationDispatcher(config)
+
+        dispatcher.dispatch([
+            {"timestamp": "2026-04-10T10:00:00Z", "severity": "info", "event_type": "low_info", "message": "Below threshold", "details": {}},
+            {"timestamp": "2026-04-10T10:00:01Z", "severity": "warning", "event_type": "disabled_event", "message": "Disabled", "details": {}},
+            {"timestamp": "2026-04-10T10:00:02Z", "severity": "warning", "event_type": "signal_warning", "message": "Sent", "details": {"snr": 30}},
+        ])
+        dispatcher.dispatch([
+            {"timestamp": "2026-04-10T10:00:03Z", "severity": "warning", "event_type": "signal_warning", "message": "Suppressed by cooldown", "details": {}},
+        ])
+
+        assert mock_post.call_count == 1
+        assert mock_post.call_args.args[0] == "http://apprise:8000/notify"
+        sent_json = mock_post.call_args.kwargs["json"]
+        assert sent_json["title"] == "DOCSight: Signal Warning"
+        assert sent_json["type"] == "warning"
+        assert "Sent" in sent_json["body"]
+        assert "snr: 30" in sent_json["body"]
+
+    @patch("app.notifier.requests.post")
+    def test_apprise_test_notification_returns_sanitized_http_error(self, mock_post):
+        resp = MagicMock(status_code=401)
+        resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+        mock_post.return_value = resp
+        key_marker = "REDACTED-CONFIG-KEY"
+        apprise_token_marker = "REDACTED-TOKEN"
+        config = self._make_config(
+            None,
+            apprise_enabled=True,
+            apprise_url="http://apprise:8000",
+            apprise_key=key_marker,
+            apprise_token=apprise_token_marker,
+        )
+        dispatcher = NotificationDispatcher(config)
+
+        result = dispatcher.test()
+
+        assert result == {"success": False, "error": "AppriseChannel: HTTP 401"}
+        assert key_marker not in result.get("error", "")
+        assert apprise_token_marker not in result.get("error", "")


### PR DESCRIPTION
## Summary
- Adds a sanitized HTTP status detail for failed Apprise test notifications.
- Adds regression coverage that Apprise dispatch still respects severity filtering, disabled per-event cooldowns, and repeated-event cooldowns before delivery.
- Links Apprise notification docs from the README and documents the sidecar with localhost-bound Compose examples, target examples, and Home Assistant/PWA separation.

## Validation
- `python3 -m pytest tests/test_notifier.py tests/test_config.py tests/e2e/test_settings.py::TestSettingsFormElements::test_notifications_panel_has_apprise_fields tests/e2e/test_settings.py::TestSettingsDirtyState::test_saved_apprise_secret_is_masked_when_unrelated_setting_is_saved -q`
- `python3 -m pytest tests --ignore=tests/e2e -q`
- `nice -n 19 ionice -c3 python3 -m pytest tests/e2e --collect-only -q`
- `nice -n 19 ionice -c3 python3 -m pytest tests/e2e -q`
- Added-line security and public-copy scans
