### PR TITLE
fix: align dashboard KPI status with averages

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -638,15 +638,18 @@
     {% set signal_health = 'crit' if 'ds_power_critical' in s.health_issues or 'snr_critical' in s.health_issues
        else ('warn' if 'ds_power_marginal' in s.health_issues or 'snr_marginal' in s.health_issues
        else ('tolerated' if 'ds_power_tolerated' in s.health_issues or 'snr_tolerated' in s.health_issues else 'good')) %}
-    {% set us_health = 'crit' if 'us_power_critical_low' in s.health_issues or 'us_power_critical_high' in s.health_issues
+    {% set us_health_fallback = 'crit' if 'us_power_critical_low' in s.health_issues or 'us_power_critical_high' in s.health_issues
        else ('warn' if 'us_power_marginal_low' in s.health_issues or 'us_power_marginal_high' in s.health_issues
        else ('tolerated' if 'us_power_tolerated_low' in s.health_issues or 'us_power_tolerated_high' in s.health_issues else 'good')) %}
+    {% set us_health = metric_ranges.us_power.health if metric_ranges.us_power is defined and metric_ranges.us_power.health is defined else us_health_fallback %}
     {% set error_health = 'crit' if 'uncorr_errors_critical' in s.health_issues else ('warn' if 'uncorr_errors_high' in s.health_issues else 'good') %}
 
     {# ── DS Power health ── #}
-    {% set ds_pwr_health = 'crit' if 'ds_power_critical' in s.health_issues else ('warn' if 'ds_power_marginal' in s.health_issues else ('tolerated' if 'ds_power_tolerated' in s.health_issues else 'good')) %}
+    {% set ds_pwr_health_fallback = 'crit' if 'ds_power_critical' in s.health_issues else ('warn' if 'ds_power_marginal' in s.health_issues else ('tolerated' if 'ds_power_tolerated' in s.health_issues else 'good')) %}
+    {% set ds_pwr_health = metric_ranges.ds_power.health if metric_ranges.ds_power is defined and metric_ranges.ds_power.health is defined else ds_pwr_health_fallback %}
     {# ── SNR health ── #}
-    {% set snr_health = 'crit' if 'snr_critical' in s.health_issues else ('warn' if 'snr_marginal' in s.health_issues else ('tolerated' if 'snr_tolerated' in s.health_issues else 'good')) %}
+    {% set snr_health_fallback = 'crit' if 'snr_critical' in s.health_issues else ('warn' if 'snr_marginal' in s.health_issues else ('tolerated' if 'snr_tolerated' in s.health_issues else 'good')) %}
+    {% set snr_health = metric_ranges.snr.health if metric_ranges.snr is defined and metric_ranges.snr.health is defined else snr_health_fallback %}
 
     {% macro metric_range_viz(range_data, health, good_label, context_label='', context_value='') -%}
     {% if range_data %}

--- a/app/web.py
+++ b/app/web.py
@@ -812,6 +812,39 @@ def _channel_threshold_candidates(channels, *, snr=False):
     return candidates
 
 
+def _power_metric_health(value, threshold):
+    if value is None:
+        return "good"
+    good = threshold.get("good") or [-4.0, 13.0]
+    warning = threshold.get("warning") or good
+    critical = threshold.get("critical") or [warning[0] - 2.0, warning[1] + 2.0]
+    crit_min, crit_max = float(critical[0]), float(critical[1])
+    warn_min, warn_max = float(warning[0]), float(warning[1])
+    good_min, good_max = float(good[0]), float(good[1])
+    if value < crit_min or value > crit_max:
+        return "crit"
+    if value < warn_min or value > warn_max:
+        return "warn"
+    if value < good_min or value > good_max:
+        return "tolerated"
+    return "good"
+
+
+def _snr_metric_health(value, threshold):
+    if value is None:
+        return "good"
+    crit_min = float(threshold.get("critical_min", 29.0))
+    warn_min = float(threshold.get("warning_min", threshold.get("good_min", 33.0)))
+    good_min = float(threshold.get("good_min", 33.0))
+    if value < crit_min:
+        return "crit"
+    if value < warn_min:
+        return "warn"
+    if value < good_min:
+        return "tolerated"
+    return "good"
+
+
 def _power_metric_range(value, observed_min, observed_max, threshold, unit):
     good = threshold.get("good") or [-4.0, 13.0]
     warning = threshold.get("warning") or good
@@ -833,6 +866,7 @@ def _power_metric_range(value, observed_min, observed_max, threshold, unit):
     ]
     span_start, span_width = _range_span(observed_min, observed_max, minimum, maximum)
     return {
+        "health": _power_metric_health(value, threshold),
         "marker": _range_pct(value, minimum, maximum),
         "span_start": span_start,
         "span_width": span_width,
@@ -862,6 +896,7 @@ def _snr_metric_range(value, observed_min, observed_max, threshold):
     ]
     span_start, span_width = _range_span(observed_min, observed_max, minimum, maximum)
     return {
+        "health": _snr_metric_health(value, threshold),
         "marker": _range_pct(value, minimum, maximum),
         "span_start": span_start,
         "span_width": span_width,

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -6,6 +6,15 @@ from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.modules.bnetz.storage import BnetzStorage
 
+
+def _metric_card(html, label):
+    label_markup = f'<span class="metric-label">{label}</span>'
+    label_idx = html.index(label_markup)
+    start = html.rfind('<div class="metric-card', 0, label_idx)
+    end = html.find('<div class="metric-card', label_idx)
+    return html[start:end if end != -1 else len(html)]
+
+
 class TestIndexRoute:
     def test_redirect_to_setup_when_unconfigured(self, tmp_path):
         mgr = ConfigManager(str(tmp_path / "data2"))
@@ -65,6 +74,42 @@ class TestIndexRoute:
         assert b'id="metric-errors-card"' not in resp.data
         assert b">None<" not in resp.data
         assert b"None Corr" not in resp.data
+
+    def test_average_kpi_cards_do_not_use_worst_channel_status(self, client, sample_analysis):
+        """Average Home KPI cards keep value, marker, color, and badge aligned."""
+        summary = sample_analysis["summary"]
+        summary.update({
+            "ds_power_min": -6.9,
+            "ds_power_max": 9.3,
+            "ds_power_avg": 0.9,
+            "ds_snr_min": 34.0,
+            "ds_snr_max": 42.0,
+            "ds_snr_avg": 37.1,
+            "health": "critical",
+            "health_issues": ["ds_power_critical", "snr_critical"],
+        })
+        sample_analysis["ds_channels"][0].update({
+            "power": -6.9,
+            "snr": 34.0,
+            "modulation": "1024QAM",
+            "health": "critical",
+            "health_detail": "power critical; snr critical",
+        })
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        ds_card = _metric_card(html, "DS Power")
+        snr_card = _metric_card(html, "SNR")
+        assert "0.9<span class=\"unit\">dBmV</span>" in ds_card
+        assert "badge badge-good" in ds_card
+        assert "--metric-range-accent: var(--good);" in ds_card
+        assert "37.1<span class=\"unit\">dB</span>" in snr_card
+        assert "badge badge-tolerated" in snr_card
+        assert "--metric-range-accent: var(--tolerated);" in snr_card
+        assert "Critical" in html
 
     def test_index_with_incomplete_bnetz(self, tmp_path, sample_analysis):
         """Dashboard hides BNetzA card when entry has NULL fields (#148)."""


### PR DESCRIPTION
## Summary
- Align Home KPI card status/color with the same average value used by each card marker.
- Keep channel min-max as context while preserving worst-channel health elsewhere.
- Add regression coverage for an average-vs-worst-channel disagreement.

## Test plan
- `git diff --check`
- `uv run --with-requirements requirements-test.txt pytest -q tests/web/test_index.py`
- `uv run --with-requirements requirements-test.txt python -m py_compile app/web.py tests/web/test_index.py`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright --with playwright pytest -q tests/e2e`

Closes #481
