### PR TITLE
Fix Home modulation layout

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1108,19 +1108,19 @@ body:has(#view-dashboard.active) .app-main {
   grid-column: 1;
   grid-row: 3;
   display: grid;
-  grid-template-columns: var(--hero-side-col) minmax(0, 1fr);
+  grid-template-columns: var(--hero-side-col) minmax(150px, 180px) minmax(0, 1fr);
   gap: var(--hero-col-gap);
   min-width: 0;
-  align-items: stretch;
+  align-items: start;
   padding: var(--hero-side-pad);
   border-top: 1px solid var(--dash-muted-border);
 }
 
 .dashboard-hero .hero-chart-wrap {
-  grid-column: 2;
+  grid-column: 3;
   grid-row: 1;
   min-width: 0;
-  height: clamp(250px, 22vw, 320px);
+  height: clamp(220px, 18vw, 280px);
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   gap: var(--space-sm);
@@ -1134,7 +1134,6 @@ body:has(#view-dashboard.active) .app-main {
   padding-right: clamp(18px, 1.8vw, 26px);
   border-right: 1px solid var(--dash-muted-border);
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
   gap: var(--space-md);
 }
 
@@ -1307,18 +1306,22 @@ body:has(#view-dashboard.active) .app-main {
 }
 
 .dashboard-hero .hero-modulation-context {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: start;
   display: grid;
-  gap: 8px;
+  gap: 9px;
   min-width: 0;
-  padding-top: clamp(14px, 1.5vw, 20px);
-  border-top: 1px solid var(--dash-muted-border);
+  padding: 0 clamp(14px, 1.4vw, 18px);
+  border-left: 1px solid var(--dash-muted-border);
+  border-right: 1px solid var(--dash-muted-border);
 }
 
 .dashboard-hero .hero-modulation-head {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 4px;
   min-width: 0;
 }
 
@@ -1340,7 +1343,7 @@ body:has(#view-dashboard.active) .app-main {
   font-weight: 700;
   line-height: 1.2;
   text-decoration: none;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .dashboard-hero .hero-modulation-link:hover,
@@ -1350,19 +1353,25 @@ body:has(#view-dashboard.active) .app-main {
 
 .dashboard-hero .hero-modulation-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 9px;
   min-width: 0;
 }
 
 .dashboard-hero .hero-modulation-card {
   display: grid;
-  gap: 5px;
+  gap: 4px;
   min-width: 0;
-  padding: 9px 10px;
-  border: 1px solid var(--dash-muted-border);
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--surface-2) 62%, transparent);
+  padding: 0 0 10px;
+  border: 0;
+  border-bottom: 1px solid var(--dash-muted-border);
+  border-radius: 0;
+  background: transparent;
+}
+
+.dashboard-hero .hero-modulation-card:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
 }
 
 .dashboard-hero .hero-modulation-card-top {
@@ -1408,13 +1417,13 @@ body:has(#view-dashboard.active) .app-main {
 }
 
 .dashboard-hero .hero-modulation-warn {
-  border-color: color-mix(in srgb, var(--warn) 42%, var(--dash-muted-border));
-  background: color-mix(in srgb, var(--warn-muted) 58%, transparent);
+  padding-left: 8px;
+  border-left: 2px solid color-mix(in srgb, var(--warn) 70%, var(--dash-muted-border));
 }
 
 .dashboard-hero .hero-modulation-crit {
-  border-color: color-mix(in srgb, var(--crit) 46%, var(--dash-muted-border));
-  background: color-mix(in srgb, var(--crit-muted) 58%, transparent);
+  padding-left: 8px;
+  border-left: 2px solid color-mix(in srgb, var(--crit) 76%, var(--dash-muted-border));
 }
 
 .dashboard-hero .hero-modulation-missing {
@@ -2161,6 +2170,19 @@ body:has(#view-dashboard.active) .app-main {
     border-top: 1px solid var(--dash-muted-border);
   }
 
+  .dashboard-hero .hero-modulation-context {
+    grid-column: 1;
+    grid-row: 3;
+    padding: var(--space-md) 0 0;
+    border-left: 0;
+    border-right: 0;
+    border-top: 1px solid var(--dash-muted-border);
+  }
+
+  .dashboard-hero .hero-modulation-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .dashboard-hero .hero-channel-health-list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     align-content: stretch;
@@ -2232,6 +2254,10 @@ body:has(#view-dashboard.active) .app-main {
   }
 
   .dashboard-hero .hero-channel-health-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard-hero .hero-modulation-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v14';
+var CACHE_VERSION = 'v15';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -568,13 +568,6 @@
         </div>
         {% endif %}
         <div class="hero-visual-row">
-            <div class="hero-chart-wrap">
-                <div class="hero-chart-head">
-                    <span>{{ t.get('dashboard_signal_trend', '24h signal trend') }}</span>
-                    <span>{{ t.get('dashboard_signal_scope', 'DS power / US power / SNR') }}</span>
-                </div>
-                <canvas id="hero-trend-chart" role="img" aria-label="{{ t.get('dashboard_signal_trend', '24h signal trend') }}"></canvas>
-            </div>
             <aside class="hero-channel-health" aria-label="{{ t.get('dashboard_channel_health', 'Channel health') }}">
                 <div class="hero-channel-health-head">
                     <span>{{ t.get('dashboard_section_channels', 'Channels') }}</span>
@@ -630,39 +623,46 @@
                         </div>
                     </div>
                 </div>
-                <div class="hero-modulation-context" aria-label="{{ t.get('dashboard_modulation_context', 'Modulation context') }}">
-                    <div class="hero-modulation-head">
-                        <span>{{ t.get('dashboard_modulation_context', 'Modulation context') }}</span>
-                        <a class="hero-modulation-link" href="#modulation">
-                            {{ t.get('dashboard_modulation_open_detail', t.get('docsight.modulation.title', 'Modulation Performance')) }}
-                            <i data-lucide="arrow-right" style="width:12px;height:12px;"></i>
-                        </a>
-                    </div>
-                    <div class="hero-modulation-grid">
-                    {% for mod in home_modulation_context %}
-                        {% set mod_label = t.downstream if mod.dir == 'ds' else t.upstream %}
-                        {% set mod_issue_label = issue_labels.get(mod.issue, '') if mod.issue else '' %}
-                        <div class="hero-modulation-card hero-modulation-{{ mod.health }}" data-modulation-dir="{{ mod.dir }}">
-                            <div class="hero-modulation-card-top">
-                                <span>{{ mod_label }}</span>
-                                <strong>{{ mod.primary if mod.primary else t.get('dashboard_modulation_unavailable', 'Modulation data unavailable') }}</strong>
-                            </div>
-                            {% if mod.issue %}
-                            <div class="hero-modulation-status">{{ mod_issue_label }}</div>
-                            <div class="hero-modulation-cause">{{ t.get('dashboard_modulation_us_cause', 'Reduced modulation contributes to this state') }}</div>
-                            {% elif mod.health == 'missing' %}
-                            <div class="hero-modulation-status">{{ t.get('dashboard_modulation_missing_hint', 'No current QAM value reported by the modem') }}</div>
-                            {% else %}
-                            <div class="hero-modulation-status">{{ t.get('dashboard_modulation_normal', 'No modulation degradation detected') }}</div>
-                            {% if mod.dir == 'ds' %}
-                            <div class="hero-modulation-cause muted">{{ t.get('dashboard_modulation_ds_detail_hint', 'Downstream detail remains in the Modulation Performance view') }}</div>
-                            {% endif %}
-                            {% endif %}
-                        </div>
-                    {% endfor %}
-                    </div>
-                </div>
             </aside>
+            <div class="hero-modulation-context" aria-label="{{ t.get('dashboard_modulation_context', 'Modulation context') }}">
+                <div class="hero-modulation-head">
+                    <span>{{ t.get('dashboard_modulation_context', 'Modulation context') }}</span>
+                    <a class="hero-modulation-link" href="#modulation">
+                        {{ t.get('dashboard_modulation_open_detail', t.get('docsight.modulation.title', 'Modulation Performance')) }}
+                        <i data-lucide="arrow-right" style="width:12px;height:12px;"></i>
+                    </a>
+                </div>
+                <div class="hero-modulation-grid">
+                {% for mod in home_modulation_context %}
+                    {% set mod_label = t.downstream if mod.dir == 'ds' else t.upstream %}
+                    {% set mod_issue_label = issue_labels.get(mod.issue, '') if mod.issue else '' %}
+                    <div class="hero-modulation-card hero-modulation-{{ mod.health }}" data-modulation-dir="{{ mod.dir }}">
+                        <div class="hero-modulation-card-top">
+                            <span>{{ mod_label }}</span>
+                            <strong>{{ mod.primary if mod.primary else t.get('dashboard_modulation_unavailable', 'Modulation data unavailable') }}</strong>
+                        </div>
+                        {% if mod.issue %}
+                        <div class="hero-modulation-status">{{ mod_issue_label }}</div>
+                        <div class="hero-modulation-cause">{{ t.get('dashboard_modulation_us_cause', 'Reduced modulation contributes to this state') }}</div>
+                        {% elif mod.health == 'missing' %}
+                        <div class="hero-modulation-status">{{ t.get('dashboard_modulation_missing_hint', 'No current QAM value reported by the modem') }}</div>
+                        {% else %}
+                        <div class="hero-modulation-status">{{ t.get('dashboard_modulation_normal', 'No modulation degradation detected') }}</div>
+                        {% if mod.dir == 'ds' %}
+                        <div class="hero-modulation-cause muted">{{ t.get('dashboard_modulation_ds_detail_hint', 'Downstream detail remains in the Modulation Performance view') }}</div>
+                        {% endif %}
+                        {% endif %}
+                    </div>
+                {% endfor %}
+                </div>
+            </div>
+            <div class="hero-chart-wrap">
+                <div class="hero-chart-head">
+                    <span>{{ t.get('dashboard_signal_trend', '24h signal trend') }}</span>
+                    <span>{{ t.get('dashboard_signal_scope', 'DS power / US power / SNR') }}</span>
+                </div>
+                <canvas id="hero-trend-chart" role="img" aria-label="{{ t.get('dashboard_signal_trend', '24h signal trend') }}"></canvas>
+            </div>
         </div>
     </section>
 

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -57,6 +57,73 @@ class TestModulationNavigation:
 
         expect(demo_page.locator("#view-modulation")).to_be_visible()
 
+    def test_home_modulation_context_sits_between_health_and_graph(self, page, live_server):
+        page.set_viewport_size({"width": 1280, "height": 900})
+        page.goto(live_server)
+        page.wait_for_load_state("networkidle")
+
+        visual = page.locator(".hero-visual-row")
+        health = page.locator(".hero-channel-health")
+        context = page.locator(".hero-modulation-context")
+        chart = page.locator(".hero-chart-wrap")
+        expect(visual).to_be_visible()
+        expect(health).to_be_visible()
+        expect(context).to_be_visible()
+        expect(chart).to_be_visible()
+
+        layout = page.evaluate(
+            """
+            () => {
+                const rect = (selector) => {
+                    const r = document.querySelector(selector).getBoundingClientRect();
+                    return {left: r.left, right: r.right, top: r.top, bottom: r.bottom, width: r.width, height: r.height};
+                };
+                return {
+                    visual: rect('.hero-visual-row'),
+                    health: rect('.hero-channel-health'),
+                    context: rect('.hero-modulation-context'),
+                    chart: rect('.hero-chart-wrap'),
+                    gridColumns: getComputedStyle(document.querySelector('.hero-visual-row')).gridTemplateColumns,
+                };
+            }
+            """
+        )
+
+        assert layout["gridColumns"].count("px") >= 3
+        assert layout["health"]["right"] <= layout["context"]["left"] + 1
+        assert layout["context"]["right"] <= layout["chart"]["left"] + 1
+        assert abs(layout["health"]["top"] - layout["context"]["top"]) <= 16
+        assert layout["visual"]["height"] <= 360
+
+    def test_home_modulation_context_stacks_without_narrow_overflow(self, page, live_server):
+        for width in (393, 760, 1100):
+            page.set_viewport_size({"width": width, "height": 900})
+            page.goto(live_server)
+            page.wait_for_load_state("networkidle")
+
+            layout = page.evaluate(
+                """
+                () => {
+                    const rect = (selector) => {
+                        const r = document.querySelector(selector).getBoundingClientRect();
+                        return {left: r.left, right: r.right, top: r.top, bottom: r.bottom, width: r.width, height: r.height};
+                    };
+                    return {
+                        overflowX: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+                        health: rect('.hero-channel-health'),
+                        context: rect('.hero-modulation-context'),
+                        chart: rect('.hero-chart-wrap'),
+                        gridColumns: getComputedStyle(document.querySelector('.hero-visual-row')).gridTemplateColumns,
+                    };
+                }
+                """
+            )
+
+            assert layout["overflowX"] <= 1
+            assert layout["gridColumns"].count("px") == 1
+            assert layout["chart"]["bottom"] <= layout["health"]["top"] + 1
+            assert layout["health"]["bottom"] <= layout["context"]["top"] + 1
+
 
 # ── Tab Structure ──
 

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -74,7 +74,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v14';" in sw_js
+    assert "var CACHE_VERSION = 'v15';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js
@@ -148,6 +148,20 @@ def test_dashboard_insight_layout_uses_safe_responsive_columns():
     assert "grid-template-columns: 42px minmax(0, 1fr);" in css
     assert "grid-column: 2;" in css
     assert "minmax(280px, 1fr) minmax(230px" not in css
+
+
+def test_dashboard_modulation_layout_is_sidecar_not_below_channel_health():
+    css = MAIN_CSS.read_text(encoding="utf-8")
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    visual_block = css[css.index(".dashboard-hero .hero-visual-row {") : css.index(".dashboard-hero .hero-chart-wrap {")]
+    health_block = css[css.index(".dashboard-hero .hero-channel-health {") : css.index(".dashboard-hero .hero-channel-health-head")]
+
+    assert "grid-template-columns: var(--hero-side-col) minmax(150px, 180px) minmax(0, 1fr);" in visual_block
+    assert "align-items: start;" in visual_block
+    assert "grid-column: 2;" in css[css.index(".dashboard-hero .hero-modulation-context {") : css.index(".dashboard-hero .hero-modulation-head {")]
+    assert "<aside class=\"hero-channel-health" in template
+    assert template.index('class="hero-channel-health"') < template.index('class="hero-modulation-context"') < template.index('class="hero-chart-wrap"')
+    assert "grid-template-rows: auto minmax(0, 1fr);" not in health_block
 
 
 def test_connection_monitor_mobile_pinned_bar_stays_hidden_by_default():

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -182,7 +182,9 @@ class TestIndexRoute:
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
         assert 'class="hero-modulation-context"' in html
-        modulation_context = html[html.index('class="hero-modulation-context"'):html.index("</aside>")]
+        modulation_context = html[
+            html.index('class="hero-modulation-context"'):html.index('class="hero-chart-wrap"')
+        ]
         assert "Modulation data unavailable" in modulation_context
         assert "None" not in modulation_context
         assert 'class="hero-modulation-card hero-modulation-warn"' not in modulation_context


### PR DESCRIPTION
## Summary
- Move the Home modulation context into the hero visual row between Channel Health and the 24h Signal Trend.
- Tighten the hero chart height so the graph no longer leaves a large empty area below it.
- Preserve responsive stacking and bump the service-worker cache for the updated static layout.

## Test plan
- `pytest -q tests/test_static_contracts.py::test_dashboard_modulation_layout_is_sidecar_not_below_channel_health tests/web/test_index.py::TestIndexRoute::test_home_modulation_context_handles_missing_modulation_without_false_alarm`
- `TZ=UTC pytest -q tests/e2e/test_modulation.py::TestModulationNavigation::test_home_modulation_context_sits_between_health_and_graph tests/e2e/test_modulation.py::TestModulationNavigation::test_home_modulation_context_stacks_without_narrow_overflow tests/e2e/test_modulation.py::TestModulationNavigation::test_home_modulation_context_links_to_detail`
- `pytest -q tests --ignore=tests/e2e`
- `python scripts/i18n_check.py --validate`
- `TZ=UTC pytest -q tests/e2e`
