### PR TITLE
Align Home modulation rows

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1323,6 +1323,7 @@ body:has(#view-dashboard.active) .app-main {
   flex-direction: column;
   gap: 4px;
   min-width: 0;
+  min-height: 42px;
 }
 
 .dashboard-hero .hero-modulation-head span {
@@ -1354,7 +1355,7 @@ body:has(#view-dashboard.active) .app-main {
 .dashboard-hero .hero-modulation-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 9px;
+  gap: 39px;
   min-width: 0;
 }
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v15';
+var CACHE_VERSION = 'v16';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -95,6 +95,31 @@ class TestModulationNavigation:
         assert abs(layout["health"]["top"] - layout["context"]["top"]) <= 16
         assert layout["visual"]["height"] <= 360
 
+    def test_home_modulation_rows_align_with_channel_health_rows(self, page, live_server):
+        page.set_viewport_size({"width": 1280, "height": 900})
+        page.goto(live_server)
+        page.wait_for_load_state("networkidle")
+
+        layout = page.evaluate(
+            """
+            () => {
+                const rect = (selector) => {
+                    const r = document.querySelector(selector).getBoundingClientRect();
+                    return {top: r.top, bottom: r.bottom, height: r.height};
+                };
+                return {
+                    dsHealth: rect('.hero-health-card:nth-child(1) .hero-health-name'),
+                    usHealth: rect('.hero-health-card:nth-child(2) .hero-health-name'),
+                    dsMod: rect('.hero-modulation-card[data-modulation-dir="ds"] .hero-modulation-card-top span'),
+                    usMod: rect('.hero-modulation-card[data-modulation-dir="us"] .hero-modulation-card-top span'),
+                };
+            }
+            """
+        )
+
+        assert abs(layout["dsHealth"]["top"] - layout["dsMod"]["top"]) <= 4
+        assert abs(layout["usHealth"]["top"] - layout["usMod"]["top"]) <= 4
+
     def test_home_modulation_context_stacks_without_narrow_overflow(self, page, live_server):
         for width in (393, 760, 1100):
             page.set_viewport_size({"width": width, "height": 900})

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -74,7 +74,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v15';" in sw_js
+    assert "var CACHE_VERSION = 'v16';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js


### PR DESCRIPTION
## Summary
- Align the Home Modulation Context Downstream and Upstream rows with the matching Channel Health rows.
- Keep the modulation header height stable so the row alignment does not depend on link wrapping.
- Bump the service-worker cache version for the updated dashboard CSS.

## Testing
- `pytest -q tests/test_static_contracts.py::test_static_cache_version_was_bumped_for_ui_followup_assets tests/test_static_contracts.py::test_dashboard_modulation_layout_is_sidecar_not_below_channel_health`
- `TZ=UTC nice -n 19 ionice -c3 pytest -q tests/e2e/test_modulation.py::TestModulationNavigation::test_home_modulation_rows_align_with_channel_health_rows tests/e2e/test_modulation.py::TestModulationNavigation::test_home_modulation_context_sits_between_health_and_graph tests/e2e/test_modulation.py::TestModulationNavigation::test_home_modulation_context_stacks_without_narrow_overflow tests/e2e/test_modulation.py::TestModulationNavigation::test_home_modulation_context_links_to_detail`
- `pytest -q tests --ignore=tests/e2e`
- `python scripts/i18n_check.py --validate`
- `TZ=UTC pytest -q tests/e2e --collect-only`
- `TZ=UTC nice -n 19 ionice -c3 pytest -q tests/e2e`

Follow-up to #484.
