### PR TITLE
Fix Speedtest Tracker self-signed HTTPS support

### DIFF
--- a/app/blueprints/polling_bp.py
+++ b/app/blueprints/polling_bp.py
@@ -19,6 +19,15 @@ log = logging.getLogger("docsis.web")
 polling_bp = Blueprint("polling_bp", __name__)
 
 
+def _as_bool(value):
+    """Parse booleans from JSON/form payloads."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
 @polling_bp.route("/api/test-modem", methods=["POST"])
 @polling_bp.route("/api/test-fritz", methods=["POST"])  # deprecated alias
 @require_auth
@@ -96,13 +105,14 @@ def api_test_speedtest():
         data = request.get_json()
         url = data.get("speedtest_tracker_url", "")
         token = data.get("speedtest_tracker_token", "")
+        tls_insecure = _as_bool(data.get("speedtest_tls_insecure", False))
         # Resolve masked token to real value
         if token == PASSWORD_MASK and _config_manager:
             token = _config_manager.get("speedtest_tracker_token", "")
         if not url or not token:
             return jsonify({"success": False, "error": "URL and token are required"})
         from app.modules.speedtest.client import SpeedtestClient
-        client = SpeedtestClient(url, token)
+        client = SpeedtestClient(url, token, tls_insecure=tls_insecure)
         results, error = client.get_latest_with_error(1)
         if error:
             return jsonify({"success": False, "error": error})

--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,7 @@ DEFAULTS = {
     "demo_mode": False,
     "gaming_quality_enabled": True,
     "segment_utilization_enabled": True,
+    "speedtest_tls_insecure": False,
     "notify_webhook_url": "",
     "notify_webhook_token": "",
     "notify_apprise_enabled": False,
@@ -104,6 +105,7 @@ ENV_MAP = {
     "bqm_url": "BQM_URL",
     "speedtest_tracker_url": "SPEEDTEST_TRACKER_URL",
     "speedtest_tracker_token": "SPEEDTEST_TRACKER_TOKEN",
+    "speedtest_tls_insecure": "SPEEDTEST_TLS_INSECURE",
     "booked_download": "BOOKED_DOWNLOAD",
     "booked_upload": "BOOKED_UPLOAD",
     "demo_mode": "DEMO_MODE",
@@ -163,9 +165,9 @@ INT_KEYS = {"poll_interval", "web_port", "history_days", "notify_cooldown", "hea
             "sc_global_cooldown", "sc_trigger_cooldown", "sc_max_actions_per_hour",
             "sc_flapping_window", "sc_flapping_threshold",
             "sc_trigger_error_spike_min_delta"}
-BOOL_KEYS = {"demo_mode", "gaming_quality_enabled", "segment_utilization_enabled", "notify_apprise_enabled", "sc_enabled",
-             "sc_trigger_modulation", "sc_trigger_snr", "sc_trigger_error_spike", "sc_trigger_health",
-             "sc_trigger_packet_loss"}
+BOOL_KEYS = {"demo_mode", "gaming_quality_enabled", "segment_utilization_enabled", "notify_apprise_enabled",
+             "speedtest_tls_insecure", "sc_enabled", "sc_trigger_modulation", "sc_trigger_snr",
+             "sc_trigger_error_spike", "sc_trigger_health", "sc_trigger_packet_loss"}
 
 URL_KEYS = {"modem_url", "bqm_url", "speedtest_tracker_url", "notify_webhook_url", "notify_apprise_url"}
 _ALLOWED_URL_SCHEMES = {"http", "https"}

--- a/app/modules/speedtest/client.py
+++ b/app/modules/speedtest/client.py
@@ -8,17 +8,30 @@ import requests
 log = logging.getLogger("docsis.speedtest")
 
 
+def _as_bool(value):
+    """Parse booleans from config/form values."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
 class SpeedtestClient:
     """Client for the Speedtest Tracker API (github.com/alexjustesen/speedtest-tracker)."""
 
-    def __init__(self, url, token):
+    def __init__(self, url, token, tls_insecure: bool | str = False):
+        tls_insecure = _as_bool(tls_insecure)
         self.base_url = url.rstrip("/")
         self.token = token
+        self.verify_tls = not tls_insecure
         self.session = requests.Session()
         self.session.headers.update({
             "Authorization": "Bearer " + token,
             "Accept": "application/json",
         })
+        if tls_insecure:
+            log.warning("Speedtest Tracker TLS certificate verification disabled")
 
     @staticmethod
     def _normalize_ts(ts):
@@ -97,6 +110,7 @@ class SpeedtestClient:
                 self.base_url + "/api/v1/results",
                 params={"page[size]": count, "sort": "-created_at"},
                 timeout=15,
+                verify=self.verify_tls,
             )
             resp.raise_for_status()
             results = resp.json().get("data", [])
@@ -132,6 +146,7 @@ class SpeedtestClient:
                         "sort": "-created_at",
                     },
                     timeout=30,
+                    verify=self.verify_tls,
                 )
                 resp.raise_for_status()
                 body = resp.json()
@@ -164,6 +179,7 @@ class SpeedtestClient:
                         "sort": "-created_at",
                     },
                     timeout=30,
+                    verify=self.verify_tls,
                 )
                 resp.raise_for_status()
                 body = resp.json()

--- a/app/modules/speedtest/collector.py
+++ b/app/modules/speedtest/collector.py
@@ -3,7 +3,7 @@
 import logging
 
 from app.collectors.base import Collector, CollectorResult
-from .client import SpeedtestClient
+from .client import SpeedtestClient, _as_bool
 from .storage import SpeedtestStorage
 
 log = logging.getLogger("docsis.collector.speedtest")
@@ -21,6 +21,7 @@ class SpeedtestCollector(Collector):
         self._web = web
         self._client = None
         self._last_url = None
+        self._last_tls_insecure = None
         self.on_import = None  # Optional callback for Smart Capture
 
     def is_enabled(self) -> bool:
@@ -29,10 +30,12 @@ class SpeedtestCollector(Collector):
     def _ensure_client(self):
         """Re-initialize client if the configured URL changed."""
         url = self._config_mgr.get("speedtest_tracker_url")
-        if url != self._last_url:
+        tls_insecure = _as_bool(self._config_mgr.get("speedtest_tls_insecure", False))
+        if url != self._last_url or tls_insecure != self._last_tls_insecure:
             token = self._config_mgr.get("speedtest_tracker_token")
-            self._client = SpeedtestClient(url, token)
+            self._client = SpeedtestClient(url, token, tls_insecure=tls_insecure)
             self._last_url = url
+            self._last_tls_insecure = tls_insecure
             # Detect server switch and clear stale cache
             self._storage.check_source_url(url)
             log.info("Speedtest Tracker: %s", url)

--- a/app/modules/speedtest/i18n/de.json
+++ b/app/modules/speedtest/i18n/de.json
@@ -4,6 +4,8 @@
   "speedtest_url_hint": "Basis-URL deiner Speedtest Tracker Instanz",
   "speedtest_token": "API-Token",
   "speedtest_token_hint": "Bearer-Token aus den Speedtest Tracker Einstellungen",
+  "speedtest_tls_insecure": "Unsicheres TLS",
+  "speedtest_tls_insecure_hint": "TLS-Zertifikatsprüfung für selbstsignierte HTTPS-Zertifikate überspringen",
   "booked_download": "Gebuchter Download (Mbps)",
   "booked_download_hint": "Vertraglich gebuchte Download-Geschwindigkeit in Mbps für die Bewertung",
   "booked_upload": "Gebuchter Upload (Mbps)",

--- a/app/modules/speedtest/i18n/en.json
+++ b/app/modules/speedtest/i18n/en.json
@@ -4,6 +4,8 @@
   "speedtest_url_hint": "Base URL of your Speedtest Tracker instance",
   "speedtest_token": "API Token",
   "speedtest_token_hint": "Bearer token from Speedtest Tracker settings",
+  "speedtest_tls_insecure": "Insecure TLS",
+  "speedtest_tls_insecure_hint": "Skip TLS certificate verification for self-signed HTTPS certificates",
   "booked_download": "Booked Download (Mbps)",
   "booked_download_hint": "Contracted download speed in Mbps for health calculation",
   "booked_upload": "Booked Upload (Mbps)",

--- a/app/modules/speedtest/i18n/es.json
+++ b/app/modules/speedtest/i18n/es.json
@@ -4,6 +4,8 @@
   "speedtest_url_hint": "URL base de tu instancia de Speedtest Tracker",
   "speedtest_token": "Token API",
   "speedtest_token_hint": "Token Bearer de la configuración de Speedtest Tracker",
+  "speedtest_tls_insecure": "TLS inseguro",
+  "speedtest_tls_insecure_hint": "Omitir la verificación del certificado TLS para certificados HTTPS autofirmados",
   "booked_download": "Descarga contratada (Mbps)",
   "booked_download_hint": "Velocidad de descarga contratada en Mbps para el calculo de estado",
   "booked_upload": "Subida contratada (Mbps)",

--- a/app/modules/speedtest/i18n/fr.json
+++ b/app/modules/speedtest/i18n/fr.json
@@ -4,6 +4,8 @@
   "speedtest_url_hint": "URL de base de votre instance Speedtest Tracker",
   "speedtest_token": "Jeton API",
   "speedtest_token_hint": "Jeton Bearer depuis les paramètres de Speedtest Tracker",
+  "speedtest_tls_insecure": "TLS non sécurisé",
+  "speedtest_tls_insecure_hint": "Ignorer la vérification du certificat TLS pour les certificats HTTPS auto-signés",
   "booked_download": "Debit descendant souscrit (Mbps)",
   "booked_download_hint": "Debit descendant contractuel en Mbps pour le calcul de sante",
   "booked_upload": "Debit montant souscrit (Mbps)",

--- a/app/modules/speedtest/routes.py
+++ b/app/modules/speedtest/routes.py
@@ -24,6 +24,15 @@ _last_trigger_ts = 0
 _TRIGGER_COOLDOWN = 60  # seconds
 
 
+def _as_bool(value):
+    """Parse booleans from config/form payloads."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _get_speedtest_storage():
     global _storage
     if _storage is None:
@@ -111,9 +120,11 @@ def api_speedtest():
     if ss:
         try:
             stt_url = _config_manager.get("speedtest_tracker_url")
+            tls_insecure = _as_bool(_config_manager.get("speedtest_tls_insecure", False))
             client = SpeedtestClient(
                 stt_url,
                 _config_manager.get("speedtest_tracker_token"),
+                tls_insecure=tls_insecure,
             )
             # Detect server switch and clear stale cache
             ss.check_source_url(stt_url)
@@ -149,9 +160,11 @@ def api_speedtest():
         _annotate_smart_capture(enriched, ss.db_path)
         return jsonify(enriched)
     # Fallback: no storage, fetch directly
+    tls_insecure = _as_bool(_config_manager.get("speedtest_tls_insecure", False))
     client = SpeedtestClient(
         _config_manager.get("speedtest_tracker_url"),
         _config_manager.get("speedtest_tracker_token"),
+        tls_insecure=tls_insecure,
     )
     results = client.get_results(per_page=count)
     return jsonify([_enrich_speedtest(r) for r in results])
@@ -241,11 +254,13 @@ def api_speedtest_run():
 
     url = _config_manager.get("speedtest_tracker_url", "").rstrip("/")
     token = _config_manager.get("speedtest_tracker_token", "")
+    tls_insecure = _as_bool(_config_manager.get("speedtest_tls_insecure", False))
     try:
         resp = requests.post(
             f"{url}/api/v1/speedtests/run",
             headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
             timeout=90,
+            verify=not tls_insecure,
         )
         if resp.status_code == 201:
             _last_trigger_ts = now

--- a/app/modules/speedtest/templates/speedtest_settings.html
+++ b/app/modules/speedtest/templates/speedtest_settings.html
@@ -23,6 +23,17 @@
                 <input class="form-input" type="password" id="speedtest_tracker_token" name="speedtest_tracker_token" value="" placeholder="{% if config.speedtest_tracker_token %}{{ t.saved_ph }}{% endif %}"{% if config.speedtest_tracker_token %} data-saved-secret="true"{% endif %}>
                 <span class="form-hint">{{ t['docsight.speedtest.speedtest_token_hint'] or 'Bearer token from Speedtest Tracker settings' }}</span>
             </div>
+            <div class="toggle-row" style="grid-column: 1 / -1">
+                <div class="toggle-info">
+                    <span class="toggle-title">{{ t['docsight.speedtest.speedtest_tls_insecure'] or 'Insecure TLS' }}</span>
+                    <span class="toggle-desc">{{ t['docsight.speedtest.speedtest_tls_insecure_hint'] or 'Skip TLS certificate verification for self-signed HTTPS certificates' }}</span>
+                </div>
+                <input type="hidden" name="speedtest_tls_insecure" value="false">
+                <label class="toggle" for="speedtest_tls_insecure">
+                    <input type="checkbox" id="speedtest_tls_insecure" name="speedtest_tls_insecure" value="true" {% if config.speedtest_tls_insecure %}checked{% endif %}>
+                    <span class="toggle-slider"></span>
+                </label>
+            </div>
             <div class="form-field" style="grid-column: 1 / -1; display: flex; gap: 12px; align-items: flex-start; flex-wrap: wrap;">
                 <button type="button" class="btn btn-secondary" onclick="testSpeedtest()">
                     <i data-lucide="plug-zap"></i>

--- a/app/smart_capture/adapters/speedtest.py
+++ b/app/smart_capture/adapters/speedtest.py
@@ -18,6 +18,15 @@ log = logging.getLogger("docsis.smart_capture.adapters.speedtest")
 MATCH_WINDOW_SECONDS = 300  # 5 minutes
 
 
+def _as_bool(value: Any) -> bool:
+    """Parse booleans from config values."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
 class SpeedtestAdapter(ActionAdapter):
     """Triggers a Speedtest Tracker run and matches imported results."""
 
@@ -27,7 +36,9 @@ class SpeedtestAdapter(ActionAdapter):
         self._config = config_mgr
         url = config_mgr.get("speedtest_tracker_url", "").rstrip("/")
         token = config_mgr.get("speedtest_tracker_token", "")
+        tls_insecure = _as_bool(config_mgr.get("speedtest_tls_insecure", False))
         self._run_url = f"{url}/api/v1/speedtests/run"
+        self._verify_tls = not tls_insecure
         self._session = requests.Session()
         self._session.headers.update({
             "Authorization": f"Bearer {token}",
@@ -37,7 +48,7 @@ class SpeedtestAdapter(ActionAdapter):
     def execute(self, execution_id: int, event: EventDict) -> tuple[bool, str | None]:
         """POST to STT run endpoint. Updates execution to FIRED or EXPIRED."""
         try:
-            resp = self._session.post(self._run_url, timeout=15)
+            resp = self._session.post(self._run_url, timeout=15, verify=self._verify_tls)
             if resp.status_code == 201:
                 ts = utc_now()
                 self._storage.update_execution(

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -418,7 +418,11 @@ function testSpeedtest() {
     fetch('/api/test-speedtest', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({speedtest_tracker_url: data.speedtest_tracker_url, speedtest_tracker_token: data.speedtest_tracker_token})
+        body: JSON.stringify({
+            speedtest_tracker_url: data.speedtest_tracker_url,
+            speedtest_tracker_token: data.speedtest_tracker_token,
+            speedtest_tls_insecure: data.speedtest_tls_insecure
+        })
     })
     .then(function(r) { return r.json(); })
     .then(function(res) {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v16';
+var CACHE_VERSION = 'v17';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/collectors/test_external_collectors.py
+++ b/tests/collectors/test_external_collectors.py
@@ -52,7 +52,26 @@ class TestSpeedtestCollector:
 
         c, *_ = self._make_collector()
         c.collect()
-        mock_cls.assert_called_once_with("http://speed:8999", "tok")
+        mock_cls.assert_called_once_with("http://speed:8999", "tok", tls_insecure=False)
+
+    @patch("app.modules.speedtest.collector.SpeedtestClient")
+    def test_collect_reinitializes_client_when_tls_setting_changes(self, mock_cls):
+        mock_client = MagicMock()
+        mock_client.get_latest_with_error.return_value = ([{"id": 1, "download_mbps": 100}], None)
+        mock_client.get_results.return_value = []
+        mock_cls.return_value = mock_client
+
+        c, config_mgr, *_ = self._make_collector()
+        c.collect()
+        config_mgr.get.side_effect = lambda k, *a: {
+            "speedtest_tracker_url": "http://speed:8999",
+            "speedtest_tracker_token": "[REDACTED]",
+            "speedtest_tls_insecure": True,
+        }.get(k, a[0] if a else None)
+        c.collect()
+
+        assert mock_cls.call_args_list[-1].kwargs["tls_insecure"] is True
+        assert mock_cls.call_count == 2
 
     @patch("app.modules.speedtest.collector.SpeedtestClient")
     def test_collect_updates_web_state(self, mock_cls):

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -429,6 +429,29 @@ class TestSpeedtestModule:
         button = settings_page.get_by_role("button", name="Test Connection")
         assert button.is_visible()
 
+    def test_speedtest_test_connection_sends_insecure_tls_flag(self, settings_page):
+        captured = []
+
+        def capture_request(route):
+            captured.append(route.request.post_data_json)
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body='{"success": true, "results": 0}',
+            )
+
+        settings_page.route("**/api/test-speedtest", capture_request)
+        settings_page.locator('button[data-section="mod-docsight_speedtest"]').click()
+        settings_page.locator("#speedtest_tracker_url").fill("https://speedtest.local:8443")
+        settings_page.locator("#speedtest_tracker_token").fill("[REDACTED]")
+        settings_page.locator("#panel-mod-docsight_speedtest label.toggle").click()
+        expect(settings_page.locator("#speedtest_tls_insecure")).to_be_checked()
+        settings_page.get_by_role("button", name="Test Connection").click()
+
+        expect(settings_page.locator("#speedtest-test")).to_contain_text("Connected")
+        assert captured
+        assert captured[0]["speedtest_tls_insecure"] == "true"
+
     def test_speedtest_test_connection_success(self, settings_page):
         settings_page.route(
             "**/api/test-speedtest",

--- a/tests/test_smart_capture_adapter_speedtest.py
+++ b/tests/test_smart_capture_adapter_speedtest.py
@@ -49,6 +49,7 @@ class TestCollectorOnImport:
         mock_client.get_latest_with_error.return_value = (new_results[:1], None)
         collector._client = mock_client
         collector._last_url = "http://stt:8999"  # prevent _ensure_client from overwriting
+        collector._last_tls_insecure = False
         collector.collect()
 
         callback.assert_called_once()
@@ -94,6 +95,7 @@ class TestCollectorOnImport:
         mock_client.get_latest_with_error.return_value = ([], None)
         collector._client = mock_client
         collector._last_url = "http://stt:8999"
+        collector._last_tls_insecure = False
         collector.collect()
 
         callback.assert_not_called()
@@ -128,9 +130,54 @@ class TestSpeedtestAdapterExecute:
             success, error = adapter.execute(eid, {"event_type": "modulation_change"})
         assert success is True
         assert error is None
+        assert mock_session.post.call_args.kwargs["verify"] is True
         row = storage.get_execution(eid)
         assert row["status"] == "fired"
         assert row["fired_at"] is not None
+
+    def test_insecure_tls_disables_certificate_verification(self, storage):
+        config = _make_config(speedtest_tls_insecure="true")
+        eid = storage.save_execution(
+            trigger_type="modulation_change", action_type="capture",
+            status=ExecutionStatus.PENDING,
+        )
+        with patch("app.smart_capture.adapters.speedtest.requests.Session") as MockSession:
+            mock_session = MagicMock()
+            mock_session.post.return_value = MagicMock(status_code=201)
+            MockSession.return_value = mock_session
+            from app.smart_capture.adapters.speedtest import SpeedtestAdapter
+            adapter = SpeedtestAdapter(storage, config)
+            success, error = adapter.execute(eid, {
+                "timestamp": "2026-03-15T10:00:00Z",
+                "severity": "warning",
+                "event_type": "modulation_change",
+                "message": "modulation changed",
+            })
+        assert success is True
+        assert error is None
+        assert mock_session.post.call_args.kwargs["verify"] is False
+
+    def test_string_false_keeps_certificate_verification_enabled(self, storage):
+        config = _make_config(speedtest_tls_insecure="false")
+        eid = storage.save_execution(
+            trigger_type="modulation_change", action_type="capture",
+            status=ExecutionStatus.PENDING,
+        )
+        with patch("app.smart_capture.adapters.speedtest.requests.Session") as MockSession:
+            mock_session = MagicMock()
+            mock_session.post.return_value = MagicMock(status_code=201)
+            MockSession.return_value = mock_session
+            from app.smart_capture.adapters.speedtest import SpeedtestAdapter
+            adapter = SpeedtestAdapter(storage, config)
+            success, error = adapter.execute(eid, {
+                "timestamp": "2026-03-15T10:00:00Z",
+                "severity": "warning",
+                "event_type": "modulation_change",
+                "message": "modulation changed",
+            })
+        assert success is True
+        assert error is None
+        assert mock_session.post.call_args.kwargs["verify"] is True
 
     def test_failed_trigger_sets_expired(self, storage):
         config = _make_config()

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -137,6 +137,33 @@ class TestSpeedtestClient:
         assert client.session.headers["Authorization"] == "Bearer test-token"
         assert client.session.headers["Accept"] == "application/json"
 
+    @patch("app.modules.speedtest.client.requests.Session.get")
+    def test_insecure_tls_disables_certificate_verification(self, mock_get):
+        """Self-hosted HTTPS instances with self-signed certs can opt out of cert verification."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": [SAMPLE_RESULT]}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        client = SpeedtestClient("https://speedtest.local:8443", "[REDACTED]", tls_insecure=True)
+        results = client.get_latest(1)
+
+        assert len(results) == 1
+        assert mock_get.call_args.kwargs["verify"] is False
+
+    @patch("app.modules.speedtest.client.requests.Session.get")
+    def test_string_false_keeps_certificate_verification_enabled(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": [SAMPLE_RESULT]}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        client = SpeedtestClient("https://speedtest.local:8443", "[REDACTED]", tls_insecure="false")
+        results = client.get_latest(1)
+
+        assert len(results) == 1
+        assert mock_get.call_args.kwargs["verify"] is True
+
     def test_url_trailing_slash(self):
         client = SpeedtestClient("http://example.com:8999/", "tok")
         assert client.base_url == "http://example.com:8999"
@@ -226,6 +253,11 @@ class TestSpeedtestConfig:
         # But get() returns decrypted
         assert mgr.get("speedtest_tracker_token") == "my-secret-token"
 
+    def test_speedtest_tls_insecure_is_boolean_config(self, tmp_path):
+        mgr = ConfigManager(str(tmp_path / "data"))
+        mgr.save({"speedtest_tls_insecure": "true"})
+        assert mgr.get("speedtest_tls_insecure") is True
+
 
 # ── API Tests ──
 
@@ -279,13 +311,31 @@ class TestSpeedtestAPI:
 
         resp = speedtest_client.post("/api/test-speedtest", json={
             "speedtest_tracker_url": "http://speedtest.local:8999",
-            "speedtest_tracker_token": "test-token",
+            "speedtest_tracker_token": "[REDACTED]",
         })
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["success"] is True
         assert data["results"] == 1
         assert "download" in data["latest"]
+        assert mock_get.call_args.kwargs["verify"] is True
+
+    @patch("app.modules.speedtest.client.requests.Session.get")
+    def test_api_test_speedtest_passes_insecure_tls_flag(self, mock_get, speedtest_client):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": [SAMPLE_RESULT]}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        resp = speedtest_client.post("/api/test-speedtest", json={
+            "speedtest_tracker_url": "https://speedtest.local:8443",
+            "speedtest_tracker_token": "[REDACTED]",
+            "speedtest_tls_insecure": "true",
+        })
+
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        assert mock_get.call_args.kwargs["verify"] is False
 
     def test_api_test_speedtest_missing_fields(self, speedtest_client):
         resp = speedtest_client.post("/api/test-speedtest", json={})
@@ -301,7 +351,7 @@ class TestSpeedtestAPI:
 
         resp = speedtest_client.post("/api/test-speedtest", json={
             "speedtest_tracker_url": "http://speedtest.local:8999",
-            "speedtest_tracker_token": "test-token",
+            "speedtest_tracker_token": "[REDACTED]",
         })
         assert resp.status_code == 200
         data = resp.get_json()
@@ -403,6 +453,22 @@ class TestSpeedtestRun:
         data = resp.get_json()
         assert data["success"] is True
         mock_post.assert_called_once()
+        assert mock_post.call_args.kwargs["verify"] is True
+
+    @patch("app.modules.speedtest.routes.requests.post")
+    def test_run_uses_insecure_tls_config(self, mock_post, speedtest_client):
+        self._reset_rate_limit()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_post.return_value = mock_resp
+        from app.web import get_config_manager
+
+        get_config_manager().save({"speedtest_tls_insecure": True})
+
+        resp = speedtest_client.post("/api/speedtest/run")
+
+        assert resp.status_code == 200
+        assert mock_post.call_args.kwargs["verify"] is False
 
     @patch("app.modules.speedtest.routes.requests.post")
     def test_run_rate_limited(self, mock_post, speedtest_client):
@@ -460,7 +526,7 @@ class TestSpeedtestRun:
             "modem_type": "fritzbox",
             "demo_mode": True,
             "speedtest_tracker_url": "http://speedtest.local:8999",
-            "speedtest_tracker_token": "test-token",
+            "speedtest_tracker_token": "[REDACTED]",
         })
         init_config(mgr)
         init_storage(None)

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -74,7 +74,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v16';" in sw_js
+    assert "var CACHE_VERSION = 'v17';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js


### PR DESCRIPTION
## Summary
- Add a Speedtest-specific `speedtest_tls_insecure` setting/env var that defaults to secure TLS verification
- Propagate the setting through the Speedtest client, collector, connection test, manual run, settings UI, and Smart Capture trigger path
- Add i18n strings, bump the service worker cache, and cover secure-default/insecure TLS behavior with unit and E2E tests

Closes #477

## Verification
- `.venv/bin/python -m pytest -q tests --ignore=tests/e2e` → 2358 passed, 11 skipped, 1 existing InsecureRequestWarning
- `TZ=UTC .venv/bin/python -m pytest -q tests/e2e` → 387 passed
- `TZ=UTC .venv/bin/python -m pytest tests/e2e/test_settings.py::TestSpeedtestModule -q` → 4 passed
- `git diff --check`
- `.venv/bin/python scripts/i18n_check.py --validate` → all 39 language files in sync
- Static secret scan on added lines: OK
