### PR TITLE
Document Speedtest self-signed HTTPS option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ DATA_DIR=/data                 # Data directory (rarely needed)
 # ── Speedtest Tracker ────────────────────────────────────────────────────────
 # SPEEDTEST_TRACKER_URL=       # Your Speedtest Tracker instance URL
 # SPEEDTEST_TRACKER_TOKEN=     # API token from Speedtest Tracker settings
+# SPEEDTEST_TLS_INSECURE=false # Disable TLS cert verification for self-signed Speedtest Tracker HTTPS
 # BOOKED_DOWNLOAD=0            # Booked download speed in Mbit/s
 # BOOKED_UPLOAD=0              # Booked upload speed in Mbit/s
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -717,6 +717,7 @@ GET /api/collectors/status
   "history_days": 7,
   "mqtt_host": "localhost",
   "speedtest_tracker_url": "http://...",
+  "speedtest_tls_insecure": false,
   ...
 }
 ```


### PR DESCRIPTION
## Summary
- Document `SPEEDTEST_TLS_INSECURE` in `.env.example`
- Add `speedtest_tls_insecure` to the architecture configuration example

Refs #477

## Verification
- `git diff --check`
- Documentation contract check for `.env.example` and `ARCHITECTURE.md`
