### PR TITLE
Add per-severity notification cooldowns

### DIFF
--- a/app/notifier.py
+++ b/app/notifier.py
@@ -229,13 +229,25 @@ class NotificationDispatcher:
 
     def __init__(self, config_mgr):
         self._config_mgr = config_mgr
-        self._cooldown_tracker = {}  # event_type -> last_sent_timestamp
+        # key -> last_sent_timestamp, where key is either event_type or
+        # event_type:severity when a severity-specific cooldown is configured.
+        self._cooldown_tracker = {}
 
     def _get_cooldown_overrides(self) -> dict[str, int]:
         try:
-            return json.loads(self._config_mgr.get("notify_cooldowns", "{}"))
+            data = json.loads(self._config_mgr.get("notify_cooldowns", "{}"))
         except (json.JSONDecodeError, TypeError):
             return {}
+        if not isinstance(data, dict):
+            return {}
+        return data
+
+    @staticmethod
+    def _coerce_cooldown(value, default: int) -> int:
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return default
 
     def _get_channels(self) -> list[NotificationChannel]:
         channels = []
@@ -288,30 +300,34 @@ class NotificationDispatcher:
         if event_level < min_level:
             return False
 
-        # Cooldown per event_type
+        # Cooldown per event_type and severity. Exact event_type:severity
+        # overrides take precedence. Legacy event-only overrides still provide
+        # the cooldown value for every severity of that event, but non-disabled
+        # cooldown tracking remains severity-specific.
         now = time.time()
-        key = event.get("event_type", "unknown")
-        
-        try:
-            default_cooldown = int(self._config_mgr.get("notify_cooldown", 3600))
-        except (ValueError, TypeError):
-            default_cooldown = 3600
-            
+        event_type = str(event.get("event_type", "unknown") or "unknown")
+        severity = str(event.get("severity", "info") or "info").lower()
+
+        default_cooldown = self._coerce_cooldown(
+            self._config_mgr.get("notify_cooldown", 3600),
+            3600,
+        )
+
         overrides = self._get_cooldown_overrides()
-        cooldown = overrides.get(key, default_cooldown)
-        
-        if isinstance(cooldown, str):
-            try:
-                cooldown = int(cooldown)
-            except ValueError:
-                cooldown = default_cooldown
-        
-        if cooldown == 0:  # 0 = disabled, never send this type
+        severity_key = f"{event_type}:{severity}"
+        if severity_key in overrides:
+            cooldown = overrides[severity_key]
+        else:
+            cooldown = overrides.get(event_type, default_cooldown)
+
+        cooldown = self._coerce_cooldown(cooldown, default_cooldown)
+
+        if cooldown == 0:  # 0 = disabled, never send this type/severity
             return False
-        if key in self._cooldown_tracker:
-            if (now - self._cooldown_tracker[key]) < cooldown:
+        if severity_key in self._cooldown_tracker:
+            if (now - self._cooldown_tracker[severity_key]) < cooldown:
                 return False
-        self._cooldown_tracker[key] = now
+        self._cooldown_tracker[severity_key] = now
         return True
 
     @staticmethod

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -303,7 +303,9 @@ function getFormData() {
     data.theme = document.documentElement.getAttribute('data-theme') || 'dark';
     var cooldowns = {};
     document.querySelectorAll('.notify-event-row').forEach(function(row) {
-        var key = row.getAttribute('data-event');
+        var eventKey = row.getAttribute('data-event');
+        var severity = row.getAttribute('data-severity') || '';
+        var key = severity ? eventKey + ':' + severity : eventKey;
         var toggle = row.querySelector('.notify-toggle');
         var inp = row.querySelector('.notify-cooldown-input');
         if (!toggle.checked) {
@@ -644,10 +646,12 @@ function _serializeSettingsForm(form) {
         fields.push(field);
     });
     document.querySelectorAll('.notify-event-row').forEach(function(row) {
-        var key = row.getAttribute('data-event');
+        var eventKey = row.getAttribute('data-event');
+        var severity = row.getAttribute('data-severity') || '';
+        var key = severity ? eventKey + ':' + severity : eventKey;
         var toggle = row.querySelector('.notify-toggle');
         var inp = row.querySelector('.notify-cooldown-input');
-        if (!key || !toggle || !inp) return;
+        if (!eventKey || !toggle || !inp) return;
         fields.push({
             name: 'notify_cooldown:' + key,
             id: key,
@@ -1333,17 +1337,23 @@ function initNotificationCooldownControls() {
     try {
         var saved = typeof savedCooldowns !== 'undefined' ? savedCooldowns : {};
         document.querySelectorAll('.notify-event-row').forEach(function(row) {
-            var key = row.getAttribute('data-event');
+            var eventKey = row.getAttribute('data-event');
+            var severity = row.getAttribute('data-severity') || '';
+            var key = severity ? eventKey + ':' + severity : eventKey;
             var toggle = row.querySelector('.notify-toggle');
             var inp = row.querySelector('.notify-cooldown-input');
             if (!toggle || !inp) return;
-            if (saved[key] !== undefined) {
-                if (saved[key] === 0) {
+            var savedValue = saved[key];
+            if (savedValue === undefined && severity) {
+                savedValue = saved[eventKey];
+            }
+            if (savedValue !== undefined) {
+                if (savedValue === 0) {
                     toggle.checked = false;
                     inp.disabled = true;
                     inp.style.opacity = '0.4';
                 } else {
-                    inp.value = saved[key];
+                    inp.value = savedValue;
                 }
             }
             toggle.addEventListener('change', function() {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v17';
+var CACHE_VERSION = 'v18';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/settings/notifications.html
+++ b/app/templates/settings/notifications.html
@@ -134,66 +134,37 @@
                 </tr>
             </thead>
             <tbody>
-                <tr class="notify-event-row" data-event="health_change">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="health_change" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_health_change }}</span></td>
-                    <td><span class="badge badge-danger">{{ t.severity_critical }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="health_change" min="1" step="1" placeholder="default"></td>
+                {% macro cooldown_row(event_key, event_label, severity, severity_label, badge_class) -%}
+                <tr class="notify-event-row" data-event="{{ event_key }}" data-severity="{{ severity }}">
+                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="{{ event_key }}" data-severity="{{ severity }}" checked><span class="toggle-slider"></span></label></td>
+                    <td><span class="event-name">{{ event_label }}</span></td>
+                    <td><span class="badge {{ badge_class }}">{{ severity_label }}</span></td>
+                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="{{ event_key }}" data-severity="{{ severity }}" min="1" step="1" placeholder="default"></td>
                 </tr>
-                <tr class="notify-event-row" data-event="power_change">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="power_change" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_power_change }}</span></td>
-                    <td><span class="badge badge-warning">{{ t.severity_warning }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="power_change" min="1" step="1" placeholder="default"></td>
-                </tr>
-                <tr class="notify-event-row" data-event="snr_change">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="snr_change" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_snr_change }}</span></td>
-                    <td><span class="badge badge-warning">{{ t.severity_warning }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="snr_change" min="1" step="1" placeholder="default"></td>
-                </tr>
-                <tr class="notify-event-row" data-event="channel_change">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="channel_change" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_channel_change }}</span></td>
-                    <td><span class="badge badge-muted">{{ t.severity_info }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="channel_change" min="1" step="1" placeholder="default"></td>
-                </tr>
-                <tr class="notify-event-row" data-event="modulation_change">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="modulation_change" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_modulation_change }}</span></td>
-                    <td><span class="badge badge-muted">{{ t.severity_info }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="modulation_change" min="1" step="1" placeholder="default"></td>
-                </tr>
-                <tr class="notify-event-row" data-event="device_reboot">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="device_reboot" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_device_reboot }}</span></td>
-                    <td><span class="badge badge-warning">{{ t.severity_warning }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="device_reboot" min="1" step="1" placeholder="default"></td>
-                </tr>
-                <tr class="notify-event-row" data-event="device_sw_update">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="device_sw_update" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_device_sw_update }}</span></td>
-                    <td><span class="badge badge-muted">{{ t.severity_info }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="device_sw_update" min="1" step="1" placeholder="default"></td>
-                </tr>
-                <tr class="notify-event-row" data-event="device_ip_change">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="device_ip_change" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_device_ip_change }}</span></td>
-                    <td><span class="badge badge-muted">{{ t.severity_info }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="device_ip_change" min="1" step="1" placeholder="default"></td>
-                </tr>
-                <tr class="notify-event-row" data-event="error_spike">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="error_spike" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_error_spike }}</span></td>
-                    <td><span class="badge badge-danger">{{ t.severity_critical }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="error_spike" min="1" step="1" placeholder="default"></td>
-                </tr>
-                <tr class="notify-event-row" data-event="monitoring_started">
-                    <td><label class="toggle"><input type="checkbox" class="notify-toggle" data-event="monitoring_started" checked><span class="toggle-slider"></span></label></td>
-                    <td><span class="event-name">{{ t.notify_event_monitoring_started }}</span></td>
-                    <td><span class="badge badge-success">{{ t.severity_success }}</span></td>
-                    <td><input type="number" class="form-input cooldown-input notify-cooldown-input" data-event="monitoring_started" min="1" step="1" placeholder="default"></td>
-                </tr>
+                {%- endmacro %}
+
+                {% set severity_rows = [
+                    ('info', t.severity_info, 'badge-muted'),
+                    ('warning', t.severity_warning, 'badge-warning'),
+                    ('critical', t.severity_critical, 'badge-danger'),
+                ] %}
+                {% for event_key, event_label in [
+                    ('health_change', t.notify_event_health_change),
+                    ('power_change', t.notify_event_power_change),
+                    ('snr_change', t.notify_event_snr_change),
+                    ('modulation_change', t.notify_event_modulation_change),
+                ] %}
+                    {% for severity, severity_label, badge_class in severity_rows %}
+                        {{ cooldown_row(event_key, event_label, severity, severity_label, badge_class) }}
+                    {% endfor %}
+                {% endfor %}
+                {{ cooldown_row('channel_change', t.notify_event_channel_change, 'info', t.severity_info, 'badge-muted') }}
+                {{ cooldown_row('device_reboot', t.notify_event_device_reboot, 'warning', t.severity_warning, 'badge-warning') }}
+                {{ cooldown_row('device_sw_update', t.notify_event_device_sw_update, 'info', t.severity_info, 'badge-muted') }}
+                {{ cooldown_row('device_ip_change', t.notify_event_device_ip_change, 'info', t.severity_info, 'badge-muted') }}
+                {{ cooldown_row('cm_packet_loss_warning', t.event_type_cm_packet_loss_warning, 'warning', t.severity_warning, 'badge-warning') }}
+                {{ cooldown_row('error_spike', t.notify_event_error_spike, 'warning', t.severity_warning, 'badge-warning') }}
+                {{ cooldown_row('monitoring_started', t.notify_event_monitoring_started, 'info', t.severity_info, 'badge-success') }}
             </tbody>
         </table>
         <span class="form-hint" style="display:block;margin-top:var(--space-md);">{{ t.notify_disabled_hint }}</span>

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -69,6 +69,33 @@ class TestSettingsFormElements:
         expect(settings_page.locator('#notify_apprise_token')).to_have_count(1)
         expect(settings_page.locator('#notify_apprise_tag')).to_have_count(1)
 
+    def test_notifications_panel_has_per_severity_cooldown_rows(self, settings_page):
+        settings_page.locator('button[data-section="notifications"]').click()
+
+        for event_type in [
+            "health_change",
+            "power_change",
+            "snr_change",
+            "modulation_change",
+        ]:
+            for severity in ["info", "warning", "critical"]:
+                expect(
+                    settings_page.locator(
+                        f'.notify-event-row[data-event="{event_type}"][data-severity="{severity}"]'
+                    )
+                ).to_have_count(1)
+
+        expect(
+            settings_page.locator(
+                '.notify-event-row[data-event="cm_packet_loss_warning"][data-severity="warning"]'
+            )
+        ).to_have_count(1)
+        expect(
+            settings_page.locator(
+                '.notify-event-row[data-event="error_spike"][data-severity="warning"]'
+            )
+        ).to_have_count(1)
+
 
 class TestSettingsDirtyState:
     """Unsaved-change prompts only appear for deliberate settings edits."""
@@ -289,13 +316,13 @@ class TestSettingsInstantToggleSave:
         settings_page.route("**/api/config", capture_config)
         settings_page.locator('button[data-section="notifications"]').click()
         with settings_page.expect_request("**/api/config"):
-            settings_page.locator('.notify-event-row[data-event="health_change"] .toggle-slider').click()
+            settings_page.locator('.notify-event-row[data-event="health_change"][data-severity="critical"] .toggle-slider').click()
 
         footer = settings_page.locator("#save-footer")
         expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
         assert len(config_payloads) == 1
         cooldowns = config_payloads[0]["notify_cooldowns"]
-        assert '"health_change":0' in cooldowns.replace(" ", "")
+        assert '"health_change:critical":0' in cooldowns.replace(" ", "")
 
     def test_notification_cooldown_value_saves_immediately(self, settings_page):
         config_payloads = []
@@ -306,15 +333,15 @@ class TestSettingsInstantToggleSave:
 
         settings_page.route("**/api/config", capture_config)
         settings_page.locator('button[data-section="notifications"]').click()
-        settings_page.locator('.notify-event-row[data-event="power_change"] .notify-cooldown-input').fill('42')
+        settings_page.locator('.notify-event-row[data-event="power_change"][data-severity="warning"] .notify-cooldown-input').fill('42')
         with settings_page.expect_request("**/api/config"):
-            settings_page.locator('.notify-event-row[data-event="power_change"] .notify-cooldown-input').blur()
+            settings_page.locator('.notify-event-row[data-event="power_change"][data-severity="warning"] .notify-cooldown-input').blur()
 
         footer = settings_page.locator("#save-footer")
         expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
         assert len(config_payloads) == 1
         cooldowns = config_payloads[0]["notify_cooldowns"]
-        assert '"power_change":42' in cooldowns.replace(" ", "")
+        assert '"power_change:warning":42' in cooldowns.replace(" ", "")
 
     def test_notification_event_toggle_stays_dirty_when_instant_save_fails(self, settings_page):
         def fail_config(route):
@@ -323,7 +350,7 @@ class TestSettingsInstantToggleSave:
         settings_page.route("**/api/config", fail_config)
         settings_page.locator('button[data-section="notifications"]').click()
         with settings_page.expect_request("**/api/config"):
-            settings_page.locator('.notify-event-row[data-event="health_change"] .toggle-slider').click()
+            settings_page.locator('.notify-event-row[data-event="health_change"][data-severity="critical"] .toggle-slider').click()
 
         footer = settings_page.locator("#save-footer")
         expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
@@ -339,7 +366,7 @@ class TestSettingsInstantToggleSave:
         settings_page.route("**/api/config", capture_config)
         settings_page.locator('button[data-section="notifications"]').click()
         with settings_page.expect_request("**/api/config"):
-            settings_page.locator('.notify-event-row[data-event="health_change"] .toggle-slider').click()
+            settings_page.locator('.notify-event-row[data-event="health_change"][data-severity="critical"] .toggle-slider').click()
         settings_page.locator('button[data-section="connection"]').click()
         settings_page.locator('#modem_url').fill('http://192.168.100.1')
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -487,3 +487,50 @@ class TestDispatcherChannelSetup:
         assert result == {"success": False, "error": "AppriseChannel: HTTP 401"}
         assert key_marker not in result.get("error", "")
         assert apprise_token_marker not in result.get("error", "")
+
+
+class TestDispatcherSeverityCooldowns:
+    def _make_config(self, cooldowns, default_cooldown="3600"):
+        cfg = MagicMock()
+        cfg.get.side_effect = lambda key, default=None: {
+            "notify_min_severity": "info",
+            "notify_cooldown": default_cooldown,
+            "notify_cooldowns": json.dumps(cooldowns),
+        }.get(key, default)
+        return cfg
+
+    def test_default_cooldown_is_tracked_independently_by_severity(self):
+        dispatcher = NotificationDispatcher(self._make_config({}))
+
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "info"}) is True
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "critical"}) is True
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "info"}) is False
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "critical"}) is False
+
+    def test_severity_specific_cooldowns_are_tracked_independently(self):
+        dispatcher = NotificationDispatcher(self._make_config({
+            "modulation_change:info": 3600,
+            "modulation_change:critical": 3600,
+        }))
+
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "info"}) is True
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "critical"}) is True
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "info"}) is False
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "critical"}) is False
+
+    def test_legacy_event_cooldown_value_is_tracked_independently_by_severity(self):
+        dispatcher = NotificationDispatcher(self._make_config({"modulation_change": 3600}))
+
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "info"}) is True
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "critical"}) is True
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "info"}) is False
+        assert dispatcher._should_send({"event_type": "modulation_change", "severity": "critical"}) is False
+
+    def test_severity_specific_disable_does_not_disable_other_severities(self):
+        dispatcher = NotificationDispatcher(self._make_config({
+            "health_change:info": 0,
+            "health_change:critical": 3600,
+        }))
+
+        assert dispatcher._should_send({"event_type": "health_change", "severity": "info"}) is False
+        assert dispatcher._should_send({"event_type": "health_change", "severity": "critical"}) is True

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -74,7 +74,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v17';" in sw_js
+    assert "var CACHE_VERSION = 'v18';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js


### PR DESCRIPTION
## Summary
- add event+severity notification cooldown handling while keeping legacy event-level cooldown values as fallbacks
- expand notification settings rows for Info, Warning, and Critical where needed
- save cooldown overrides with `event_type:severity` keys and bump the PWA cache version

## Verification
- `uv run --with-requirements requirements-test.txt pytest -q --ignore=tests/e2e`
- `uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright pytest -q tests/e2e`

Closes #480