### PR TITLE
fix(modulation): bound 30-day x-axis labels

### DIFF
--- a/app/modules/modulation/static/main.js
+++ b/app/modules/modulation/static/main.js
@@ -105,6 +105,27 @@ function lowQamLegendHintForContext(pg) {
     return '';
 }
 
+function buildModulationXAxisTicks(labels, width) {
+    var count = labels ? labels.length : 0;
+    if (count <= 0) return [];
+    var maxTicks = 6;
+    if (typeof calculateMaxXTicks === 'function') {
+        maxTicks = calculateMaxXTicks(labels, width, 40, 8);
+    }
+    if (typeof buildEvenIndexTicks === 'function') {
+        return buildEvenIndexTicks(labels.length, maxTicks);
+    }
+    if (count <= maxTicks) {
+        var all = [];
+        for (var ai = 0; ai < count; ai++) all.push(ai);
+        return all;
+    }
+    var ticks = [];
+    var gap = (count - 1) / (maxTicks - 1);
+    for (var ti = 0; ti < maxTicks; ti++) ticks.push(Math.round(ti * gap));
+    return ticks;
+}
+
 var MODULATION_LEVELS = [
     '4QAM',
     '8QAM',
@@ -415,6 +436,7 @@ function renderGroupDistChart(pg, idx) {
 
     var w = container.offsetWidth || 400;
     var h = container.offsetHeight || 300;
+    var xSplits = buildModulationXAxisTicks(labels, w);
     var chart = new uPlot({
         width: w,
         height: h,
@@ -425,7 +447,7 @@ function renderGroupDistChart(pg, idx) {
         axes: [
             {
                 scale: 'x',
-                splits: function() { return xData; },
+                splits: function() { return xSplits; },
                 values: function(u, vals) { return vals.map(function(v) { return labels[v] || ''; }); },
                 stroke: textColor,
                 grid: { show: false },
@@ -491,6 +513,7 @@ function renderGroupTrendChart(pg, idx) {
 
     var w = container.offsetWidth || 400;
     var h = container.offsetHeight || 300;
+    var xSplits = buildModulationXAxisTicks(labels, w);
     var chart = new uPlot({
         width: w,
         height: h,
@@ -502,7 +525,7 @@ function renderGroupTrendChart(pg, idx) {
         axes: [
             {
                 scale: 'x',
-                splits: function() { return xData; },
+                splits: function() { return xSplits; },
                 values: function(u, vals) { return vals.map(function(v) { return labels[v] || ''; }); },
                 stroke: textColor,
                 grid: { show: false },

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v19';
+var CACHE_VERSION = 'v20';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -230,6 +230,28 @@ class TestModulationControls:
         self.page.wait_for_timeout(300)
         assert "active" in d30.get_attribute("class")
 
+    def test_30_day_charts_bound_x_axis_labels(self):
+        d30 = self.page.locator('#modulation-range-tabs .trend-tab[data-days="30"]')
+        d30.click()
+        self.page.wait_for_timeout(1000)
+
+        chart_tick_counts = self.page.evaluate(
+            """
+            () => (window._modCharts || []).map((chart) => {
+                const samples = chart.data && chart.data[0] ? chart.data[0].length : 0;
+                const axis = chart.axes && chart.axes[0];
+                const ticks = axis && axis.splits ? axis.splits(chart).length : 0;
+                return {samples, ticks};
+            })
+            """
+        )
+
+        dense_charts = [item for item in chart_tick_counts if item["samples"] >= 30]
+        assert dense_charts, f"Expected 30-day charts, got {chart_tick_counts}"
+        for item in dense_charts:
+            assert item["ticks"] < item["samples"], item
+            assert item["ticks"] <= 8, item
+
     def test_switch_direction_then_back(self):
         ds = self.page.locator('#modulation-direction-tabs .trend-tab[data-dir="ds"]')
         us = self.page.locator('#modulation-direction-tabs .trend-tab[data-dir="us"]')

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -8,6 +8,7 @@ VIEWS_CSS = ROOT / "app" / "static" / "css" / "views.css"
 CORRELATION_JS = ROOT / "app" / "static" / "js" / "correlation.js"
 CHART_ENGINE_JS = ROOT / "app" / "static" / "js" / "chart-engine.js"
 CHANNELS_JS = ROOT / "app" / "static" / "js" / "channels.js"
+MODULATION_MAIN_JS = ROOT / "app" / "modules" / "modulation" / "static" / "main.js"
 SW_JS = ROOT / "app" / "static" / "sw.js"
 MAIN_CSS = ROOT / "app" / "static" / "css" / "main.css"
 INDEX_HTML = ROOT / "app" / "templates" / "index.html"
@@ -74,10 +75,11 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v19';" in sw_js
+    assert "var CACHE_VERSION = 'v20';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js
+    assert "/modules/docsight.modulation/static/main.js" in sw_js
 
 
 def test_chart_engine_has_configurable_axis_padding_for_long_qam_labels():
@@ -107,6 +109,22 @@ def test_chart_zoom_uses_bounded_index_ticks_instead_of_all_samples():
     assert "var zoomXSplits = buildEvenIndexTicks(n, zoomMaxTicks);" in zoom_block
     assert "for (var i = 0; i < n; i++) o.push(i); return o;" not in zoom_block
     assert "filter: xTickValues" not in zoom_block
+
+
+def test_modulation_overview_charts_bound_daily_x_axis_ticks():
+    js = MODULATION_MAIN_JS.read_text(encoding="utf-8")
+    dist_block = js[js.index("function renderGroupDistChart") : js.index("function attachModulationDayClick")]
+    trend_block = js[js.index("function renderGroupTrendChart") : js.index("/* ── Intraday")]
+
+    assert "function buildModulationXAxisTicks" in js
+    assert "calculateMaxXTicks(labels, width" in js
+    assert "buildEvenIndexTicks(labels.length" in js
+    assert "var xSplits = buildModulationXAxisTicks(labels, w);" in dist_block
+    assert "var xSplits = buildModulationXAxisTicks(labels, w);" in trend_block
+    assert "splits: function() { return xSplits; }" in dist_block
+    assert "splits: function() { return xSplits; }" in trend_block
+    assert "splits: function() { return xData; }" not in dist_block
+    assert "splits: function() { return xData; }" not in trend_block
 
 
 def test_dashboard_i18n_keys_exist_in_all_language_files():


### PR DESCRIPTION
## Summary
- Limit Modulation Performance daily overview x-axis ticks so 30-day labels stay readable.
- Apply the bounded tick generation to both distribution and trend overview charts.
- Bump the service-worker cache version for the updated module script.

## Tests
- `pytest -q tests/test_static_contracts.py::test_static_cache_version_was_bumped_for_ui_followup_assets tests/test_static_contracts.py::test_modulation_overview_charts_bound_daily_x_axis_ticks`
- `TZ=UTC pytest -q tests/e2e/test_modulation.py::TestModulationControls::test_30_day_charts_bound_x_axis_labels`
- `git diff --check`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e`

Closes #495
