### PR TITLE
fix(deps): update test idna pin

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -356,9 +356,9 @@ fpdf2==2.8.7 \
     --hash=sha256:7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9 \
     --hash=sha256:d391fc508a3ce02fc43a577c830cda4fe6f37646f2d143d489839940932fbc19
     # via -r requirements.in
-idna==3.11 \
-    --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
-    --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via requests
 iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \


### PR DESCRIPTION
## Summary
- Updates the test dependency lockfile to use `idna==3.15`, matching the runtime lockfile.
- Refreshes the pinned hashes for the fixed `idna` release.
- Addresses Dependabot alert #13 for GHSA-65pc-fj4g-8rjx / CVE-2026-45409.

## Validation
- `python -m pip install --dry-run --require-hashes -r requirements-test.txt`
- `uvx pip-audit -r requirements-test.txt`
- `uvx pip-audit -r requirements.txt`
- `git diff --check`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e`
