### PR TITLE
fix: redact PWA subscription validation errors

### DIFF
--- a/app/blueprints/polling_bp.py
+++ b/app/blueprints/polling_bp.py
@@ -149,8 +149,8 @@ def api_pwa_push_subscribe():
             subscription,
             user_agent=request.headers.get("User-Agent", "")[:500],
         )
-    except ValueError as exc:
-        return jsonify({"success": False, "error": str(exc)}), 400
+    except ValueError:
+        return jsonify({"success": False, "error": "Invalid Web Push subscription"}), 400
     return jsonify({"success": True, "subscription_count": storage.count_pwa_push_subscriptions(), "id": record["id"]})
 
 

--- a/tests/test_pwa_web_push.py
+++ b/tests/test_pwa_web_push.py
@@ -99,7 +99,8 @@ def test_pwa_push_subscribe_and_unsubscribe_api_validates_subscription(tmp_path)
     insecure_subscription = {**VALID_SUBSCRIPTION, "endpoint": "http://push.example.test/send/abc123"}
     insecure = client.post("/api/notifications/pwa/subscribe", json={"subscription": insecure_subscription})
     assert insecure.status_code == 400
-    assert "HTTPS" in insecure.get_json()["error"]
+    assert insecure.get_json()["error"] == "Invalid Web Push subscription"
+    assert "HTTPS" not in json.dumps(insecure.get_json())
 
     subscribed = client.post("/api/notifications/pwa/subscribe", json={"subscription": VALID_SUBSCRIPTION})
     assert subscribed.status_code == 200


### PR DESCRIPTION
## Summary
- Redacts PWA Web Push subscription validation failures behind the existing generic API error.
- Keeps server-side HTTPS validation while avoiding exception detail exposure in client responses.
- Updates the regression test to assert the public response does not include validation internals.

## Validation
- `uv run --with-requirements requirements-test.txt pytest -q tests/test_pwa_web_push.py tests/web/test_config_api.py --tb=short`
- `uv run --with-requirements requirements-test.txt pytest -q tests/test_pwa_web_push.py tests/test_pwa_contract.py tests/test_config.py tests/test_settings_secret_fields.py tests/web/test_config_api.py --tb=short`
- `git diff --check`

Follow-up for CodeQL finding from #498.
