### PR TITLE
fix: sanitize notification test exceptions

### DIFF
--- a/app/notifier.py
+++ b/app/notifier.py
@@ -469,7 +469,12 @@ class NotificationDispatcher:
                         f"{type(channel).__name__}: {detail or 'send returned false'}",
                     )
             except Exception as e:
-                errors.append(f"{type(channel).__name__}: {e}")
+                log.warning(
+                    "Notification test failed for channel %s: %s",
+                    type(channel).__name__,
+                    type(e).__name__,
+                )
+                errors.append(f"{type(channel).__name__}: test failed; check server logs")
         if errors:
             return {"success": False, "error": "; ".join(errors)}
         return {"success": True}

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -488,6 +488,23 @@ class TestDispatcherChannelSetup:
         assert key_marker not in result.get("error", "")
         assert apprise_token_marker not in result.get("error", "")
 
+    def test_test_notification_returns_generic_error_for_unexpected_channel_exception(self, monkeypatch):
+        class BrokenChannel:
+            def send(self, payload):
+                raise RuntimeError("secret-token-123 / internal/path")
+
+        dispatcher = NotificationDispatcher(self._make_config(None))
+        monkeypatch.setattr(dispatcher, "_get_channels", lambda: [BrokenChannel()])
+
+        result = dispatcher.test()
+
+        assert result == {
+            "success": False,
+            "error": "BrokenChannel: test failed; check server logs",
+        }
+        assert "secret-token-123" not in result.get("error", "")
+        assert "internal/path" not in result.get("error", "")
+
 
 class TestDispatcherSeverityCooldowns:
     def _make_config(self, cooldowns, default_cooldown="3600"):


### PR DESCRIPTION
## Summary
- Return a generic client-facing error when a notification test channel raises an unexpected exception
- Keep sanitized channel `_last_error` details for known send failures
- Add regression coverage proving exception details are not exposed in the test response

## Test plan
- `pytest tests/test_notifier.py::TestDispatcherChannelSetup::test_test_notification_returns_generic_error_for_unexpected_channel_exception -q`
- `pytest -q tests/test_notifier.py`
- `git diff --check && pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e`

Addresses code scanning alert #79.