### PR TITLE
fix: keep instant settings saves silent

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -714,7 +714,10 @@ function runDemoMigration() {
 
 /* ── Unsaved Changes ── */
 var _formDirty = false;
+var _manualDirty = false;
 var _formBaseline = null;
+var _manualFormBaseline = null;
+var _instantSaveFailedDirty = false;
 var _secretEditVersionCounter = 0;
 
 function _isSavedSecretField(el) {
@@ -753,18 +756,21 @@ function _normalizedFormValue(el) {
     return el.value || '';
 }
 
-function _serializeSettingsForm(form) {
+function _serializeSettingsForm(form, options) {
     if (!form) return '[]';
+    options = options || {};
+    var ignoreInstantSaveControls = options.ignoreInstantSaveControls === true;
     var fields = [];
     Array.prototype.forEach.call(form.elements, function(el) {
         if (!el.name || el.type === 'submit' || el.type === 'button' || el.type === 'file') return;
+        if (ignoreInstantSaveControls && _isInstantSaveControl(el)) return;
         var field = { name: el.name, id: el.getAttribute('data-module-id') || '', type: el.type || el.tagName, value: _normalizedFormValue(el) };
         if (_isSavedSecretField(el) && el.dataset.userEditedSecret) {
             field.secretEditVersion = el.dataset.secretEditVersion || '';
         }
         fields.push(field);
     });
-    document.querySelectorAll('.notify-event-row').forEach(function(row) {
+    if (!ignoreInstantSaveControls) document.querySelectorAll('.notify-event-row').forEach(function(row) {
         var eventKey = row.getAttribute('data-event');
         var severity = row.getAttribute('data-severity') || '';
         var key = severity ? eventKey + ':' + severity : eventKey;
@@ -784,15 +790,53 @@ function _serializeSettingsForm(form) {
     return JSON.stringify(fields);
 }
 
+function _serializeManualSettingsForm(form) {
+    return _serializeSettingsForm(form, { ignoreInstantSaveControls: true });
+}
+
+function _isInstantSaveFieldRecord(field, form) {
+    if (!field || !form) return false;
+    if (field.type === 'notification-cooldown') return true;
+    return Array.prototype.some.call(form.elements, function(el) {
+        if (!el || el.name !== field.name || !_isInstantSaveControl(el)) return false;
+        var moduleId = el.getAttribute('data-module-id') || '';
+        return (field.id || '') === moduleId && (el.type || el.tagName) === field.type;
+    });
+}
+
+function _manualBaselineFromSerialized(serializedBaseline, form) {
+    if (!form) return '[]';
+    try {
+        var fields = JSON.parse(serializedBaseline || '[]').filter(function(field) {
+            return !_isInstantSaveFieldRecord(field, form);
+        });
+        fields.sort(function(a, b) {
+            return (a.name + ':' + a.id + ':' + a.type).localeCompare(b.name + ':' + b.id + ':' + b.type);
+        });
+        return JSON.stringify(fields);
+    } catch(e) {
+        return _serializeManualSettingsForm(form);
+    }
+}
+
 function _captureFormBaseline() {
     var form = document.getElementById('settings-form');
     _formBaseline = _serializeSettingsForm(form);
+    _manualFormBaseline = _serializeManualSettingsForm(form);
+}
+
+function _hasManualDirtyChanges() {
+    var form = document.getElementById('settings-form');
+    if (!form) return false;
+    if (_manualFormBaseline === null) _captureFormBaseline();
+    return _serializeManualSettingsForm(form) !== _manualFormBaseline;
 }
 
 function _syncSaveFooter() {
     var footer = document.getElementById('save-footer');
     if (!footer) return;
-    if (_formDirty && !_saveHiddenSections[_currentSection]) {
+    var shouldShowFooter = _formDirty && !_saveHiddenSections[_currentSection] && (_instantSaveFailedDirty || _manualDirty);
+    if (shouldShowFooter) {
         footer.classList.add('visible');
         footer.removeAttribute('aria-hidden');
         footer.removeAttribute('inert');
@@ -803,12 +847,32 @@ function _syncSaveFooter() {
     }
 }
 
-function _updateDirtyState() {
+function _updateDirtyState(options) {
+    options = options || {};
     var form = document.getElementById('settings-form');
     if (!form) return;
     if (_formBaseline === null) _captureFormBaseline();
     _formDirty = _serializeSettingsForm(form) !== _formBaseline;
+    if (options.updateManualDirty !== false) {
+        _manualDirty = _hasManualDirtyChanges();
+    }
     _syncSaveFooter();
+}
+
+function _isInstantSaveControl(el) {
+    if (!el || !el.matches) return false;
+    if (el.id === 'theme-toggle-appearance') return false;
+    return el.matches([
+        'label.toggle input[type="checkbox"]',
+        'label.switch input[type="checkbox"]',
+        '.module-toggle-input',
+        '.notify-toggle',
+        '.notify-cooldown-input'
+    ].join(','));
+}
+
+function _isInstantSaveDirtyEvent(e) {
+    return _isInstantSaveControl(e && e.target);
 }
 
 function initUnsavedDetection() {
@@ -819,6 +883,10 @@ function initUnsavedDetection() {
         if (_shouldTreatSavedSecretEventAsUserEdit(e)) {
             e.target.dataset.userEditedSecret = 'true';
             e.target.dataset.secretEditVersion = String(++_secretEditVersionCounter);
+        }
+        if (_isInstantSaveDirtyEvent(e)) {
+            _updateDirtyState({ updateManualDirty: false });
+            return;
         }
         _updateDirtyState();
     }
@@ -851,6 +919,8 @@ function clearDirty() {
     _resetEditedSavedSecrets();
     _captureFormBaseline();
     _formDirty = false;
+    _manualDirty = false;
+    _instantSaveFailedDirty = false;
     _syncSaveFooter();
 }
 
@@ -938,7 +1008,9 @@ function _savedSecretVersionsFromBaseline(serializedBaseline) {
     return versions;
 }
 
-function _finishSettingsSave(savedFormBaseline) {
+function _finishSettingsSave(savedFormBaseline, options) {
+    options = options || {};
+    var showSuccessToast = options.showSuccessToast !== false;
     var form = document.getElementById('settings-form');
     if (!savedFormBaseline || !form) {
         clearDirty();
@@ -948,14 +1020,19 @@ function _finishSettingsSave(savedFormBaseline) {
         _resetEditedSavedSecrets(savedSecretVersions);
         if (_serializeSettingsForm(form) === savedBaseline) {
             _formBaseline = savedBaseline;
+            _manualFormBaseline = _manualBaselineFromSerialized(savedBaseline, form);
+            _instantSaveFailedDirty = false;
+            _manualDirty = false;
             _formDirty = false;
             _syncSaveFooter();
         } else {
             _formBaseline = savedBaseline;
-            _updateDirtyState();
+            _manualFormBaseline = _manualBaselineFromSerialized(savedBaseline, form);
+            _instantSaveFailedDirty = false;
+            _updateDirtyState({ updateManualDirty: false });
         }
     }
-    showToast(T.settings_saved || 'Settings saved', true);
+    if (showSuccessToast) showToast(T.settings_saved || 'Settings saved', true);
     var newLang = document.getElementById('language').value;
     var newTz = document.getElementById('timezone').value;
     if (newLang !== currentLang || newTz !== currentTz) {
@@ -963,7 +1040,7 @@ function _finishSettingsSave(savedFormBaseline) {
     }
 }
 
-function _saveAllSettings() {
+function _saveAllSettings(options) {
     var form = document.getElementById('settings-form');
     var data = getFormData();
     var savedFormBaseline = _serializeSettingsForm(form);
@@ -981,7 +1058,7 @@ function _saveAllSettings() {
         return _saveModuleStatesIfNeeded(moduleStates);
     })
     .then(function() {
-        _finishSettingsSave(savedFormBaseline);
+        _finishSettingsSave(savedFormBaseline, options);
         return true;
     });
 }
@@ -1006,9 +1083,9 @@ function _saveForm() {
 
 var _settingsSaveQueue = Promise.resolve();
 
-function _enqueueSettingsSave() {
+function _enqueueSettingsSave(options) {
     _settingsSaveQueue = _settingsSaveQueue.catch(function() { return true; }).then(function() {
-        return _saveAllSettings();
+        return _saveAllSettings(options);
     });
     return _settingsSaveQueue;
 }
@@ -1016,12 +1093,13 @@ function _enqueueSettingsSave() {
 function _saveSettingsInstantly() {
     var errEl = document.getElementById('global-error');
     if (errEl) errEl.style.display = 'none';
-    return _enqueueSettingsSave().catch(function(err) {
+    return _enqueueSettingsSave({ showSuccessToast: false }).catch(function(err) {
         if (errEl) {
             errEl.textContent = err.message || T.network_error;
             errEl.style.display = 'block';
         }
-        _updateDirtyState();
+        _instantSaveFailedDirty = true;
+        _updateDirtyState({ updateManualDirty: false });
         return false;
     });
 }
@@ -1524,6 +1602,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     _captureFormBaseline();
     _formDirty = false;
+    _manualDirty = false;
 
     /* Restore section from URL hash, default to connection */
     var hash = location.hash.replace('#', '');

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v21';
+var CACHE_VERSION = 'v22';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -343,6 +343,105 @@ class TestSettingsInstantToggleSave:
         assert len(batch_payloads[0]["modules"]) == 1
         assert immediate_calls == []
 
+    def test_normal_instant_toggle_does_not_flash_manual_save_footer_while_save_is_pending(self, settings_page):
+        pending_routes = []
+
+        def hold_config(route):
+            pending_routes.append(route)
+
+        settings_page.route("**/api/config", hold_config)
+        settings_page.locator('button[data-section="notifications"]').click()
+        footer = settings_page.locator("#save-footer")
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('#notify_apprise_enabled + .toggle-slider').click()
+
+        assert settings_page.evaluate("() => window._formDirty") is True
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        expect(footer).to_have_attribute("aria-hidden", "true")
+        expect(footer).to_have_attribute("inert", "")
+        assert len(pending_routes) == 1
+        pending_routes[0].fulfill(json={"success": True})
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+    def test_normal_instant_toggle_success_does_not_show_settings_saved_toast(self, settings_page):
+        settings_page.route("**/api/config", lambda route: route.fulfill(json={"success": True}))
+        settings_page.locator('button[data-section="notifications"]').click()
+
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('#notify_apprise_enabled + .toggle-slider').click()
+
+        toast = settings_page.locator("#toast")
+        expect(toast).not_to_be_visible()
+        expect(toast).not_to_have_text(re.compile(r"Settings saved", re.I))
+
+    def test_queued_instant_toggles_keep_manual_save_footer_hidden_between_saves(self, settings_page):
+        pending_routes = []
+
+        def hold_config(route):
+            pending_routes.append(route)
+
+        settings_page.route("**/api/config", hold_config)
+        settings_page.locator('button[data-section="notifications"]').click()
+        footer = settings_page.locator("#save-footer")
+
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('#notify_apprise_enabled + .toggle-slider').click()
+        settings_page.evaluate(
+            """
+            () => {
+              const toggle = document.querySelector('#notify_pwa_push_enabled');
+              toggle.checked = !toggle.checked;
+              window._saveSettingsInstantly();
+            }
+            """
+        )
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+        with settings_page.expect_request("**/api/config"):
+            pending_routes[0].fulfill(json={"success": True})
+        settings_page.wait_for_timeout(50)
+
+        assert len(pending_routes) == 2
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        pending_routes[1].fulfill(json={"success": True})
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+    def test_notification_cooldown_edit_keeps_dirty_protection_until_change_save_succeeds(self, settings_page):
+        settings_page.route("**/api/config", lambda route: route.fulfill(json={"success": True}))
+        settings_page.locator('button[data-section="notifications"]').click()
+        input_el = settings_page.locator('.notify-event-row[data-event="power_change"][data-severity="warning"] .notify-cooldown-input')
+        footer = settings_page.locator("#save-footer")
+
+        input_el.fill('42')
+        assert settings_page.evaluate("() => window._formDirty") is True
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        with settings_page.expect_request("**/api/config"):
+            input_el.blur()
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+        assert settings_page.evaluate("() => window._formDirty") is False
+
+    def test_hidden_companion_instant_toggle_does_not_poison_manual_dirty_baseline(self, settings_page):
+        settings_page.route("**/api/config", lambda route: route.fulfill(json={"success": True}))
+        settings_page.locator('button[data-section="extensions"]').click()
+        footer = settings_page.locator("#save-footer")
+        instant_toggle = settings_page.locator('#panel-extensions label.toggle input[type="checkbox"]:not(.module-toggle-input)').first
+        expect(instant_toggle).to_have_count(1)
+
+        with settings_page.expect_request("**/api/config"):
+            instant_toggle.evaluate("el => { el.checked = !el.checked; el.dispatchEvent(new Event('change', {bubbles: true})); }")
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+        settings_page.locator('button[data-section="general"]').click()
+        manual_field = settings_page.locator('#poll_interval')
+        original_value = manual_field.input_value()
+        edited_value = "901" if original_value != "901" else "902"
+        manual_field.fill(edited_value)
+        expect(footer).to_have_class(re.compile(r".*\bvisible\b.*"))
+        manual_field.fill(original_value)
+        expect(footer).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
     def test_notification_event_toggle_saves_cooldowns_immediately(self, settings_page):
         config_payloads = []
 

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -75,7 +75,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v21';" in sw_js
+    assert "var CACHE_VERSION = 'v22';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js


### PR DESCRIPTION
## Summary
- Keeps successful instant-save settings controls silent, without flashing the manual save footer or showing the generic success toast.
- Separates full dirty protection from manual-save footer visibility so pending and failed instant saves still keep retry protection.
- Covers queued instant saves, cooldown input edits before blur, and checkbox controls with hidden companion fields.
- Bumps the service worker cache version for the changed settings JavaScript.

## Test plan
- `git diff --check`
- `node --check app/static/js/settings.js && node --check app/static/sw.js`
- `uv run --with-requirements requirements-test.txt python -m pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright python -m pytest -q tests/e2e --tb=short`

Refs #469
