### PR TITLE
fix: align monitor disabled state and trend fills

### DIFF
--- a/app/modules/connection_monitor/routes.py
+++ b/app/modules/connection_monitor/routes.py
@@ -455,6 +455,10 @@ def api_get_range_stats():
 @bp.route("/api/connection-monitor/summary")
 @require_auth
 def api_get_summary():
+    cfg = get_config_manager()
+    if cfg is not None and not cfg.get("connection_monitor_enabled", False):
+        return jsonify({})
+
     storage = _get_cm_storage()
     targets = storage.get_targets()
     summaries = {}

--- a/app/modules/connection_monitor/static/js/connection-monitor-card.js
+++ b/app/modules/connection_monitor/static/js/connection-monitor-card.js
@@ -27,6 +27,12 @@
                 }
 
                 var enabled = targets.filter(function(t) { return t.enabled; });
+                if (enabled.length === 0) {
+                    statusEl.textContent = '—';
+                    detailsEl.textContent = '';
+                    return;
+                }
+
                 var ok = enabled.filter(function(t) { return (t.packet_loss_pct || 0) === 0; });
                 var degraded = enabled.filter(function(t) {
                     var loss = t.packet_loss_pct || 0;

--- a/app/static/js/chart-engine.js
+++ b/app/static/js/chart-engine.js
@@ -53,6 +53,13 @@ function chartXRange(u) {
     return { min: xData[0] - edgePadding, max: xData[xData.length - 1] + edgePadding };
 }
 
+function fillToScaleMin(u, seriesIdx) {
+    var series = u && u.series ? u.series[seriesIdx] : null;
+    var scaleKey = series && series.scale ? series.scale : 'y';
+    var scale = u && u.scales ? (u.scales[scaleKey] || u.scales.y) : null;
+    return scale && scale.min != null ? scale.min : 0;
+}
+
 function buildEvenIndexTicks(count, maxTicks) {
     if (count <= 0) return [];
     if (!maxTicks || maxTicks < 2) maxTicks = 2;
@@ -414,6 +421,7 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
             spanGaps: ds.spanGaps !== undefined ? ds.spanGaps : false,
             show: ds.show !== undefined ? ds.show : true,
         };
+        if (ds.fillTo !== undefined && ds.fillTo !== null) s.fillTo = ds.fillTo;
         if (ds.scale) s.scale = ds.scale;
         if (isBar) {
             s.paths = barPaths;
@@ -725,10 +733,11 @@ function openChartZoom(canvasId) {
                 label: ds.label,
                 stroke: ds.color || 'rgba(168,85,247,0.9)',
                 width: isBar ? 0 : 2,
-                fill: isBar ? (ds.color || '#a855f7') + 'cc' : (!isMulti && !isBar ? 'rgba(168,85,247,0.15)' : undefined),
+                fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || (!isMulti && !isBar ? 'rgba(168,85,247,0.15)' : undefined)),
                 points: { show: n <= 30 && !isBar, size: isBar ? 0 : (n > 30 ? 4 : 8) },
                 spanGaps: ds.spanGaps !== undefined ? ds.spanGaps : false
             };
+            if (ds.fillTo !== undefined && ds.fillTo !== null) s.fillTo = ds.fillTo;
             if (isBar) { s.paths = barPaths; s.points = { show: false }; }
             if (ds.stepped) { s.paths = uPlot.paths.stepped({ align: -1 }); s.width = 2; }
             if (ds.dashed) { s.dash = [5, 5]; }

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -7,6 +7,7 @@ var _trendRange = 'day';
 var _lastTrendData = null;
 var _lastTrendWeather = null;
 var _lastTrendRange = 'day';
+var POWER_TREND_FILL = 'rgba(168,85,247,0.15)';
 
 /* ── Trend Tabs ── */
 function updateTrendTabs() {
@@ -105,13 +106,13 @@ function _renderTrendCharts() {
     });
     var tempOpts = (_lastTrendWeather && _lastTrendWeather.length > 0) ? { tempData: _lastTrendWeather } : null;
     renderChart('chart-ds-power', xLabels,
-        [{label: 'DS Power Avg', data: data.map(function(d){ return d.ds_power_avg; }), color: '#a855f7'}],
+        [{label: 'DS Power Avg', data: data.map(function(d){ return d.ds_power_avg; }), color: '#a855f7', fill: POWER_TREND_FILL, fillTo: fillToScaleMin}],
         null, DS_POWER_THRESHOLDS, tempOpts);
     renderChart('chart-ds-snr', xLabels,
         [{label: 'DS SNR Avg', data: data.map(function(d){ return d.ds_snr_avg; }), color: '#a855f7'}],
         null, DS_SNR_THRESHOLDS, tempOpts);
     renderChart('chart-us-power', xLabels,
-        [{label: 'US Power Avg', data: data.map(function(d){ return d.us_power_avg; }), color: '#a855f7'}],
+        [{label: 'US Power Avg', data: data.map(function(d){ return d.us_power_avg; }), color: '#a855f7', fill: POWER_TREND_FILL, fillTo: fillToScaleMin}],
         null, US_POWER_THRESHOLDS, tempOpts);
     var showErrors = _hasTrendDocsisErrorSeries(data);
     _setTrendErrorsVisible(showErrors);

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v22';
+var CACHE_VERSION = 'v23';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -111,6 +111,42 @@ class TestTrendCharts:
         assert box["width"] > 100
         assert box["height"] > 50
 
+    def test_power_trend_charts_fill_to_visible_axis_floor(self, demo_page):
+        """DS/US Power charts should render filled areas to the visible y-axis floor."""
+        navigate_to_trends(demo_page)
+        for chart_id in ["chart-ds-power", "chart-us-power"]:
+            wait_for_uplot(demo_page, chart_id)
+
+        fills = demo_page.evaluate(
+            """
+            () => ['chart-ds-power', 'chart-us-power'].map((chartId) => {
+                const chart = window.charts[chartId];
+                const dataset = chart._docsightParams.datasets[0];
+                return {
+                    chartId,
+                    configuredFill: dataset.fill,
+                    fillToValue: chart.series[1].fillTo(chart, 1),
+                    yMin: chart.scales.y.min,
+                };
+            })
+            """
+        )
+
+        assert fills == [
+            {
+                "chartId": "chart-ds-power",
+                "configuredFill": "rgba(168,85,247,0.15)",
+                "fillToValue": -18,
+                "yMin": -18,
+            },
+            {
+                "chartId": "chart-us-power",
+                "configuredFill": "rgba(168,85,247,0.15)",
+                "fillToValue": 17,
+                "yMin": 17,
+            },
+        ]
+
     def test_errors_bar_chart(self, demo_page):
         """Errors chart should render as bar chart with 2 series."""
         navigate_to_trends(demo_page)

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -185,6 +185,13 @@ class TestDashboardSections:
         assert card.get_attribute("role") == "button"
         assert card.get_attribute("tabindex") == "0"
 
+    def test_disabled_connection_monitor_card_shows_no_data_state(self, demo_page):
+        status = demo_page.locator("#cm-card-status")
+        details = demo_page.locator("#cm-card-details")
+        status.wait_for(state="visible")
+        demo_page.wait_for_function("document.querySelector('#cm-card-status').textContent.trim() === '—'")
+        assert details.text_content().strip() == ""
+
     def test_docsis_groups_expose_expanded_state(self, demo_page):
         header = demo_page.locator(".docsis-group-header").first
         assert header.get_attribute("aria-expanded") == "false"

--- a/tests/modules/connection_monitor/test_routes.py
+++ b/tests/modules/connection_monitor/test_routes.py
@@ -545,6 +545,24 @@ class TestSummaryAPI:
         resp = c.get("/api/connection-monitor/summary")
         assert resp.status_code == 200
 
+    def test_summary_is_empty_when_connection_monitor_is_disabled(self, client):
+        c, storage = client
+        tid = storage.create_target("Test", "1.1.1.1", enabled=True)
+        now = time.time()
+        storage.save_samples([
+            {"target_id": tid, "timestamp": now - 5, "latency_ms": 10.0, "timeout": False, "probe_method": "tcp"},
+        ])
+
+        mock_cfg = MagicMock()
+        mock_cfg.get.side_effect = lambda key, default=None: (
+            False if key == "connection_monitor_enabled" else default
+        )
+        with patch("app.modules.connection_monitor.routes.get_config_manager", return_value=mock_cfg):
+            resp = c.get("/api/connection-monitor/summary")
+
+        assert resp.status_code == 200
+        assert resp.get_json() == {}
+
     def test_get_range_stats(self, client):
         c, storage = client
         tid = storage.create_target("Test", "1.1.1.1")

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 VIEWS_CSS = ROOT / "app" / "static" / "css" / "views.css"
 CORRELATION_JS = ROOT / "app" / "static" / "js" / "correlation.js"
 CHART_ENGINE_JS = ROOT / "app" / "static" / "js" / "chart-engine.js"
+TRENDS_JS = ROOT / "app" / "static" / "js" / "trends.js"
 CHANNELS_JS = ROOT / "app" / "static" / "js" / "channels.js"
 MODULATION_MAIN_JS = ROOT / "app" / "modules" / "modulation" / "static" / "main.js"
 SW_JS = ROOT / "app" / "static" / "sw.js"
@@ -16,6 +17,7 @@ APP_I18N_DIR = ROOT / "app" / "i18n"
 CM_CSS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "style.css"
 CM_DETAIL_JS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "js" / "connection-monitor-detail.js"
 CM_CHARTS_JS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "js" / "connection-monitor-charts.js"
+CM_CARD_JS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "js" / "connection-monitor-card.js"
 
 
 def test_correlation_timeline_sticky_header_uses_opaque_surface():
@@ -75,7 +77,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v22';" in sw_js
+    assert "var CACHE_VERSION = 'v23';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js
@@ -109,6 +111,26 @@ def test_chart_zoom_uses_bounded_index_ticks_instead_of_all_samples():
     assert "var zoomXSplits = buildEvenIndexTicks(n, zoomMaxTicks);" in zoom_block
     assert "for (var i = 0; i < n; i++) o.push(i); return o;" not in zoom_block
     assert "filter: xTickValues" not in zoom_block
+
+
+def test_trend_power_charts_fill_to_visible_axis_floor():
+    chart_engine = CHART_ENGINE_JS.read_text(encoding="utf-8")
+    trends = TRENDS_JS.read_text(encoding="utf-8")
+
+    assert "function fillToScaleMin" in chart_engine
+    assert "if (ds.fillTo !== undefined && ds.fillTo !== null) s.fillTo = ds.fillTo;" in chart_engine
+    assert "fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || undefined)" in chart_engine
+    assert "var POWER_TREND_FILL" in trends
+    assert "fillTo: fillToScaleMin" in trends
+    assert trends.count("fill: POWER_TREND_FILL") >= 2
+
+
+def test_connection_monitor_card_treats_no_enabled_targets_as_no_data():
+    js = CM_CARD_JS.read_text(encoding="utf-8")
+    no_enabled_block = js[js.index("if (enabled.length === 0)") : js.index("var ok = enabled.filter")]
+
+    assert "statusEl.textContent = '—';" in no_enabled_block
+    assert "detailsEl.textContent = '';" in no_enabled_block
 
 
 def test_modulation_overview_charts_bound_daily_x_axis_ticks():


### PR DESCRIPTION
## Summary
- Treat a disabled Connection Monitor as no-data on the dashboard summary so stale target data does not look active
- Keep the card neutral when no enabled targets are available
- Fill DS/US Power trend charts to the visible axis floor for consistent area charts
- Bump the service-worker cache version for updated static assets

## Test Plan
- `git diff --check`
- `.venv/bin/python -m pytest -q tests --ignore=tests/e2e`
- `TZ=UTC .venv/bin/python -m pytest -q tests/e2e`

Closes #501
Closes #502
