### PR TITLE
fix: shorten missing modulation value

### DIFF
--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -100,7 +100,7 @@
   "dashboard_channel_health": "Kanalzustand",
   "dashboard_modulation_context": "Modulationskontext",
   "dashboard_modulation_open_detail": "Modulationsdetails",
-  "dashboard_modulation_unavailable": "Modulationsdaten nicht verfügbar",
+  "dashboard_modulation_unavailable": "N/A",
   "dashboard_modulation_missing_hint": "Das Modem meldet aktuell keinen QAM-Wert",
   "dashboard_modulation_normal": "Keine Modulationsverschlechterung erkannt",
   "dashboard_modulation_us_cause": "Reduzierte Modulation trägt zu diesem Zustand bei",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -100,7 +100,7 @@
   "dashboard_channel_health": "Channel health",
   "dashboard_modulation_context": "Modulation context",
   "dashboard_modulation_open_detail": "Modulation Performance",
-  "dashboard_modulation_unavailable": "Modulation data unavailable",
+  "dashboard_modulation_unavailable": "N/A",
   "dashboard_modulation_missing_hint": "No current QAM value reported by the modem",
   "dashboard_modulation_normal": "No modulation degradation detected",
   "dashboard_modulation_us_cause": "Reduced modulation contributes to this state",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -100,7 +100,7 @@
   "dashboard_channel_health": "Estado de los canales",
   "dashboard_modulation_context": "Contexto de modulación",
   "dashboard_modulation_open_detail": "Rendimiento de modulación",
-  "dashboard_modulation_unavailable": "Datos de modulación no disponibles",
+  "dashboard_modulation_unavailable": "N/A",
   "dashboard_modulation_missing_hint": "El módem no informa un valor QAM actual",
   "dashboard_modulation_normal": "No se detectó degradación de modulación",
   "dashboard_modulation_us_cause": "La modulación reducida contribuye a este estado",

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -100,7 +100,7 @@
   "dashboard_channel_health": "État des canaux",
   "dashboard_modulation_context": "Contexte de modulation",
   "dashboard_modulation_open_detail": "Performance de modulation",
-  "dashboard_modulation_unavailable": "Données de modulation indisponibles",
+  "dashboard_modulation_unavailable": "N/A",
   "dashboard_modulation_missing_hint": "Le modem ne signale pas de valeur QAM actuelle",
   "dashboard_modulation_normal": "Aucune dégradation de modulation détectée",
   "dashboard_modulation_us_cause": "La modulation réduite contribue à cet état",

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -92,7 +92,7 @@
   "dashboard_channel_health": "Channel health",
   "dashboard_modulation_context": "Modulation context",
   "dashboard_modulation_open_detail": "Modulation Performance",
-  "dashboard_modulation_unavailable": "Modulation data unavailable",
+  "dashboard_modulation_unavailable": "N/A",
   "dashboard_modulation_missing_hint": "No current QAM value reported by the modem",
   "dashboard_modulation_normal": "No modulation degradation detected",
   "dashboard_modulation_us_cause": "Reduced modulation contributes to this state",

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v23';
+var CACHE_VERSION = 'v24';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -639,7 +639,7 @@
                     <div class="hero-modulation-card hero-modulation-{{ mod.health }}" data-modulation-dir="{{ mod.dir }}">
                         <div class="hero-modulation-card-top">
                             <span>{{ mod_label }}</span>
-                            <strong>{{ mod.primary if mod.primary else t.get('dashboard_modulation_unavailable', 'Modulation data unavailable') }}</strong>
+                            <strong>{{ mod.primary if mod.primary else t.get('dashboard_modulation_unavailable', 'N/A') }}</strong>
                         </div>
                         {% if mod.issue %}
                         <div class="hero-modulation-status">{{ mod_issue_label }}</div>

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -77,7 +77,7 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v23';" in sw_js
+    assert "var CACHE_VERSION = 'v24';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -303,7 +303,9 @@ class TestIndexRoute:
         modulation_context = html[
             html.index('class="hero-modulation-context"'):html.index('class="hero-chart-wrap"')
         ]
-        assert "Modulation data unavailable" in modulation_context
+        assert ">N/A<" in modulation_context
+        assert "Modulation data unavailable" not in modulation_context
+        assert "No current QAM value reported by the modem" in modulation_context
         assert "None" not in modulation_context
         assert 'class="hero-modulation-card hero-modulation-warn"' not in modulation_context
         assert 'class="hero-modulation-card hero-modulation-crit"' not in modulation_context


### PR DESCRIPTION
## Summary
- Shortens the Home modulation missing-value label to `N/A` so it fits the compact dashboard value slot.
- Keeps the explanatory missing-QAM hint below the value.
- Bumps the service worker cache version so cached dashboard shells refresh.

## Validation
- `pytest -q tests/web/test_index.py::TestIndexRoute::test_home_modulation_context_handles_missing_modulation_without_false_alarm tests/test_static_contracts.py::test_static_cache_version_was_bumped_for_ui_followup_assets`
- `python scripts/i18n_check.py --validate`
- `pytest -q tests --ignore=tests/e2e`
- `pytest --collect-only -q tests/e2e` → 398 tests collected
- `TZ=UTC pytest -q tests/e2e`
- `git diff --check`

Closes #505
