### PR TITLE
Secure module-owned config secrets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -420,6 +420,8 @@ Drivers are loaded by name via `load_driver(modem_type, url, user, password)`. T
 
 Installed non-theme modules are discovered by `ModuleLoader` and persisted through the comma-separated `disabled_modules` config key. The Settings Extensions panel treats installed module toggles as pending form state: users can change multiple modules and save them once through `POST /api/modules/batch`. Theme modules remain on the dedicated theme APIs because preview and active-theme handling are separate flows.
 
+Module manifests can declare module-owned secret settings with a top-level `config_secrets` list. Every listed key must also appear in the module's `config` defaults. The loader registers those keys with the core `ConfigManager` secret path so they are encrypted at rest, masked in Settings, and preserved when the UI submits the saved-secret placeholder. Community collectors still receive a restricted config proxy: they can read only their own declared secret keys and cannot opt into core secrets such as `modem_password` by adding a colliding config default.
+
 Threshold-profile modules are mutually exclusive. The UI renders threshold modules as a single radio group, and the batch API validates the invariant server-side so exactly one threshold profile remains active after save.
 
 ### Vodafone Station Auto-Detection

--- a/app/collectors/__init__.py
+++ b/app/collectors/__init__.py
@@ -20,7 +20,7 @@ class _ModuleConfigProxy:
     Builtin modules receive the real ConfigManager.  Community modules
     get this proxy which blocks access to modem_password, admin_password,
     mqtt_password, and other secret/hash keys unless they are specifically
-    declared in the module's own config defaults.
+    declared as module-owned config_secrets and registered for that module.
     """
 
     def __init__(self, config_mgr, allowed_secret_keys=frozenset()):
@@ -135,7 +135,7 @@ def discover_collectors(config_mgr, storage, event_detector, mqtt_pub, web, anal
                     else:
                         mod_cfg = _ModuleConfigProxy(
                             config_mgr,
-                            allowed_secret_keys=set(mod.config.keys()) & SECRET_KEYS,
+                            allowed_secret_keys=mod.config_secrets,
                         )
                     c = mod.collector_class(
                         config_mgr=mod_cfg,

--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,8 @@ SECRET_KEYS = {
     "notify_apprise_token",
     "notify_pwa_push_vapid_private_key",
 }
+MODULE_SECRET_KEYS = set()
+MODULE_SECRET_OWNERS = {}
 DEMO_HIDE_KEYS = {"bqm_url", "speedtest_tracker_url",
                   "notify_webhook_url", "notify_apprise_url", "notify_apprise_key",
                   "notify_apprise_token", "notify_apprise_tag", "notify_pwa_push_vapid_private_key",

--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -229,9 +229,8 @@ def reserve_module_config_secrets(modules: list[ModuleInfo]) -> None:
         for key in mod.config_secrets:
             if key in (_cfg.SECRET_KEYS | _cfg.HASH_KEYS) and key not in _cfg.MODULE_SECRET_KEYS:
                 log.warning(
-                    "Module '%s' cannot reserve core secret config key '%s'",
+                    "Module '%s' cannot reserve a core secret config key",
                     mod.id,
-                    key,
                 )
                 continue
             declarations.setdefault(key, set()).add(mod.id)
@@ -242,8 +241,7 @@ def reserve_module_config_secrets(modules: list[ModuleInfo]) -> None:
         else:
             owner = _CONFLICTING_MODULE_SECRET_OWNER
             log.warning(
-                "Config secret key '%s' is declared by multiple modules: %s",
-                key,
+                "A config secret key is declared by multiple modules: %s",
                 ", ".join(sorted(owners)),
             )
         _cfg.SECRET_KEYS.add(key)
@@ -279,18 +277,15 @@ def register_module_config(
     for key, value in config_defaults.items():
         existing_owner = _cfg.MODULE_SECRET_OWNERS.get(key)
         if existing_owner and existing_owner != owner:
-            log.warning(
-                "Skipping config key '%s' reserved for another module",
-                key,
-            )
+            log.warning("Skipping a config key reserved for another module")
             continue
         if key in _cfg.DEFAULTS:
             if key in requested_secrets and existing_owner == owner:
                 reused_module_secrets.add(key)
-            log.debug("Config key '%s' already exists in core, skipping", key)
+            log.debug("Config key already exists in core, skipping")
             continue
         if not builtin and key in (_cfg.SECRET_KEYS | _cfg.HASH_KEYS) and key not in _cfg.MODULE_SECRET_KEYS:
-            log.warning("Skipping reserved core secret config key '%s'", key)
+            log.warning("Skipping a reserved core secret config key")
             continue
         _cfg.DEFAULTS[key] = value
         registered_keys.add(key)
@@ -303,8 +298,8 @@ def register_module_config(
     skipped_secrets = requested_secrets - registered_secrets
     if skipped_secrets:
         log.warning(
-            "Skipping config_secret declarations for non-owned keys: %s",
-            ", ".join(sorted(skipped_secrets)),
+            "Skipping %d config_secret declaration(s) for non-owned keys",
+            len(skipped_secrets),
         )
     _cfg.SECRET_KEYS.update(registered_secrets)
     _cfg.MODULE_SECRET_KEYS.update(registered_secrets)

--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -22,6 +22,7 @@ VALID_TYPES = {"driver", "integration", "analysis", "theme"}
 VALID_CONTRIBUTES = {"collector", "routes", "settings", "tab", "card", "i18n", "static", "publisher", "thresholds", "theme", "driver"}
 REQUIRED_FIELDS = {"id", "name", "description", "version", "author", "minAppVersion", "type", "contributes"}
 ID_PATTERN = re.compile(r"^[a-z][a-z0-9_.]+$")
+_CONFLICTING_MODULE_SECRET_OWNER = "__conflicting_module_secret_owner__"
 
 
 class ManifestError(Exception):
@@ -44,6 +45,7 @@ class ModuleInfo:
     homepage: str = ""
     license: str = ""
     config: dict[str, Any] = field(default_factory=dict)
+    config_secrets: set[str] = field(default_factory=set)
     menu: dict[str, Any] = field(default_factory=dict)
     enabled: bool = True
     error: str | None = None
@@ -104,6 +106,25 @@ def validate_manifest(raw: dict[str, Any], module_path: str) -> ModuleInfo:
                 f"Driver modules must not contribute {', '.join(sorted(forbidden))} (security)"
             )
 
+    config = raw.get("config", {})
+    if not isinstance(config, dict):
+        raise ManifestError("'config' must be a dict")
+
+    raw_config_secrets = raw.get("config_secrets", [])
+    if not isinstance(raw_config_secrets, list) or not all(
+        isinstance(key, str) for key in raw_config_secrets
+    ):
+        raise ManifestError("'config_secrets' must be a list of config key names")
+    config_secrets = set(raw_config_secrets)
+    if len(config_secrets) != len(raw_config_secrets):
+        raise ManifestError("'config_secrets' must not contain duplicate keys")
+    unknown_config_secrets = config_secrets - set(config.keys())
+    if unknown_config_secrets:
+        raise ManifestError(
+            "config_secrets must reference keys declared in config: "
+            + ", ".join(sorted(unknown_config_secrets))
+        )
+
     # Detect builtin
     norm = os.path.normpath(module_path).replace("\\", "/")
     builtin = "/app/modules/" in norm or "\\app\\modules\\" in os.path.normpath(module_path)
@@ -121,7 +142,8 @@ def validate_manifest(raw: dict[str, Any], module_path: str) -> ModuleInfo:
         builtin=builtin,
         homepage=raw.get("homepage", ""),
         license=raw.get("license", ""),
-        config=raw.get("config", {}),
+        config=config,
+        config_secrets=config_secrets,
         menu={**{"order": 999}, **raw.get("menu", {})},
         hints=raw.get("hints", {}),
     )
@@ -194,21 +216,101 @@ def discover_modules(
     return modules
 
 
-def register_module_config(config_defaults: dict[str, Any]) -> None:
+def reserve_module_config_secrets(modules: list[ModuleInfo]) -> None:
+    """Reserve module-owned secret keys across all discovered manifests.
+
+    Reservations are made before enabled modules are loaded so ownership is
+    independent of load order and disabled modules still protect previously
+    saved secrets from later claimants. Duplicate declarations are reserved as
+    conflicting and fail closed for every claimant.
+    """
+    declarations: dict[str, set[str]] = {}
+    for mod in modules:
+        for key in mod.config_secrets:
+            if key in (_cfg.SECRET_KEYS | _cfg.HASH_KEYS) and key not in _cfg.MODULE_SECRET_KEYS:
+                log.warning(
+                    "Module '%s' cannot reserve core secret config key '%s'",
+                    mod.id,
+                    key,
+                )
+                continue
+            declarations.setdefault(key, set()).add(mod.id)
+
+    for key, owners in declarations.items():
+        if len(owners) == 1:
+            owner = next(iter(owners))
+        else:
+            owner = _CONFLICTING_MODULE_SECRET_OWNER
+            log.warning(
+                "Config secret key '%s' is declared by multiple modules: %s",
+                key,
+                ", ".join(sorted(owners)),
+            )
+        _cfg.SECRET_KEYS.add(key)
+        _cfg.MODULE_SECRET_KEYS.add(key)
+        existing_owner = _cfg.MODULE_SECRET_OWNERS.get(key)
+        if existing_owner and existing_owner != owner:
+            _cfg.MODULE_SECRET_OWNERS[key] = _CONFLICTING_MODULE_SECRET_OWNER
+        else:
+            _cfg.MODULE_SECRET_OWNERS[key] = owner
+
+
+def register_module_config(
+    config_defaults: dict[str, Any],
+    config_secrets: set[str] | list[str] | tuple[str, ...] | None = None,
+    module_id: str | None = None,
+    builtin: bool = False,
+) -> set[str]:
     """Register a module's config defaults into the global config system.
 
     - Adds defaults to config.DEFAULTS (without overwriting existing keys)
     - Auto-detects bool/int keys and adds them to BOOL_KEYS/INT_KEYS
+    - Adds declared module-owned secrets to config.SECRET_KEYS when their
+      config key was actually registered by the module
+    - Tracks module-secret ownership so one community module cannot claim
+      another module's already-registered secret key
+    - Prevents community modules from claiming reserved core secret keys even
+      when a disabled built-in module has not registered that key's default yet
     """
+    requested_secrets = set(config_secrets or set())
+    owner = module_id or ""
+    registered_keys: set[str] = set()
+    reused_module_secrets: set[str] = set()
     for key, value in config_defaults.items():
+        existing_owner = _cfg.MODULE_SECRET_OWNERS.get(key)
+        if existing_owner and existing_owner != owner:
+            log.warning(
+                "Skipping config key '%s' reserved for another module",
+                key,
+            )
+            continue
         if key in _cfg.DEFAULTS:
+            if key in requested_secrets and existing_owner == owner:
+                reused_module_secrets.add(key)
             log.debug("Config key '%s' already exists in core, skipping", key)
             continue
+        if not builtin and key in (_cfg.SECRET_KEYS | _cfg.HASH_KEYS) and key not in _cfg.MODULE_SECRET_KEYS:
+            log.warning("Skipping reserved core secret config key '%s'", key)
+            continue
         _cfg.DEFAULTS[key] = value
+        registered_keys.add(key)
         if isinstance(value, bool):
             _cfg.BOOL_KEYS.add(key)
         elif isinstance(value, int):
             _cfg.INT_KEYS.add(key)
+
+    registered_secrets = (requested_secrets & registered_keys) | reused_module_secrets
+    skipped_secrets = requested_secrets - registered_secrets
+    if skipped_secrets:
+        log.warning(
+            "Skipping config_secret declarations for non-owned keys: %s",
+            ", ".join(sorted(skipped_secrets)),
+        )
+    _cfg.SECRET_KEYS.update(registered_secrets)
+    _cfg.MODULE_SECRET_KEYS.update(registered_secrets)
+    for key in registered_secrets:
+        _cfg.MODULE_SECRET_OWNERS.setdefault(key, owner)
+    return registered_secrets
 
 
 def merge_module_i18n(module_id: str, i18n_dir: str) -> None:
@@ -587,6 +689,7 @@ class ModuleLoader:
             search_paths=self._search_paths,
             disabled_ids=self._disabled_ids,
         )
+        reserve_module_config_secrets(self._modules)
 
         for mod in self._modules:
             if not mod.enabled:
@@ -631,8 +734,13 @@ class ModuleLoader:
         c = mod.contributes
 
         # Config defaults
-        if mod.config:
-            register_module_config(mod.config)
+        if mod.config or mod.config_secrets:
+            mod.config_secrets = register_module_config(
+                mod.config,
+                config_secrets=mod.config_secrets,
+                module_id=mod.id,
+                builtin=mod.builtin,
+            )
 
         # i18n
         if "i18n" in c:

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -275,6 +275,19 @@ function escHtml(s) {
     return d.innerHTML;
 }
 
+function _isConfigSecretField(inp) {
+    return !!(
+        inp &&
+        inp.name &&
+        inp.tagName === 'INPUT' &&
+        (
+            SECRET_FIELDS.indexOf(inp.name) !== -1 ||
+            inp.dataset.configSecret === 'true' ||
+            _isSavedSecretField(inp)
+        )
+    );
+}
+
 function getFormData() {
     var form = document.getElementById('settings-form');
     var data = {};
@@ -284,7 +297,7 @@ function getFormData() {
             return;
         }
         if (inp.type === 'hidden' && data[inp.name] !== undefined) return;
-        if (SECRET_FIELDS.indexOf(inp.name) !== -1) {
+        if (_isConfigSecretField(inp)) {
             if (_isSavedSecretField(inp) && !inp.dataset.userEditedSecret) {
                 data[inp.name] = MASK;
             } else {

--- a/tests/module_loader/test_loading_core.py
+++ b/tests/module_loader/test_loading_core.py
@@ -6,10 +6,11 @@ import json
 import os
 import tempfile
 import textwrap
+from types import SimpleNamespace
 
 import pytest
 from flask import Flask
-from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, load_module_driver, setup_module_static, setup_module_templates, ModuleLoader
+from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, reserve_module_config_secrets, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, load_module_driver, setup_module_static, setup_module_templates, ModuleLoader
 
 class TestRegisterModuleConfig:
     """Test module config defaults registration."""
@@ -56,6 +57,426 @@ class TestRegisterModuleConfig:
         from app import config as cfg
         register_module_config({"poll_interval": 999})
         assert cfg.DEFAULTS["poll_interval"] != 999  # unchanged
+
+    def test_register_config_secrets_encrypts_masks_and_preserves_masks(self, tmp_path):
+        """Module-owned config_secrets join the global secret storage path."""
+        from app import config as cfg
+        from app.config import ConfigManager, PASSWORD_MASK
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            register_module_config(
+                {"community_api_token": "", "community_enabled": False},
+                config_secrets={"community_api_token"},
+                module_id="community.weather",
+            )
+            assert "community_api_token" in cfg.DEFAULTS
+            assert "community_api_token" in cfg.SECRET_KEYS
+            assert cfg.MODULE_SECRET_OWNERS["community_api_token"] == "community.weather"
+
+            mgr = ConfigManager(str(tmp_path / "data"))
+            mgr.save({"community_api_token": "token-secret"})
+            raw = json.loads((tmp_path / "data" / "config.json").read_text())
+
+            assert raw["community_api_token"] != "token-secret"
+            assert mgr.get("community_api_token") == "token-secret"
+            assert mgr.get_all(mask_secrets=True)["community_api_token"] == PASSWORD_MASK
+
+            mgr.save({"community_api_token": PASSWORD_MASK})
+            assert mgr.get("community_api_token") == "token-secret"
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
+    def test_community_collector_proxy_only_allows_declared_module_secrets(self, tmp_path):
+        """Community collectors may read their own secrets but not core secrets."""
+        from app import config as cfg
+        from app.collectors import discover_collectors
+        from app.config import ConfigManager
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            register_module_config(
+                {"community_api_token": "", "modem_password": ""},
+                config_secrets={"community_api_token"},
+                module_id="community.test",
+            )
+            mgr = ConfigManager(str(tmp_path / "data"))
+            mgr.save({
+                "modem_password": "core-secret",
+                "community_api_token": "module-secret",
+            })
+            captured = {}
+
+            class CommunityCollector:
+                name = "community"
+
+                def __init__(self, config_mgr, storage, web):
+                    captured["config_mgr"] = config_mgr
+
+            mod = ModuleInfo(
+                id="community.test",
+                name="Community Test",
+                description="Test module",
+                version="1.0.0",
+                author="Test",
+                min_app_version="2026.2",
+                type="integration",
+                contributes={"collector": "collector.py:CommunityCollector"},
+                path="/modules/community-test",
+                builtin=False,
+                config={"community_api_token": "", "modem_password": ""},
+                config_secrets={"community_api_token"},
+                collector_class=CommunityCollector,
+            )
+            web = SimpleNamespace(
+                get_module_loader=lambda: SimpleNamespace(get_enabled_modules=lambda: [mod])
+            )
+
+            discover_collectors(mgr, None, None, None, web, None)
+
+            proxy = captured["config_mgr"]
+            assert proxy.get("community_api_token") == "module-secret"
+            assert proxy.get("modem_password", "blocked") == "blocked"
+            assert "modem_password" not in proxy.get_all()
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
+    def test_same_module_secret_reload_preserves_ownership(self):
+        """Reloading the same module may reuse its already-owned secret key."""
+        from app import config as cfg
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            first = register_module_config(
+                {"community_reload_token": ""},
+                config_secrets={"community_reload_token"},
+                module_id="community.reload",
+            )
+            second = register_module_config(
+                {"community_reload_token": ""},
+                config_secrets={"community_reload_token"},
+                module_id="community.reload",
+            )
+
+            assert first == {"community_reload_token"}
+            assert second == {"community_reload_token"}
+            assert cfg.MODULE_SECRET_OWNERS["community_reload_token"] == "community.reload"
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
+    def test_other_module_cannot_claim_existing_module_secret(self, tmp_path):
+        """A community module cannot read another module's colliding secret key."""
+        from app import config as cfg
+        from app.collectors import discover_collectors
+        from app.config import ConfigManager
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            first = register_module_config(
+                {"community_shared_token": ""},
+                config_secrets={"community_shared_token"},
+                module_id="community.first",
+            )
+            second = register_module_config(
+                {"community_shared_token": ""},
+                config_secrets={"community_shared_token"},
+                module_id="community.second",
+            )
+            assert first == {"community_shared_token"}
+            assert second == set()
+            assert cfg.MODULE_SECRET_OWNERS["community_shared_token"] == "community.first"
+
+            mgr = ConfigManager(str(tmp_path / "data"))
+            mgr.save({"community_shared_token": "first-module-secret"})
+            captured = {}
+
+            class SecondCommunityCollector:
+                name = "community-second"
+
+                def __init__(self, config_mgr, storage, web):
+                    captured["config_mgr"] = config_mgr
+
+            mod = ModuleInfo(
+                id="community.second",
+                name="Community Second",
+                description="Test module",
+                version="1.0.0",
+                author="Test",
+                min_app_version="2026.2",
+                type="integration",
+                contributes={"collector": "collector.py:SecondCommunityCollector"},
+                path="/modules/community-second",
+                builtin=False,
+                config={"community_shared_token": ""},
+                config_secrets=second,
+                collector_class=SecondCommunityCollector,
+            )
+            web = SimpleNamespace(
+                get_module_loader=lambda: SimpleNamespace(get_enabled_modules=lambda: [mod])
+            )
+
+            discover_collectors(mgr, None, None, None, web, None)
+
+            proxy = captured["config_mgr"]
+            assert proxy.get("community_shared_token", "blocked") == "blocked"
+            assert "community_shared_token" not in proxy.get_all()
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
+    def test_declared_secret_duplicate_is_reserved_fail_closed_before_load(self, tmp_path):
+        """Duplicate config_secrets cannot be won by whichever module loads first."""
+        from app import config as cfg
+        from app.collectors import discover_collectors
+        from app.config import ConfigManager
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            shared_key = "community_duplicate_token"
+            victim = ModuleInfo(
+                id="community.victim",
+                name="Community Victim",
+                description="Victim module",
+                version="1.0.0",
+                author="Test",
+                min_app_version="2026.2",
+                type="integration",
+                contributes={},
+                path="/modules/community-victim",
+                builtin=False,
+                enabled=False,
+                config={shared_key: ""},
+                config_secrets={shared_key},
+            )
+            claimant = ModuleInfo(
+                id="community.claimant",
+                name="Community Claimant",
+                description="Claimant module",
+                version="1.0.0",
+                author="Test",
+                min_app_version="2026.2",
+                type="integration",
+                contributes={"collector": "collector.py:ClaimantCollector"},
+                path="/modules/community-claimant",
+                builtin=False,
+                config={shared_key: ""},
+                config_secrets={shared_key},
+            )
+            reserve_module_config_secrets([victim, claimant])
+
+            claimant.config_secrets = register_module_config(
+                claimant.config,
+                config_secrets=claimant.config_secrets,
+                module_id=claimant.id,
+            )
+            victim_registered = register_module_config(
+                victim.config,
+                config_secrets=victim.config_secrets,
+                module_id=victim.id,
+            )
+
+            assert claimant.config_secrets == set()
+            assert victim_registered == set()
+            assert shared_key in cfg.SECRET_KEYS
+            assert shared_key in cfg.MODULE_SECRET_KEYS
+
+            mgr = ConfigManager(str(tmp_path / "data"))
+            mgr.save({shared_key: "victim-secret"})
+            captured = {}
+
+            class ClaimantCollector:
+                name = "community-claimant"
+
+                def __init__(self, config_mgr, storage, web):
+                    captured["config_mgr"] = config_mgr
+
+            claimant.collector_class = ClaimantCollector
+            web = SimpleNamespace(
+                get_module_loader=lambda: SimpleNamespace(get_enabled_modules=lambda: [claimant])
+            )
+
+            discover_collectors(mgr, None, None, None, web, None)
+
+            proxy = captured["config_mgr"]
+            assert proxy.get(shared_key, "blocked") == "blocked"
+            assert shared_key not in proxy.get_all()
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
+    def test_builtin_can_register_reserved_core_secret_default(self):
+        """Built-in modules may still provide defaults for static core secrets."""
+        from app import config as cfg
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            cfg.DEFAULTS.pop("mqtt_password", None)
+
+            registered = register_module_config(
+                {"mqtt_password": ""},
+                module_id="docsight.mqtt",
+                builtin=True,
+            )
+
+            assert registered == set()
+            assert "mqtt_password" in cfg.DEFAULTS
+            assert "mqtt_password" in cfg.SECRET_KEYS
+            assert "mqtt_password" not in cfg.MODULE_SECRET_KEYS
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
+    def test_core_hash_key_without_registered_default_is_not_module_owned(self):
+        """Modules cannot claim reserved hash-backed credentials either."""
+        from app import config as cfg
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            cfg.DEFAULTS.pop("admin_password", None)
+            assert "admin_password" in cfg.HASH_KEYS
+            assert "admin_password" not in cfg.MODULE_SECRET_KEYS
+
+            registered = register_module_config(
+                {"admin_password": ""},
+                config_secrets={"admin_password"},
+                module_id="community.claimant",
+            )
+
+            assert registered == set()
+            assert "admin_password" in cfg.HASH_KEYS
+            assert "admin_password" not in cfg.MODULE_SECRET_KEYS
+            assert "admin_password" not in cfg.MODULE_SECRET_OWNERS
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
+    @pytest.mark.parametrize("reserved_key", ["mqtt_password", "speedtest_tracker_token"])
+    def test_core_secret_without_registered_default_is_not_module_owned(self, reserved_key):
+        """Modules cannot claim reserved core secrets before their defaults are loaded."""
+        from app import config as cfg
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            cfg.DEFAULTS.pop(reserved_key, None)
+            assert reserved_key in cfg.SECRET_KEYS
+            assert reserved_key not in cfg.MODULE_SECRET_KEYS
+
+            registered = register_module_config(
+                {reserved_key: ""},
+                config_secrets={reserved_key},
+                module_id="community.claimant",
+            )
+
+            assert registered == set()
+            assert reserved_key in cfg.SECRET_KEYS
+            assert reserved_key not in cfg.MODULE_SECRET_KEYS
+            assert reserved_key not in cfg.MODULE_SECRET_OWNERS
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
+    def test_core_secret_collision_is_not_registered_as_module_owned(self):
+        """Modules cannot claim existing core secret keys as module-owned secrets."""
+        from app import config as cfg
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            registered = register_module_config(
+                {"modem_password": ""},
+                config_secrets={"modem_password"},
+                module_id="community.claimant",
+            )
+
+            assert registered == set()
+            assert "modem_password" in cfg.SECRET_KEYS
+            assert "modem_password" not in cfg.MODULE_SECRET_KEYS
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
 
 
 class TestMergeModuleI18n:

--- a/tests/module_loader/test_loading_core.py
+++ b/tests/module_loader/test_loading_core.py
@@ -352,6 +352,85 @@ class TestRegisterModuleConfig:
             cfg.MODULE_SECRET_OWNERS.clear()
             cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
 
+    def test_config_secret_skip_logs_do_not_echo_secret_key_names(self, caplog):
+        """Secret ownership warnings avoid logging key names as clear text."""
+        from app import config as cfg
+
+        original_defaults = dict(cfg.DEFAULTS)
+        original_secrets = set(cfg.SECRET_KEYS)
+        original_module_secrets = set(cfg.MODULE_SECRET_KEYS)
+        original_module_secret_owners = dict(cfg.MODULE_SECRET_OWNERS)
+        try:
+            duplicate_key = "community_sensitive_secret_marker"
+            first = ModuleInfo(
+                id="community.first",
+                name="Community First",
+                description="First module",
+                version="1.0.0",
+                author="Test",
+                min_app_version="2026.2",
+                type="integration",
+                contributes={},
+                path="/modules/community-first",
+                builtin=False,
+                config={duplicate_key: ""},
+                config_secrets={duplicate_key},
+            )
+            second = ModuleInfo(
+                id="community.second",
+                name="Community Second",
+                description="Second module",
+                version="1.0.0",
+                author="Test",
+                min_app_version="2026.2",
+                type="integration",
+                contributes={},
+                path="/modules/community-second",
+                builtin=False,
+                config={duplicate_key: ""},
+                config_secrets={duplicate_key},
+            )
+            core_secret_claimant = ModuleInfo(
+                id="community.core-claimant",
+                name="Core Secret Claimant",
+                description="Attempts to claim a core secret",
+                version="1.0.0",
+                author="Test",
+                min_app_version="2026.2",
+                type="integration",
+                contributes={},
+                path="/modules/community-core-claimant",
+                builtin=False,
+                config={"admin_password": ""},
+                config_secrets={"admin_password"},
+            )
+
+            with caplog.at_level("DEBUG", logger="docsis.modules"):
+                reserve_module_config_secrets([core_secret_claimant])
+                reserve_module_config_secrets([first, second])
+                register_module_config(
+                    {"admin_password": ""},
+                    config_secrets={"admin_password"},
+                    module_id="community.claimant",
+                )
+                register_module_config(
+                    {duplicate_key: ""},
+                    config_secrets={duplicate_key},
+                    module_id="community.second",
+                )
+
+            assert duplicate_key not in caplog.text
+            assert "admin_password" not in caplog.text
+        finally:
+            cfg.DEFAULTS.clear()
+            cfg.DEFAULTS.update(original_defaults)
+            cfg.SECRET_KEYS.clear()
+            cfg.SECRET_KEYS.update(original_secrets)
+            cfg.MODULE_SECRET_KEYS.clear()
+            cfg.MODULE_SECRET_KEYS.update(original_module_secrets)
+            cfg.MODULE_SECRET_OWNERS.clear()
+            cfg.MODULE_SECRET_OWNERS.update(original_module_secret_owners)
+
     def test_builtin_can_register_reserved_core_secret_default(self):
         """Built-in modules may still provide defaults for static core secrets."""
         from app import config as cfg

--- a/tests/module_loader/test_manifest_and_discovery.py
+++ b/tests/module_loader/test_manifest_and_discovery.py
@@ -54,14 +54,52 @@ class TestValidateManifest:
                 "i18n": "i18n/",
                 "static": "static/",
             },
-            "config": {"weather_enabled": False},
+            "config": {"weather_enabled": False, "weather_api_token": ""},
+            "config_secrets": ["weather_api_token"],
             "menu": {"label_key": "weather.name", "icon": "thermometer", "order": 50},
         }
         info = validate_manifest(raw, "/modules/weather")
         assert info.id == "docsight.weather"
         assert info.contributes["collector"] == "collector.py:WeatherCollector"
-        assert info.config == {"weather_enabled": False}
+        assert info.config == {"weather_enabled": False, "weather_api_token": ""}
+        assert info.config_secrets == {"weather_api_token"}
         assert info.menu["icon"] == "thermometer"
+
+    def test_config_secrets_must_be_a_list_of_strings(self):
+        """config_secrets must be an explicit list of config key names."""
+        raw = {
+            "id": "docsight.weather",
+            "name": "Weather",
+            "description": "Weather overlay",
+            "version": "1.0.0",
+            "author": "DOCSight Team",
+            "minAppVersion": "2026.2",
+            "type": "integration",
+            "contributes": {},
+            "config": {"weather_api_token": ""},
+            "config_secrets": "weather_api_token",
+        }
+
+        with pytest.raises(ManifestError, match="config_secrets"):
+            validate_manifest(raw, "/modules/weather")
+
+    def test_config_secrets_must_reference_config_keys(self):
+        """Secret declarations must be owned by the module config block."""
+        raw = {
+            "id": "docsight.weather",
+            "name": "Weather",
+            "description": "Weather overlay",
+            "version": "1.0.0",
+            "author": "DOCSight Team",
+            "minAppVersion": "2026.2",
+            "type": "integration",
+            "contributes": {},
+            "config": {"weather_enabled": False},
+            "config_secrets": ["weather_api_token"],
+        }
+
+        with pytest.raises(ManifestError, match="weather_api_token"):
+            validate_manifest(raw, "/modules/weather")
 
     def test_missing_required_field_raises(self):
         """Missing 'id' should raise ManifestError."""

--- a/tests/test_settings_secret_fields.py
+++ b/tests/test_settings_secret_fields.py
@@ -29,7 +29,7 @@ def test_saved_secret_inputs_use_stable_marker():
 
 
 def test_frontend_secret_fields_cover_saved_secret_inputs():
-    """Every saved-secret input must be covered by the frontend masking list."""
+    """Every core saved-secret input must be covered by the frontend masking list."""
     js = (ROOT / "app" / "static" / "js" / "settings.js").read_text(encoding="utf-8")
     match = re.search(r"SECRET_FIELDS\s*=\s*\[(?P<fields>[^\]]+)\]", js)
     assert match is not None
@@ -46,6 +46,15 @@ def test_frontend_secret_fields_cover_saved_secret_inputs():
     }
 
     assert expected <= secret_fields
+
+
+def test_frontend_masks_saved_secret_inputs_without_hardcoded_names():
+    """Community module secret fields should use the saved marker, not JS edits."""
+    js = (ROOT / "app" / "static" / "js" / "settings.js").read_text(encoding="utf-8")
+
+    assert "function _isConfigSecretField" in js
+    assert "_isSavedSecretField(inp)" in js
+    assert "if (_isConfigSecretField(inp))" in js
 
 
 def test_saved_secret_dirty_detection_requires_active_field_before_user_edit():


### PR DESCRIPTION
## Summary
- add manifest support for module-owned `config_secrets`
- reserve module secret ownership before loading modules so duplicate declarations fail closed
- keep community collectors blocked from core, hash-backed, and unowned secret keys

## Tests
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright --with playwright pytest -q tests/e2e --tb=short`