### PR TITLE
Fix modulation health and channel loss warnings

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -130,6 +130,66 @@ def _get_us_modulation_thresholds():
     }
 
 
+def _modulation_issue(health: str | None) -> str | None:
+    if health in {"critical", "warning", "tolerated"}:
+        return f"modulation {health}"
+    return None
+
+
+def _assess_ds_modulation(modulation: str, docsis_ver: str) -> str:
+    """Return downstream modulation health for display and channel scoring."""
+    mod = (modulation or "").upper().replace("-", "").strip()
+    if mod == "OFDM":
+        return "good"
+    qam_order = _parse_qam_order(mod)
+    if qam_order is None:
+        return "good"
+
+    if docsis_ver == "3.1":
+        if qam_order >= 1024:
+            return "good"
+        if qam_order >= 512:
+            return "tolerated"
+        if qam_order >= 256:
+            return "warning"
+        return "critical"
+
+    if qam_order >= 256:
+        return "good"
+    if qam_order >= 128:
+        return "tolerated"
+    if qam_order >= 64:
+        return "warning"
+    return "critical"
+
+
+def _assess_us_modulation(ch, docsis_ver: str) -> str:
+    """Return upstream modulation health, including OFDMA profile QAM."""
+    modulation = ch.get("modulation") or ch.get("type") or ""
+    channel_type = (ch.get("type") or ch.get("multiplex") or modulation).upper().replace("-", "").strip()
+    profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
+    assessment_modulation = profile_modulation if channel_type == "OFDMA" and profile_modulation else modulation
+    qam_order = _parse_qam_order(assessment_modulation)
+    if qam_order is None:
+        return "good"
+
+    if docsis_ver == "3.1" and channel_type == "OFDMA":
+        if qam_order <= 32:
+            return "critical"
+        if qam_order <= 64:
+            return "warning"
+        if qam_order <= 128:
+            return "tolerated"
+        return "good"
+
+    mt = _get_us_modulation_thresholds()
+    if qam_order <= mt["critical_max_qam"]:
+        return "critical"
+    if qam_order <= mt["warning_max_qam"]:
+        return "warning"
+    return "good"
+
+
 def _get_uncorr_thresholds():
     """Get uncorrectable error thresholds (percent-based)."""
     errors = _t().get("errors", {})
@@ -457,6 +517,10 @@ def _assess_ds_channel(ch, docsis_ver):
         elif snr_val < st["good_min"]:
             issues.append("snr tolerated")
 
+    mod_issue = _modulation_issue(_assess_ds_modulation(modulation, docsis_ver))
+    if mod_issue:
+        issues.append(mod_issue)
+
     return _channel_health(issues), _health_detail(issues)
 
 
@@ -483,13 +547,10 @@ def _assess_us_channel(ch, docsis_ver="3.0"):
             issues.append("power tolerated low")
         elif power > pt["good_max"]:
             issues.append("power tolerated high")
-    qam_order = _parse_qam_order(modulation)
-    if qam_order is not None:
-        mt = _get_us_modulation_thresholds()
-        if qam_order <= mt["critical_max_qam"]:
-            issues.append("modulation critical")
-        elif qam_order <= mt["warning_max_qam"]:
-            issues.append("modulation warning")
+    mod_health = _assess_us_modulation(ch, docsis_ver)
+    mod_issue = _modulation_issue(mod_health)
+    if mod_issue:
+        issues.append(mod_issue)
 
     return _channel_health(issues), _health_detail(issues)
 
@@ -530,6 +591,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
         snr = abs(_parse_float(ch.get("mse"))) if ch.get("mse") else None
         health, health_detail = _assess_ds_channel(ch, "3.0")
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
+        metric_h["modulation_health"] = _assess_ds_modulation(ch.get("modulation") or ch.get("type", ""), "3.0")
         channel = {
             "channel_id": _parse_channel_id(ch.get("channelID", 0)),
             "frequency": ch.get("frequency", ""),
@@ -552,6 +614,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
         snr = _parse_float(ch.get("mer")) if ch.get("mer") else None
         health, health_detail = _assess_ds_channel(ch, "3.1")
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
+        metric_h["modulation_health"] = _assess_ds_modulation(ch.get("modulation") or ch.get("type", ""), "3.1")
         channel = {
             "channel_id": _parse_channel_id(ch.get("channelID", 0)),
             "frequency": ch.get("frequency", ""),
@@ -576,6 +639,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
     for ch in us30:
         health, health_detail = _assess_us_channel(ch, "3.0")
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
+        metric_h["modulation_health"] = _assess_us_modulation(ch, "3.0")
         mod = ch.get("modulation") or ch.get("type", "")
         bitrate = _channel_bitrate_mbps(mod, ch.get("symbolRate"))
         channel = {
@@ -596,6 +660,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
     for ch in us31:
         health, health_detail = _assess_us_channel(ch, "3.1")
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
+        metric_h["modulation_health"] = _assess_us_modulation(ch, "3.1")
         mod = ch.get("modulation") or ch.get("type", "")
         bitrate = _channel_bitrate_mbps(mod, ch.get("symbolRate"))
         raw_power = ch.get("powerLevel")
@@ -667,6 +732,14 @@ def analyze(data: DocsisData) -> AnalysisResult:
         issues.append("ds_power_marginal")
     elif any("power tolerated" in c["health_detail"] for c in ds_channels):
         issues.append("ds_power_tolerated")
+
+    # DS modulation: aggregate from individual channel health_detail
+    if any("modulation critical" in c["health_detail"] for c in ds_channels):
+        issues.append("ds_modulation_critical")
+    elif any("modulation warning" in c["health_detail"] for c in ds_channels):
+        issues.append("ds_modulation_marginal")
+    elif any("modulation tolerated" in c["health_detail"] for c in ds_channels):
+        issues.append("ds_modulation_tolerated")
 
     # US power: aggregate from individual channel health_detail (directional)
     us_crit_low = any("power critical low" in c["health_detail"] for c in us_channels)

--- a/app/event_detector.py
+++ b/app/event_detector.py
@@ -138,7 +138,7 @@ class EventDetector:
         # SNR change
         self._check_snr(events, ts, analysis, prev)
         # Channel count change
-        self._check_channels(events, ts, cur_s, prev_s)
+        self._check_channels(events, ts, analysis, prev)
         # Modulation change
         self._check_modulation(events, ts, analysis, prev)
         # Restart detection (before errors — restart causes negative delta)
@@ -336,27 +336,70 @@ class EventDetector:
         affected.sort(key=lambda ch: (ch["current"], str(ch["channel"])))
         return affected
 
-    def _check_channels(self, events, ts, cur, prev):
+    def _check_channels(self, events, ts, cur_analysis, prev_analysis):
+        cur = cur_analysis.get("summary", {})
+        prev = prev_analysis.get("summary", {})
         ds_cur = cur.get("ds_total", 0)
         ds_prev = prev.get("ds_total", 0)
         us_cur = cur.get("us_total", 0)
         us_prev = prev.get("us_total", 0)
 
+        def channel_map(analysis, source):
+            mapped = {}
+            for ch in analysis.get(source, []):
+                key = _normalize_channel_id(ch.get("channel_id"))
+                if key is not None:
+                    mapped[key] = ch
+            return mapped
+
+        def channel_detail(ch, direction):
+            detail = {
+                "channel": ch.get("channel_id"),
+                "frequency": ch.get("frequency") or "",
+                "docsis_version": ch.get("docsis_version") or "",
+                "channel_type": _channel_type_label(direction, ch),
+                "modulation": ch.get("modulation") or "",
+            }
+            return {k: v for k, v in detail.items() if v not in (None, "")}
+
+        def changed_channels(direction, source):
+            cur_map = channel_map(cur_analysis, source)
+            prev_map = channel_map(prev_analysis, source)
+            lost = [channel_detail(prev_map[key], direction) for key in set(prev_map) - set(cur_map)]
+            added = [channel_detail(cur_map[key], direction) for key in set(cur_map) - set(prev_map)]
+            lost.sort(key=lambda ch: str(ch.get("channel", "")))
+            added.sort(key=lambda ch: str(ch.get("channel", "")))
+            return lost, added
+
         if ds_cur != ds_prev:
+            lost, added = changed_channels("DS", "ds_channels")
+            is_loss = ds_cur < ds_prev
+            details = {"direction": "downstream", "prev": ds_prev, "current": ds_cur, "change": "loss" if is_loss else "gain"}
+            if lost:
+                details["lost_channels"] = lost
+            if added:
+                details["added_channels"] = added
             events.append({
                 "timestamp": ts,
-                "severity": "info",
+                "severity": "warning" if is_loss else "info",
                 "event_type": "channel_change",
                 "message": f"DS channel count changed from {ds_prev} to {ds_cur}",
-                "details": {"direction": "downstream", "prev": ds_prev, "current": ds_cur},
+                "details": details,
             })
         if us_cur != us_prev:
+            lost, added = changed_channels("US", "us_channels")
+            is_loss = us_cur < us_prev
+            details = {"direction": "upstream", "prev": us_prev, "current": us_cur, "change": "loss" if is_loss else "gain"}
+            if lost:
+                details["lost_channels"] = lost
+            if added:
+                details["added_channels"] = added
             events.append({
                 "timestamp": ts,
-                "severity": "info",
+                "severity": "warning" if is_loss else "info",
                 "event_type": "channel_change",
                 "message": f"US channel count changed from {us_prev} to {us_cur}",
-                "details": {"direction": "upstream", "prev": us_prev, "current": us_cur},
+                "details": details,
             })
 
     def _check_modulation(self, events, ts, cur_analysis, prev_analysis):

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -932,7 +932,7 @@
                             <td>{{ ch.frequency }}{% if ch.frequency and 'MHz' not in ch.frequency|string %} MHz{% endif %}</td>
                             <td data-health="{{ ch.power_health or 'good' }}">{{ ch.power if ch.power is not none else "—" }}{% if ch.power is not none %} dBmV{% endif %}</td>
                             <td data-health="{{ ch.snr_health or 'good' }}">{{ ch.snr if ch.snr is not none else "—" }}{% if ch.snr is not none %} dB{% endif %}</td>
-                            <td>{{ ch.modulation }}</td>
+                            <td data-health="{{ ch.modulation_health or 'good' }}">{{ ch.modulation }}</td>
                             <td>
                                 {% if ch.health == "good" %}<span class="badge badge-good">{{ health_labels.good }}</span>
                                 {% elif ch.health == "critical" %}<span class="badge badge-crit" title="{{ ch_tip_parts|join(', ') }}">{{ health_labels.crit }}</span>

--- a/app/templates/settings/notifications.html
+++ b/app/templates/settings/notifications.html
@@ -214,6 +214,7 @@
                     {% endfor %}
                 {% endfor %}
                 {{ cooldown_row('channel_change', t.notify_event_channel_change, 'info', t.severity_info, 'badge-muted') }}
+                {{ cooldown_row('channel_change', t.notify_event_channel_change, 'warning', t.severity_warning, 'badge-warning') }}
                 {{ cooldown_row('device_reboot', t.notify_event_device_reboot, 'warning', t.severity_warning, 'badge-warning') }}
                 {{ cooldown_row('device_sw_update', t.notify_event_device_sw_update, 'info', t.severity_info, 'badge-muted') }}
                 {{ cooldown_row('device_ip_change', t.notify_event_device_ip_change, 'info', t.severity_info, 'badge-muted') }}

--- a/tests/analyzer/test_thresholds.py
+++ b/tests/analyzer/test_thresholds.py
@@ -168,6 +168,101 @@ class TestOFDMAUpstream:
         assert channel["profile_modulation"] == "128QAM"
         assert channel["power_health"] == "tolerated"
 
+    def test_ofdma_profile_modulation_sets_channel_and_summary_health(self):
+        data = _make_data(
+            us31=[{
+                "channelID": 5,
+                "frequency": "18.000 - 44.000",
+                "powerLevel": "45.0",
+                "modulation": "OFDMA",
+                "profile_modulation": "64QAM",
+                "type": "OFDMA",
+                "multiplex": "OFDMA",
+            }]
+        )
+
+        result = analyze(data)
+        channel = result["us_channels"][0]
+        assert channel.get("power_health", "good") == "good"
+        assert channel["modulation_health"] == "warning"
+        assert channel["health"] == "warning"
+        assert "modulation warning" in channel["health_detail"]
+        assert result["summary"]["health"] == "marginal"
+        assert "us_modulation_marginal" in result["summary"]["health_issues"]
+
+    @pytest.mark.parametrize(
+        ("profile_modulation", "expected_health"),
+        [
+            ("32QAM", "critical"),
+            ("64QAM", "warning"),
+            ("128QAM", "tolerated"),
+            ("256QAM", "good"),
+        ],
+    )
+    def test_ofdma_profile_modulation_health_bands(self, profile_modulation, expected_health):
+        ch = {
+            "powerLevel": "45.0",
+            "modulation": "OFDMA",
+            "profile_modulation": profile_modulation,
+            "type": "OFDMA",
+            "multiplex": "OFDMA",
+        }
+
+        health, detail = analyzer._assess_us_channel(ch, "3.1")
+
+        assert health == expected_health
+        if expected_health == "good":
+            assert "modulation" not in detail
+        else:
+            assert f"modulation {expected_health}" in detail
+
+
+class TestDownstreamModulationHealth:
+    """Test downstream modulation health classification."""
+
+    def setup_method(self):
+        self._orig = analyzer._thresholds.copy()
+        analyzer.set_thresholds(_TEST_THRESHOLDS)
+
+    def teardown_method(self):
+        analyzer._thresholds = self._orig
+
+    @pytest.mark.parametrize(
+        ("modulation", "expected_health"),
+        [
+            ("1024QAM", "good"),
+            ("512QAM", "tolerated"),
+            ("256QAM", "warning"),
+            ("64QAM", "critical"),
+        ],
+    )
+    def test_docsis31_ofdm_downstream_modulation_health_bands(self, modulation, expected_health):
+        data = _make_data(ds31=[{**_make_ds31(100, power=5.0, mer="40.0"), "modulation": modulation}])
+
+        result = analyze(data)
+        channel = result["ds_channels"][0]
+
+        assert channel["modulation_health"] == expected_health
+        assert channel["health"] == expected_health
+
+    @pytest.mark.parametrize(
+        ("modulation", "expected_health"),
+        [
+            ("256QAM", "good"),
+            ("128QAM", "tolerated"),
+            ("64QAM", "warning"),
+            ("32QAM", "critical"),
+        ],
+    )
+    def test_docsis30_sc_qam_downstream_modulation_health_bands(self, modulation, expected_health):
+        data = _make_data(ds30=[{**_make_ds30(1, power=3.0, mse="-40.0"), "modulation": modulation}])
+
+        result = analyze(data)
+        channel = result["ds_channels"][0]
+
+        assert channel["modulation_health"] == expected_health
+        assert channel["health"] == expected_health
+
 
 class TestPercentErrors:
     """Test percent-based error thresholds."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -655,6 +655,7 @@ class TestEventDetector:
         ch_events = [e for e in events if e["event_type"] == "channel_change"]
         assert len(ch_events) == 1
         assert "DS" in ch_events[0]["message"]
+        assert ch_events[0]["severity"] == "warning"
 
     def test_us_channel_count_change(self, detector):
         detector.check(_make_analysis(ds_total=33, us_total=4))
@@ -662,6 +663,42 @@ class TestEventDetector:
         ch_events = [e for e in events if e["event_type"] == "channel_change"]
         assert len(ch_events) == 1
         assert "US" in ch_events[0]["message"]
+        assert ch_events[0]["severity"] == "warning"
+
+    def test_channel_gain_remains_info(self, detector):
+        detector.check(_make_analysis(ds_total=30, us_total=3))
+
+        events = detector.check(_make_analysis(ds_total=33, us_total=4))
+        ch_events = [e for e in events if e["event_type"] == "channel_change"]
+
+        assert [e["severity"] for e in ch_events] == ["info", "info"]
+
+    def test_channel_loss_warning_includes_lost_channel_details(self, detector):
+        prev_ds = [
+            {"channel_id": 1, "power": 3.0, "modulation": "4096QAM", "snr": 40.0,
+             "correctable_errors": 10, "uncorrectable_errors": 5,
+             "docsis_version": "3.1", "health": "good", "health_detail": "", "frequency": "159 MHz"},
+            {"channel_id": 100, "power": 3.0, "modulation": "OFDM", "snr": 40.0,
+             "correctable_errors": 10, "uncorrectable_errors": 5,
+             "docsis_version": "3.1", "health": "good", "health_detail": "", "frequency": "602 MHz"},
+        ]
+        cur_ds = [prev_ds[0]]
+        detector.check(_make_analysis(ds_total=2, us_total=4, ds_channels=prev_ds))
+
+        events = detector.check(_make_analysis(ds_total=1, us_total=4, ds_channels=cur_ds))
+        channel_event = next(e for e in events if e["event_type"] == "channel_change")
+
+        assert channel_event["severity"] == "warning"
+        assert channel_event["details"]["change"] == "loss"
+        assert channel_event["details"]["lost_channels"] == [
+            {
+                "channel": 100,
+                "frequency": "602 MHz",
+                "docsis_version": "3.1",
+                "channel_type": "OFDM",
+                "modulation": "OFDM",
+            },
+        ]
 
     def test_modulation_downgrade_warning(self, detector):
         """256QAM → 64QAM = 2-level drop = warning"""

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -15,6 +15,7 @@ MODULATION_MAIN_JS = ROOT / "app" / "modules" / "modulation" / "static" / "main.
 SW_JS = ROOT / "app" / "static" / "sw.js"
 MAIN_CSS = ROOT / "app" / "static" / "css" / "main.css"
 INDEX_HTML = ROOT / "app" / "templates" / "index.html"
+NOTIFICATIONS_HTML = ROOT / "app" / "templates" / "settings" / "notifications.html"
 APP_I18N_DIR = ROOT / "app" / "i18n"
 EUROPEAN_LANGUAGE_PACK = {
     "bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr",
@@ -160,6 +161,20 @@ def test_modulation_overview_charts_bound_daily_x_axis_ticks():
     assert "splits: function() { return xSplits; }" in trend_block
     assert "splits: function() { return xData; }" not in dist_block
     assert "splits: function() { return xData; }" not in trend_block
+
+
+def test_downstream_channel_modulation_column_exposes_health_classification():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    ds_table_block = template[template.index("DOWNSTREAM CHANNELS") : template.index("UPSTREAM CHANNELS")]
+
+    assert '<td data-health="{{ ch.modulation_health or \'good\' }}">{{ ch.modulation }}</td>' in ds_table_block
+
+
+def test_notification_settings_expose_channel_change_warning_cooldown():
+    template = NOTIFICATIONS_HTML.read_text(encoding="utf-8")
+
+    assert "cooldown_row('channel_change', t.notify_event_channel_change, 'info'" in template
+    assert "cooldown_row('channel_change', t.notify_event_channel_change, 'warning'" in template
 
 
 def test_dashboard_i18n_keys_exist_in_all_language_files():


### PR DESCRIPTION
## Summary
- classify downstream modulation health and expose it in the channel table
- include OFDMA profile modulation in upstream channel health so degraded modulation affects overall health
- mark channel loss events as warnings, preserve channel gains as info, and add warning cooldown settings for channel changes

## Tests
- `git diff --check`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e`

Closes #509
Closes #510
