### PR TITLE
fix: treat DOCSIS 3.0 downstream 64QAM as healthy

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -154,12 +154,10 @@ def _assess_ds_modulation(modulation: str, docsis_ver: str) -> str:
             return "warning"
         return "critical"
 
-    if qam_order >= 256:
-        return "good"
-    if qam_order >= 128:
-        return "tolerated"
+    # DOCSIS 3.0 downstream commonly uses 64QAM or 256QAM. A 64QAM
+    # downstream channel is valid and must not be treated as marginal.
     if qam_order >= 64:
-        return "warning"
+        return "good"
     return "critical"
 
 

--- a/tests/analyzer/test_thresholds.py
+++ b/tests/analyzer/test_thresholds.py
@@ -249,8 +249,8 @@ class TestDownstreamModulationHealth:
         ("modulation", "expected_health"),
         [
             ("256QAM", "good"),
-            ("128QAM", "tolerated"),
-            ("64QAM", "warning"),
+            ("128QAM", "good"),
+            ("64QAM", "good"),
             ("32QAM", "critical"),
         ],
     )

--- a/tests/test_analyzer_modulation.py
+++ b/tests/test_analyzer_modulation.py
@@ -1,0 +1,29 @@
+"""Regression tests for DOCSIS modulation health semantics."""
+
+from app.analyzer import analyze
+
+
+def test_docsis_30_downstream_64qam_is_healthy_not_marginal():
+    """64QAM is valid for DOCSIS 3.0 downstream and must not create a DS warning."""
+    result = analyze({
+        "channelDs": {
+            "docsis30": [{
+                "channelID": "65",
+                "frequency": "698 MHz",
+                "powerLevel": "0.4",
+                "mse": "-36.3",
+                "modulation": "64QAM",
+                "corrErrors": 0,
+                "nonCorrErrors": 0,
+            }],
+            "docsis31": [],
+        },
+        "channelUs": {"docsis30": [], "docsis31": []},
+    })
+
+    channel = result["ds_channels"][0]
+    assert channel.get("modulation_health") == "good"
+    assert channel["health"] == "good"
+    assert "modulation warning" not in channel["health_detail"]
+    assert "ds_modulation_marginal" not in result["summary"]["health_issues"]
+    assert result["summary"]["health"] == "good"


### PR DESCRIPTION
## Summary
- Treat DOCSIS 3.0 downstream 64QAM as healthy instead of marginal
- Update downstream modulation health-band coverage
- Add a regression test that prevents the dashboard from surfacing `ds_modulation_marginal` for healthy DOCSIS 3.0 64QAM downstream channels

## Test Plan
- `git diff --check`
- `.venv311/bin/python -m pytest -q tests --ignore=tests/e2e`
- `TZ=UTC .venv311/bin/python -m pytest -q tests/e2e`
