### PR TITLE
feat(analysis): filter correlation events by severity

### DIFF
--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -8,18 +8,43 @@ var _corrWeatherData = [];
 var _corrSegmentData = [];
 var _corrChartState = null; // Stores scales/data for tooltip lookups
 var _corrZoom = null; // { tMin, tMax } when zoomed in
-// Event type sub-filter: operational events hidden by default
+// Event type/severity sub-filter: operational events hidden by default
 var _corrEventFilter = {};
+var _corrEventSeverityFilter = {};
 var _OPERATIONAL_EVENTS = { monitoring_started: true, monitoring_stopped: true };
+var _CORR_SEVERITIES = ['info', 'warning', 'critical'];
+function _corrEscapeAttr(value) {
+    return escapeHtml(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+function _corrNormalizeSeverity(e) {
+    var severity = String((e && e.severity) || 'info').toLowerCase();
+    return _CORR_SEVERITIES.indexOf(severity) !== -1 ? severity : 'info';
+}
+function _corrEnsureEventSeverityFilter(eventType) {
+    if (!(eventType in _corrEventSeverityFilter)) {
+        _corrEventSeverityFilter[eventType] = { info: true, warning: true, critical: true };
+    }
+    return _corrEventSeverityFilter[eventType];
+}
 function _corrEventTypeAllowed(e) {
     var t = e.event_type || 'unknown';
     if (!(t in _corrEventFilter)) _corrEventFilter[t] = !_OPERATIONAL_EVENTS[t];
     return _corrEventFilter[t];
 }
+function _corrEventSeverityAllowed(e) {
+    var t = e.event_type || 'unknown';
+    var severity = _corrNormalizeSeverity(e);
+    var severityFilter = _corrEnsureEventSeverityFilter(t);
+    if (!(severity in severityFilter)) severityFilter[severity] = true;
+    return severityFilter[severity] !== false;
+}
+function _corrEventAllowed(e) {
+    return _corrEventTypeAllowed(e) && _corrEventSeverityAllowed(e);
+}
 function _corrFilteredEvents(events) {
     if (!_corrVisible.events) return [];
     return events.filter(function(e) {
-        return _corrEventTypeAllowed(e);
+        return _corrEventAllowed(e);
     });
 }
 
@@ -449,7 +474,7 @@ function renderCorrelationChart(data) {
     if (_corrVisible.events && filteredEvents.length > 0) {
         for (var i = 0; i < filteredEvents.length; i++) {
             var x = xScale(new Date(filteredEvents[i].timestamp).getTime());
-            var sev = filteredEvents[i].severity;
+            var sev = _corrNormalizeSeverity(filteredEvents[i]);
             ctx.strokeStyle = sev === 'critical' ? critColor : sev === 'warning' ? warnColor : textColor;
             ctx.lineWidth = 1;
             ctx.setLineDash([3, 3]);
@@ -547,14 +572,21 @@ function renderCorrelationChart(data) {
         legendItems.push({ metric: 'upload', color: uploadColor, label: '&#9644; ' + (T.correlation_upload || 'Upload (Mbps)') });
     }
     if (events.length > 0) {
-        // Populate _corrEventFilter for all event types in current data
+        // Populate filters for all event types/severities in current data
         var eventTypes = {};
+        var eventSeverityCounts = {};
+        var visibleEventCount = 0;
         for (var i = 0; i < events.length; i++) {
             var et = events[i].event_type || 'unknown';
+            var sev = _corrNormalizeSeverity(events[i]);
             eventTypes[et] = (eventTypes[et] || 0) + 1;
+            if (!(et in eventSeverityCounts)) eventSeverityCounts[et] = {};
+            eventSeverityCounts[et][sev] = (eventSeverityCounts[et][sev] || 0) + 1;
             if (!(et in _corrEventFilter)) _corrEventFilter[et] = !_OPERATIONAL_EVENTS[et];
+            _corrEnsureEventSeverityFilter(et);
+            if (_corrEventAllowed(events[i])) visibleEventCount++;
         }
-        legendItems.push({ metric: 'events', color: warnColor, label: '&#9650; ' + (T.correlation_events || 'Events'), eventTypes: eventTypes });
+        legendItems.push({ metric: 'events', color: warnColor, label: '&#9650; ' + (T.correlation_events || 'Events'), eventTypes: eventTypes, eventSeverityCounts: eventSeverityCounts, visibleEventCount: visibleEventCount, totalEventCount: events.length });
     }
     if (weather.length > 0) {
         legendItems.push({ metric: 'temperature', color: tempColor, label: '- - ' + (T.temperature || 'Temperature') + ' (' + (typeof TEMPERATURE_UNIT !== 'undefined' && TEMPERATURE_UNIT === 'fahrenheit' ? '°F' : '°C') + ')' });
@@ -566,9 +598,7 @@ function renderCorrelationChart(data) {
     legend.innerHTML = legendItems.map(function(item) {
         var cls = _corrVisible[item.metric] ? '' : ' disabled';
         if (item.metric === 'events') {
-            var filterCount = 0, totalTypes = 0;
-            for (var et in item.eventTypes) { totalTypes++; if (_corrEventFilter[et]) filterCount++; }
-            var filterBadge = filterCount < totalTypes ? ' <span style="font-size:0.7em;opacity:0.7;">(' + filterCount + '/' + totalTypes + ')</span>' : '';
+            var filterBadge = item.visibleEventCount < item.totalEventCount ? ' <span style="font-size:0.7em;opacity:0.7;">(' + item.visibleEventCount + '/' + item.totalEventCount + ')</span>' : '';
             return '<span data-metric="events" tabindex="0" role="button" class="' + cls + ' corr-legend-events" title="' + (T.correlation_toggle_hint || 'Click to toggle') + '" style="color:' + item.color + ';">' + item.label + filterBadge +
                 ' <span class="corr-event-filter-btn" title="' + (T.correlation_event_filter || 'Event Filter') + '">&#9881;</span></span>';
         }
@@ -595,23 +625,49 @@ function renderCorrelationChart(data) {
                 monitoring_started: T.event_type_monitoring_started || 'Monitoring Started',
                 monitoring_stopped: T.event_type_monitoring_stopped || 'Monitoring Stopped'
             };
+            var severityLabel = {
+                info: T.event_severity_info || 'Info',
+                warning: T.event_severity_warning || 'Warning',
+                critical: T.event_severity_critical || 'Critical'
+            };
             var html = '<div style="font-weight:600; margin-bottom:6px; color:var(--text,#f0f0f0);">' + (T.event_filter_title || 'Event Types') + '</div>';
             var sortedTypes = Object.keys(eventTypes).sort();
             for (var si = 0; si < sortedTypes.length; si++) {
                 var et = sortedTypes[si];
                 var checked = _corrEventFilter[et] ? ' checked' : '';
                 var label = typeLabel[et] || et.replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
-                html += '<label style="display:flex; align-items:center; gap:6px; padding:3px 0; cursor:pointer; color:var(--text-secondary,#9ca3af);">' +
-                    '<input type="checkbox" data-event-type="' + escapeHtml(et) + '"' + checked + ' style="accent-color:' + warnColor + ';"> ' +
-                    escapeHtml(label) + ' <span style="opacity:0.5; font-size:0.85em;">(' + eventTypes[et] + ')</span></label>';
+                var severityFilter = _corrEnsureEventSeverityFilter(et);
+                html += '<div class="corr-event-filter-group" style="padding:5px 0 7px; border-top:1px solid rgba(148,163,184,0.14);">' +
+                    '<label style="display:flex; align-items:center; gap:6px; padding:3px 0; cursor:pointer; color:var(--text-secondary,#9ca3af);">' +
+                    '<input type="checkbox" data-event-type="' + _corrEscapeAttr(et) + '"' + checked + ' style="accent-color:' + warnColor + ';"> ' +
+                    '<span style="font-weight:600; color:var(--text,#f0f0f0);">' + escapeHtml(label) + '</span> <span style="opacity:0.5; font-size:0.85em;">(' + eventTypes[et] + ')</span></label>' +
+                    '<div style="display:flex; flex-wrap:wrap; gap:6px; padding-left:22px; margin-top:2px;">';
+                for (var sj = 0; sj < _CORR_SEVERITIES.length; sj++) {
+                    var sv = _CORR_SEVERITIES[sj];
+                    var svChecked = severityFilter[sv] !== false ? ' checked' : '';
+                    var svCount = (eventSeverityCounts[et] && eventSeverityCounts[et][sv]) || 0;
+                    html += '<label style="display:inline-flex; align-items:center; gap:4px; cursor:pointer; color:var(--text-secondary,#9ca3af); font-size:0.85em;">' +
+                        '<input type="checkbox" data-event-type="' + _corrEscapeAttr(et) + '" data-event-severity="' + _corrEscapeAttr(sv) + '"' + svChecked + ' style="accent-color:' + warnColor + ';"> ' +
+                        escapeHtml(severityLabel[sv] || sv) + ' <span style="opacity:0.5;">(' + svCount + ')</span></label>';
+                }
+                html += '</div></div>';
             }
             pop.innerHTML = html;
             this.parentElement.appendChild(pop);
             // Prevent clicks inside popover from bubbling to legend toggle
             pop.addEventListener('click', function(e) { e.stopPropagation(); });
-            pop.querySelectorAll('input[data-event-type]').forEach(function(cb) {
+            pop.querySelectorAll('input[data-event-type]:not([data-event-severity])').forEach(function(cb) {
                 cb.addEventListener('change', function() {
                     _corrEventFilter[this.getAttribute('data-event-type')] = this.checked;
+                    renderCorrelationChart(data);
+                    renderCorrelationTable(data);
+                });
+            });
+            pop.querySelectorAll('input[data-event-severity]').forEach(function(cb) {
+                cb.addEventListener('change', function() {
+                    var eventType = this.getAttribute('data-event-type') || 'unknown';
+                    var severity = this.getAttribute('data-event-severity') || 'info';
+                    _corrEnsureEventSeverityFilter(eventType)[severity] = this.checked;
                     renderCorrelationChart(data);
                     renderCorrelationTable(data);
                 });
@@ -1264,8 +1320,8 @@ function renderCorrelationTable(data) {
 
         // Skip modem entries that are not health transitions
         if (e.source === 'modem' && !modemTransitionTs[e.timestamp]) continue;
-        // Keep table rows aligned with the event type filter used by chart markers.
-        if (e.source === 'event' && !_corrEventTypeAllowed(e)) continue;
+        // Keep table rows aligned with the event filters used by chart markers.
+        if (e.source === 'event' && !_corrEventAllowed(e)) continue;
 
         var tr = document.createElement('tr');
         tr.setAttribute('data-ts', e.timestamp);
@@ -1318,10 +1374,11 @@ function renderCorrelationTable(data) {
                 details = escapeHtml(e.last_error || '');
             }
         } else if (src === 'event') {
-            var sevColor = e.severity === 'critical' ? 'var(--crit)' : e.severity === 'warning' ? 'var(--warn)' : 'var(--muted)';
-            src = '<span style="color:' + sevColor + ';">' + (sevLabels[e.severity] || e.severity) + '</span>';
+            var eventSeverity = _corrNormalizeSeverity(e);
+            var sevColor = eventSeverity === 'critical' ? 'var(--crit)' : eventSeverity === 'warning' ? 'var(--warn)' : 'var(--muted)';
+            src = '<span style="color:' + sevColor + ';">' + escapeHtml(sevLabels[eventSeverity] || eventSeverity) + '</span>';
             msg = escapeHtml(e.message || '');
-            details = typeLabels[e.event_type] || e.event_type || '';
+            details = escapeHtml(typeLabels[e.event_type] || e.event_type || '');
         }
 
         tr.innerHTML = '<td data-label="' + escapeHtml(T.timestamp || 'Timestamp') + '" class="correlation-cell-timestamp">' + ts + '</td>'

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v24';
+var CACHE_VERSION = 'v25';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_correlation_ui.py
+++ b/tests/e2e/test_correlation_ui.py
@@ -51,10 +51,86 @@ def _sample_correlation_data():
     ]
 
 
-def _route_sample_correlation(page):
-    page.route("**/api/correlation?**", lambda route: route.fulfill(json=_sample_correlation_data()))
+def _sample_correlation_severity_data():
+    base = datetime.now(timezone.utc).replace(microsecond=0)
+
+    def ts(minutes_ago):
+        return (base - timedelta(minutes=minutes_ago)).isoformat().replace("+00:00", "Z")
+
+    return [
+        {
+            "source": "modem",
+            "timestamp": ts(60),
+            "health": "good",
+            "ds_snr_min": 38.5,
+            "ds_power_avg": 1.1,
+            "us_power_avg": 41.8,
+            "ds_uncorrectable_errors": 0,
+        },
+        {
+            "source": "event",
+            "timestamp": ts(45),
+            "event_type": "health_change",
+            "severity": "warning",
+            "message": "Health warning",
+        },
+        {
+            "source": "event",
+            "timestamp": ts(35),
+            "event_type": "health_change",
+            "severity": "critical",
+            "message": "Health critical",
+        },
+        {
+            "source": "event",
+            "timestamp": ts(25),
+            "event_type": "snr_change",
+            "severity": "info",
+            "message": "Informational SNR movement",
+        },
+    ]
+
+
+def _sample_correlation_severity_edge_data():
+    base = datetime.now(timezone.utc).replace(microsecond=0)
+
+    def ts(minutes_ago):
+        return (base - timedelta(minutes=minutes_ago)).isoformat().replace("+00:00", "Z")
+
+    return [
+        {
+            "source": "modem",
+            "timestamp": ts(60),
+            "health": "good",
+            "ds_snr_min": 38.5,
+            "ds_power_avg": 1.1,
+            "us_power_avg": 41.8,
+            "ds_uncorrectable_errors": 0,
+        },
+        {
+            "source": "event",
+            "timestamp": ts(40),
+            "event_type": 'custom" data-owned="1',
+            "message": "Missing severity stays filterable",
+        },
+        {
+            "source": "event",
+            "timestamp": ts(30),
+            "event_type": "snr_change",
+            "severity": "debug",
+            "message": "Unknown severity falls back to info",
+        },
+    ]
+
+
+def _route_correlation(page, payload=None):
+    page.route("**/api/correlation?**", lambda route: route.fulfill(json=payload or _sample_correlation_data()))
     page.route("**/api/weather/range?**", lambda route: route.fulfill(json=[]))
     page.route("**/api/fritzbox/segment-utilization/range?**", lambda route: route.fulfill(json=[]))
+
+
+def _route_sample_correlation(page):
+    _route_correlation(page)
 
 
 def _open_correlation(page):
@@ -136,7 +212,7 @@ def test_correlation_event_type_filter_updates_table_in_browser(demo_page):
     expect(page.locator("#correlation-legend .corr-legend-events")).to_contain_text("(1/2)")
 
     page.locator("#correlation-legend .corr-event-filter-btn").click()
-    page.locator('#corr-event-popover input[data-event-type="health_change"]').evaluate(
+    page.locator('#corr-event-popover input[data-event-type="health_change"]:not([data-event-severity])').evaluate(
         """
         (checkbox) => {
             checkbox.checked = false;
@@ -147,6 +223,74 @@ def test_correlation_event_type_filter_updates_table_in_browser(demo_page):
 
     expect(event_rows).to_have_count(0)
     expect(page.locator("#correlation-legend .corr-legend-events")).to_contain_text("(0/2)")
+
+
+def test_correlation_event_severity_filter_updates_chart_and_table_in_browser(demo_page):
+    page = demo_page
+    _route_correlation(page, _sample_correlation_severity_data())
+    _open_correlation(page)
+
+    event_rows = page.locator('#correlation-tbody tr[data-src="event"]')
+    expect(event_rows).to_have_count(3)
+    expect(event_rows).to_contain_text(["Informational SNR movement", "Health critical", "Health warning"])
+
+    page.locator("#correlation-legend .corr-event-filter-btn").click()
+    expect(page.locator('#corr-event-popover input[data-event-severity="info"]')).to_have_count(2)
+    page.locator('#corr-event-popover input[data-event-type="snr_change"][data-event-severity="info"]').evaluate(
+        """
+        (checkbox) => {
+            checkbox.checked = false;
+            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        """
+    )
+
+    expect(event_rows).to_have_count(2)
+    row_text = "\n".join(event_rows.all_text_contents())
+    assert "Informational SNR movement" not in row_text
+    assert "Health critical" in row_text
+    assert "Health warning" in row_text
+    visible_markers = page.locator("#correlation-legend .corr-legend-events").evaluate("(node) => node.textContent")
+    assert "2/3" in visible_markers
+
+
+def test_correlation_event_severity_normalizes_edge_cases_and_escapes_filter_attributes(demo_page):
+    page = demo_page
+    malicious_type = 'custom" data-owned="1'
+    _route_correlation(page, _sample_correlation_severity_edge_data())
+    _open_correlation(page)
+
+    event_rows = page.locator('#correlation-tbody tr[data-src="event"]')
+    expect(event_rows).to_have_count(2)
+    row_text = "\n".join(event_rows.all_text_contents())
+    assert "Info" in row_text
+    assert "undefined" not in row_text
+    assert "debug" not in row_text
+
+    page.locator("#correlation-legend .corr-event-filter-btn").click()
+    expect(page.locator("#corr-event-popover input[data-owned]")).to_have_count(0)
+    popover_event_types = page.locator("#corr-event-popover input[data-event-type]").evaluate_all(
+        "(inputs) => inputs.map((input) => input.dataset.eventType)"
+    )
+    assert malicious_type in popover_event_types
+
+    page.evaluate(
+        """
+        (eventType) => {
+            const checkbox = [...document.querySelectorAll('#corr-event-popover input[data-event-severity="info"]')]
+                .find((input) => input.dataset.eventType === eventType);
+            if (!checkbox) throw new Error('Expected malicious event type info checkbox');
+            checkbox.checked = false;
+            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        """,
+        malicious_type,
+    )
+
+    expect(event_rows).to_have_count(1)
+    remaining_text = "\n".join(event_rows.all_text_contents())
+    assert "Missing severity stays filterable" not in remaining_text
+    assert "Unknown severity falls back to info" in remaining_text
 
 
 def test_correlation_table_uses_card_layout_without_mobile_overflow(demo_page):

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -81,17 +81,33 @@ def test_correlation_event_type_filter_applies_to_table_and_chart():
     assert "function _corrEventTypeAllowed" in js
     assert "_corrFilteredEvents(events)" in js
     table_block = js[js.index("function renderCorrelationTable") :]
-    assert "_corrEventTypeAllowed(e)" in table_block
+    assert "_corrEventAllowed(e)" in table_block
 
     popover_block = js[js.index("cb.addEventListener('change'") : js.index("// Close on outside click")]
     assert "renderCorrelationChart(data)" in popover_block
     assert "renderCorrelationTable(data)" in popover_block
 
 
+def test_correlation_event_severity_filter_applies_to_table_and_chart():
+    js = CORRELATION_JS.read_text(encoding="utf-8")
+
+    assert "var _corrEventSeverityFilter = {};" in js
+    assert "function _corrEventSeverityAllowed" in js
+    assert "function _corrEventAllowed" in js
+    assert "function _corrEscapeAttr" in js
+    assert "_CORR_SEVERITIES.indexOf(severity) !== -1 ? severity : 'info'" in js
+    assert "_corrFilteredEvents(events)" in js
+    filtered_block = js[js.index("function _corrFilteredEvents") : js.index("// Re-render chart")]
+    assert "_corrEventAllowed(e)" in filtered_block
+    table_block = js[js.index("function renderCorrelationTable") :]
+    assert "_corrEventAllowed(e)" in table_block
+    assert "data-event-severity" in js
+
+
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v24';" in sw_js
+    assert "var CACHE_VERSION = 'v25';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js


### PR DESCRIPTION
## Summary
- Adds per-event severity filters for Info, Warning, and Critical in the Correlation View event filter popover.
- Keeps chart event markers and the Unified Timeline table aligned across event-type and severity filters.
- Normalizes missing or unknown event severities to Info, escapes filter attributes safely, and bumps the static cache version.

## Validation
- `git diff --check`
- `node --check app/static/js/correlation.js`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e --tb=short` — 2423 passed, 11 skipped
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e --tb=short` — 404 passed

Closes #515
