### PR TITLE
feat(channels): add temperature overlays

### DIFF
--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -268,6 +268,117 @@ function _setChartCardVisible(cardId, chartId, visible) {
     }
 }
 
+
+function _channelWeatherHasData(tempData) {
+    return !!(tempData && tempData.some(function(v) { return v !== null; }));
+}
+
+function _formatChannelWeatherTime(ms) {
+    return new Date(ms).toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function _getChannelWeatherRange(timestamps) {
+    var times = (timestamps || []).map(function(ts) {
+        var ms = new Date(ts).getTime();
+        return isFinite(ms) ? ms : null;
+    }).filter(function(ms) { return ms !== null; }).sort(function(a, b) { return a - b; });
+    if (!times.length) return null;
+    var margin = 90 * 60 * 1000;
+    return {
+        start: _formatChannelWeatherTime(times[0] - margin),
+        end: _formatChannelWeatherTime(times[times.length - 1] + margin)
+    };
+}
+
+function _fetchChannelWeatherForTimestamps(timestamps) {
+    var wr = _getChannelWeatherRange(timestamps);
+    if (!wr) return Promise.resolve([]);
+    var url = '/api/weather/range?start=' + encodeURIComponent(wr.start) + '&end=' + encodeURIComponent(wr.end);
+    return fetch(url).then(function(r) { return r.json(); }).catch(function() { return []; });
+}
+
+function _alignWeatherToChannelTimestamps(timestamps, weatherData, days) {
+    if (!weatherData || !weatherData.length) return null;
+    var weather = weatherData.map(function(row) {
+        var ms = row && row.timestamp ? new Date(row.timestamp).getTime() : NaN;
+        var temp = row ? row.temperature : null;
+        if (!isFinite(ms) || temp == null || !isFinite(Number(temp))) return null;
+        return { ts: ms, temp: Number(temp), day: row.timestamp.substring(0, 10) };
+    }).filter(function(row) { return row !== null; });
+    if (!weather.length) return null;
+
+    if (parseInt(days) >= 30) {
+        var dailyTemps = {};
+        weather.forEach(function(row) {
+            if (!dailyTemps[row.day]) dailyTemps[row.day] = [];
+            dailyTemps[row.day].push(row.temp);
+        });
+        var dailyAvg = {};
+        Object.keys(dailyTemps).forEach(function(day) {
+            var vals = dailyTemps[day];
+            var sum = 0;
+            vals.forEach(function(v) { sum += v; });
+            dailyAvg[day] = Math.round(sum / vals.length * 10) / 10;
+        });
+        return (timestamps || []).map(function(ts) {
+            var day = ts ? String(ts).substring(0, 10) : '';
+            return dailyAvg[day] !== undefined ? dailyAvg[day] : null;
+        });
+    }
+
+    return (timestamps || []).map(function(ts) {
+        if (!ts) return null;
+        var target = new Date(ts).getTime();
+        if (!isFinite(target)) return null;
+        var best = null;
+        var bestDist = Infinity;
+        weather.forEach(function(row) {
+            var dist = Math.abs(row.ts - target);
+            if (dist < bestDist) {
+                bestDist = dist;
+                best = row.temp;
+            }
+        });
+        return bestDist <= 90 * 60 * 1000 ? best : null;
+    });
+}
+
+function _updateTempToggleButton(btnId, tempData) {
+    var btn = document.getElementById(btnId);
+    if (!btn) return;
+    var hasWeather = _channelWeatherHasData(tempData);
+    btn.style.display = hasWeather ? '' : 'none';
+    btn.classList.toggle('active', _tempOverlayVisible && hasWeather);
+    btn.setAttribute('aria-pressed', (_tempOverlayVisible && hasWeather) ? 'true' : 'false');
+    btn.title = _tempOverlayVisible ? (T.temp_overlay_hide || 'Hide temperature overlay') : (T.temp_overlay_show || 'Show temperature overlay');
+}
+
+function _updateChannelTempToggle() {
+    _updateTempToggleButton('channel-temp-toggle-btn', _lastChannelWeather);
+}
+
+function _updateCompareTempToggle() {
+    _updateTempToggleButton('compare-temp-toggle-btn', _lastCompareWeather);
+}
+
+function toggleChannelTempOverlay() {
+    _tempOverlayVisible = !_tempOverlayVisible;
+    _updateChannelTempToggle();
+    _updateCompareTempToggle();
+    _renderChannelTimelineCharts();
+    _renderCompareCharts();
+}
+window.toggleChannelTempOverlay = toggleChannelTempOverlay;
+
+function toggleCompareTempOverlay() {
+    _tempOverlayVisible = !_tempOverlayVisible;
+    _updateChannelTempToggle();
+    _updateCompareTempToggle();
+    _renderChannelTimelineCharts();
+    _renderCompareCharts();
+}
+window.toggleCompareTempOverlay = toggleCompareTempOverlay;
+
 function _updateChannelInfoBar(direction, channelId) {
     var bar = document.getElementById('channel-info-bar');
     if (!bar) return;
@@ -304,6 +415,88 @@ function _updateChannelInfoBar(direction, channelId) {
 }
 
 var _cachedChannelData = null;
+var _lastChannelTimelineData = null;
+var _lastChannelTimelineContext = null;
+var _lastChannelWeather = null;
+var _channelTimelineRequestSeq = 0;
+
+function _renderChannelTimelineCharts() {
+    var data = _lastChannelTimelineData;
+    var ctx = _lastChannelTimelineContext || {};
+    if (!data || data.length === 0) return;
+    var direction = ctx.direction || 'ds';
+    var docsisVersion = ctx.docsisVersion || '3.0';
+    var days = ctx.days || '7';
+
+    var xLabels = data.map(function(d) {
+        if (!d.timestamp) return '';
+        if (parseInt(days) <= 1) return d.timestamp.substring(11, 16);
+        if (parseInt(days) >= 30) return d.timestamp.substring(5, 10);
+        return d.timestamp.substring(5, 16).replace('T', ' ');
+    });
+    var tempOpts = _channelWeatherHasData(_lastChannelWeather) ? { tempData: _lastChannelWeather } : null;
+    var powerDatasets = [{label: T.power_dbmv || 'Power (dBmV)', data: data.map(function(d){ return d.power; }), color: '#00e5f0'}];
+    var powerThresholds = direction === 'ds' ? DS_POWER_THRESHOLDS : US_POWER_THRESHOLDS;
+    var powerCard = document.querySelector('#channel-charts .chart-card:first-child');
+    var powerLabel = powerCard ? powerCard.querySelector('.chart-label') : null;
+    if (direction === 'ds') {
+        powerDatasets.push({label: T.snr_db || 'SNR (dB)', data: data.map(function(d){ return d.snr; }), color: '#66ff77'});
+        powerThresholds = null; /* DS combines Power + SNR, thresholds don't apply */
+        if (powerLabel) powerLabel.textContent = (T.power_dbmv || 'Power') + ' & ' + (T.snr_db || 'SNR');
+        var showErrors = _hasChannelDocsisErrorSeries(data);
+        _setChartCardVisible('channel-errors-card', 'chart-ch-errors', showErrors);
+        if (showErrors) {
+            renderChart('chart-ch-errors', xLabels, [
+                {label: T.correctable || 'Correctable', data: data.map(function(d){ return d.correctable_errors; }), color: '#2196f3'},
+                {label: T.uncorrectable || 'Uncorrectable', data: data.map(function(d){ return d.uncorrectable_errors; }), color: '#f44336'}
+            ], 'bar');
+        }
+    } else {
+        if (powerLabel) powerLabel.textContent = T.power_dbmv || 'Power (dBmV)';
+        _setChartCardVisible('channel-errors-card', 'chart-ch-errors', false);
+    }
+    renderChart('chart-ch-power', xLabels, powerDatasets, null, powerThresholds, tempOpts);
+
+    // Modulation timeline (stepped line chart)
+    var modCard = document.getElementById('channel-modulation-card');
+    var mods = data.filter(function(d) { return d.modulation; });
+    if (mods.length === 0) {
+        modCard.style.display = 'none';
+    } else {
+        modCard.style.display = '';
+        // Fixed QAM scales per channel direction and DOCSIS version
+        var is31 = docsisVersion === '3.1' || docsisVersion === '4.0';
+        var usQam30 = [4, 8, 16, 32, 64, 128];
+        var usQam31 = [4, 8, 16, 32, 64, 128, 256, 512, 1024];
+        var dsQam30 = [64, 256];
+        var dsQam31 = [16, 64, 256, 1024, 2048, 4096];
+        var qamSteps;
+        if (direction === 'us') { qamSteps = is31 ? usQam31 : usQam30; }
+        else { qamSteps = is31 ? dsQam31 : dsQam30; }
+        var qamLabel = {}; qamSteps.forEach(function(v) { qamLabel[v] = v + 'QAM'; });
+        var qamMap = {}; qamSteps.forEach(function(v, i) { qamMap[v + 'QAM'] = i; });
+        var modLabels = mods.map(function(d) {
+            if (parseInt(days) >= 30) return d.timestamp.substring(5, 10);
+            return d.timestamp.substring(5, 16).replace('T', ' ');
+        });
+        var modValues = mods.map(function(d) { return qamMap[d.modulation] !== undefined ? qamMap[d.modulation] : -1; });
+        var tickValues = [];
+        for (var qi = 0; qi < qamSteps.length; qi++) tickValues.push(qi);
+        renderChart('chart-ch-modulation', modLabels, [
+            {label: T.modulation || 'Modulation', data: modValues, color: '#ffab40', stepped: true}
+        ], null, null, {
+            yTickCallback: function(value) { return qamLabel[qamSteps[value]] || ''; },
+            tooltipLabelCallback: function(ctx) { return (T.modulation || 'Modulation') + ': ' + (qamLabel[qamSteps[ctx.raw]] || ctx.raw); },
+            yMin: -0.5,
+            yMax: qamSteps.length - 0.5,
+            yAxisSize: 72,
+            zoomYAxisSize: 80,
+            yAfterBuildTicks: function(axis) {
+                axis.ticks = tickValues.map(function(v) { return {value: v}; });
+            }
+        });
+    }
+}
 
 function loadChannelTimeline() {
     var sel = document.getElementById('channel-select');
@@ -318,6 +511,11 @@ function loadChannelTimeline() {
         noDataEl.style.display = 'none';
         loadingEl.style.display = 'none';
         if (infoBar) infoBar.style.display = 'none';
+        _channelTimelineRequestSeq++;
+        _lastChannelTimelineData = null;
+        _lastChannelWeather = null;
+        _lastChannelTimelineContext = null;
+        _updateChannelTempToggle();
         emptyEl.style.display = '';
         writeChannelHash();
         return;
@@ -329,6 +527,7 @@ function loadChannelTimeline() {
     var docsisVersion = selectedOpt ? selectedOpt.dataset.docsis || '3.0' : '3.0';
     var days = getPillValue('channel-time-tabs');
     writeChannelHash();
+    var requestId = ++_channelTimelineRequestSeq;
 
     loadingEl.style.display = '';
     chartsEl.style.display = 'none';
@@ -339,82 +538,36 @@ function loadChannelTimeline() {
     fetch('/api/channel-history?channel_id=' + channelId + '&direction=' + direction + '&days=' + days)
         .then(function(r) { return r.json(); })
         .then(function(data) {
+            if (requestId !== _channelTimelineRequestSeq) return;
             loadingEl.style.display = 'none';
             if (!data || data.length === 0) {
+                _lastChannelTimelineData = null;
+                _lastChannelWeather = null;
+                _lastChannelTimelineContext = null;
+                _updateChannelTempToggle();
                 noDataEl.textContent = T.no_channel_data || 'No data available for this channel.';
                 noDataEl.style.display = '';
                 return;
             }
             chartsEl.style.display = '';
-            var xLabels = data.map(function(d) {
-                if (!d.timestamp) return '';
-                if (parseInt(days) <= 1) return d.timestamp.substring(11, 16);
-                if (parseInt(days) >= 30) return d.timestamp.substring(5, 10);
-                return d.timestamp.substring(5, 16).replace('T', ' ');
+            _lastChannelTimelineData = data;
+            _lastChannelTimelineContext = {
+                direction: direction,
+                docsisVersion: docsisVersion,
+                days: days
+            };
+            _lastChannelWeather = null;
+            _updateChannelTempToggle();
+            var timestamps = data.map(function(d) { return d.timestamp; }).filter(function(ts) { return !!ts; });
+            return _fetchChannelWeatherForTimestamps(timestamps).then(function(weatherData) {
+                if (requestId !== _channelTimelineRequestSeq) return;
+                _lastChannelWeather = _alignWeatherToChannelTimestamps(timestamps, weatherData, days);
+                _updateChannelTempToggle();
+                _renderChannelTimelineCharts();
             });
-            var powerDatasets = [{label: T.power_dbmv || 'Power (dBmV)', data: data.map(function(d){ return d.power; }), color: '#00e5f0'}];
-            var powerThresholds = direction === 'ds' ? DS_POWER_THRESHOLDS : US_POWER_THRESHOLDS;
-            var powerCard = document.querySelector('#channel-charts .chart-card:first-child');
-            var powerLabel = powerCard ? powerCard.querySelector('.chart-label') : null;
-            if (direction === 'ds') {
-                powerDatasets.push({label: T.snr_db || 'SNR (dB)', data: data.map(function(d){ return d.snr; }), color: '#66ff77'});
-                powerThresholds = null; /* DS combines Power + SNR, thresholds don't apply */
-                if (powerLabel) powerLabel.textContent = (T.power_dbmv || 'Power') + ' & ' + (T.snr_db || 'SNR');
-                var showErrors = _hasChannelDocsisErrorSeries(data);
-                _setChartCardVisible('channel-errors-card', 'chart-ch-errors', showErrors);
-                if (showErrors) {
-                    renderChart('chart-ch-errors', xLabels, [
-                        {label: T.correctable || 'Correctable', data: data.map(function(d){ return d.correctable_errors; }), color: '#2196f3'},
-                        {label: T.uncorrectable || 'Uncorrectable', data: data.map(function(d){ return d.uncorrectable_errors; }), color: '#f44336'}
-                    ], 'bar');
-                }
-            } else {
-                if (powerLabel) powerLabel.textContent = T.power_dbmv || 'Power (dBmV)';
-                _setChartCardVisible('channel-errors-card', 'chart-ch-errors', false);
-            }
-            renderChart('chart-ch-power', xLabels, powerDatasets, null, powerThresholds);
-
-            // Modulation timeline (stepped line chart)
-            var modCard = document.getElementById('channel-modulation-card');
-            var mods = data.filter(function(d) { return d.modulation; });
-            if (mods.length === 0) {
-                modCard.style.display = 'none';
-            } else {
-                modCard.style.display = '';
-                // Fixed QAM scales per channel direction and DOCSIS version
-                var is31 = docsisVersion === '3.1' || docsisVersion === '4.0';
-                var usQam30 = [4, 8, 16, 32, 64, 128];
-                var usQam31 = [4, 8, 16, 32, 64, 128, 256, 512, 1024];
-                var dsQam30 = [64, 256];
-                var dsQam31 = [16, 64, 256, 1024, 2048, 4096];
-                var qamSteps;
-                if (direction === 'us') { qamSteps = is31 ? usQam31 : usQam30; }
-                else { qamSteps = is31 ? dsQam31 : dsQam30; }
-                var qamLabel = {}; qamSteps.forEach(function(v) { qamLabel[v] = v + 'QAM'; });
-                var qamMap = {}; qamSteps.forEach(function(v, i) { qamMap[v + 'QAM'] = i; });
-                var modLabels = mods.map(function(d) {
-                    if (parseInt(days) >= 30) return d.timestamp.substring(5, 10);
-                    return d.timestamp.substring(5, 16).replace('T', ' ');
-                });
-                var modValues = mods.map(function(d) { return qamMap[d.modulation] !== undefined ? qamMap[d.modulation] : -1; });
-                var tickValues = [];
-                for (var qi = 0; qi < qamSteps.length; qi++) tickValues.push(qi);
-                renderChart('chart-ch-modulation', modLabels, [
-                    {label: T.modulation || 'Modulation', data: modValues, color: '#ffab40', stepped: true}
-                ], null, null, {
-                    yTickCallback: function(value) { return qamLabel[qamSteps[value]] || ''; },
-                    tooltipLabelCallback: function(ctx) { return (T.modulation || 'Modulation') + ': ' + (qamLabel[qamSteps[ctx.raw]] || ctx.raw); },
-                    yMin: -0.5,
-                    yMax: qamSteps.length - 0.5,
-                    yAxisSize: 72,
-                    zoomYAxisSize: 80,
-                    yAfterBuildTicks: function(axis) {
-                        axis.ticks = tickValues.map(function(v) { return {value: v}; });
-                    }
-                });
-            }
         })
         .catch(function() {
+            if (requestId !== _channelTimelineRequestSeq) return;
             loadingEl.style.display = 'none';
             noDataEl.textContent = T.trend_error || 'Error loading data.';
             noDataEl.style.display = '';
@@ -429,6 +582,9 @@ var _compareChannelData = null;
 var _comparePreset = null;
 var _compareState = { ds: { channels: [], preset: null }, us: { channels: [], preset: null } };
 var _lastCompareDir = 'ds';
+var _lastCompareWeather = null;
+var _lastCompareRenderContext = null;
+var _compareRequestSeq = 0;
 
 function compareColor(index) {
     if (index < _compareColors.length) return _compareColors[index];
@@ -472,6 +628,10 @@ function showCompareError(message, error) {
 }
 
 function clearCompareCharts() {
+    _compareRequestSeq++;
+    _lastCompareWeather = null;
+    _lastCompareRenderContext = null;
+    _updateCompareTempToggle();
     document.getElementById('compare-charts').style.display = 'none';
     document.getElementById('compare-loading').style.display = 'none';
     ['chart-cmp-power', 'chart-cmp-snr', 'chart-cmp-errors', 'chart-cmp-modulation'].forEach(function(id) {
@@ -642,11 +802,152 @@ function renderCompareChips() {
     });
 }
 
+function _renderCompareCharts() {
+    var ctx = _lastCompareRenderContext;
+    if (!ctx || !ctx.data || !ctx.timestamps || ctx.timestamps.length === 0) return;
+    var data = ctx.data;
+    var timestamps = ctx.timestamps;
+    var days = ctx.days || '7';
+    var dir = ctx.dir || getCompareDirection();
+    var xLabels = timestamps.map(function(ts) {
+        if (parseInt(days) <= 1) return ts.substring(11, 16);
+        if (parseInt(days) >= 30) return ts.substring(5, 10);
+        return ts.substring(5, 16).replace('T', ' ');
+    });
+    var showPoints = _compareChannels.length <= 6;
+    var tempOpts = _channelWeatherHasData(_lastCompareWeather) ? { tempData: _lastCompareWeather } : null;
+
+    // Build lookup maps per channel: timestamp -> data point
+    var lookups = {};
+    _compareChannels.forEach(function(ch) {
+        var map = {};
+        (data[String(ch.id)] || []).forEach(function(d) { map[d.timestamp] = d; });
+        lookups[ch.id] = map;
+    });
+
+    // Power Chart
+    var powerDatasets = _compareChannels.map(function(ch) {
+        return {
+            label: 'CH ' + ch.id,
+            data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.power : null; }),
+            color: ch.color,
+            showPoints: showPoints
+        };
+    });
+    var powerThresholds = dir === 'ds' ? DS_POWER_THRESHOLDS : US_POWER_THRESHOLDS;
+    renderChart('chart-cmp-power', xLabels, powerDatasets, null, powerThresholds, tempOpts);
+
+    // SNR Chart (DS only)
+    var snrCard = document.getElementById('compare-snr-card');
+    if (dir === 'ds') {
+        snrCard.style.display = '';
+        var snrDatasets = _compareChannels.map(function(ch) {
+            return {
+                label: 'CH ' + ch.id,
+                data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.snr : null; }),
+                color: ch.color,
+                showPoints: showPoints
+            };
+        });
+        renderChart('chart-cmp-snr', xLabels, snrDatasets, null, DS_SNR_THRESHOLDS, tempOpts);
+    } else {
+        snrCard.style.display = 'none';
+    }
+
+    // Errors Chart (DS only, lines not bars)
+    if (dir === 'ds') {
+        var compareHasErrors = _compareChannels.some(function(ch) {
+            return _hasChannelDocsisErrorSeries(data[String(ch.id)] || []);
+        });
+        _setChartCardVisible('compare-errors-card', 'chart-cmp-errors', compareHasErrors);
+        if (compareHasErrors) {
+            var errorDatasets = [];
+            _compareChannels.forEach(function(ch) {
+                errorDatasets.push({
+                    label: 'CH ' + ch.id + ' ' + (T.uncorrectable || 'Uncorr.'),
+                    data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.uncorrectable_errors != null ? d.uncorrectable_errors : null; }),
+                    color: ch.color,
+                    showPoints: showPoints
+                });
+                errorDatasets.push({
+                    label: 'CH ' + ch.id + ' ' + (T.correctable || 'Corr.'),
+                    data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.correctable_errors != null ? d.correctable_errors : null; }),
+                    color: ch.color,
+                    dashed: true,
+                    showPoints: showPoints
+                });
+            });
+            renderChart('chart-cmp-errors', xLabels, errorDatasets, null, null, tempOpts);
+        }
+    } else {
+        _setChartCardVisible('compare-errors-card', 'chart-cmp-errors', false);
+    }
+
+    // Modulation Chart
+    var modCard = document.getElementById('compare-modulation-card');
+    var hasMod = false;
+    _compareChannels.forEach(function(ch) {
+        var chData = data[String(ch.id)] || [];
+        if (chData.some(function(d) { return d.modulation; })) hasMod = true;
+    });
+    if (!hasMod) {
+        modCard.style.display = 'none';
+    } else {
+        modCard.style.display = '';
+        // Collect all unique QAM values
+        var allQam = {};
+        _compareChannels.forEach(function(ch) {
+            (data[String(ch.id)] || []).forEach(function(d) {
+                if (d.modulation) allQam[d.modulation] = true;
+            });
+        });
+        var qamNames = Object.keys(allQam).sort(function(a, b) {
+            var na = parseInt(a) || 0, nb = parseInt(b) || 0;
+            return na - nb;
+        });
+        var qamMap = {};
+        qamNames.forEach(function(name, idx) { qamMap[name] = idx; });
+        var qamLabel = {};
+        qamNames.forEach(function(name, idx) { qamLabel[idx] = name; });
+
+        var modDatasets = _compareChannels.map(function(ch) {
+            return {
+                label: 'CH ' + ch.id,
+                data: timestamps.map(function(ts) {
+                    var d = lookups[ch.id][ts];
+                    if (!d || !d.modulation) return null;
+                    return qamMap[d.modulation] !== undefined ? qamMap[d.modulation] : null;
+                }),
+                color: ch.color,
+                stepped: true,
+                showPoints: false
+            };
+        });
+        var tickValues = [];
+        for (var qi = 0; qi < qamNames.length; qi++) tickValues.push(qi);
+        renderChart('chart-cmp-modulation', xLabels, modDatasets, null, null, {
+            yTickCallback: function(value) { return qamLabel[value] || ''; },
+            tooltipLabelCallback: function(ctx) { return ctx.dataset.label + ': ' + (qamLabel[ctx.raw] || ctx.raw); },
+            yMin: -0.5,
+            yMax: qamNames.length - 0.5,
+            yAxisSize: 72,
+            zoomYAxisSize: 80,
+            yAfterBuildTicks: function(axis) {
+                axis.ticks = tickValues.map(function(v) { return {value: v}; });
+            }
+        });
+    }
+}
+
 function loadCompareCharts() {
     var chartsEl = document.getElementById('compare-charts');
     var emptyEl = document.getElementById('compare-empty');
     var loadingEl = document.getElementById('compare-loading');
     if (_compareChannels.length === 0) {
+        _compareRequestSeq++;
+        _lastCompareWeather = null;
+        _lastCompareRenderContext = null;
+        _updateCompareTempToggle();
         chartsEl.style.display = 'none';
         emptyEl.textContent = T.no_channels_selected || 'Select channels to compare';
         emptyEl.style.display = '';
@@ -656,6 +957,7 @@ function loadCompareCharts() {
     var days = getPillValue('compare-time-tabs') || '7';
     var ids = _compareChannels.map(function(c) { return c.id; }).join(',');
     writeChannelHash();
+    var requestId = ++_compareRequestSeq;
 
     loadingEl.style.display = '';
     chartsEl.style.display = 'none';
@@ -664,6 +966,7 @@ function loadCompareCharts() {
     fetch('/api/channel-compare?channels=' + ids + '&direction=' + dir + '&days=' + days)
         .then(function(r) { return r.json(); })
         .then(function(data) {
+            if (requestId !== _compareRequestSeq) return;
             loadingEl.style.display = 'none';
             _compareChannelData = data;
 
@@ -675,141 +978,32 @@ function loadCompareCharts() {
             });
             var timestamps = Object.keys(tsSet).sort();
             if (timestamps.length === 0) {
+                _compareRequestSeq++;
+                _lastCompareWeather = null;
+                _lastCompareRenderContext = null;
+                _updateCompareTempToggle();
                 emptyEl.textContent = T.compare_no_data_range || 'No data for the selected channels in this time range.';
                 emptyEl.style.display = '';
                 return;
             }
             chartsEl.style.display = '';
-
-            var xLabels = timestamps.map(function(ts) {
-                if (parseInt(days) <= 1) return ts.substring(11, 16);
-                if (parseInt(days) >= 30) return ts.substring(5, 10);
-                return ts.substring(5, 16).replace('T', ' ');
+            _lastCompareRenderContext = {
+                data: data,
+                timestamps: timestamps,
+                days: days,
+                dir: dir
+            };
+            _lastCompareWeather = null;
+            _updateCompareTempToggle();
+            return _fetchChannelWeatherForTimestamps(timestamps).then(function(weatherData) {
+                if (requestId !== _compareRequestSeq) return;
+                _lastCompareWeather = _alignWeatherToChannelTimestamps(timestamps, weatherData, days);
+                _updateCompareTempToggle();
+                _renderCompareCharts();
             });
-            var showPoints = _compareChannels.length <= 6;
-
-            // Build lookup maps per channel: timestamp -> data point
-            var lookups = {};
-            _compareChannels.forEach(function(ch) {
-                var map = {};
-                (data[String(ch.id)] || []).forEach(function(d) { map[d.timestamp] = d; });
-                lookups[ch.id] = map;
-            });
-
-            // Power Chart
-            var powerDatasets = _compareChannels.map(function(ch) {
-                return {
-                    label: 'CH ' + ch.id,
-                    data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.power : null; }),
-                    color: ch.color,
-                    showPoints: showPoints
-                };
-            });
-            var powerThresholds = dir === 'ds' ? DS_POWER_THRESHOLDS : US_POWER_THRESHOLDS;
-            renderChart('chart-cmp-power', xLabels, powerDatasets, null, powerThresholds);
-
-            // SNR Chart (DS only)
-            var snrCard = document.getElementById('compare-snr-card');
-            if (dir === 'ds') {
-                snrCard.style.display = '';
-                var snrDatasets = _compareChannels.map(function(ch) {
-                    return {
-                        label: 'CH ' + ch.id,
-                        data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.snr : null; }),
-                        color: ch.color,
-                        showPoints: showPoints
-                    };
-                });
-                renderChart('chart-cmp-snr', xLabels, snrDatasets, null, DS_SNR_THRESHOLDS);
-            } else {
-                snrCard.style.display = 'none';
-            }
-
-            // Errors Chart (DS only, lines not bars)
-            if (dir === 'ds') {
-                var compareHasErrors = _compareChannels.some(function(ch) {
-                    return _hasChannelDocsisErrorSeries(data[String(ch.id)] || []);
-                });
-                _setChartCardVisible('compare-errors-card', 'chart-cmp-errors', compareHasErrors);
-                if (compareHasErrors) {
-                    var errorDatasets = [];
-                    _compareChannels.forEach(function(ch) {
-                        errorDatasets.push({
-                            label: 'CH ' + ch.id + ' ' + (T.uncorrectable || 'Uncorr.'),
-                            data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.uncorrectable_errors != null ? d.uncorrectable_errors : null; }),
-                            color: ch.color,
-                            showPoints: showPoints
-                        });
-                        errorDatasets.push({
-                            label: 'CH ' + ch.id + ' ' + (T.correctable || 'Corr.'),
-                            data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.correctable_errors != null ? d.correctable_errors : null; }),
-                            color: ch.color,
-                            dashed: true,
-                            showPoints: showPoints
-                        });
-                    });
-                    renderChart('chart-cmp-errors', xLabels, errorDatasets);
-                }
-            } else {
-                _setChartCardVisible('compare-errors-card', 'chart-cmp-errors', false);
-            }
-
-            // Modulation Chart
-            var modCard = document.getElementById('compare-modulation-card');
-            var hasMod = false;
-            _compareChannels.forEach(function(ch) {
-                var chData = data[String(ch.id)] || [];
-                if (chData.some(function(d) { return d.modulation; })) hasMod = true;
-            });
-            if (!hasMod) {
-                modCard.style.display = 'none';
-            } else {
-                modCard.style.display = '';
-                // Collect all unique QAM values
-                var allQam = {};
-                _compareChannels.forEach(function(ch) {
-                    (data[String(ch.id)] || []).forEach(function(d) {
-                        if (d.modulation) allQam[d.modulation] = true;
-                    });
-                });
-                var qamNames = Object.keys(allQam).sort(function(a, b) {
-                    var na = parseInt(a) || 0, nb = parseInt(b) || 0;
-                    return na - nb;
-                });
-                var qamMap = {};
-                qamNames.forEach(function(name, idx) { qamMap[name] = idx; });
-                var qamLabel = {};
-                qamNames.forEach(function(name, idx) { qamLabel[idx] = name; });
-
-                var modDatasets = _compareChannels.map(function(ch) {
-                    return {
-                        label: 'CH ' + ch.id,
-                        data: timestamps.map(function(ts) {
-                            var d = lookups[ch.id][ts];
-                            if (!d || !d.modulation) return null;
-                            return qamMap[d.modulation] !== undefined ? qamMap[d.modulation] : null;
-                        }),
-                        color: ch.color,
-                        stepped: true,
-                        showPoints: false
-                    };
-                });
-                var tickValues = [];
-                for (var qi = 0; qi < qamNames.length; qi++) tickValues.push(qi);
-                renderChart('chart-cmp-modulation', xLabels, modDatasets, null, null, {
-                    yTickCallback: function(value) { return qamLabel[value] || ''; },
-                    tooltipLabelCallback: function(ctx) { return ctx.dataset.label + ': ' + (qamLabel[ctx.raw] || ctx.raw); },
-                    yMin: -0.5,
-                    yMax: qamNames.length - 0.5,
-                    yAxisSize: 72,
-                    zoomYAxisSize: 80,
-                    yAfterBuildTicks: function(axis) {
-                        axis.ticks = tickValues.map(function(v) { return {value: v}; });
-                    }
-                });
-            }
         })
         .catch(function() {
+            if (requestId !== _compareRequestSeq) return;
             loadingEl.style.display = 'none';
             emptyEl.textContent = T.trend_error || 'Error loading data.';
             emptyEl.style.display = '';

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v25';
+var CACHE_VERSION = 'v26';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1593,6 +1593,7 @@
                 <button class="trend-tab active" data-value="7" onclick="selectPill(this, loadChannelTimeline)">7d</button>
                 <button class="trend-tab" data-value="30" onclick="selectPill(this, loadChannelTimeline)">30d</button>
             </div>
+            <button id="channel-temp-toggle-btn" class="trend-tab temp-toggle active" onclick="toggleChannelTempOverlay()" style="display:none;" aria-pressed="true" title="{{ t.temp_overlay_hide }}">{{ t.temperature }}</button>
         </span>
         <span id="channel-compare-controls" style="display:none;">
             <div class="trend-tabs" id="compare-dir-tabs">
@@ -1609,6 +1610,7 @@
                 <button class="trend-tab active" data-value="7" onclick="selectPill(this, loadCompareCharts)">7d</button>
                 <button class="trend-tab" data-value="30" onclick="selectPill(this, loadCompareCharts)">30d</button>
             </div>
+            <button id="compare-temp-toggle-btn" class="trend-tab temp-toggle active" onclick="toggleCompareTempOverlay()" style="display:none;" aria-pressed="true" title="{{ t.temp_overlay_hide }}">{{ t.temperature }}</button>
         </span>
     </div>
 

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -420,6 +420,311 @@ class TestCompareCharts:
                 assert chips.count() >= 1
 
 
+class TestChannelTemperatureOverlay:
+    """Weather temperature overlays in Channels timeline and compare charts."""
+
+    def test_channel_timeline_fetches_weather_and_toggles_temperature_overlay(self, demo_page):
+        history = [
+            {
+                "timestamp": "2026-05-01T12:00:00",
+                "power": 1.2,
+                "snr": 38.5,
+                "modulation": "256QAM",
+                "correctable_errors": 1,
+                "uncorrectable_errors": 0,
+            },
+            {
+                "timestamp": "2026-05-01T13:00:00",
+                "power": 1.4,
+                "snr": 38.7,
+                "modulation": "256QAM",
+                "correctable_errors": 2,
+                "uncorrectable_errors": 0,
+            },
+        ]
+        weather_requests = []
+
+        demo_page.route(
+            "**/api/channels",
+            lambda route: route.fulfill(json={
+                "ds_channels": [{
+                    "channel_id": 1,
+                    "frequency": "690 MHz",
+                    "docsis_version": "3.0",
+                    "power": 1.2,
+                    "snr": 38.5,
+                    "health": "good",
+                }],
+                "us_channels": [],
+            }),
+        )
+        demo_page.route("**/api/channel-history**", lambda route: route.fulfill(json=history))
+
+        def weather_route(route):
+            weather_requests.append(route.request.url)
+            route.fulfill(json=[
+                {"timestamp": "2026-05-01T12:05:00", "temperature": 12.5},
+                {"timestamp": "2026-05-01T13:05:00", "temperature": 13.5},
+            ])
+
+        demo_page.route("**/api/weather/range**", weather_route)
+
+        navigate_to_channels(demo_page)
+        demo_page.locator("#channel-select").select_option("ds-1")
+        wait_for_uplot(demo_page, "chart-ch-power")
+
+        toggle = demo_page.locator("#channel-temp-toggle-btn")
+        assert toggle.count() == 1
+        assert toggle.is_visible()
+        assert weather_requests, "channel timeline should fetch weather for the displayed timestamps"
+
+        overlay = demo_page.evaluate(
+            """
+            () => {
+                const chart = window.charts['chart-ch-power'];
+                return {
+                    labels: chart.series.map((s) => s.label),
+                    tempScale: !!chart.scales.temp,
+                    tempData: chart.data[chart.data.length - 1],
+                };
+            }
+            """
+        )
+        assert "Temperature" in overlay["labels"]
+        assert overlay["tempScale"] is True
+        assert overlay["tempData"] == [12.5, 13.5]
+
+        toggle.click()
+        demo_page.wait_for_timeout(300)
+        labels_after_toggle = demo_page.evaluate(
+            "() => window.charts['chart-ch-power'].series.map((s) => s.label)"
+        )
+        assert "Temperature" not in labels_after_toggle
+
+    def test_channel_timeline_hides_temperature_toggle_without_weather_data(self, demo_page):
+        history = [
+            {
+                "timestamp": "2026-05-01T12:00:00",
+                "power": 1.2,
+                "snr": 38.5,
+                "modulation": "256QAM",
+                "correctable_errors": 1,
+                "uncorrectable_errors": 0,
+            }
+        ]
+
+        demo_page.route(
+            "**/api/channels",
+            lambda route: route.fulfill(json={
+                "ds_channels": [{
+                    "channel_id": 1,
+                    "frequency": "690 MHz",
+                    "docsis_version": "3.0",
+                    "power": 1.2,
+                    "snr": 38.5,
+                    "health": "good",
+                }],
+                "us_channels": [],
+            }),
+        )
+        demo_page.route("**/api/channel-history**", lambda route: route.fulfill(json=history))
+        demo_page.route("**/api/weather/range**", lambda route: route.fulfill(json=[]))
+
+        navigate_to_channels(demo_page)
+        demo_page.locator("#channel-select").select_option("ds-1")
+        wait_for_uplot(demo_page, "chart-ch-power")
+
+        assert demo_page.locator("#channel-temp-toggle-btn").is_hidden()
+        labels = demo_page.evaluate("() => window.charts['chart-ch-power'].series.map((s) => s.label)")
+        assert "Temperature" not in labels
+
+    def test_channel_compare_uses_one_common_temperature_series(self, demo_page):
+        compare_payload = {
+            "1": [
+                {
+                    "timestamp": "2026-05-01T12:00:00",
+                    "power": 1.2,
+                    "snr": 38.5,
+                    "modulation": "256QAM",
+                    "correctable_errors": 1,
+                    "uncorrectable_errors": 0,
+                },
+                {
+                    "timestamp": "2026-05-01T13:00:00",
+                    "power": 1.4,
+                    "snr": 38.7,
+                    "modulation": "256QAM",
+                    "correctable_errors": 2,
+                    "uncorrectable_errors": 0,
+                },
+            ],
+            "2": [
+                {
+                    "timestamp": "2026-05-01T12:00:00",
+                    "power": 2.2,
+                    "snr": 37.5,
+                    "modulation": "256QAM",
+                    "correctable_errors": 0,
+                    "uncorrectable_errors": 0,
+                },
+                {
+                    "timestamp": "2026-05-01T13:00:00",
+                    "power": 2.4,
+                    "snr": 37.7,
+                    "modulation": "256QAM",
+                    "correctable_errors": 1,
+                    "uncorrectable_errors": 0,
+                },
+            ],
+        }
+        weather_requests = []
+
+        demo_page.route(
+            "**/api/channels",
+            lambda route: route.fulfill(json={
+                "ds_channels": [
+                    {"channel_id": 1, "frequency": "690 MHz", "docsis_version": "3.0"},
+                    {"channel_id": 2, "frequency": "698 MHz", "docsis_version": "3.0"},
+                ],
+                "us_channels": [],
+            }),
+        )
+        demo_page.route("**/api/channel-compare**", lambda route: route.fulfill(json=compare_payload))
+
+        def weather_route(route):
+            weather_requests.append(route.request.url)
+            route.fulfill(json=[
+                {"timestamp": "2026-05-01T12:10:00", "temperature": 17.0},
+                {"timestamp": "2026-05-01T13:10:00", "temperature": 18.0},
+            ])
+
+        demo_page.route("**/api/weather/range**", weather_route)
+
+        navigate_to_channels(demo_page)
+        demo_page.locator('.trend-tab[data-value="compare"]').click()
+        demo_page.locator("#compare-add-all-btn").click()
+        wait_for_uplot(demo_page, "chart-cmp-power")
+
+        toggle = demo_page.locator("#compare-temp-toggle-btn")
+        assert toggle.count() == 1
+        assert toggle.is_visible()
+        assert len(weather_requests) == 1
+
+        overlay = demo_page.evaluate(
+            """
+            () => {
+                const chart = window.charts['chart-cmp-power'];
+                return {
+                    labels: chart.series.map((s) => s.label),
+                    tempScale: !!chart.scales.temp,
+                    tempData: chart.data[chart.data.length - 1],
+                    tempSeriesCount: chart.series.filter((s) => s.label === 'Temperature').length,
+                };
+            }
+            """
+        )
+        assert overlay["tempScale"] is True
+        assert overlay["tempData"] == [17.0, 18.0]
+        assert overlay["tempSeriesCount"] == 1
+
+    def test_channel_compare_hides_temperature_toggle_without_weather_data(self, demo_page):
+        compare_payload = {
+            "1": [
+                {
+                    "timestamp": "2026-05-01T12:00:00",
+                    "power": 1.2,
+                    "snr": 38.5,
+                    "modulation": "256QAM",
+                    "correctable_errors": 1,
+                    "uncorrectable_errors": 0,
+                }
+            ]
+        }
+
+        demo_page.route(
+            "**/api/channels",
+            lambda route: route.fulfill(json={
+                "ds_channels": [{"channel_id": 1, "frequency": "690 MHz", "docsis_version": "3.0"}],
+                "us_channels": [],
+            }),
+        )
+        demo_page.route("**/api/channel-compare**", lambda route: route.fulfill(json=compare_payload))
+        demo_page.route("**/api/weather/range**", lambda route: route.fulfill(json=[]))
+
+        navigate_to_channels(demo_page)
+        demo_page.locator('.trend-tab[data-value="compare"]').click()
+        demo_page.locator("#compare-add-all-btn").click()
+        wait_for_uplot(demo_page, "chart-cmp-power")
+
+        assert demo_page.locator("#compare-temp-toggle-btn").is_hidden()
+        labels = demo_page.evaluate("() => window.charts['chart-cmp-power'].series.map((s) => s.label)")
+        assert "Temperature" not in labels
+
+    def test_channel_temperature_toggle_state_stays_in_sync_across_modes(self, demo_page):
+        rows = [
+            {
+                "timestamp": "2026-05-01T12:00:00",
+                "power": 1.2,
+                "snr": 38.5,
+                "modulation": "256QAM",
+                "correctable_errors": 1,
+                "uncorrectable_errors": 0,
+            },
+            {
+                "timestamp": "2026-05-01T13:00:00",
+                "power": 1.4,
+                "snr": 38.7,
+                "modulation": "256QAM",
+                "correctable_errors": 2,
+                "uncorrectable_errors": 0,
+            },
+        ]
+
+        demo_page.route(
+            "**/api/channels",
+            lambda route: route.fulfill(json={
+                "ds_channels": [{"channel_id": 1, "frequency": "690 MHz", "docsis_version": "3.0"}],
+                "us_channels": [],
+            }),
+        )
+        demo_page.route("**/api/channel-history**", lambda route: route.fulfill(json=rows))
+        demo_page.route("**/api/channel-compare**", lambda route: route.fulfill(json={"1": rows}))
+        demo_page.route(
+            "**/api/weather/range**",
+            lambda route: route.fulfill(json=[
+                {"timestamp": "2026-05-01T12:00:00", "temperature": 12.0},
+                {"timestamp": "2026-05-01T13:00:00", "temperature": 13.0},
+            ]),
+        )
+
+        navigate_to_channels(demo_page)
+        demo_page.locator("#channel-select").select_option("ds-1")
+        wait_for_uplot(demo_page, "chart-ch-power")
+        assert "Temperature" in demo_page.evaluate(
+            "() => window.charts['chart-ch-power'].series.map((s) => s.label)"
+        )
+
+        demo_page.locator('.trend-tab[data-value="compare"]').click()
+        demo_page.locator("#compare-add-all-btn").click()
+        wait_for_uplot(demo_page, "chart-cmp-power")
+        assert "Temperature" in demo_page.evaluate(
+            "() => window.charts['chart-cmp-power'].series.map((s) => s.label)"
+        )
+
+        demo_page.locator('.trend-tab[data-value="timeline"]').click()
+        demo_page.locator("#channel-temp-toggle-btn").click()
+        demo_page.wait_for_timeout(300)
+        assert "Temperature" not in demo_page.evaluate(
+            "() => window.charts['chart-ch-power'].series.map((s) => s.label)"
+        )
+
+        demo_page.locator('.trend-tab[data-value="compare"]').click()
+        assert demo_page.locator("#compare-temp-toggle-btn").get_attribute("aria-pressed") == "false"
+        assert "Temperature" not in demo_page.evaluate(
+            "() => window.charts['chart-cmp-power'].series.map((s) => s.label)"
+        )
+
+
 class TestUnsupportedDocsisErrorCharts:
     """Unsupported DOCSIS error counters should remove misleading error charts."""
 

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,11 +107,29 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v25';" in sw_js
+    assert "var CACHE_VERSION = 'v26';" in sw_js
     assert "/static/css/main.css" in sw_js
+    assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js
     assert "/modules/docsight.modulation/static/main.js" in sw_js
+
+
+def test_channels_weather_overlay_contract_is_wired():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    channels_js = CHANNELS_JS.read_text(encoding="utf-8")
+
+    assert 'id="channel-temp-toggle-btn"' in template
+    assert 'id="compare-temp-toggle-btn"' in template
+    assert "function _getChannelWeatherRange" in channels_js
+    assert "function _alignWeatherToChannelTimestamps" in channels_js
+    assert "function _fetchChannelWeatherForTimestamps" in channels_js
+    assert "function _updateChannelTempToggle" in channels_js
+    assert "function _updateCompareTempToggle" in channels_js
+    assert "_renderChannelTimelineCharts()" in channels_js
+    assert "_renderCompareCharts()" in channels_js
+    assert "tempData: _lastChannelWeather" in channels_js
+    assert "tempData: _lastCompareWeather" in channels_js
 
 
 def test_chart_engine_has_configurable_axis_padding_for_long_qam_labels():


### PR DESCRIPTION
## Summary
- Adds weather-backed temperature overlays to Channels Timeline and Channel Compare charts.
- Aligns `/api/weather/range` readings to channel timestamps and uses a single shared temperature series in Compare.
- Hides overlay controls when weather data is unavailable, keeps toggle state synchronized across channel modes, and guards against stale weather responses.
- Bumps the service-worker cache version for updated channel assets.

## Tests
- `node --check app/static/js/channels.js && node --check app/static/sw.js && git diff --check`
- `python -m pytest -q tests/test_channel_timeline.py tests/test_static_contracts.py tests/e2e/test_channels.py tests/e2e/test_security.py::TestChannelCompareChipEscaping::test_compare_add_channel tests/e2e/test_charts.py::TestChannelTemperatureOverlay --tb=short`
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q --tb=short`

Closes #516
