### PR TITLE
fix(trends): fill DS SNR chart area

### DIFF
--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -109,7 +109,7 @@ function _renderTrendCharts() {
         [{label: 'DS Power Avg', data: data.map(function(d){ return d.ds_power_avg; }), color: '#a855f7', fill: POWER_TREND_FILL, fillTo: fillToScaleMin}],
         null, DS_POWER_THRESHOLDS, tempOpts);
     renderChart('chart-ds-snr', xLabels,
-        [{label: 'DS SNR Avg', data: data.map(function(d){ return d.ds_snr_avg; }), color: '#a855f7'}],
+        [{label: 'DS SNR Avg', data: data.map(function(d){ return d.ds_snr_avg; }), color: '#a855f7', fill: POWER_TREND_FILL, fillTo: fillToScaleMin}],
         null, DS_SNR_THRESHOLDS, tempOpts);
     renderChart('chart-us-power', xLabels,
         [{label: 'US Power Avg', data: data.map(function(d){ return d.us_power_avg; }), color: '#a855f7', fill: POWER_TREND_FILL, fillTo: fillToScaleMin}],

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v26';
+var CACHE_VERSION = 'v27';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -111,15 +111,15 @@ class TestTrendCharts:
         assert box["width"] > 100
         assert box["height"] > 50
 
-    def test_power_trend_charts_fill_to_visible_axis_floor(self, demo_page):
-        """DS/US Power charts should render filled areas to the visible y-axis floor."""
+    def test_trend_single_metric_charts_fill_to_visible_axis_floor(self, demo_page):
+        """DS Power, DS SNR, and US Power charts should fill to the visible y-axis floor."""
         navigate_to_trends(demo_page)
-        for chart_id in ["chart-ds-power", "chart-us-power"]:
+        for chart_id in ["chart-ds-power", "chart-ds-snr", "chart-us-power"]:
             wait_for_uplot(demo_page, chart_id)
 
         fills = demo_page.evaluate(
             """
-            () => ['chart-ds-power', 'chart-us-power'].map((chartId) => {
+            () => ['chart-ds-power', 'chart-ds-snr', 'chart-us-power'].map((chartId) => {
                 const chart = window.charts[chartId];
                 const dataset = chart._docsightParams.datasets[0];
                 return {
@@ -138,6 +138,12 @@ class TestTrendCharts:
                 "configuredFill": "rgba(168,85,247,0.15)",
                 "fillToValue": -18,
                 "yMin": -18,
+            },
+            {
+                "chartId": "chart-ds-snr",
+                "configuredFill": "rgba(168,85,247,0.15)",
+                "fillToValue": 20,
+                "yMin": 20,
             },
             {
                 "chartId": "chart-us-power",

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,7 +107,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v26';" in sw_js
+    assert "var CACHE_VERSION = 'v27';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
@@ -161,16 +161,18 @@ def test_chart_zoom_uses_bounded_index_ticks_instead_of_all_samples():
     assert "filter: xTickValues" not in zoom_block
 
 
-def test_trend_power_charts_fill_to_visible_axis_floor():
+def test_trend_single_metric_charts_fill_to_visible_axis_floor():
     chart_engine = CHART_ENGINE_JS.read_text(encoding="utf-8")
     trends = TRENDS_JS.read_text(encoding="utf-8")
+    snr_block = trends[trends.index("renderChart('chart-ds-snr'") : trends.index("renderChart('chart-us-power'")]
 
     assert "function fillToScaleMin" in chart_engine
     assert "if (ds.fillTo !== undefined && ds.fillTo !== null) s.fillTo = ds.fillTo;" in chart_engine
     assert "fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || undefined)" in chart_engine
     assert "var POWER_TREND_FILL" in trends
-    assert "fillTo: fillToScaleMin" in trends
-    assert trends.count("fill: POWER_TREND_FILL") >= 2
+    assert "fill: POWER_TREND_FILL" in snr_block
+    assert "fillTo: fillToScaleMin" in snr_block
+    assert trends.count("fill: POWER_TREND_FILL") >= 3
 
 
 def test_connection_monitor_card_treats_no_enabled_targets_as_no_data():


### PR DESCRIPTION
## Summary
- Fill the Signal Trends DS SNR chart area with the same translucent treatment used by the power charts.
- Anchor the DS SNR fill to the visible y-axis floor instead of relying on the zoom-only single-series fallback.
- Bump the service-worker cache version so the updated chart asset is refreshed.

## Test Plan
- `git diff --check`
- `uv run --with-requirements requirements-test.txt pytest -q tests/test_static_contracts.py::test_trend_single_metric_charts_fill_to_visible_axis_floor tests/test_static_contracts.py::test_static_cache_version_was_bumped_for_ui_followup_assets`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright --with playwright pytest -q tests/e2e/test_charts.py::TestTrendCharts::test_trend_single_metric_charts_fill_to_visible_axis_floor --tb=short`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright --with playwright pytest -q tests/e2e`
- Live browser smoke of Signal Trends confirmed DS SNR uses the same filled area treatment as the power charts.

Refs #502
