### PR TITLE
fix(correlation): keep event filter popover above timeline

### DIFF
--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -787,13 +787,16 @@
 }
 
 .corr-event-popover {
-    position: absolute;
-    z-index: 100;
+    position: fixed;
+    z-index: 10000;
     background: var(--bg);
     border: 1px solid var(--card-border);
     border-radius: var(--radius-sm);
     padding: var(--space-sm) var(--space-sm);
     min-width: 180px;
+    max-width: calc(100vw - 16px);
+    box-sizing: border-box;
+    overflow: auto;
     box-shadow: var(--shadow-lg);
     font-size: 0.85em;
 }

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -13,6 +13,35 @@ var _corrEventFilter = {};
 var _corrEventSeverityFilter = {};
 var _OPERATIONAL_EVENTS = { monitoring_started: true, monitoring_stopped: true };
 var _CORR_SEVERITIES = ['info', 'warning', 'critical'];
+function _corrCloseEventPopover() {
+    var pop = document.getElementById('corr-event-popover');
+    if (!pop) return;
+    if (pop._corrCleanup) pop._corrCleanup();
+    pop.remove();
+}
+function _corrPositionEventPopover(pop, anchor) {
+    if (!pop || !anchor) return;
+    var margin = 8;
+    var anchorRect = anchor.getBoundingClientRect();
+    pop.style.maxHeight = Math.max(160, window.innerHeight - (margin * 2)) + 'px';
+
+    // Measure after attaching to the body so positioning is based on the real viewport.
+    var popRect = pop.getBoundingClientRect();
+    var left = anchorRect.left;
+    if (left + popRect.width > window.innerWidth - margin) {
+        left = window.innerWidth - margin - popRect.width;
+    }
+    left = Math.max(margin, left);
+
+    var top = anchorRect.bottom + margin;
+    if (top + popRect.height > window.innerHeight - margin) {
+        top = anchorRect.top - popRect.height - margin;
+    }
+    top = Math.max(margin, top);
+
+    pop.style.left = left + 'px';
+    pop.style.top = top + 'px';
+}
 function _corrEscapeAttr(value) {
     return escapeHtml(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
@@ -113,6 +142,7 @@ function loadCorrelationData() {
 }
 
 function renderCorrelationChart(data) {
+    _corrCloseEventPopover();
     // Clear pin state when chart is redrawn (legend toggle, zoom, resize)
     if (_corrPinnedRow) _corrUnpinRow();
     var canvas = document.getElementById('correlation-chart');
@@ -611,7 +641,7 @@ function renderCorrelationChart(data) {
         filterBtn.addEventListener('click', function(e) {
             e.stopPropagation();
             var existing = document.getElementById('corr-event-popover');
-            if (existing) { existing.remove(); return; }
+            if (existing) { _corrCloseEventPopover(); return; }
             var pop = document.createElement('div');
             pop.id = 'corr-event-popover';
             pop.className = 'corr-event-popover';
@@ -653,7 +683,17 @@ function renderCorrelationChart(data) {
                 html += '</div></div>';
             }
             pop.innerHTML = html;
-            this.parentElement.appendChild(pop);
+            document.body.appendChild(pop);
+            _corrPositionEventPopover(pop, filterBtn);
+            var positionPopover = function() { _corrPositionEventPopover(pop, filterBtn); };
+            var closePopover = null;
+            window.addEventListener('resize', positionPopover);
+            window.addEventListener('scroll', positionPopover, true);
+            pop._corrCleanup = function() {
+                window.removeEventListener('resize', positionPopover);
+                window.removeEventListener('scroll', positionPopover, true);
+                if (closePopover) document.removeEventListener('click', closePopover);
+            };
             // Prevent clicks inside popover from bubbling to legend toggle
             pop.addEventListener('click', function(e) { e.stopPropagation(); });
             pop.querySelectorAll('input[data-event-type]:not([data-event-severity])').forEach(function(cb) {
@@ -674,12 +714,12 @@ function renderCorrelationChart(data) {
             });
             // Close on outside click
             setTimeout(function() {
-                document.addEventListener('click', function closePopover(ev) {
+                closePopover = function(ev) {
                     if (!pop.contains(ev.target) && ev.target !== filterBtn) {
-                        pop.remove();
-                        document.removeEventListener('click', closePopover);
+                        _corrCloseEventPopover();
                     }
-                });
+                };
+                document.addEventListener('click', closePopover);
             }, 0);
         });
     }

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v27';
+var CACHE_VERSION = 'v28';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_correlation_ui.py
+++ b/tests/e2e/test_correlation_ui.py
@@ -225,6 +225,50 @@ def test_correlation_event_type_filter_updates_table_in_browser(demo_page):
     expect(page.locator("#correlation-legend .corr-legend-events")).to_contain_text("(0/2)")
 
 
+def test_correlation_event_filter_popover_stays_above_unified_timeline(demo_page):
+    page = demo_page
+    _route_sample_correlation(page)
+    _open_correlation(page)
+
+    page.locator("#correlation-legend .corr-event-filter-btn").click()
+    popover = page.locator("#corr-event-popover")
+    expect(popover).to_be_visible()
+
+    layering = popover.evaluate(
+        """
+        (node) => {
+            const rect = node.getBoundingClientRect();
+            const samples = [
+                [rect.left + Math.min(rect.width - 2, Math.max(2, rect.width * 0.5)), rect.bottom - 2],
+                [rect.left + Math.min(rect.width - 2, Math.max(2, rect.width * 0.2)), rect.bottom - 10],
+                [rect.left + Math.min(rect.width - 2, Math.max(2, rect.width * 0.8)), rect.bottom - 10],
+            ];
+            const blockers = samples
+                .map(([x, y]) => document.elementFromPoint(x, y))
+                .filter((el) => el && !node.contains(el));
+            const tableCard = document.querySelector('#correlation-table-card');
+            const tableRect = tableCard.getBoundingClientRect();
+            return {
+                blockers: blockers.map((el) => ({
+                    id: el.id,
+                    tag: el.tagName,
+                    className: typeof el.className === 'string' ? el.className : '',
+                    text: (el.textContent || '').trim().slice(0, 60),
+                })),
+                overlapsTable: rect.bottom > tableRect.top,
+                popoverBottom: rect.bottom,
+                tableTop: tableRect.top,
+                popoverParentTag: node.parentElement && node.parentElement.tagName,
+            };
+        }
+        """
+    )
+
+    assert layering["overlapsTable"]
+    assert layering["popoverParentTag"] == "BODY"
+    assert layering["blockers"] == []
+
+
 def test_correlation_event_severity_filter_updates_chart_and_table_in_browser(demo_page):
     page = demo_page
     _route_correlation(page, _sample_correlation_severity_data())

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,7 +107,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v27';" in sw_js
+    assert "var CACHE_VERSION = 'v28';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js


### PR DESCRIPTION
## Summary
- Render the Correlation View event filter popover at the document layer so the Unified Timeline table cannot paint over it.
- Keep the popover positioned against the Events control, clamped to the viewport, and clean up resize/scroll handlers when it closes or the chart redraws.
- Add browser regression coverage for the reported overlap and bump the static cache version.

## Validation
- `node --check app/static/js/correlation.js`
- `node --check app/static/sw.js`
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e --tb=short` — 2430 passed, 11 skipped
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e --tb=short` — 410 passed

Refs #515
