### PR TITLE
Fix Channels chart temperature follow-ups

### DIFF
--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -435,12 +435,17 @@ function _renderChannelTimelineCharts() {
         return d.timestamp.substring(5, 16).replace('T', ' ');
     });
     var tempOpts = _channelWeatherHasData(_lastChannelWeather) ? { tempData: _lastChannelWeather } : null;
-    var powerDatasets = [{label: T.power_dbmv || 'Power (dBmV)', data: data.map(function(d){ return d.power; }), color: '#00e5f0'}];
+    var tempByTimestamp = null;
+    if (tempOpts) {
+        tempByTimestamp = {};
+        data.forEach(function(d, idx) { tempByTimestamp[d.timestamp] = _lastChannelWeather[idx]; });
+    }
+    var powerDatasets = [{label: T.power_dbmv || 'Power (dBmV)', data: data.map(function(d){ return d.power; }), color: '#00e5f0', showPoints: false}];
     var powerThresholds = direction === 'ds' ? DS_POWER_THRESHOLDS : US_POWER_THRESHOLDS;
     var powerCard = document.querySelector('#channel-charts .chart-card:first-child');
     var powerLabel = powerCard ? powerCard.querySelector('.chart-label') : null;
     if (direction === 'ds') {
-        powerDatasets.push({label: T.snr_db || 'SNR (dB)', data: data.map(function(d){ return d.snr; }), color: '#66ff77'});
+        powerDatasets.push({label: T.snr_db || 'SNR (dB)', data: data.map(function(d){ return d.snr; }), color: '#66ff77', showPoints: false});
         powerThresholds = null; /* DS combines Power + SNR, thresholds don't apply */
         if (powerLabel) powerLabel.textContent = (T.power_dbmv || 'Power') + ' & ' + (T.snr_db || 'SNR');
         var showErrors = _hasChannelDocsisErrorSeries(data);
@@ -483,10 +488,14 @@ function _renderChannelTimelineCharts() {
         var tickValues = [];
         for (var qi = 0; qi < qamSteps.length; qi++) tickValues.push(qi);
         renderChart('chart-ch-modulation', modLabels, [
-            {label: T.modulation || 'Modulation', data: modValues, color: '#ffab40', stepped: true}
+            {label: T.modulation || 'Modulation', data: modValues, color: '#ffab40', stepped: true, showPoints: false}
         ], null, null, {
+            tempData: tempOpts ? mods.map(function(d) { return tempByTimestamp[d.timestamp]; }) : null,
             yTickCallback: function(value) { return qamLabel[qamSteps[value]] || ''; },
-            tooltipLabelCallback: function(ctx) { return (T.modulation || 'Modulation') + ': ' + (qamLabel[qamSteps[ctx.raw]] || ctx.raw); },
+            tooltipLabelCallback: function(ctx) {
+                if (ctx.dataset.yAxisID === 'y-temp') return ctx.dataset.label + ': ' + fmtTemp(ctx.raw);
+                return (T.modulation || 'Modulation') + ': ' + (qamLabel[qamSteps[ctx.raw]] || ctx.raw);
+            },
             yMin: -0.5,
             yMax: qamSteps.length - 0.5,
             yAxisSize: 72,
@@ -814,7 +823,6 @@ function _renderCompareCharts() {
         if (parseInt(days) >= 30) return ts.substring(5, 10);
         return ts.substring(5, 16).replace('T', ' ');
     });
-    var showPoints = _compareChannels.length <= 6;
     var tempOpts = _channelWeatherHasData(_lastCompareWeather) ? { tempData: _lastCompareWeather } : null;
 
     // Build lookup maps per channel: timestamp -> data point
@@ -831,7 +839,7 @@ function _renderCompareCharts() {
             label: 'CH ' + ch.id,
             data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.power : null; }),
             color: ch.color,
-            showPoints: showPoints
+            showPoints: false
         };
     });
     var powerThresholds = dir === 'ds' ? DS_POWER_THRESHOLDS : US_POWER_THRESHOLDS;
@@ -846,7 +854,7 @@ function _renderCompareCharts() {
                 label: 'CH ' + ch.id,
                 data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.snr : null; }),
                 color: ch.color,
-                showPoints: showPoints
+                showPoints: false
             };
         });
         renderChart('chart-cmp-snr', xLabels, snrDatasets, null, DS_SNR_THRESHOLDS, tempOpts);
@@ -867,14 +875,14 @@ function _renderCompareCharts() {
                     label: 'CH ' + ch.id + ' ' + (T.uncorrectable || 'Uncorr.'),
                     data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.uncorrectable_errors != null ? d.uncorrectable_errors : null; }),
                     color: ch.color,
-                    showPoints: showPoints
+                    showPoints: false
                 });
                 errorDatasets.push({
                     label: 'CH ' + ch.id + ' ' + (T.correctable || 'Corr.'),
                     data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.correctable_errors != null ? d.correctable_errors : null; }),
                     color: ch.color,
                     dashed: true,
-                    showPoints: showPoints
+                    showPoints: false
                 });
             });
             renderChart('chart-cmp-errors', xLabels, errorDatasets, null, null, tempOpts);
@@ -926,8 +934,12 @@ function _renderCompareCharts() {
         var tickValues = [];
         for (var qi = 0; qi < qamNames.length; qi++) tickValues.push(qi);
         renderChart('chart-cmp-modulation', xLabels, modDatasets, null, null, {
+            tempData: _channelWeatherHasData(_lastCompareWeather) ? _lastCompareWeather : null,
             yTickCallback: function(value) { return qamLabel[value] || ''; },
-            tooltipLabelCallback: function(ctx) { return ctx.dataset.label + ': ' + (qamLabel[ctx.raw] || ctx.raw); },
+            tooltipLabelCallback: function(ctx) {
+                if (ctx.dataset.yAxisID === 'y-temp') return ctx.dataset.label + ': ' + fmtTemp(ctx.raw);
+                return ctx.dataset.label + ': ' + (qamLabel[ctx.raw] || ctx.raw);
+            },
             yMin: -0.5,
             yMax: qamNames.length - 0.5,
             yAxisSize: 72,

--- a/app/static/js/chart-engine.js
+++ b/app/static/js/chart-engine.js
@@ -708,7 +708,6 @@ function openChartZoom(canvasId) {
         var textColor = isDark ? '#888' : '#666';
         var isBar = params.type === 'bar';
         var n = params.labels.length;
-        var isMulti = params.datasets.length > 1;
         var zoomYAxisSize = params.opts && params.opts.zoomYAxisSize ? params.opts.zoomYAxisSize : DEFAULT_ZOOM_Y_AXIS_SIZE;
         var w = zoomContainer.offsetWidth || 800;
         var h = zoomContainer.offsetHeight || 500;
@@ -729,12 +728,14 @@ function openChartZoom(canvasId) {
         var barPaths = isBar ? uPlot.paths.bars({size: [0.7, 50], gap: 1}) : null;
         var uSeries = [{ label: 'X', value: function(u, v) { return params.labels[v] || ''; } }];
         params.datasets.forEach(function(ds) {
+            var zoomShowPoints = ds.showPoints;
+            if (zoomShowPoints === undefined) zoomShowPoints = n <= 30 && !isBar;
             var s = {
                 label: ds.label,
                 stroke: ds.color || 'rgba(168,85,247,0.9)',
                 width: isBar ? 0 : 2,
-                fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || (!isMulti && !isBar ? 'rgba(168,85,247,0.15)' : undefined)),
-                points: { show: n <= 30 && !isBar, size: isBar ? 0 : (n > 30 ? 4 : 8) },
+                fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || undefined),
+                points: { show: zoomShowPoints, size: isBar ? 0 : (ds.pointSize || (n > 30 ? 4 : 8)) },
                 spanGaps: ds.spanGaps !== undefined ? ds.spanGaps : false
             };
             if (ds.fillTo !== undefined && ds.fillTo !== null) s.fillTo = ds.fillTo;

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v28';
+var CACHE_VERSION = 'v29';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1583,7 +1583,11 @@
                 <button class="trend-tab active" data-value="7" onclick="selectPill(this, loadChannelTimeline)">7d</button>
                 <button class="trend-tab" data-value="30" onclick="selectPill(this, loadChannelTimeline)">30d</button>
             </div>
-            <button id="channel-temp-toggle-btn" class="trend-tab temp-toggle active" onclick="toggleChannelTempOverlay()" style="display:none;" aria-pressed="true" title="{{ t.temp_overlay_hide }}">{{ t.temperature }}</button>
+            <button id="channel-temp-toggle-btn" class="trend-tab temp-toggle active" onclick="toggleChannelTempOverlay()" style="display:none;" aria-pressed="true" title="{{ t.temp_overlay_hide }}" aria-label="{{ t.temperature }}">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle;" aria-hidden="true">
+                    <path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/>
+                </svg>
+            </button>
         </span>
         <span id="channel-compare-controls" style="display:none;">
             <div class="trend-tabs" id="compare-dir-tabs">
@@ -1600,7 +1604,11 @@
                 <button class="trend-tab active" data-value="7" onclick="selectPill(this, loadCompareCharts)">7d</button>
                 <button class="trend-tab" data-value="30" onclick="selectPill(this, loadCompareCharts)">30d</button>
             </div>
-            <button id="compare-temp-toggle-btn" class="trend-tab temp-toggle active" onclick="toggleCompareTempOverlay()" style="display:none;" aria-pressed="true" title="{{ t.temp_overlay_hide }}">{{ t.temperature }}</button>
+            <button id="compare-temp-toggle-btn" class="trend-tab temp-toggle active" onclick="toggleCompareTempOverlay()" style="display:none;" aria-pressed="true" title="{{ t.temp_overlay_hide }}" aria-label="{{ t.temperature }}">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle;" aria-hidden="true">
+                    <path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/>
+                </svg>
+            </button>
         </span>
     </div>
 
@@ -1677,7 +1685,7 @@
                         <svg class="chart-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
                         </svg>
-                        <div class="chart-label">{{ t.power_history }}</div>
+                        <div class="chart-label">{{ t.power_dbmv }}</div>
                     </div>
                     <button class="chart-expand-btn" data-chart="chart-cmp-power" title="{{ t.expand }}">&#x26F6;</button>
                 </div>
@@ -1689,7 +1697,7 @@
                         <svg class="chart-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
                         </svg>
-                        <div class="chart-label">{{ t.snr_history }}</div>
+                        <div class="chart-label">{{ t.snr_db }}</div>
                     </div>
                     <button class="chart-expand-btn" data-chart="chart-cmp-snr" title="{{ t.expand }}">&#x26F6;</button>
                 </div>

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -305,6 +305,8 @@ class TestChannelCharts:
                     lastX: xData[xData.length - 1],
                     splitCount: xSplits.length,
                     samples: xData.length,
+                    fill: chart.series[1].fill || null,
+                    pointsVisible: chart.series[1].points.show === true,
                 };
             }
             """
@@ -314,6 +316,8 @@ class TestChannelCharts:
         assert layout["xMax"] - layout["lastX"] >= 4
         assert layout["splitCount"] <= 4
         assert layout["splitCount"] < layout["samples"]
+        assert layout["fill"] is None
+        assert layout["pointsVisible"] is False
 
         demo_page.locator('.chart-expand-btn[data-chart="chart-ch-modulation"]').click()
         demo_page.wait_for_selector("#chart-zoom-canvas .uplot", timeout=5000)
@@ -326,6 +330,8 @@ class TestChannelCharts:
                     yAxisSize: chart.bbox.left,
                     splitCount: splits.length,
                     samples: chart.data[0].length,
+                    fill: chart.series[1].fill || null,
+                    pointsVisible: chart.series[1].points.show === true,
                 };
             }
             """
@@ -333,6 +339,8 @@ class TestChannelCharts:
         assert zoom_layout["yAxisSize"] >= 80
         assert zoom_layout["splitCount"] <= 10
         assert zoom_layout["splitCount"] < zoom_layout["samples"]
+        assert zoom_layout["fill"] is None
+        assert zoom_layout["pointsVisible"] is False
 
     def test_channel_selection_renders_charts(self, demo_page):
         """Selecting a channel should render Power and Errors charts."""
@@ -478,6 +486,7 @@ class TestChannelTemperatureOverlay:
         navigate_to_channels(demo_page)
         demo_page.locator("#channel-select").select_option("ds-1")
         wait_for_uplot(demo_page, "chart-ch-power")
+        wait_for_uplot(demo_page, "chart-ch-modulation")
 
         toggle = demo_page.locator("#channel-temp-toggle-btn")
         assert toggle.count() == 1
@@ -487,7 +496,32 @@ class TestChannelTemperatureOverlay:
         overlay = demo_page.evaluate(
             """
             () => {
-                const chart = window.charts['chart-ch-power'];
+                const powerChart = window.charts['chart-ch-power'];
+                const modulationChart = window.charts['chart-ch-modulation'];
+                return {
+                    labels: powerChart.series.map((s) => s.label),
+                    tempScale: !!powerChart.scales.temp,
+                    tempData: powerChart.data[powerChart.data.length - 1],
+                    modulationLabels: modulationChart.series.map((s) => s.label),
+                    modulationTempScale: !!modulationChart.scales.temp,
+                    modulationTempData: modulationChart.data[modulationChart.data.length - 1],
+                };
+            }
+            """
+        )
+        assert "Temperature" in overlay["labels"]
+        assert overlay["tempScale"] is True
+        assert overlay["tempData"] == [12.5, 13.5]
+        assert "Temperature" in overlay["modulationLabels"]
+        assert overlay["modulationTempScale"] is True
+        assert overlay["modulationTempData"] == [12.5, 13.5]
+
+        demo_page.locator('.chart-expand-btn[data-chart="chart-ch-modulation"]').click()
+        demo_page.wait_for_selector("#chart-zoom-canvas .uplot", timeout=5000)
+        zoom_overlay = demo_page.evaluate(
+            """
+            () => {
+                const chart = window.zoomChart;
                 return {
                     labels: chart.series.map((s) => s.label),
                     tempScale: !!chart.scales.temp,
@@ -496,16 +530,23 @@ class TestChannelTemperatureOverlay:
             }
             """
         )
-        assert "Temperature" in overlay["labels"]
-        assert overlay["tempScale"] is True
-        assert overlay["tempData"] == [12.5, 13.5]
+        assert "Temperature" in zoom_overlay["labels"]
+        assert zoom_overlay["tempScale"] is True
+        assert zoom_overlay["tempData"] == [12.5, 13.5]
+        demo_page.locator("#chart-zoom-overlay .modal-close").click()
 
         toggle.click()
         demo_page.wait_for_timeout(300)
         labels_after_toggle = demo_page.evaluate(
-            "() => window.charts['chart-ch-power'].series.map((s) => s.label)"
+            """
+            () => ({
+                power: window.charts['chart-ch-power'].series.map((s) => s.label),
+                modulation: window.charts['chart-ch-modulation'].series.map((s) => s.label),
+            })
+            """
         )
-        assert "Temperature" not in labels_after_toggle
+        assert "Temperature" not in labels_after_toggle["power"]
+        assert "Temperature" not in labels_after_toggle["modulation"]
 
     def test_channel_timeline_hides_temperature_toggle_without_weather_data(self, demo_page):
         history = [
@@ -610,6 +651,7 @@ class TestChannelTemperatureOverlay:
         demo_page.locator('.trend-tab[data-value="compare"]').click()
         demo_page.locator("#compare-add-all-btn").click()
         wait_for_uplot(demo_page, "chart-cmp-power")
+        wait_for_uplot(demo_page, "chart-cmp-modulation")
 
         toggle = demo_page.locator("#compare-temp-toggle-btn")
         assert toggle.count() == 1
@@ -619,12 +661,17 @@ class TestChannelTemperatureOverlay:
         overlay = demo_page.evaluate(
             """
             () => {
-                const chart = window.charts['chart-cmp-power'];
+                const powerChart = window.charts['chart-cmp-power'];
+                const modulationChart = window.charts['chart-cmp-modulation'];
                 return {
-                    labels: chart.series.map((s) => s.label),
-                    tempScale: !!chart.scales.temp,
-                    tempData: chart.data[chart.data.length - 1],
-                    tempSeriesCount: chart.series.filter((s) => s.label === 'Temperature').length,
+                    labels: powerChart.series.map((s) => s.label),
+                    tempScale: !!powerChart.scales.temp,
+                    tempData: powerChart.data[powerChart.data.length - 1],
+                    tempSeriesCount: powerChart.series.filter((s) => s.label === 'Temperature').length,
+                    modulationLabels: modulationChart.series.map((s) => s.label),
+                    modulationTempScale: !!modulationChart.scales.temp,
+                    modulationTempData: modulationChart.data[modulationChart.data.length - 1],
+                    modulationTempSeriesCount: modulationChart.series.filter((s) => s.label === 'Temperature').length,
                 };
             }
             """
@@ -632,6 +679,9 @@ class TestChannelTemperatureOverlay:
         assert overlay["tempScale"] is True
         assert overlay["tempData"] == [17.0, 18.0]
         assert overlay["tempSeriesCount"] == 1
+        assert overlay["modulationTempScale"] is True
+        assert overlay["modulationTempData"] == [17.0, 18.0]
+        assert overlay["modulationTempSeriesCount"] == 1
 
     def test_channel_compare_hides_temperature_toggle_without_weather_data(self, demo_page):
         compare_payload = {

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,7 +107,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v28';" in sw_js
+    assert "var CACHE_VERSION = 'v29';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
@@ -130,6 +130,50 @@ def test_channels_weather_overlay_contract_is_wired():
     assert "_renderCompareCharts()" in channels_js
     assert "tempData: _lastChannelWeather" in channels_js
     assert "tempData: _lastCompareWeather" in channels_js
+
+
+def test_channels_modulation_charts_receive_temperature_overlay_options():
+    channels_js = CHANNELS_JS.read_text(encoding="utf-8")
+    timeline_block = channels_js[
+        channels_js.index("renderChart('chart-ch-modulation'") : channels_js.index("function loadChannelTimeline")
+    ]
+    compare_block = channels_js[
+        channels_js.index("renderChart('chart-cmp-modulation'") : channels_js.index("function loadCompareCharts")
+    ]
+
+    assert "tempData:" in timeline_block
+    assert "tempByTimestamp" in timeline_block
+    assert "tempByTimestamp[d.timestamp] = _lastChannelWeather[idx]" in channels_js
+    assert "tempData:" in compare_block
+    assert "_lastCompareWeather" in compare_block
+
+
+def test_channels_chart_contracts_disable_implicit_points_and_zoom_fill():
+    channels_js = CHANNELS_JS.read_text(encoding="utf-8")
+    chart_engine = CHART_ENGINE_JS.read_text(encoding="utf-8")
+    zoom_block = chart_engine[chart_engine.index("function openChartZoom") :]
+
+    assert "showPoints: false" in channels_js[channels_js.index("var powerDatasets") : channels_js.index("renderChart('chart-ch-power'")]
+    assert "showPoints: false" in channels_js[channels_js.index("var powerDatasets = _compareChannels.map") : channels_js.index("renderChart('chart-cmp-power'")]
+    assert "var zoomShowPoints = ds.showPoints;" in zoom_block
+    assert "if (zoomShowPoints === undefined) zoomShowPoints = n <= 30 && !isBar;" in zoom_block
+    assert "points: { show: zoomShowPoints" in zoom_block
+    assert "fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || (!isMulti && !isBar ? 'rgba(168,85,247,0.15)' : undefined))" not in zoom_block
+    assert "fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || undefined)" in zoom_block
+
+
+def test_channels_controls_and_compare_titles_are_standardized():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    channel_toggle = template[template.index('id="channel-temp-toggle-btn"') : template.index('id="channel-compare-controls"')]
+    compare_toggle = template[template.index('id="compare-temp-toggle-btn"') : template.index('id="channel-no-data"')]
+    compare_charts = template[template.index('id="compare-charts"') : template.index('id="compare-errors-card"')]
+
+    assert "<svg" in channel_toggle
+    assert "<svg" in compare_toggle
+    assert "{{ t.power_dbmv }}" in compare_charts
+    assert "{{ t.snr_db }}" in compare_charts
+    assert "{{ t.power_history }}" not in compare_charts
+    assert "{{ t.snr_history }}" not in compare_charts
 
 
 def test_chart_engine_has_configurable_axis_padding_for_long_qam_labels():


### PR DESCRIPTION
## Summary
- add Channels Timeline and Compare temperature overlays to modulation charts
- make Channels card and zoom rendering respect dataset fill/point-marker intent
- standardize Compare Power/SNR headings and Channels temperature-toggle visuals
- bump the service-worker cache version for changed static assets

Closes #524.
Closes #525.

## Verification
- `node --check app/static/js/channels.js app/static/js/chart-engine.js app/static/sw.js`
- `.venv311/bin/python -m pytest -q tests --ignore=tests/e2e` — 2433 passed, 11 skipped, 1 warning
- resource-safe E2E batches covering all 410 collected tests:
  - batch 1: 121 passed
  - batch 2: 174 passed
  - batch 3: 115 passed
- targeted chart follow-up tests: 7 passed
- `git diff --check`
- static security scan: clean
