### PR TITLE
Rework Home signal cards around DOCSIS families

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -484,7 +484,191 @@ def _metric_healths(issues):
     return result
 
 
-def _assess_ds_channel(ch, docsis_ver):
+_HEALTH_RANK = {"missing": -1, "good": 0, "tolerated": 1, "warning": 2, "critical": 3}
+
+
+def _worst_health(values):
+    """Return the worst health value, ignoring missing/unavailable metrics."""
+    ranked = [value for value in values if value and value != "missing"]
+    if not ranked:
+        return "missing"
+    return max(ranked, key=lambda value: _HEALTH_RANK.get(value, 0))
+
+
+def _stats(values):
+    """Return rounded min/avg/max stats without turning unavailable into zero."""
+    filtered = [value for value in values if value is not None]
+    if not filtered:
+        return {"available": False, "min": None, "avg": None, "max": None}
+    return {
+        "available": True,
+        "min": round(min(filtered), 1),
+        "avg": round(sum(filtered) / len(filtered), 1),
+        "max": round(max(filtered), 1),
+    }
+
+
+def _distinct_modulations(channels, *, prefer_profile=False):
+    values = []
+    for channel in channels:
+        if prefer_profile:
+            value = channel.get("profile_modulation") or channel.get("modulation")
+        else:
+            value = channel.get("modulation") or channel.get("profile_modulation")
+        if value:
+            values.append(str(value))
+    return sorted(set(values), key=lambda value: (_parse_qam_order(value) or 0, value))
+
+
+def _channel_text(channel, *keys):
+    return " ".join(str(channel.get(key, "") or "") for key in keys).upper().replace("-", "")
+
+
+def _classify_ds_family(channel):
+    """Classify downstream channels into SC-QAM, OFDM, or unknown families."""
+    docsis_version = str(channel.get("docsis_version", "") or "")
+    is_docsis31_plus = "3.1" in docsis_version or "4.0" in docsis_version
+    type_text = _channel_text(channel, "type")
+    modulation_text = _channel_text(channel, "modulation")
+    profile_text = _channel_text(channel, "profile_modulation")
+
+    if "OFDM" in type_text or "OFDMA" in type_text:
+        return "ofdm"
+    if "SCQAM" in type_text or type_text == "QAM":
+        return "sc_qam"
+    if "OFDM" in modulation_text or "OFDMA" in modulation_text:
+        return "ofdm"
+
+    modulation_rank = _parse_qam_order(modulation_text)
+    if modulation_rank:
+        if modulation_rank >= 1024 and is_docsis31_plus:
+            return "ofdm"
+        return "sc_qam"
+
+    # Profile modulation is an OFDM profile signal, not an SC-QAM channel type.
+    # A degraded DOCSIS 3.1 OFDM profile can be 256QAM/512QAM and must still
+    # remain on the OFDM/MER Home lane when explicit modulation/type is absent.
+    if profile_text and is_docsis31_plus:
+        return "ofdm"
+    if _parse_qam_order(profile_text):
+        return "sc_qam"
+
+    if is_docsis31_plus:
+        return "ofdm"
+    if "3.0" in docsis_version:
+        return "sc_qam"
+    return "unknown"
+
+
+def _classify_us_family(channel):
+    """Classify upstream channels into SC-QAM, OFDMA, or unknown families."""
+    docsis_version = str(channel.get("docsis_version", "") or "")
+    is_docsis31_plus = "3.1" in docsis_version or "4.0" in docsis_version
+    type_text = _channel_text(channel, "type", "multiplex")
+    modulation_text = _channel_text(channel, "modulation")
+    profile_text = _channel_text(channel, "profile_modulation")
+
+    if "OFDMA" in type_text:
+        return "ofdma"
+    if any(token in type_text for token in ("ATDMA", "SCQAM", "TDMA")):
+        return "sc_qam"
+    if "OFDMA" in modulation_text:
+        return "ofdma"
+    if _parse_qam_order(modulation_text):
+        return "sc_qam"
+
+    # OFDMA profile modulation can be reduced to low QAM values; keep those
+    # profile-only DOCSIS 3.1 channels in the OFDMA lane instead of treating the
+    # profile QAM value as an SC-QAM channel modulation.
+    if profile_text and is_docsis31_plus:
+        return "ofdma"
+    if is_docsis31_plus:
+        return "ofdma"
+    if "3.0" in docsis_version:
+        return "sc_qam"
+    return "unknown"
+
+
+def _family_summary(family, channels, *, direction):
+    # The analyzer normalizes downstream OFDM MER into the per-channel `snr` slot;
+    # expose it as `mer` at the family-summary boundary so Home labels stay honest.
+    quality_key = "mer" if direction == "downstream" and family == "ofdm" else "snr"
+    prefer_profile = family in {"ofdm", "ofdma"}
+    power = _stats([channel.get("power") for channel in channels])
+    quality = _stats([channel.get("snr") for channel in channels]) if direction == "downstream" else None
+    modulation_values = _distinct_modulations(channels, prefer_profile=prefer_profile)
+    power_health = _worst_health(
+        channel.get("power_health", "good") for channel in channels if channel.get("power") is not None
+    )
+    quality_health = (
+        _worst_health(channel.get("snr_health", "good") for channel in channels if channel.get("snr") is not None)
+        if direction == "downstream"
+        else "missing"
+    )
+    modulation_health = _worst_health(
+        channel.get("modulation_health", "good")
+        for channel in channels
+        if channel.get("modulation") or channel.get("profile_modulation")
+    )
+
+    metrics = [power_health, modulation_health]
+    if direction == "downstream":
+        metrics.append(quality_health)
+
+    result = {
+        "family": family,
+        "count": len(channels),
+        "health": _worst_health(metrics),
+        "power": {**power, "health": power_health},
+        "modulation": {
+            "available": bool(modulation_values),
+            "value": modulation_values[0] if modulation_values else None,
+            "secondary": modulation_values[-1] if len(modulation_values) > 1 else None,
+            "distinct": modulation_values,
+            "health": modulation_health,
+        },
+    }
+    if direction == "downstream":
+        assert quality is not None
+        result[quality_key] = {**quality, "health": quality_health}
+    return result
+
+
+def _build_signal_family_summary(ds_channels, us_channels):
+    """Build family-level signal summaries for Home without changing legacy globals."""
+    ds_groups = {"sc_qam": [], "ofdm": [], "unknown": []}
+    for channel in ds_channels:
+        family = channel.get("channel_family") or _classify_ds_family(channel)
+        ds_groups.setdefault(family, []).append(channel)
+
+    us_groups = {"sc_qam": [], "ofdma": [], "unknown": []}
+    for channel in us_channels:
+        family = channel.get("channel_family") or _classify_us_family(channel)
+        us_groups.setdefault(family, []).append(channel)
+
+    downstream = {
+        key: _family_summary(key, channels, direction="downstream")
+        for key, channels in ds_groups.items()
+        if channels
+    }
+    upstream = {
+        key: _family_summary(key, channels, direction="upstream")
+        for key, channels in us_groups.items()
+        if channels
+    }
+    return {
+        "downstream": {
+            "health": _worst_health(family["health"] for family in downstream.values()),
+            "families": downstream,
+        },
+        "upstream": {
+            "health": _worst_health(family["health"] for family in upstream.values()),
+            "families": upstream,
+        },
+    }
+
+
+def _assess_ds_channel(ch, docsis_ver, *, modulation_docsis_ver: str | None = None):
     """Assess a single downstream channel. Returns (health, health_detail)."""
     issues = []
     raw_power = ch.get("powerLevel")
@@ -515,7 +699,7 @@ def _assess_ds_channel(ch, docsis_ver):
         elif snr_val < st["good_min"]:
             issues.append("snr tolerated")
 
-    mod_issue = _modulation_issue(_assess_ds_modulation(modulation, docsis_ver))
+    mod_issue = _modulation_issue(_assess_ds_modulation(modulation, modulation_docsis_ver or docsis_ver))
     if mod_issue:
         issues.append(mod_issue)
 
@@ -590,6 +774,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
         health, health_detail = _assess_ds_channel(ch, "3.0")
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
         metric_h["modulation_health"] = _assess_ds_modulation(ch.get("modulation") or ch.get("type", ""), "3.0")
+        profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
         channel = {
             "channel_id": _parse_channel_id(ch.get("channelID", 0)),
             "frequency": ch.get("frequency", ""),
@@ -599,35 +784,50 @@ def analyze(data: DocsisData) -> AnalysisResult:
             "correctable_errors": ch.get("corrErrors"),
             "uncorrectable_errors": ch.get("nonCorrErrors"),
             "docsis_version": "3.0",
+            "channel_family": "sc_qam",
             "health": health,
             "health_detail": health_detail,
             **metric_h,
         }
-        if ch.get("profile_modulation"):
-            channel["profile_modulation"] = ch["profile_modulation"]
+        if profile_modulation:
+            channel["profile_modulation"] = profile_modulation
         ds_channels.append(channel)
     for ch in ds31:
         raw_power = ch.get("powerLevel")
         power = _parse_float(raw_power) if raw_power is not None else None
         snr = _parse_float(ch.get("mer")) if ch.get("mer") else None
-        health, health_detail = _assess_ds_channel(ch, "3.1")
+        ds_modulation = ch.get("modulation") or ch.get("type", "")
+        profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
+        channel_family = _classify_ds_family({
+            "type": ch.get("type", ""),
+            "modulation": ds_modulation,
+            "profile_modulation": profile_modulation,
+            "docsis_version": "3.1",
+        })
+        modulation_docsis_ver = "3.0" if channel_family == "sc_qam" else "3.1"
+        health, health_detail = _assess_ds_channel(
+            ch,
+            "3.1",
+            modulation_docsis_ver=modulation_docsis_ver,
+        )
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
-        metric_h["modulation_health"] = _assess_ds_modulation(ch.get("modulation") or ch.get("type", ""), "3.1")
+        metric_h["modulation_health"] = _assess_ds_modulation(ds_modulation, modulation_docsis_ver)
         channel = {
             "channel_id": _parse_channel_id(ch.get("channelID", 0)),
             "frequency": ch.get("frequency", ""),
             "power": power,
-            "modulation": ch.get("modulation") or ch.get("type", ""),
+            "modulation": ds_modulation,
             "snr": snr,
             "correctable_errors": ch.get("corrErrors"),
             "uncorrectable_errors": ch.get("nonCorrErrors"),
             "docsis_version": "3.1",
+            "channel_family": channel_family,
             "health": health,
             "health_detail": health_detail,
             **metric_h,
         }
-        if ch.get("profile_modulation"):
-            channel["profile_modulation"] = ch["profile_modulation"]
+        if profile_modulation:
+            channel["profile_modulation"] = profile_modulation
         ds_channels.append(channel)
 
     ds_channels.sort(key=lambda c: c["channel_id"])
@@ -647,6 +847,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
             "modulation": mod,
             "multiplex": ch.get("multiplex", ""),
             "docsis_version": "3.0",
+            "channel_family": "sc_qam",
             "health": health,
             "health_detail": health_detail,
             "theoretical_bitrate": bitrate,
@@ -662,6 +863,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
         mod = ch.get("modulation") or ch.get("type", "")
         bitrate = _channel_bitrate_mbps(mod, ch.get("symbolRate"))
         raw_power = ch.get("powerLevel")
+        profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
         channel = {
             "channel_id": _parse_channel_id(ch.get("channelID", 0)),
             "frequency": ch.get("frequency", ""),
@@ -669,13 +871,20 @@ def analyze(data: DocsisData) -> AnalysisResult:
             "modulation": mod,
             "multiplex": ch.get("multiplex", ""),
             "docsis_version": "3.1",
+            "channel_family": _classify_us_family({
+                "type": ch.get("type", ""),
+                "multiplex": ch.get("multiplex", ""),
+                "modulation": mod,
+                "profile_modulation": profile_modulation,
+                "docsis_version": "3.1",
+            }),
             "health": health,
             "health_detail": health_detail,
             "theoretical_bitrate": bitrate,
             **metric_h,
         }
-        if ch.get("profile_modulation"):
-            channel["profile_modulation"] = ch["profile_modulation"]
+        if profile_modulation:
+            channel["profile_modulation"] = profile_modulation
         us_channels.append(channel)
 
     us_channels.sort(key=lambda c: c["channel_id"])
@@ -702,6 +911,10 @@ def analyze(data: DocsisData) -> AnalysisResult:
     us_bitrates = [c["theoretical_bitrate"] for c in us_channels if c["theoretical_bitrate"] is not None]
     us_capacity = round(sum(us_bitrates), 1) if us_bitrates else None
 
+    signal_families = _build_signal_family_summary(ds_channels, us_channels)
+    ds_family_summaries = signal_families["downstream"]["families"]
+    us_family_summaries = signal_families["upstream"]["families"]
+
     summary = {
         "ds_total": len(ds_channels),
         "us_total": len(us_channels),
@@ -718,6 +931,13 @@ def analyze(data: DocsisData) -> AnalysisResult:
         "ds_uncorrectable_errors": total_uncorr,
         "errors_supported": has_error_data,
         "us_capacity_mbps": us_capacity,
+        "signal_families": signal_families,
+        "ds_scqam_power_avg": ds_family_summaries.get("sc_qam", {}).get("power", {}).get("avg"),
+        "ds_scqam_snr_avg": ds_family_summaries.get("sc_qam", {}).get("snr", {}).get("avg"),
+        "ds_ofdm_power_avg": ds_family_summaries.get("ofdm", {}).get("power", {}).get("avg"),
+        "ds_ofdm_mer_avg": ds_family_summaries.get("ofdm", {}).get("mer", {}).get("avg"),
+        "us_scqam_power_avg": us_family_summaries.get("sc_qam", {}).get("power", {}).get("avg"),
+        "us_ofdma_power_avg": us_family_summaries.get("ofdma", {}).get("power", {}).get("avg"),
     }
 
     # --- Overall health (aggregate from per-channel assessments) ---

--- a/app/collectors/demo.py
+++ b/app/collectors/demo.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from .base import Collector, CollectorResult
 from ..analyzer import (
     _assess_us_channel,
+    _build_signal_family_summary,
     _channel_bitrate_mbps,
     _metric_healths,
     _recent_spike_active,
@@ -425,6 +426,10 @@ class DemoCollector(Collector):
         us_bitrates = [ch["theoretical_bitrate"] for ch in us_channels if ch.get("theoretical_bitrate")]
         us_capacity = round(sum(us_bitrates), 1) if us_bitrates else None
 
+        signal_families = _build_signal_family_summary(ds_channels, us_channels)
+        ds_family_summaries = signal_families["downstream"]["families"]
+        us_family_summaries = signal_families["upstream"]["families"]
+
         return {
             "summary": {
                 "ds_total": ds_count,
@@ -440,6 +445,13 @@ class DemoCollector(Collector):
                 "ds_correctable_errors": total_corr,
                 "ds_uncorrectable_errors": total_uncorr,
                 "us_capacity_mbps": us_capacity,
+                "signal_families": signal_families,
+                "ds_scqam_power_avg": ds_family_summaries.get("sc_qam", {}).get("power", {}).get("avg"),
+                "ds_scqam_snr_avg": ds_family_summaries.get("sc_qam", {}).get("snr", {}).get("avg"),
+                "ds_ofdm_power_avg": ds_family_summaries.get("ofdm", {}).get("power", {}).get("avg"),
+                "ds_ofdm_mer_avg": ds_family_summaries.get("ofdm", {}).get("mer", {}).get("avg"),
+                "us_scqam_power_avg": us_family_summaries.get("sc_qam", {}).get("power", {}).get("avg"),
+                "us_ofdma_power_avg": us_family_summaries.get("ofdma", {}).get("power", {}).get("avg"),
                 "health": health,
                 "health_issues": [],
             },

--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Отворете настройките на BQM",
   "previous_month": "Предишния месец",
   "next_month": "Следващия месец",
-  "bqm_csv_import": "BQM CSV импортиране"
+  "bqm_csv_import": "BQM CSV импортиране",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Otevřete nastavení BQM",
   "previous_month": "Předchozí měsíc",
   "next_month": "Příští měsíc",
-  "bqm_csv_import": "Import BQM CSV"
+  "bqm_csv_import": "Import BQM CSV",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Åbn BQM-indstillinger",
   "previous_month": "Forrige måned",
   "next_month": "Næste måned",
-  "bqm_csv_import": "BQM CSV import"
+  "bqm_csv_import": "BQM CSV import",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "BQM-Einstellungen öffnen",
   "previous_month": "Vorheriger Monat",
   "next_month": "Nächster Monat",
-  "bqm_csv_import": "BQM CSV-Import"
+  "bqm_csv_import": "BQM CSV-Import",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Pegel",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Nicht verfügbar"
 }

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Ανοίξτε τις ρυθμίσεις BQM",
   "previous_month": "Προηγούμενος μήνας",
   "next_month": "Τον επόμενο μήνα",
-  "bqm_csv_import": "Εισαγωγή BQM CSV"
+  "bqm_csv_import": "Εισαγωγή BQM CSV",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Open BQM settings",
   "previous_month": "Previous month",
   "next_month": "Next month",
-  "bqm_csv_import": "BQM CSV import"
+  "bqm_csv_import": "BQM CSV import",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1035,5 +1035,14 @@
   "bqm_setup_open_settings": "Abrir configuración de BQM",
   "previous_month": "Mes anterior",
   "next_month": "Mes siguiente",
-  "bqm_csv_import": "Importación CSV de BQM"
+  "bqm_csv_import": "Importación CSV de BQM",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Avage BQM seaded",
   "previous_month": "Eelmine kuu",
   "next_month": "Järgmine kuu",
-  "bqm_csv_import": "BQM CSV import"
+  "bqm_csv_import": "BQM CSV import",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Avaa BQM-asetukset",
   "previous_month": "Edellinen kuukausi",
   "next_month": "Ensi kuussa",
-  "bqm_csv_import": "BQM CSV tuonti"
+  "bqm_csv_import": "BQM CSV tuonti",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -1032,5 +1032,14 @@
   "bqm_setup_open_settings": "Ouvrir les paramètres BQM",
   "previous_month": "Mois précédent",
   "next_month": "Mois suivant",
-  "bqm_csv_import": "Import CSV BQM"
+  "bqm_csv_import": "Import CSV BQM",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Oscail socruithe BQM",
   "previous_month": "An mhí roimhe sin",
   "next_month": "an mhí seo chugainn",
-  "bqm_csv_import": "BQM CSV allmhairiú"
+  "bqm_csv_import": "BQM CSV allmhairiú",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Otvorite postavke BQM",
   "previous_month": "Prethodni mjesec",
   "next_month": "Sljedeći mjesec",
-  "bqm_csv_import": "BQM CSV uvoz"
+  "bqm_csv_import": "BQM CSV uvoz",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Nyissa meg a BQM beállításokat",
   "previous_month": "Előző hónap",
   "next_month": "Jövő hónapban",
-  "bqm_csv_import": "BQM CSV import"
+  "bqm_csv_import": "BQM CSV import",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Aprire le impostazioni BQM",
   "previous_month": "Mese precedente",
   "next_month": "Il mese prossimo",
-  "bqm_csv_import": "BQM CSV importazione"
+  "bqm_csv_import": "BQM CSV importazione",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Atidarykite BQM nustatymus",
   "previous_month": "Ankstesnis mėnuo",
   "next_month": "Kitą mėnesį",
-  "bqm_csv_import": "BQM CSV importas"
+  "bqm_csv_import": "BQM CSV importas",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Atveriet BQM iestatījumus",
   "previous_month": "Iepriekšējais mēnesis",
   "next_month": "Nākamajā mēnesī",
-  "bqm_csv_import": "BQM CSV imports"
+  "bqm_csv_import": "BQM CSV imports",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Åpne BQM-innstillinger",
   "previous_month": "Forrige måned",
   "next_month": "Neste måned",
-  "bqm_csv_import": "BQM CSV import"
+  "bqm_csv_import": "BQM CSV import",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "BQM-instellingen openen",
   "previous_month": "Vorige maand",
   "next_month": "Volgende maand",
-  "bqm_csv_import": "BQM CSV importeren"
+  "bqm_csv_import": "BQM CSV importeren",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Otwórz ustawienia BQM",
   "previous_month": "Poprzedni miesiąc",
   "next_month": "Następny miesiąc",
-  "bqm_csv_import": "Import BQM CSV"
+  "bqm_csv_import": "Import BQM CSV",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Abra as configurações do BQM",
   "previous_month": "Mês anterior",
   "next_month": "Próximo mês",
-  "bqm_csv_import": "Importação BQM CSV"
+  "bqm_csv_import": "Importação BQM CSV",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Deschideți setările BQM",
   "previous_month": "Luna anterioară",
   "next_month": "Luna viitoare",
-  "bqm_csv_import": "BQM CSV import"
+  "bqm_csv_import": "BQM CSV import",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Otvorte nastavenia BQM",
   "previous_month": "Predchádzajúci mesiac",
   "next_month": "Budúci mesiac",
-  "bqm_csv_import": "Import BQM CSV"
+  "bqm_csv_import": "Import BQM CSV",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Odprite nastavitve BQM",
   "previous_month": "Prejšnji mesec",
   "next_month": "Naslednji mesec",
-  "bqm_csv_import": "BQM CSV uvoz"
+  "bqm_csv_import": "BQM CSV uvoz",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -1040,5 +1040,14 @@
   "bqm_setup_open_settings": "Öppna BQM-inställningarna",
   "previous_month": "Föregående månad",
   "next_month": "Nästa månad",
-  "bqm_csv_import": "BQM CSV import"
+  "bqm_csv_import": "BQM CSV import",
+  "signal_family_ds_sc_qam": "DS SC-QAM",
+  "signal_family_ds_ofdm": "DS OFDM",
+  "signal_family_us_sc_qam": "US SC-QAM",
+  "signal_family_us_ofdma": "US OFDMA",
+  "signal_family_metric_power": "Power",
+  "signal_family_metric_snr": "SNR",
+  "signal_family_metric_mer": "MER",
+  "signal_family_modulation_label": "Modulation",
+  "signal_family_unavailable": "Unavailable"
 }

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -885,5 +885,14 @@
   "bqm_setup_open_settings": "",
   "previous_month": "",
   "next_month": "",
-  "bqm_csv_import": ""
+  "bqm_csv_import": "",
+  "signal_family_ds_sc_qam": "",
+  "signal_family_ds_ofdm": "",
+  "signal_family_us_sc_qam": "",
+  "signal_family_us_ofdma": "",
+  "signal_family_metric_power": "",
+  "signal_family_metric_snr": "",
+  "signal_family_metric_mer": "",
+  "signal_family_modulation_label": "",
+  "signal_family_unavailable": ""
 }

--- a/app/static/js/sparklines.js
+++ b/app/static/js/sparklines.js
@@ -7,12 +7,28 @@
 (function() {
     'use strict';
 
-    var SPARKS = [
+    var DEFAULT_SPARKS = [
         { id: 'spark-ds-power',  key: 'ds_power_avg',           color: '#a78bfa' },
         { id: 'spark-us-power',  key: 'us_power_avg',           color: '#06b6d4' },
         { id: 'spark-snr',       key: 'ds_snr_avg',             color: '#10b981' },
         { id: 'spark-errors',    key: 'ds_uncorrectable_errors', color: '#f59e0b' }
     ];
+
+    function collectSparks() {
+        var sparks = DEFAULT_SPARKS.slice();
+        var seen = {};
+        sparks.forEach(function(s) { seen[s.id] = true; });
+        document.querySelectorAll('canvas.metric-spark[data-spark-key]').forEach(function(canvas) {
+            if (!canvas.id || seen[canvas.id]) return;
+            sparks.push({
+                id: canvas.id,
+                key: canvas.dataset.sparkKey,
+                color: canvas.dataset.sparkColor || '#10b981'
+            });
+            seen[canvas.id] = true;
+        });
+        return sparks;
+    }
 
     function drawSparkline(canvas, values, color) {
         if (!canvas || values.length < 2) return;
@@ -85,7 +101,7 @@
                 });
                 if (filtered.length < 2) return;
 
-                SPARKS.forEach(function(s) {
+                collectSparks().forEach(function(s) {
                     var canvas = document.getElementById(s.id);
                     if (!canvas) return;
                     var vals = filtered.map(function(d) { return d[s.key]; }).filter(function(v) { return v != null; });

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v29';
+var CACHE_VERSION = 'v30';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -379,7 +379,7 @@
         "uncorr_errors_high": t.issue_uncorr_errors_high_desc,
         "uncorr_errors_critical": t.issue_uncorr_errors_critical_desc,
     } %}
-    {% set health_labels = {'good': t.health_good, 'tolerated': t.health_tolerated, 'warn': t.health_marginal, 'crit': t.health_critical} %}
+    {% set health_labels = {'good': t.health_good, 'tolerated': t.health_tolerated, 'warn': t.health_marginal, 'warning': t.health_marginal, 'crit': t.health_critical, 'critical': t.health_critical, 'missing': t.get('signal_family_unavailable', 'Unavailable')} %}
     {% set ds_good = ds|selectattr('health', 'equalto', 'good')|list|length %}
     {% set ds_tolerated = ds|selectattr('health', 'equalto', 'tolerated')|list|length %}
     {% set ds_warn = ds|selectattr('health', 'equalto', 'warning')|list|length %}
@@ -715,6 +715,34 @@
     {% endif %}
     {%- endmacro %}
 
+    {% macro signal_family_card(card_id, label, family, metric_key, metric_unit, metric_label, spark_key, icon_class, icon_name) -%}
+        {% set metric = family.get(metric_key, {}) %}
+        {% set modulation = family.get('modulation', {}) %}
+        {% set raw_health = family.get('health', 'missing') %}
+        {% set health_class = 'crit' if raw_health == 'critical' else ('warn' if raw_health == 'warning' else ('muted' if raw_health == 'missing' else raw_health)) %}
+        {% set metric_value = metric.get('avg') %}
+        <div class="metric-card glass" id="{{ card_id }}">
+            <div class="metric-header">
+                <span class="metric-label">{{ label }}</span>
+                <div class="metric-icon {{ icon_class }}"><i data-lucide="{{ icon_name }}"></i></div>
+            </div>
+            <div class="metric-value-row">
+                <div class="metric-value" style="color:var(--{{ health_class }});">{% if metric_value is not none %}{{ metric_value }}<span class="unit">{{ metric_unit }} {{ metric_label }}</span>{% else %}{{ t.get('signal_family_unavailable', 'Unavailable') }}<span class="unit">{{ metric_label }}</span>{% endif %}</div>
+                <canvas class="metric-spark" id="spark-{{ card_id|replace('metric-', '') }}" data-spark-key="{{ spark_key }}" width="144" height="56" aria-hidden="true"></canvas>
+            </div>
+            <div class="metric-sub metric-status-row">
+                <span class="metric-context">
+                    <span class="metric-sub-label">{{ t.get('metric_status_label', 'Status') }}</span>
+                    <span class="badge badge-{{ raw_health }} badge-{{ health_class }}">{{ health_labels.get(raw_health, health_labels.get(health_class, raw_health|title)) }}</span>
+                </span>
+                {% if modulation.get('value') %}<span class="range">{{ t.get('signal_family_modulation_label', 'Modulation') }}: {{ modulation.get('value') }}{% if modulation.get('secondary') %} — {{ modulation.get('secondary') }}{% endif %}</span>{% endif %}
+            </div>
+        </div>
+    {%- endmacro %}
+    {% set signal_families = s.get('signal_families', {}) %}
+    {% set ds_signal_families = signal_families.get('downstream', {}).get('families', {}) if signal_families else {} %}
+    {% set us_signal_families = signal_families.get('upstream', {}).get('families', {}) if signal_families else {} %}
+
     {# ══════════════════════════════════════════════════════════════════════════
        METRICS GRID — Compact signal + error + speed cards
        ══════════════════════════════════════════════════════════════════════════ #}
@@ -790,6 +818,20 @@
             </div>
             {{ metric_range_viz(metric_ranges.snr, snr_health, health_labels.good, t.get('metric_channel_span', 'Channel min-max'), snr_min ~ ' — ' ~ snr_max) }}
         </div>
+
+        {# Family-aware signal cards: keep SC-QAM SNR, OFDM MER, SC-QAM upstream and OFDMA upstream separate. #}
+        {% if ds_signal_families.get('sc_qam') %}
+        {{ signal_family_card('metric-ds-sc-qam-card', t.get('signal_family_ds_sc_qam', 'DS SC-QAM'), ds_signal_families.get('sc_qam'), 'snr', 'dB', t.get('signal_family_metric_snr', 'SNR'), 'ds_scqam_snr_avg', 'green', 'signal') }}
+        {% endif %}
+        {% if ds_signal_families.get('ofdm') %}
+        {{ signal_family_card('metric-ds-ofdm-card', t.get('signal_family_ds_ofdm', 'DS OFDM'), ds_signal_families.get('ofdm'), 'mer', 'dB', t.get('signal_family_metric_mer', 'MER'), 'ds_ofdm_mer_avg', 'green', 'radio-tower') }}
+        {% endif %}
+        {% if us_signal_families.get('sc_qam') %}
+        {{ signal_family_card('metric-us-sc-qam-card', t.get('signal_family_us_sc_qam', 'US SC-QAM'), us_signal_families.get('sc_qam'), 'power', 'dBmV', t.get('signal_family_metric_power', 'Power'), 'us_scqam_power_avg', 'blue', 'arrow-up') }}
+        {% endif %}
+        {% if us_signal_families.get('ofdma') %}
+        {{ signal_family_card('metric-us-ofdma-card', t.get('signal_family_us_ofdma', 'US OFDMA'), us_signal_families.get('ofdma'), 'power', 'dBmV', t.get('signal_family_metric_power', 'Power'), 'us_ofdma_power_avg', 'blue', 'radio-tower') }}
+        {% endif %}
 
         {# Card 4: Errors #}
         {% if (s.errors_supported is not defined or s.errors_supported) and s.ds_uncorr_pct is not none %}

--- a/app/types.py
+++ b/app/types.py
@@ -34,6 +34,7 @@ class RawChannel(TypedDict, total=False):
     symbolRate: int | None
     multiplex: str
     profile_modulation: str
+    profileModulation: str
 
 
 class _DocsisVersionChannels(TypedDict, total=False):
@@ -78,6 +79,8 @@ class DownstreamChannel(TypedDict):
     docsis_version: str
     health: str
     health_detail: str
+    # Optional channel family for Home signal-family summaries
+    channel_family: NotRequired[str]
     # Optional per-metric health keys (present when health_detail is non-empty)
     power_health: NotRequired[str]
     snr_health: NotRequired[str]
@@ -98,6 +101,8 @@ class UpstreamChannel(TypedDict):
     health: str
     health_detail: str
     theoretical_bitrate: float | None
+    # Optional channel family for Home signal-family summaries
+    channel_family: NotRequired[str]
     # Optional per-metric health keys
     power_health: NotRequired[str]
     modulation_health: NotRequired[str]
@@ -134,6 +139,52 @@ class ErrorBaseline(TypedDict):
 # ── Analysis Summary ─────────────────────────────────────────────
 
 
+class SignalFamilyMetric(TypedDict):
+    """Aggregated min/avg/max metric for a DOCSIS signal family."""
+
+    available: bool
+    min: float | None
+    avg: float | None
+    max: float | None
+    health: str
+
+
+class SignalFamilyModulation(TypedDict):
+    """Aggregated modulation/profile values for a DOCSIS signal family."""
+
+    available: bool
+    value: str | None
+    secondary: str | None
+    distinct: list[str]
+    health: str
+
+
+class SignalFamilySummary(TypedDict, total=False):
+    """Summary for one DOCSIS signal family on the Home dashboard."""
+
+    family: str
+    count: int
+    health: str
+    power: SignalFamilyMetric
+    snr: SignalFamilyMetric
+    mer: SignalFamilyMetric
+    modulation: SignalFamilyModulation
+
+
+class SignalDirectionSummary(TypedDict):
+    """Signal-family summaries for one traffic direction."""
+
+    health: str
+    families: dict[str, SignalFamilySummary]
+
+
+class SignalFamiliesSummary(TypedDict):
+    """Family-level downstream/upstream signal summaries."""
+
+    downstream: SignalDirectionSummary
+    upstream: SignalDirectionSummary
+
+
 class AnalysisSummary(TypedDict):
     """Summary metrics from analyzer.analyze()."""
 
@@ -152,6 +203,13 @@ class AnalysisSummary(TypedDict):
     ds_uncorrectable_errors: int | None
     errors_supported: bool
     us_capacity_mbps: float | None
+    signal_families: NotRequired[SignalFamiliesSummary]
+    ds_scqam_power_avg: NotRequired[float | None]
+    ds_scqam_snr_avg: NotRequired[float | None]
+    ds_ofdm_power_avg: NotRequired[float | None]
+    ds_ofdm_mer_avg: NotRequired[float | None]
+    us_scqam_power_avg: NotRequired[float | None]
+    us_ofdma_power_avg: NotRequired[float | None]
     ds_uncorr_pct: float | None
     health: str
     health_issues: list[str]

--- a/tests/analyzer/test_signal_metrics.py
+++ b/tests/analyzer/test_signal_metrics.py
@@ -262,6 +262,176 @@ class TestOFDMThresholds:
         assert "snr tolerated" in ch["health_detail"]
 
 
+# -- Family-level signal summaries --
+
+class TestSignalFamilySummaries:
+    def test_sc_qam_only_downstream_summary_uses_sc_qam_snr(self):
+        data = _make_data(
+            ds30=[_make_ds30(1, power=1.0, mse="-35"), _make_ds30(2, power=3.0, mse="-37")],
+            us30=[_make_us30(1, power=42.0)],
+        )
+        result = analyze(data)
+
+        families = result["summary"]["signal_families"]["downstream"]["families"]
+        assert set(families) == {"sc_qam"}
+        assert families["sc_qam"]["power"]["avg"] == 2.0
+        assert families["sc_qam"]["snr"]["avg"] == 36.0
+        assert families["sc_qam"]["modulation"]["value"] == "256QAM"
+        assert result["ds_channels"][0]["channel_family"] == "sc_qam"
+
+    def test_mixed_downstream_keeps_sc_qam_snr_and_ofdm_mer_separate(self):
+        data = _make_data(
+            ds30=[_make_ds30(1, power=1.0, mse="-36")],
+            ds31=[_make_ds31(33, power=0.5, mer="37.0")],
+            us30=[_make_us30(1, power=42.0)],
+        )
+        result = analyze(data)
+
+        downstream = result["summary"]["signal_families"]["downstream"]
+        families = downstream["families"]
+        assert set(families) == {"sc_qam", "ofdm"}
+        assert families["sc_qam"]["snr"]["avg"] == 36.0
+        assert families["ofdm"]["mer"]["avg"] == 37.0
+        assert families["ofdm"]["mer"]["health"] == "warning"
+        assert downstream["health"] == "warning"
+
+    def test_docsis31_high_qam_profile_is_ofdm_not_sc_qam(self):
+        data = _make_data(
+            ds31=[_make_ds31(33, power=1.0, mer="41.0")],
+            us30=[_make_us30(1, power=42.0)],
+        )
+        result = analyze(data)
+
+        families = result["summary"]["signal_families"]["downstream"]["families"]
+        assert set(families) == {"ofdm"}
+        assert result["ds_channels"][0]["channel_family"] == "ofdm"
+        assert families["ofdm"]["mer"]["avg"] == 41.0
+
+    def test_docsis31_explicit_low_qam_modulation_stays_sc_qam(self):
+        data = _make_data(
+            ds31=[{
+                "channelID": 33,
+                "frequency": "159 MHz",
+                "powerLevel": "1.0",
+                "modulation": "256QAM",
+                "mer": "34.0",
+            }],
+            us30=[_make_us30(1, power=42.0)],
+        )
+        result = analyze(data)
+
+        families = result["summary"]["signal_families"]["downstream"]["families"]
+        assert set(families) == {"sc_qam"}
+        assert result["ds_channels"][0]["channel_family"] == "sc_qam"
+        assert result["ds_channels"][0]["modulation_health"] == "good"
+        assert result["ds_channels"][0]["health"] == "good"
+        assert families["sc_qam"]["modulation"]["health"] == "good"
+        assert families["sc_qam"]["modulation"]["value"] == "256QAM"
+
+    def test_docsis31_profile_only_low_qam_stays_ofdm_not_sc_qam(self):
+        data = _make_data(
+            ds31=[{
+                "channelID": 33,
+                "frequency": "159 MHz",
+                "powerLevel": "1.0",
+                "profile_modulation": "256QAM",
+                "mer": "34.0",
+            }],
+            us30=[_make_us30(1, power=42.0)],
+        )
+        result = analyze(data)
+
+        families = result["summary"]["signal_families"]["downstream"]["families"]
+        assert set(families) == {"ofdm"}
+        assert result["ds_channels"][0]["channel_family"] == "ofdm"
+        assert families["ofdm"]["mer"]["avg"] == 34.0
+        assert families["ofdm"]["modulation"]["value"] == "256QAM"
+
+    def test_docsis31_upstream_profile_only_low_qam_stays_ofdma_not_sc_qam(self):
+        us_ofdma = {
+            "channelID": 5,
+            "frequency": "30-65 MHz",
+            "profile_modulation": "64QAM",
+        }
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us31=[us_ofdma],
+        )
+        result = analyze(data)
+
+        upstream = result["summary"]["signal_families"]["upstream"]["families"]
+        assert set(upstream) == {"ofdma"}
+        assert result["us_channels"][0]["channel_family"] == "ofdma"
+        assert upstream["ofdma"]["modulation"]["value"] == "64QAM"
+
+    def test_docsis31_upstream_profile_only_camel_case_profile_key_stays_ofdma(self):
+        us_ofdma = {
+            "channelID": 5,
+            "frequency": "30-65 MHz",
+            "profileModulation": "64QAM",
+        }
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us31=[us_ofdma],
+        )
+        result = analyze(data)
+
+        upstream = result["summary"]["signal_families"]["upstream"]["families"]
+        assert set(upstream) == {"ofdma"}
+        assert result["us_channels"][0]["channel_family"] == "ofdma"
+        assert upstream["ofdma"]["modulation"]["value"] == "64QAM"
+
+    def test_docsis31_profile_only_camel_case_profile_key_stays_ofdm(self):
+        data = _make_data(
+            ds31=[{
+                "channelID": 33,
+                "frequency": "159 MHz",
+                "powerLevel": "1.0",
+                "profileModulation": "256QAM",
+                "mer": "34.0",
+            }],
+            us30=[_make_us30(1, power=42.0)],
+        )
+        result = analyze(data)
+
+        families = result["summary"]["signal_families"]["downstream"]["families"]
+        assert set(families) == {"ofdm"}
+        assert result["ds_channels"][0]["channel_family"] == "ofdm"
+        assert families["ofdm"]["modulation"]["value"] == "256QAM"
+
+    def test_missing_ofdm_mer_stays_unavailable_not_zero(self):
+        ds_ofdm = _make_ds31(33, power=1.0, mer="38.0")
+        ds_ofdm.pop("mer")
+        data = _make_data(ds31=[ds_ofdm], us30=[_make_us30(1, power=42.0)])
+        result = analyze(data)
+
+        ofdm = result["summary"]["signal_families"]["downstream"]["families"]["ofdm"]
+        assert ofdm["mer"]["available"] is False
+        assert ofdm["mer"]["avg"] is None
+        assert ofdm["mer"]["health"] == "missing"
+
+    def test_upstream_ofdma_missing_power_and_low_profile_modulation_are_visible(self):
+        us_ofdma = {
+            "channelID": 5,
+            "frequency": "30-65 MHz",
+            "type": "OFDMA",
+            "profile_modulation": "64QAM",
+        }
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us30=[_make_us30(1, power=43.0, modulation="64QAM")],
+            us31=[us_ofdma],
+        )
+        result = analyze(data)
+
+        upstream = result["summary"]["signal_families"]["upstream"]["families"]
+        assert set(upstream) == {"sc_qam", "ofdma"}
+        assert upstream["ofdma"]["power"]["available"] is False
+        assert upstream["ofdma"]["power"]["avg"] is None
+        assert upstream["ofdma"]["modulation"]["value"] == "64QAM"
+        assert upstream["ofdma"]["modulation"]["health"] == "warning"
+
+
 # -- Upstream bitrate calculation --
 
 class TestChannelBitrate:

--- a/tests/analyzer/test_thresholds.py
+++ b/tests/analyzer/test_thresholds.py
@@ -237,7 +237,7 @@ class TestDownstreamModulationHealth:
         ],
     )
     def test_docsis31_ofdm_downstream_modulation_health_bands(self, modulation, expected_health):
-        data = _make_data(ds31=[{**_make_ds31(100, power=5.0, mer="40.0"), "modulation": modulation}])
+        data = _make_data(ds31=[{**_make_ds31(100, power=5.0, mer="40.0"), "type": "OFDM", "modulation": modulation}])
 
         result = analyze(data)
         channel = result["ds_channels"][0]

--- a/tests/collectors/test_demo_signal_families.py
+++ b/tests/collectors/test_demo_signal_families.py
@@ -1,0 +1,26 @@
+"""Tests for demo history signal-family trend fields."""
+
+from app.collectors.demo import DemoCollector
+
+
+def test_demo_historical_analysis_populates_signal_family_trend_keys():
+    collector = object.__new__(DemoCollector)
+
+    analysis = collector._generate_historical_analysis(
+        index=1,
+        diurnal=0.0,
+        seasonal=0.0,
+        bad_period=False,
+        hour=12,
+        day_of_year=120,
+    )
+
+    summary = analysis["summary"]
+    families = summary["signal_families"]
+
+    assert set(families["downstream"]["families"]) == {"sc_qam", "ofdm"}
+    assert set(families["upstream"]["families"]) == {"sc_qam", "ofdma"}
+    assert summary["ds_scqam_snr_avg"] is not None
+    assert summary["ds_ofdm_mer_avg"] is not None
+    assert summary["us_scqam_power_avg"] is not None
+    assert summary["us_ofdma_power_avg"] is not None

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,12 +107,21 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v29';" in sw_js
+    assert "var CACHE_VERSION = 'v30';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js
     assert "/modules/docsight.modulation/static/main.js" in sw_js
+
+
+def test_home_signal_family_sparklines_use_data_keys():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    sparklines_js = (ROOT / "app" / "static" / "js" / "sparklines.js").read_text(encoding="utf-8")
+
+    assert "data-spark-key=\"{{ spark_key }}\"" in template
+    assert "querySelectorAll('canvas.metric-spark[data-spark-key]')" in sparklines_js
+    assert "canvas.dataset.sparkKey" in sparklines_js
 
 
 def test_channels_weather_overlay_contract_is_wired():

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -18,6 +18,88 @@ def _metric_card(html, label):
     return html[start:end if end != -1 else len(html)]
 
 
+def _element_by_id(html, element_id):
+    marker = f'id="{element_id}"'
+    marker_idx = html.index(marker)
+    start = html.rfind('<div class="metric-card', 0, marker_idx)
+    end = html.find('<div class="metric-card', marker_idx + len(marker))
+    return html[start:end if end != -1 else len(html)]
+
+
+def _family_metric(health, avg, minimum=None, maximum=None, available=True):
+    return {
+        "available": available,
+        "avg": avg,
+        "min": minimum if minimum is not None else avg,
+        "max": maximum if maximum is not None else avg,
+        "health": health,
+    }
+
+
+def _family_modulation(value, health="good"):
+    return {
+        "available": value is not None,
+        "value": value,
+        "secondary": None,
+        "distinct": [value] if value is not None else [],
+        "health": health,
+    }
+
+
+def _add_mixed_signal_families(analysis):
+    analysis["summary"].update({
+        "ds_scqam_power_avg": 1.0,
+        "ds_scqam_snr_avg": 36.0,
+        "ds_ofdm_power_avg": 0.5,
+        "ds_ofdm_mer_avg": 37.0,
+        "us_scqam_power_avg": 43.0,
+        "us_ofdma_power_avg": None,
+        "signal_families": {
+            "downstream": {
+                "health": "warning",
+                "families": {
+                    "sc_qam": {
+                        "family": "sc_qam",
+                        "count": 1,
+                        "health": "good",
+                        "power": _family_metric("good", 1.0),
+                        "snr": _family_metric("good", 36.0),
+                        "modulation": _family_modulation("256QAM"),
+                    },
+                    "ofdm": {
+                        "family": "ofdm",
+                        "count": 1,
+                        "health": "warning",
+                        "power": _family_metric("good", 0.5),
+                        "mer": _family_metric("warning", 37.0),
+                        "modulation": _family_modulation("4096QAM"),
+                    },
+                },
+            },
+            "upstream": {
+                "health": "warning",
+                "families": {
+                    "sc_qam": {
+                        "family": "sc_qam",
+                        "count": 1,
+                        "health": "good",
+                        "power": _family_metric("good", 43.0),
+                        "modulation": _family_modulation("64QAM"),
+                    },
+                    "ofdma": {
+                        "family": "ofdma",
+                        "count": 1,
+                        "health": "warning",
+                        "power": _family_metric("missing", None, available=False),
+                        "modulation": _family_modulation("64QAM", "warning"),
+                    },
+                },
+            },
+        },
+    })
+    return analysis
+
+
 class TestIndexRoute:
     @pytest.mark.parametrize(
         ("channel", "family"),
@@ -310,6 +392,55 @@ class TestIndexRoute:
         snr_card = _metric_card(resp.get_data(as_text=True), "SNR/MER")
         assert "39.0<span class=\"unit\">dB</span>" in snr_card
         assert "Avg across all DS channels" not in snr_card
+
+    def test_home_renders_downstream_signal_family_cards_without_mixed_average(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        sample_analysis["summary"].update({"ds_snr_avg": 38.5})
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        scqam_card = _element_by_id(html, "metric-ds-sc-qam-card")
+        ofdm_card = _element_by_id(html, "metric-ds-ofdm-card")
+        assert "DS SC-QAM" in scqam_card
+        assert "36.0<span class=\"unit\">dB SNR</span>" in scqam_card
+        assert "256QAM" in scqam_card
+        assert "DS OFDM" in ofdm_card
+        assert "37.0<span class=\"unit\">dB MER</span>" in ofdm_card
+        assert "4096QAM" in ofdm_card
+        assert "38.5<span class=\"unit\">dB</span>" not in scqam_card + ofdm_card
+
+    def test_home_renders_upstream_signal_family_cards_separately(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        scqam_card = _element_by_id(html, "metric-us-sc-qam-card")
+        ofdma_card = _element_by_id(html, "metric-us-ofdma-card")
+        assert "US SC-QAM" in scqam_card
+        assert "43.0<span class=\"unit\">dBmV Power</span>" in scqam_card
+        assert "64QAM" in scqam_card
+        assert "US OFDMA" in ofdma_card
+        assert "Unavailable<span class=\"unit\">Power</span>" in ofdma_card
+        assert "badge badge-warning" in ofdma_card
+
+    def test_home_family_cards_expose_family_sparkline_keys(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'data-spark-key="ds_scqam_snr_avg"' in _element_by_id(html, "metric-ds-sc-qam-card")
+        assert 'data-spark-key="ds_ofdm_mer_avg"' in _element_by_id(html, "metric-ds-ofdm-card")
+        assert 'data-spark-key="us_scqam_power_avg"' in _element_by_id(html, "metric-us-sc-qam-card")
+        assert 'data-spark-key="us_ofdma_power_avg"' in _element_by_id(html, "metric-us-ofdma-card")
 
     def test_home_surfaces_normal_modulation_context(self, client, sample_analysis):
         update_state(analysis=sample_analysis)


### PR DESCRIPTION
## Summary
- Add family-level signal summaries for downstream SC-QAM/OFDM and upstream SC-QAM/OFDMA without removing existing summary fields.
- Render Home signal cards from the family-specific basis so SC-QAM SNR, OFDM MER, upstream SC-QAM power, and OFDMA power/modulation stay separate.
- Wire family-specific sparkline keys into history/demo data and keep missing telemetry unavailable instead of treating it as zero.
- Add regression coverage for mixed DOCSIS families, profile-modulation classification, missing OFDM/OFDMA fields, Home rendering, and sparkline contracts.

## Test plan
- `git diff --check`
- Targeted signal-family/Home checks: 40 passed
- `pytest -q tests --ignore=tests/e2e`: 2448 passed, 11 skipped, 1 existing warning
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`: all 299 language files in sync
- `TZ=UTC pytest -q tests/e2e`: 410 passed

Closes #522
Refs #478
