### PR TITLE
fix: restore home signal family card ranges

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -715,13 +715,14 @@
     {% endif %}
     {%- endmacro %}
 
-    {% macro signal_family_card(card_id, label, family, metric_key, metric_unit, metric_label, spark_key, icon_class, icon_name) -%}
+    {% macro signal_family_card(card_id, label, family, metric_key, metric_unit, metric_label, spark_key, icon_class, icon_name, range_data=None, glossary_text=None) -%}
         {% set metric = family.get(metric_key, {}) %}
         {% set modulation = family.get('modulation', {}) %}
         {% set raw_health = family.get('health', 'missing') %}
         {% set health_class = 'crit' if raw_health == 'critical' else ('warn' if raw_health == 'warning' else ('muted' if raw_health == 'missing' else raw_health)) %}
         {% set metric_value = metric.get('avg') %}
         <div class="metric-card glass" id="{{ card_id }}">
+            {% if glossary_text %}<span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ glossary_text }}</div></span>{% endif %}
             <div class="metric-header">
                 <span class="metric-label">{{ label }}</span>
                 <div class="metric-icon {{ icon_class }}"><i data-lucide="{{ icon_name }}"></i></div>
@@ -737,11 +738,17 @@
                 </span>
                 {% if modulation.get('value') %}<span class="range">{{ t.get('signal_family_modulation_label', 'Modulation') }}: {{ modulation.get('value') }}{% if modulation.get('secondary') %} — {{ modulation.get('secondary') }}{% endif %}</span>{% endif %}
             </div>
+            {% if metric_value is not none and range_data %}
+            {% set metric_min = metric.get('min') if metric.get('min') is not none else metric_value %}
+            {% set metric_max = metric.get('max') if metric.get('max') is not none else metric_value %}
+            {{ metric_range_viz(range_data, range_data.health if range_data.health is defined else health_class, health_labels.good, t.get('metric_channel_span', 'Channel min-max'), metric_min ~ ' — ' ~ metric_max) }}
+            {% endif %}
         </div>
     {%- endmacro %}
     {% set signal_families = s.get('signal_families', {}) %}
     {% set ds_signal_families = signal_families.get('downstream', {}).get('families', {}) if signal_families else {} %}
     {% set us_signal_families = signal_families.get('upstream', {}).get('families', {}) if signal_families else {} %}
+    {% set has_downstream_family_cards = ds_signal_families.get('sc_qam') or ds_signal_families.get('ofdm') %}
 
     {# ══════════════════════════════════════════════════════════════════════════
        METRICS GRID — Compact signal + error + speed cards
@@ -794,7 +801,8 @@
             {{ metric_range_viz(metric_ranges.us_power, us_health, health_labels.good, t.get('metric_channel_span', 'Channel min-max'), s.us_power_min ~ ' — ' ~ s.us_power_max) }}
         </div>
 
-        {# Card 3: SNR/MER #}
+        {# Card 3: SNR/MER (legacy compact fallback when no explicit downstream family cards are available) #}
+        {% if not has_downstream_family_cards %}
         {% set snr_display = home_snr_display if home_snr_display is defined else {} %}
         {% set snr_label = t.get(snr_display.label_key, 'SNR') if snr_display.label_key is defined else 'SNR' %}
         {% set snr_value = snr_display.value if snr_display.value is defined and snr_display.value is not none else s.ds_snr_avg %}
@@ -818,19 +826,20 @@
             </div>
             {{ metric_range_viz(metric_ranges.snr, snr_health, health_labels.good, t.get('metric_channel_span', 'Channel min-max'), snr_min ~ ' — ' ~ snr_max) }}
         </div>
+        {% endif %}
 
         {# Family-aware signal cards: keep SC-QAM SNR, OFDM MER, SC-QAM upstream and OFDMA upstream separate. #}
         {% if ds_signal_families.get('sc_qam') %}
-        {{ signal_family_card('metric-ds-sc-qam-card', t.get('signal_family_ds_sc_qam', 'DS SC-QAM'), ds_signal_families.get('sc_qam'), 'snr', 'dB', t.get('signal_family_metric_snr', 'SNR'), 'ds_scqam_snr_avg', 'green', 'signal') }}
+        {{ signal_family_card('metric-ds-sc-qam-card', t.get('signal_family_ds_sc_qam', 'DS SC-QAM'), ds_signal_families.get('sc_qam'), 'snr', 'dB', t.get('signal_family_metric_snr', 'SNR'), 'ds_scqam_snr_avg', 'green', 'signal', metric_ranges.get('ds_sc_qam_snr'), t.glossary_snr) }}
         {% endif %}
         {% if ds_signal_families.get('ofdm') %}
-        {{ signal_family_card('metric-ds-ofdm-card', t.get('signal_family_ds_ofdm', 'DS OFDM'), ds_signal_families.get('ofdm'), 'mer', 'dB', t.get('signal_family_metric_mer', 'MER'), 'ds_ofdm_mer_avg', 'green', 'radio-tower') }}
+        {{ signal_family_card('metric-ds-ofdm-card', t.get('signal_family_ds_ofdm', 'DS OFDM'), ds_signal_families.get('ofdm'), 'mer', 'dB', t.get('signal_family_metric_mer', 'MER'), 'ds_ofdm_mer_avg', 'green', 'radio-tower', metric_ranges.get('ds_ofdm_mer'), t.glossary_snr) }}
         {% endif %}
         {% if us_signal_families.get('sc_qam') %}
-        {{ signal_family_card('metric-us-sc-qam-card', t.get('signal_family_us_sc_qam', 'US SC-QAM'), us_signal_families.get('sc_qam'), 'power', 'dBmV', t.get('signal_family_metric_power', 'Power'), 'us_scqam_power_avg', 'blue', 'arrow-up') }}
+        {{ signal_family_card('metric-us-sc-qam-card', t.get('signal_family_us_sc_qam', 'US SC-QAM'), us_signal_families.get('sc_qam'), 'power', 'dBmV', t.get('signal_family_metric_power', 'Power'), 'us_scqam_power_avg', 'blue', 'arrow-up', metric_ranges.get('us_sc_qam_power'), t.glossary_us_power) }}
         {% endif %}
         {% if us_signal_families.get('ofdma') %}
-        {{ signal_family_card('metric-us-ofdma-card', t.get('signal_family_us_ofdma', 'US OFDMA'), us_signal_families.get('ofdma'), 'power', 'dBmV', t.get('signal_family_metric_power', 'Power'), 'us_ofdma_power_avg', 'blue', 'radio-tower') }}
+        {{ signal_family_card('metric-us-ofdma-card', t.get('signal_family_us_ofdma', 'US OFDMA'), us_signal_families.get('ofdma'), 'power', 'dBmV', t.get('signal_family_metric_power', 'Power'), 'us_ofdma_power_avg', 'blue', 'radio-tower', metric_ranges.get('us_ofdma_power'), t.glossary_us_power) }}
         {% endif %}
 
         {# Card 4: Errors #}

--- a/app/web.py
+++ b/app/web.py
@@ -813,6 +813,22 @@ def _channel_threshold_candidates(channels, *, snr=False):
     return candidates
 
 
+def _family_modulation_threshold_candidates(family):
+    modulation = (family or {}).get("modulation") or {}
+    raw_values = []
+    for key in ("value", "secondary"):
+        if modulation.get(key):
+            raw_values.append(modulation.get(key))
+    raw_values.extend(modulation.get("distinct") or [])
+
+    candidates = []
+    text = " ".join(str(value) for value in raw_values if value is not None).upper()
+    for qam in ("4096QAM", "1024QAM", "256QAM", "64QAM"):
+        if qam in text:
+            candidates.append(qam)
+    return candidates
+
+
 def _power_metric_health(value, threshold):
     if value is None:
         return "good"
@@ -956,7 +972,8 @@ def _build_metric_ranges(analysis):
     else:
         snr_candidates = _channel_threshold_candidates(ds_channels, snr=True) + ["256QAM", "ofdm", "4096QAM", "1024QAM", "64QAM"]
     snr_threshold = _choose_threshold(thresholds.get("snr", {}), snr_candidates)
-    return {
+
+    ranges = {
         "ds_power": _power_metric_range(
             _to_float(summary.get("ds_power_avg")),
             _to_float(summary.get("ds_power_min")),
@@ -982,6 +999,43 @@ def _build_metric_ranges(analysis):
             thresholds.get("errors", {}),
         ),
     }
+
+    signal_families = summary.get("signal_families") or {}
+    ds_families = (signal_families.get("downstream") or {}).get("families") or {}
+    us_families = (signal_families.get("upstream") or {}).get("families") or {}
+
+    def _family_metric_values(family, metric_name):
+        metric = (family or {}).get(metric_name) or {}
+        if metric.get("available") is False:
+            return None
+        value = _to_float(metric.get("avg"))
+        if value is None:
+            return None
+        minimum = _to_float(metric.get("min"))
+        maximum = _to_float(metric.get("max"))
+        return value, minimum if minimum is not None else value, maximum if maximum is not None else value
+
+    def _add_family_snr_range(range_key, family, metric_name, candidates):
+        values = _family_metric_values(family, metric_name)
+        if not values:
+            return
+        threshold = _choose_threshold(thresholds.get("snr", {}), candidates)
+        ranges[range_key] = _snr_metric_range(values[0], values[1], values[2], threshold)
+
+    def _add_family_power_range(range_key, family, candidates):
+        values = _family_metric_values(family, "power")
+        if not values:
+            return
+        threshold = _choose_threshold(thresholds.get("upstream_power", {}), candidates)
+        ranges[range_key] = _power_metric_range(values[0], values[1], values[2], threshold, "dBmV")
+
+    sc_qam_candidates = _family_modulation_threshold_candidates(ds_families.get("sc_qam")) + ["256QAM", "64QAM"]
+    ofdm_candidates = ["ofdm"] + _family_modulation_threshold_candidates(ds_families.get("ofdm")) + ["4096QAM", "1024QAM"]
+    _add_family_snr_range("ds_sc_qam_snr", ds_families.get("sc_qam"), "snr", sc_qam_candidates)
+    _add_family_snr_range("ds_ofdm_mer", ds_families.get("ofdm"), "mer", ofdm_candidates)
+    _add_family_power_range("us_sc_qam_power", us_families.get("sc_qam"), ["sc_qam"])
+    _add_family_power_range("us_ofdma_power", us_families.get("ofdma"), ["ofdma"])
+    return ranges
 
 
 def _snr_channel_family(channel):

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -411,6 +411,42 @@ class TestIndexRoute:
         assert "37.0<span class=\"unit\">dB MER</span>" in ofdm_card
         assert "4096QAM" in ofdm_card
         assert "38.5<span class=\"unit\">dB</span>" not in scqam_card + ofdm_card
+        assert '<span class="metric-label">DS SNR (SC-QAM)</span>' not in html
+
+    def test_home_signal_family_cards_show_metric_health_bars(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        for element_id, caption in [
+            ("metric-ds-sc-qam-card", "Channel min-max"),
+            ("metric-ds-ofdm-card", "Channel min-max"),
+            ("metric-us-sc-qam-card", "Channel min-max"),
+        ]:
+            card = _element_by_id(html, element_id)
+            assert 'class="metric-range-viz"' in card
+            assert caption in card
+        ofdma_card = _element_by_id(html, "metric-us-ofdma-card")
+        assert 'class="metric-range-viz"' not in ofdma_card
+
+    def test_home_signal_family_health_bar_falls_back_to_value_for_missing_min_max(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        family_metric = sample_analysis["summary"]["signal_families"]["downstream"]["families"]["sc_qam"]["snr"]
+        family_metric.pop("min")
+        family_metric.pop("max")
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        card = _element_by_id(resp.get_data(as_text=True), "metric-ds-sc-qam-card")
+        assert 'class="metric-range-viz"' in card
+        assert "Channel min-max" in card
+        assert "36.0 — 36.0" in card
+        assert "None — None" not in card
 
     def test_home_renders_upstream_signal_family_cards_separately(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)


### PR DESCRIPTION
## Summary
- hides the legacy downstream SNR card when explicit downstream signal-family cards are present
- adds the same health-bar range visualization to signal-family cards where a measured family metric is available
- falls back to the displayed value for the range caption when family min/max values are missing, avoiding `None — None`

## Test plan
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt python -m py_compile app/web.py`
- `uv run --with-requirements requirements-test.txt pytest -q tests/web/test_index.py --tb=short`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright pytest -q tests/e2e --tb=short`
