### PR TITLE
Fix BQM lost-poll chart rendering

### DIFF
--- a/app/modules/bqm/static/js/bqm-chart.js
+++ b/app/modules/bqm/static/js/bqm-chart.js
@@ -21,6 +21,7 @@ var BQMChart = (function() {
         return {
             hooks: {
                 draw: [function(u) {
+                    if (!u.series[seriesIdx] || u.series[seriesIdx].show === false) return;
                     var data = u.data[seriesIdx];
                     if (!data) return;
                     var ctx = u.ctx;
@@ -94,6 +95,7 @@ var BQMChart = (function() {
                 color: 'rgba(239,68,68,0.9)',
                 spanGaps: false,
                 scale: 'loss',
+                lineWidth: 0,
                 showPoints: false,
             },
         ], 'line', null, {

--- a/app/static/js/chart-engine.js
+++ b/app/static/js/chart-engine.js
@@ -415,7 +415,7 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
         var s = {
             label: ds.label,
             stroke: ds.color || 'rgba(168,85,247,0.9)',
-            width: isBar ? 0 : 2,
+            width: ds.lineWidth !== undefined ? ds.lineWidth : (isBar ? 0 : 2),
             fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || undefined),
             points: { show: showPoints, size: ds.pointSize || 6 },
             spanGaps: ds.spanGaps !== undefined ? ds.spanGaps : false,
@@ -733,7 +733,7 @@ function openChartZoom(canvasId) {
             var s = {
                 label: ds.label,
                 stroke: ds.color || 'rgba(168,85,247,0.9)',
-                width: isBar ? 0 : 2,
+                width: ds.lineWidth !== undefined ? ds.lineWidth : (isBar ? 0 : 2),
                 fill: isBar ? (ds.color || '#a855f7') + 'cc' : (ds.fill || undefined),
                 points: { show: zoomShowPoints, size: isBar ? 0 : (ds.pointSize || (n > 30 ? 4 : 8)) },
                 spanGaps: ds.spanGaps !== undefined ? ds.spanGaps : false

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v30';
+var CACHE_VERSION = 'v31';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -668,6 +668,24 @@ class TestBqmChartConfig:
         assert "return [sentMax, 0]" in js
         assert "return [0, sentMax]" not in js
 
+    def test_loss_poll_overlay_has_no_zero_baseline(self):
+        """Lost-poll events should draw as plugin bars only, not a red zero-value line."""
+        with open("app/modules/bqm/static/js/bqm-chart.js", "r", encoding="utf-8") as f:
+            js = f.read()
+        with open("app/static/js/chart-engine.js", "r", encoding="utf-8") as f:
+            chart_engine = f.read()
+
+        loss_dataset = js[js.index("label: (T && T.bqm_chart_lost_polls)") : js.index("], 'line', null")]
+        assert "lineWidth: 0" in loss_dataset
+        assert "width: ds.lineWidth" in chart_engine
+
+    def test_loss_poll_toggle_controls_plugin_overlay(self):
+        """Hiding Lost Polls in the legend should hide the real loss markers too."""
+        with open("app/modules/bqm/static/js/bqm-chart.js", "r", encoding="utf-8") as f:
+            js = f.read()
+        plugin_body = js[js.index("function bqmLossPlugin") : js.index("function render(container")]
+        assert "u.series[seriesIdx].show === false" in plugin_body
+
     def test_toggle_logic_in_bqm_js(self):
         """bqm.js must contain toggle handler wiring."""
         with open("app/static/js/bqm.js", "r") as f:

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,7 +107,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v30';" in sw_js
+    assert "var CACHE_VERSION = 'v31';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js


### PR DESCRIPTION
## Summary
- remove the misleading red zero baseline from the BQM Lost Polls series by making it a zero-width carrier series
- keep the custom lost-poll overlay as the only visible lost-poll rendering and make it respect uPlot legend visibility
- support dataset-level `lineWidth` in normal and zoomed uPlot charts
- bump the service-worker cache version for the changed static assets

Fixes #530

## Verification
- `uv run --with-requirements requirements-test.txt pytest -q tests/test_bqm.py::TestBqmChartConfig` → `6 passed in 0.01s`
- `uv run --with-requirements requirements-test.txt pytest -q tests/test_bqm.py tests/test_static_contracts.py` → `83 passed in 0.43s`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e` → `2452 passed, 11 skipped, 1 warning in 36.17s`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e` → `410 passed in 599.33s (0:09:59)`
