### PR TITLE
Normalize time range controls

### DIFF
--- a/app/blueprints/analysis_bp.py
+++ b/app/blueprints/analysis_bp.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from flask import Blueprint, request, jsonify
 
 from app.analyzer import get_thresholds
+from app.time_ranges import parse_time_range_hours
 from app.tz import utc_now, utc_cutoff
 from app.web import (
     require_auth,
@@ -129,23 +130,38 @@ def api_gaming_score():
     })
 
 
+def _channel_history_window_args():
+    range_value = request.args.get("range")
+    if range_value is not None:
+        hours = parse_time_range_hours(range_value, default="1d")
+        if hours is None:
+            return None, (jsonify({"error": "range must be one of 1h, 6h, 1d, 2d, 3d, 7d, 30d, 90d"}), 400)
+        return {"hours": hours}, None
+    days = request.args.get("days", 7, type=int)
+    days = max(1, min(days, 90))
+    return {"days": days}, None
+
+
 @analysis_bp.route("/api/channel-history")
 @require_auth
 def api_channel_history():
     """Return per-channel time series data.
-    ?channel_id=X&direction=ds|us&days=7"""
+    ?channel_id=X&direction=ds|us&range=1h|6h|1d|2d|3d|7d|30d|90d
+    Legacy ?days=N remains supported."""
     _storage = get_storage()
     if not _storage:
         return jsonify([])
     channel_id = request.args.get("channel_id", type=int)
     direction = request.args.get("direction", "ds")
-    days = request.args.get("days", 7, type=int)
+    window_args, range_error = _channel_history_window_args()
+    if range_error:
+        return range_error
+    assert window_args is not None
     if channel_id is None:
         return jsonify({"error": "channel_id is required"}), 400
     if direction not in ("ds", "us"):
         return jsonify({"error": "direction must be 'ds' or 'us'"}), 400
-    days = max(1, min(days, 90))
-    data = _storage.get_channel_history(channel_id, direction, days)
+    data = _storage.get_channel_history(channel_id, direction, **window_args)
     _localize_timestamps(data)
     return jsonify(data)
 
@@ -154,18 +170,21 @@ def api_channel_history():
 @require_auth
 def api_channel_compare():
     """Return per-channel time series for multiple channels.
-    ?channels=1,2,3&direction=ds|us&days=7"""
+    ?channels=1,2,3&direction=ds|us&range=1h|6h|1d|2d|3d|7d|30d|90d
+    Legacy ?days=N remains supported."""
     _storage = get_storage()
     if not _storage:
         return jsonify({})
     channels_param = request.args.get("channels", "")
     direction = request.args.get("direction", "ds")
-    days = request.args.get("days", 7, type=int)
+    window_args, range_error = _channel_history_window_args()
+    if range_error:
+        return range_error
+    assert window_args is not None
     if not channels_param:
         return jsonify({"error": "channels parameter is required"}), 400
     if direction not in ("ds", "us"):
         return jsonify({"error": "direction must be 'ds' or 'us'"}), 400
-    days = max(1, min(days, 90))
     try:
         channel_ids = [int(c.strip()) for c in channels_param.split(",") if c.strip()]
     except ValueError:
@@ -174,7 +193,7 @@ def api_channel_compare():
         return jsonify({"error": "maximum 64 channels"}), 400
     if not channel_ids:
         return jsonify({"error": "at least one channel required"}), 400
-    result = _storage.get_multi_channel_history(channel_ids, direction, days)
+    result = _storage.get_multi_channel_history(channel_ids, direction, **window_args)
     # Convert int keys to strings for JSON
     return jsonify({str(k): v for k, v in result.items()})
 
@@ -186,14 +205,14 @@ def api_channel_compare():
 def api_correlation():
     """Return unified timeline with data from all sources for cross-source correlation.
     Query params:
-      hours: int (default 24, max 168)
+      hours: int (default 24, max 2160 / 90d)
       sources: comma-separated list of modem,speedtest,events,bnetz,capture,segment (default all)
     """
     _storage = get_storage()
     if not _storage:
         return jsonify([])
     hours = request.args.get("hours", 24, type=int)
-    hours = max(1, min(hours, 168))
+    hours = max(1, min(hours, 2160))
     end_ts = utc_now()
     start_ts = utc_cutoff(hours=hours)
 

--- a/app/blueprints/data_bp.py
+++ b/app/blueprints/data_bp.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from flask import Blueprint, request, jsonify
 
+from app.time_ranges import parse_time_range_hours
 from app.web import (
     require_auth,
     get_storage, get_config_manager, get_state,
@@ -55,35 +56,42 @@ data_bp = Blueprint("data_bp", __name__)
 @data_bp.route("/api/trends")
 @require_auth
 def api_trends():
-    """Return trend data for a date range.
-    ?range=day|week|month&date=YYYY-MM-DD (date defaults to today)."""
+    """Return trend data for a normalized time range.
+
+    Supports the normalized UI ranges (1h, 6h, 1d, 2d, 3d, 7d, 30d, 90d)
+    plus the legacy day/week/month names for backwards compatibility.
+    The date query parameter anchors only legacy day/week/month requests;
+    normalized ranges are rolling windows ending at the current snapshot time.
+    """
     _storage = get_storage()
     if not _storage:
         return jsonify([])
-    range_type = request.args.get("range", "day")
+    range_type = (request.args.get("range", "1d") or "1d").strip().lower()
     date_str = request.args.get("date", datetime.now().strftime("%Y-%m-%d"))
 
-    try:
-        ref_date = datetime.strptime(date_str, "%Y-%m-%d")
-    except ValueError:
-        return jsonify({"error": "Invalid date format"}), 400
+    hours = parse_time_range_hours(range_type, default="1d", allow_legacy=True)
+    if hours is None:
+        return jsonify({"error": "Invalid range (use 1h, 6h, 1d, 2d, 3d, 7d, 30d, 90d)"}), 400
+
+    ref_date = datetime.now()
+    if range_type in ("day", "week", "month"):
+        try:
+            ref_date = datetime.strptime(date_str, "%Y-%m-%d")
+        except ValueError:
+            return jsonify({"error": "Invalid date format"}), 400
 
     if range_type == "day":
         data = _storage.get_intraday_data(date_str)
-        _localize_timestamps(data)
-        return jsonify(data)
     elif range_type == "week":
         start = (ref_date - timedelta(days=6)).strftime("%Y-%m-%d")
         data = _storage.get_summary_range(start, date_str)
-        _localize_timestamps(data)
-        return jsonify(data)
     elif range_type == "month":
         start = (ref_date - timedelta(days=29)).strftime("%Y-%m-%d")
         data = _storage.get_summary_range(start, date_str)
-        _localize_timestamps(data)
-        return jsonify(data)
     else:
-        return jsonify({"error": "Invalid range (use day, week, month)"}), 400
+        data = _storage.get_summary_since(hours)
+    _localize_timestamps(data)
+    return jsonify(data)
 
 
 @data_bp.route("/api/export")

--- a/app/modules/connection_monitor/templates/connection_monitor_detail.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_detail.html
@@ -18,10 +18,12 @@
     <div class="cm-control-strip">
         <div class="cm-range-group">
             <span class="cm-control-label">{{ t.get('docsight.connection_monitor.cm_timerange', 'Time range') }}</span>
-            <div class="cm-range-picker" role="group" aria-label="{{ t.get('docsight.connection_monitor.cm_timerange', 'Time range') }}">
+            <div class="cm-range-picker trend-tabs" role="group" aria-label="{{ t.get('docsight.connection_monitor.cm_timerange', 'Time range') }}">
                 <button class="trend-tab active" data-cm-range="3600" onclick="cmSetRange(this, 3600)">1h</button>
                 <button class="trend-tab" data-cm-range="21600" onclick="cmSetRange(this, 21600)">6h</button>
-                <button class="trend-tab" data-cm-range="86400" onclick="cmSetRange(this, 86400)">24h</button>
+                <button class="trend-tab" data-cm-range="86400" onclick="cmSetRange(this, 86400)">1d</button>
+                <button class="trend-tab" data-cm-range="172800" onclick="cmSetRange(this, 172800)">2d</button>
+                <button class="trend-tab" data-cm-range="259200" onclick="cmSetRange(this, 259200)">3d</button>
                 <button class="trend-tab" data-cm-range="604800" onclick="cmSetRange(this, 604800)">7d</button>
                 <button class="trend-tab" data-cm-range="2592000" onclick="cmSetRange(this, 2592000)">30d</button>
                 <button class="trend-tab" data-cm-range="7776000" onclick="cmSetRange(this, 7776000)">90d</button>

--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -3,9 +3,29 @@
    DS_POWER_THRESHOLDS, DS_SNR_THRESHOLDS, US_POWER_THRESHOLDS */
 
 /* ── Channel State URL Persistence ── */
-/* Hash format: #channels?mode=timeline&dir=ds&channel=42&days=7
-   Compare:     #channels?mode=compare&dir=us&days=30&channels=1,2,3
-   Preset:      #channels?mode=compare&dir=ds&days=7&preset=all */
+/* Hash format: #channels?mode=timeline&dir=ds&channel=42&range=1d
+   Compare:     #channels?mode=compare&dir=us&range=30d&channels=1,2,3
+   Preset:      #channels?mode=compare&dir=ds&range=7d&preset=all */
+
+function _channelRangeHours(range) {
+    var raw = String(range || '1d');
+    if (/^\d+$/.test(raw)) return parseInt(raw, 10) * 24;
+    var match = raw.match(/^(\d+)(h|d)$/);
+    if (!match) return 24;
+    var value = parseInt(match[1], 10);
+    return match[2] === 'h' ? value : value * 24;
+}
+
+function _channelRangeDays(range) {
+    return _channelRangeHours(range) / 24;
+}
+
+function _normalizeChannelRangeValue(value) {
+    var raw = String(value || '1d');
+    if (/^\d+$/.test(raw)) raw = raw + 'd';
+    var allowed = ['1h', '6h', '1d', '2d', '3d', '7d', '30d', '90d'];
+    return allowed.indexOf(raw) !== -1 ? raw : '1d';
+}
 
 function parseChannelHash() {
     var hash = location.hash.replace('#', '');
@@ -31,10 +51,10 @@ function writeChannelHash() {
             params.push('dir=' + parts[0]);
             params.push('channel=' + parts[1]);
         }
-        params.push('days=' + (getPillValue('channel-time-tabs') || '7'));
+        params.push('range=' + encodeURIComponent(getPillValue('channel-time-tabs') || '1d'));
     } else {
         params.push('dir=' + getCompareDirection());
-        params.push('days=' + (getPillValue('compare-time-tabs') || '7'));
+        params.push('range=' + encodeURIComponent(getPillValue('compare-time-tabs') || '1d'));
         if (_comparePreset === 'all') {
             params.push('preset=all');
         } else if (_compareChannels.length > 0) {
@@ -59,9 +79,9 @@ function initChannelView() {
     var params = parseChannelHash();
     loadChannelList(function() {
         if (!params.mode) {
-            // No hash params → reset to defaults (timeline, no selection, 7d)
+            // No hash params → reset to defaults (timeline, no selection, 1d)
             setPillByValue('channel-mode-tabs', 'timeline');
-            setPillByValue('channel-time-tabs', '7');
+            setPillByValue('channel-time-tabs', '1d');
             var sel = document.getElementById('channel-select');
             if (sel) sel.value = '';
             _compareChannels = [];
@@ -78,7 +98,7 @@ function initChannelView() {
         switchChannelMode();
 
         if (params.mode === 'timeline') {
-            setPillByValue('channel-time-tabs', params.days || '7');
+            setPillByValue('channel-time-tabs', _normalizeChannelRangeValue(params.range || params.days || '1d'));
             var sel = document.getElementById('channel-select');
             if (params.dir && params.channel) {
                 sel.value = params.dir + '-' + params.channel;
@@ -94,7 +114,7 @@ function initChannelView() {
         } else if (params.mode === 'compare') {
             setPillByValue('compare-dir-tabs', params.dir || 'ds');
             _lastCompareDir = params.dir || 'ds';
-            setPillByValue('compare-time-tabs', params.days || '7');
+            setPillByValue('compare-time-tabs', _normalizeChannelRangeValue(params.range || params.days || '1d'));
             _compareChannels = [];
             _comparePreset = null;
             _compareState.ds = { channels: [], preset: null };
@@ -307,7 +327,7 @@ function _alignWeatherToChannelTimestamps(timestamps, weatherData, days) {
     }).filter(function(row) { return row !== null; });
     if (!weather.length) return null;
 
-    if (parseInt(days) >= 30) {
+    if (_channelRangeDays(days) >= 30) {
         var dailyTemps = {};
         weather.forEach(function(row) {
             if (!dailyTemps[row.day]) dailyTemps[row.day] = [];
@@ -426,12 +446,12 @@ function _renderChannelTimelineCharts() {
     if (!data || data.length === 0) return;
     var direction = ctx.direction || 'ds';
     var docsisVersion = ctx.docsisVersion || '3.0';
-    var days = ctx.days || '7';
+    var days = ctx.days || '1d';
 
     var xLabels = data.map(function(d) {
         if (!d.timestamp) return '';
-        if (parseInt(days) <= 1) return d.timestamp.substring(11, 16);
-        if (parseInt(days) >= 30) return d.timestamp.substring(5, 10);
+        if (_channelRangeHours(days) <= 24) return d.timestamp.substring(11, 16);
+        if (_channelRangeDays(days) >= 30) return d.timestamp.substring(5, 10);
         return d.timestamp.substring(5, 16).replace('T', ' ');
     });
     var tempOpts = _channelWeatherHasData(_lastChannelWeather) ? { tempData: _lastChannelWeather } : null;
@@ -481,7 +501,7 @@ function _renderChannelTimelineCharts() {
         var qamLabel = {}; qamSteps.forEach(function(v) { qamLabel[v] = v + 'QAM'; });
         var qamMap = {}; qamSteps.forEach(function(v, i) { qamMap[v + 'QAM'] = i; });
         var modLabels = mods.map(function(d) {
-            if (parseInt(days) >= 30) return d.timestamp.substring(5, 10);
+            if (_channelRangeDays(days) >= 30) return d.timestamp.substring(5, 10);
             return d.timestamp.substring(5, 16).replace('T', ' ');
         });
         var modValues = mods.map(function(d) { return qamMap[d.modulation] !== undefined ? qamMap[d.modulation] : -1; });
@@ -534,7 +554,7 @@ function loadChannelTimeline() {
     var channelId = parts[1];
     var selectedOpt = sel.options[sel.selectedIndex];
     var docsisVersion = selectedOpt ? selectedOpt.dataset.docsis || '3.0' : '3.0';
-    var days = getPillValue('channel-time-tabs');
+    var days = getPillValue('channel-time-tabs') || '1d';
     writeChannelHash();
     var requestId = ++_channelTimelineRequestSeq;
 
@@ -544,7 +564,7 @@ function loadChannelTimeline() {
     noDataEl.style.display = 'none';
     _updateChannelInfoBar(direction, channelId);
 
-    fetch('/api/channel-history?channel_id=' + channelId + '&direction=' + direction + '&days=' + days)
+    fetch('/api/channel-history?channel_id=' + channelId + '&direction=' + direction + '&range=' + encodeURIComponent(days))
         .then(function(r) { return r.json(); })
         .then(function(data) {
             if (requestId !== _channelTimelineRequestSeq) return;
@@ -816,11 +836,11 @@ function _renderCompareCharts() {
     if (!ctx || !ctx.data || !ctx.timestamps || ctx.timestamps.length === 0) return;
     var data = ctx.data;
     var timestamps = ctx.timestamps;
-    var days = ctx.days || '7';
+    var days = ctx.days || '1d';
     var dir = ctx.dir || getCompareDirection();
     var xLabels = timestamps.map(function(ts) {
-        if (parseInt(days) <= 1) return ts.substring(11, 16);
-        if (parseInt(days) >= 30) return ts.substring(5, 10);
+        if (_channelRangeHours(days) <= 24) return ts.substring(11, 16);
+        if (_channelRangeDays(days) >= 30) return ts.substring(5, 10);
         return ts.substring(5, 16).replace('T', ' ');
     });
     var tempOpts = _channelWeatherHasData(_lastCompareWeather) ? { tempData: _lastCompareWeather } : null;
@@ -966,7 +986,7 @@ function loadCompareCharts() {
         return;
     }
     var dir = getCompareDirection();
-    var days = getPillValue('compare-time-tabs') || '7';
+    var days = getPillValue('compare-time-tabs') || '1d';
     var ids = _compareChannels.map(function(c) { return c.id; }).join(',');
     writeChannelHash();
     var requestId = ++_compareRequestSeq;
@@ -975,7 +995,7 @@ function loadCompareCharts() {
     chartsEl.style.display = 'none';
     emptyEl.style.display = 'none';
 
-    fetch('/api/channel-compare?channels=' + ids + '&direction=' + dir + '&days=' + days)
+    fetch('/api/channel-compare?channels=' + ids + '&direction=' + dir + '&range=' + encodeURIComponent(days))
         .then(function(r) { return r.json(); })
         .then(function(data) {
             if (requestId !== _compareRequestSeq) return;

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -13,6 +13,14 @@ var _corrEventFilter = {};
 var _corrEventSeverityFilter = {};
 var _OPERATIONAL_EVENTS = { monitoring_started: true, monitoring_stopped: true };
 var _CORR_SEVERITIES = ['info', 'warning', 'critical'];
+function _corrRangeHours(range) {
+    var raw = String(range || '1d');
+    if (/^\d+$/.test(raw)) return parseInt(raw, 10);
+    var match = raw.match(/^(\d+)(h|d)$/);
+    if (!match) return 24;
+    var value = parseInt(match[1], 10);
+    return match[2] === 'h' ? value : value * 24;
+}
 function _corrCloseEventPopover() {
     var pop = document.getElementById('corr-event-popover');
     if (!pop) return;
@@ -95,7 +103,7 @@ function _corrFilteredEvents(events) {
 })();
 
 function loadCorrelationData() {
-    var hours = getPillValue('correlation-tabs');
+    var hours = _corrRangeHours(getPillValue('correlation-tabs'));
 
     var loading = document.getElementById('correlation-loading');
     var noData = document.getElementById('correlation-no-data');

--- a/app/static/js/hero-chart.js
+++ b/app/static/js/hero-chart.js
@@ -49,7 +49,8 @@
         var container = getContainer();
         if (!container) return;
 
-        fetch('/api/trends?range=week')
+        // The hero card is a 24h sparkline, so fetch the normalized 1d trend range directly.
+        fetch('/api/trends?range=1d')
             .then(function(r) {
                 if (!r.ok) throw new Error('API error: ' + r.status);
                 return r.json();

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -3,11 +3,20 @@
    todayStr, formatDateDE, DS_POWER_THRESHOLDS, DS_SNR_THRESHOLDS,
    US_POWER_THRESHOLDS, _tempOverlayVisible (chart-engine.js) */
 
-var _trendRange = 'day';
+var _trendRange = '1d';
 var _lastTrendData = null;
 var _lastTrendWeather = null;
-var _lastTrendRange = 'day';
+var _lastTrendRange = '1d';
 var POWER_TREND_FILL = 'rgba(168,85,247,0.15)';
+
+function _trendRangeHours(range) {
+    var map = { day: 24, week: 168, month: 720 };
+    if (map[range]) return map[range];
+    var match = String(range || '1d').match(/^(\d+)(h|d)$/);
+    if (!match) return 24;
+    var value = parseInt(match[1], 10);
+    return match[2] === 'h' ? value : value * 24;
+}
 
 /* ── Trend Tabs ── */
 function updateTrendTabs() {
@@ -23,26 +32,18 @@ document.querySelectorAll('#trend-tabs .trend-tab').forEach(function(btn) {
     });
 });
 
-function _getWeatherRange(range, date) {
-    var d = new Date(date + 'T00:00:00');
-    var end = date + ' 23:59:59Z';
-    var start;
-    if (range === 'day') {
-        start = date + ' 00:00:00Z';
-    } else if (range === 'week') {
-        var s = new Date(d.getTime() - 6 * 86400000);
-        start = s.toISOString().substring(0, 10) + ' 00:00:00Z';
-    } else {
-        var s = new Date(d.getTime() - 29 * 86400000);
-        start = s.toISOString().substring(0, 10) + ' 00:00:00Z';
-    }
+function _getWeatherRange(range) {
+    var endDt = new Date();
+    var startDt = new Date(endDt.getTime() - _trendRangeHours(range) * 3600000);
+    var end = endDt.toISOString().substring(0, 19) + 'Z';
+    var start = startDt.toISOString().substring(0, 19) + 'Z';
     return { start: start, end: end };
 }
 
 function _alignWeatherToTrends(trendData, weatherData, range) {
     if (!weatherData || weatherData.length === 0) return null;
     var temps = [];
-    if (range === 'day') {
+    if (_trendRangeHours(range) <= 24) {
         for (var i = 0; i < trendData.length; i++) {
             if (!trendData[i].timestamp) { temps.push(null); continue; }
             var tTs = new Date(trendData[i].timestamp).getTime();
@@ -100,8 +101,8 @@ function _renderTrendCharts() {
     if (!data || data.length === 0) return;
     var xLabels = data.map(function(d) {
         if (!d.timestamp) return '';
-        if (range === 'day') return d.timestamp.substring(11, 16);
-        if (range === 'week') return d.timestamp.substring(5, 16).replace('T', ' ');
+        if (_trendRangeHours(range) <= 24) return d.timestamp.substring(11, 16);
+        if (_trendRangeHours(range) < 24 * 30) return d.timestamp.substring(5, 16).replace('T', ' ');
         return d.date ? formatDateDE(d.date) : formatDateDE(d.timestamp.substring(0, 10));
     });
     var tempOpts = (_lastTrendWeather && _lastTrendWeather.length > 0) ? { tempData: _lastTrendWeather } : null;
@@ -125,16 +126,15 @@ function _renderTrendCharts() {
 }
 
 function loadTrends(range) {
-    var date = todayStr();
     var title = document.getElementById('trend-title');
     var noData = document.getElementById('trend-no-data');
     var grid = document.getElementById('charts-grid');
-    var labels = {day: T.day_trend, week: T.week_trend, month: T.month_trend};
-    title.textContent = (labels[range] || 'Trend') + ' - ' + formatDateDE(date);
+    var label = String(range || '1d');
+    title.textContent = (T.signal_trends || 'Signal Trends') + ' (' + label + ')';
     _lastTrendRange = range;
 
-    var wr = _getWeatherRange(range, date);
-    var trendsUrl = '/api/trends?range=' + range + '&date=' + date;
+    var wr = _getWeatherRange(range);
+    var trendsUrl = '/api/trends?range=' + encodeURIComponent(range || '1d');
     var weatherUrl = '/api/weather/range?start=' + encodeURIComponent(wr.start) + '&end=' + encodeURIComponent(wr.end);
 
     Promise.all([

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v32';
+var CACHE_VERSION = 'v33';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -162,13 +162,13 @@ class AnalysisMixin:
         timeline.sort(key=lambda x: x["timestamp"])
         return timeline
 
-    def get_channel_history(self, channel_id, direction, days=7):
-        """Return time series for a single channel over the last N days.
+    def get_channel_history(self, channel_id, direction, days=7, hours=None):
+        """Return time series for a single channel over the selected window.
         direction: 'ds' or 'us'. Returns list of dicts with timestamp + channel fields."""
         _COL_MAP = {"ds": "ds_channels_json", "us": "us_channels_json"}
         channel_id = int(channel_id)
         _COL_MAP[direction]  # validated in web.py to be 'ds' or 'us'
-        cutoff = utc_cutoff(days=days)
+        cutoff = utc_cutoff(hours=hours) if hours is not None else utc_cutoff(days=days)
         with sqlite3.connect(self.db_path) as conn:
             if direction == "ds":
                 rows = conn.execute(
@@ -201,12 +201,12 @@ class AnalysisMixin:
                     break
         return results
 
-    def get_multi_channel_history(self, channel_ids, direction, days=7):
-        """Return time series for multiple channels over the last N days.
+    def get_multi_channel_history(self, channel_ids, direction, days=7, hours=None):
+        """Return time series for multiple channels over the selected window.
         direction: 'ds' or 'us'. Returns dict {channel_id: [{timestamp, power, snr, ...}, ...]}"""
         channel_ids = [int(c) for c in channel_ids]
         channel_set = set(channel_ids)
-        cutoff = utc_cutoff(days=days)
+        cutoff = utc_cutoff(hours=hours) if hours is not None else utc_cutoff(days=days)
         col = "ds_channels_json" if direction == "ds" else "us_channels_json"
         with sqlite3.connect(self.db_path) as conn:
             rows = conn.execute(

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -8,7 +8,7 @@ import sqlite3
 from typing import cast
 
 from ..types import AnalysisResult
-from ..tz import local_date_to_utc_range, utc_now
+from ..tz import local_date_to_utc_range, utc_cutoff, utc_now
 
 log = logging.getLogger("docsis.storage")
 
@@ -119,6 +119,25 @@ class SnapshotMixin:
             results.append(entry)
         return results
 
+    def _summary_rows_to_entries(self, rows):
+        results = []
+        for row in rows:
+            entry = {"timestamp": row[0]}
+            entry.update(_normalize_summary_errors(json.loads(row[1])))
+            results.append(entry)
+        return results
+
+    def get_summary_since(self, hours):
+        """Get summary snapshots from the last N hours."""
+        cutoff = utc_cutoff(hours=hours)
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT timestamp, summary_json FROM snapshots "
+                "WHERE timestamp >= ? ORDER BY timestamp",
+                (cutoff,),
+            ).fetchall()
+        return self._summary_rows_to_entries(rows)
+
     def get_summary_range(self, start_date, end_date):
         """Get all snapshots (summary only) between two dates. Like get_intraday_data but multi-day.
 
@@ -133,12 +152,7 @@ class SnapshotMixin:
                 "ORDER BY timestamp",
                 (range_start, range_end),
             ).fetchall()
-        results = []
-        for row in rows:
-            entry = {"timestamp": row[0]}
-            entry.update(_normalize_summary_errors(json.loads(row[1])))
-            results.append(entry)
-        return results
+        return self._summary_rows_to_entries(rows)
 
     def get_closest_snapshot(self, timestamp: str) -> dict | None:
         """Find the snapshot closest to a given ISO timestamp (within 2 hours).

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1137,16 +1137,21 @@
     <div class="trend-header">
         <span class="trend-title" id="trend-title"></span>
         <div style="display:flex; align-items:center; gap:8px;">
+            <div class="trend-tabs" id="trend-tabs">
+                <button class="trend-tab" data-range="1h">1h</button>
+                <button class="trend-tab" data-range="6h">6h</button>
+                <button class="trend-tab active" data-range="1d">1d</button>
+                <button class="trend-tab" data-range="2d">2d</button>
+                <button class="trend-tab" data-range="3d">3d</button>
+                <button class="trend-tab" data-range="7d">7d</button>
+                <button class="trend-tab" data-range="30d">30d</button>
+                <button class="trend-tab" data-range="90d">90d</button>
+            </div>
             <button class="trend-tab temp-toggle" id="temp-toggle-btn" style="display:none;" title="{{ t.temp_overlay_show }}">
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle;">
                     <path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/>
                 </svg>
             </button>
-            <div class="trend-tabs" id="trend-tabs">
-                <button class="trend-tab active" data-range="day">{{ t.day }}</button>
-                <button class="trend-tab" data-range="week">{{ t.week }}</button>
-                <button class="trend-tab" data-range="month">{{ t.month }}</button>
-            </div>
         </div>
     </div>
     <div id="trend-no-data" class="no-data-msg" style="display:none"></div>
@@ -1376,9 +1381,14 @@
             <span class="correlation-view-subtitle">{{ t.get('correlation_subtitle', 'Build evidence for ISP complaints') }}</span>
         </div>
         <div class="trend-tabs" id="correlation-tabs">
-            <button class="trend-tab active" data-value="24" onclick="selectPill(this, loadCorrelationData)">{{ t.correlation_hours_24 }}</button>
-            <button class="trend-tab" data-value="48" onclick="selectPill(this, loadCorrelationData)">{{ t.correlation_hours_48 }}</button>
-            <button class="trend-tab" data-value="168" onclick="selectPill(this, loadCorrelationData)">{{ t.correlation_hours_168 }}</button>
+            <button class="trend-tab" data-value="1h" onclick="selectPill(this, loadCorrelationData)">1h</button>
+            <button class="trend-tab" data-value="6h" onclick="selectPill(this, loadCorrelationData)">6h</button>
+            <button class="trend-tab active" data-value="1d" onclick="selectPill(this, loadCorrelationData)">1d</button>
+            <button class="trend-tab" data-value="2d" onclick="selectPill(this, loadCorrelationData)">2d</button>
+            <button class="trend-tab" data-value="3d" onclick="selectPill(this, loadCorrelationData)">3d</button>
+            <button class="trend-tab" data-value="7d" onclick="selectPill(this, loadCorrelationData)">7d</button>
+            <button class="trend-tab" data-value="30d" onclick="selectPill(this, loadCorrelationData)">30d</button>
+            <button class="trend-tab" data-value="90d" onclick="selectPill(this, loadCorrelationData)">90d</button>
         </div>
     </div>
 
@@ -1637,10 +1647,14 @@
                 <option value="">{{ t.select_channel }}</option>
             </select>
             <div class="trend-tabs" id="channel-time-tabs">
-                <button class="trend-tab" data-value="1" onclick="selectPill(this, loadChannelTimeline)">1d</button>
-                <button class="trend-tab" data-value="3" onclick="selectPill(this, loadChannelTimeline)">3d</button>
-                <button class="trend-tab active" data-value="7" onclick="selectPill(this, loadChannelTimeline)">7d</button>
-                <button class="trend-tab" data-value="30" onclick="selectPill(this, loadChannelTimeline)">30d</button>
+                <button class="trend-tab" data-value="1h" onclick="selectPill(this, loadChannelTimeline)">1h</button>
+                <button class="trend-tab" data-value="6h" onclick="selectPill(this, loadChannelTimeline)">6h</button>
+                <button class="trend-tab active" data-value="1d" onclick="selectPill(this, loadChannelTimeline)">1d</button>
+                <button class="trend-tab" data-value="2d" onclick="selectPill(this, loadChannelTimeline)">2d</button>
+                <button class="trend-tab" data-value="3d" onclick="selectPill(this, loadChannelTimeline)">3d</button>
+                <button class="trend-tab" data-value="7d" onclick="selectPill(this, loadChannelTimeline)">7d</button>
+                <button class="trend-tab" data-value="30d" onclick="selectPill(this, loadChannelTimeline)">30d</button>
+                <button class="trend-tab" data-value="90d" onclick="selectPill(this, loadChannelTimeline)">90d</button>
             </div>
             <button id="channel-temp-toggle-btn" class="trend-tab temp-toggle active" onclick="toggleChannelTempOverlay()" style="display:none;" aria-pressed="true" title="{{ t.temp_overlay_hide }}" aria-label="{{ t.temperature }}">
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle;" aria-hidden="true">
@@ -1658,10 +1672,14 @@
             <button id="compare-add-all-btn" class="compare-add-btn" onclick="addAllCompareChannels()">{{ t.all_downstream }}</button>
             <button id="compare-clear-btn" class="compare-add-btn" onclick="clearCompareChannels()">{{ t.clear_selection }}</button>
             <div class="trend-tabs" id="compare-time-tabs">
-                <button class="trend-tab" data-value="1" onclick="selectPill(this, loadCompareCharts)">1d</button>
-                <button class="trend-tab" data-value="3" onclick="selectPill(this, loadCompareCharts)">3d</button>
-                <button class="trend-tab active" data-value="7" onclick="selectPill(this, loadCompareCharts)">7d</button>
-                <button class="trend-tab" data-value="30" onclick="selectPill(this, loadCompareCharts)">30d</button>
+                <button class="trend-tab" data-value="1h" onclick="selectPill(this, loadCompareCharts)">1h</button>
+                <button class="trend-tab" data-value="6h" onclick="selectPill(this, loadCompareCharts)">6h</button>
+                <button class="trend-tab active" data-value="1d" onclick="selectPill(this, loadCompareCharts)">1d</button>
+                <button class="trend-tab" data-value="2d" onclick="selectPill(this, loadCompareCharts)">2d</button>
+                <button class="trend-tab" data-value="3d" onclick="selectPill(this, loadCompareCharts)">3d</button>
+                <button class="trend-tab" data-value="7d" onclick="selectPill(this, loadCompareCharts)">7d</button>
+                <button class="trend-tab" data-value="30d" onclick="selectPill(this, loadCompareCharts)">30d</button>
+                <button class="trend-tab" data-value="90d" onclick="selectPill(this, loadCompareCharts)">90d</button>
             </div>
             <button id="compare-temp-toggle-btn" class="trend-tab temp-toggle active" onclick="toggleCompareTempOverlay()" style="display:none;" aria-pressed="true" title="{{ t.temp_overlay_hide }}" aria-label="{{ t.temperature }}">
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle;" aria-hidden="true">

--- a/app/time_ranges.py
+++ b/app/time_ranges.py
@@ -1,0 +1,35 @@
+"""Shared UI time-range normalization helpers."""
+
+from __future__ import annotations
+
+NORMALIZED_TIME_RANGE_HOURS: dict[str, int] = {
+    "1h": 1,
+    "6h": 6,
+    "1d": 24,
+    "2d": 48,
+    "3d": 72,
+    "7d": 168,
+    "30d": 720,
+    "90d": 2160,
+}
+
+LEGACY_TREND_RANGE_HOURS: dict[str, int] = {
+    "day": 24,
+    "week": 168,
+    "month": 720,
+}
+
+
+def parse_time_range_hours(
+    value: str | None,
+    *,
+    default: str = "1d",
+    allow_legacy: bool = False,
+) -> int | None:
+    """Return a normalized range as hours, or None when unsupported."""
+    normalized = (value or default).strip().lower()
+    if normalized in NORMALIZED_TIME_RANGE_HOURS:
+        return NORMALIZED_TIME_RANGE_HOURS[normalized]
+    if allow_legacy and normalized in LEGACY_TREND_RANGE_HOURS:
+        return LEGACY_TREND_RANGE_HOURS[normalized]
+    return None

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -161,14 +161,13 @@ class TestTrendCharts:
         assert legend.is_visible()
 
     def test_trend_tabs_switch_range(self, demo_page):
-        """Clicking Week/Month tabs should reload charts."""
+        """Clicking normalized 7d tab should reload charts."""
         navigate_to_trends(demo_page)
         wait_for_uplot(demo_page, "chart-ds-power")
 
-        # Click Week tab
-        week_tab = demo_page.locator('.trend-tab[data-range="week"]')
-        if week_tab.count() > 0:
-            week_tab.click()
+        range_tab = demo_page.locator('.trend-tab[data-range="7d"]')
+        if range_tab.count() > 0:
+            range_tab.click()
             demo_page.wait_for_timeout(1500)
             canvases = count_uplot_canvases(demo_page, "chart-ds-power")
             assert canvases >= 1, "Chart should still render after range switch"

--- a/tests/test_channel_timeline.py
+++ b/tests/test_channel_timeline.py
@@ -1,9 +1,10 @@
 """Tests for per-channel timeline: storage, /api/channels, /api/channel-history."""
 
 import json
+import sqlite3
 import time
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from app.storage import SnapshotStorage
 from app.web import app, init_config, init_storage
@@ -11,6 +12,23 @@ from app.config import ConfigManager
 
 
 # ── Fixtures ──
+
+def _utc_ts(delta: timedelta) -> str:
+    return (datetime.now(timezone.utc) - delta).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _insert_snapshot(storage, analysis, timestamp):
+    with sqlite3.connect(storage.db_path) as conn:
+        conn.execute(
+            "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?, ?, ?, ?)",
+            (
+                timestamp,
+                json.dumps(analysis["summary"]),
+                json.dumps(analysis["ds_channels"]),
+                json.dumps(analysis["us_channels"]),
+            ),
+        )
+
 
 def _make_analysis(ds_channels=None, us_channels=None):
     if ds_channels is None:
@@ -100,16 +118,9 @@ class TestGetChannelHistory:
 
     def test_respects_days_param(self, storage):
         # Save snapshot with a timestamp in the past
-        import sqlite3
         old_ts = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S")
         analysis = _make_analysis()
-        with sqlite3.connect(storage.db_path) as conn:
-            conn.execute(
-                "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?, ?, ?, ?)",
-                (old_ts, json.dumps(analysis["summary"]),
-                 json.dumps(analysis["ds_channels"]),
-                 json.dumps(analysis["us_channels"])),
-            )
+        _insert_snapshot(storage, analysis, old_ts)
         # Recent snapshot
         storage.save_snapshot(_make_analysis())
         # 7-day window should only get the recent one
@@ -118,6 +129,26 @@ class TestGetChannelHistory:
         # 30-day window should get both
         result_30 = storage.get_channel_history(1, "ds", days=30)
         assert len(result_30) == 2
+
+    def test_respects_hours_param_for_subday_ranges(self, storage):
+        analysis = _make_analysis()
+        _insert_snapshot(storage, analysis, _utc_ts(timedelta(hours=2)))
+        _insert_snapshot(storage, analysis, _utc_ts(timedelta(minutes=20)))
+
+        result = storage.get_channel_history(1, "ds", hours=1)
+
+        assert len(result) == 1
+        assert result[0]["timestamp"] >= _utc_ts(timedelta(hours=1))
+
+    def test_multi_channel_respects_hours_param_for_subday_ranges(self, storage):
+        analysis = _make_analysis()
+        _insert_snapshot(storage, analysis, _utc_ts(timedelta(hours=2)))
+        _insert_snapshot(storage, analysis, _utc_ts(timedelta(minutes=20)))
+
+        result = storage.get_multi_channel_history([1, 2], "ds", hours=1)
+
+        assert len(result[1]) == 1
+        assert len(result[2]) == 1
 
     def test_preserves_unsupported_error_values(self, storage):
         ds = [
@@ -305,6 +336,26 @@ class TestChannelHistoryEndpoint:
         resp2 = c.get("/api/channel-history?channel_id=1&direction=ds&days=200")
         assert resp2.status_code == 200
 
+    def test_range_param_supports_one_hour_window(self, client):
+        c, s = client
+        analysis = _make_analysis()
+        _insert_snapshot(s, analysis, _utc_ts(timedelta(hours=2)))
+        _insert_snapshot(s, analysis, _utc_ts(timedelta(minutes=20)))
+
+        resp = c.get("/api/channel-history?channel_id=1&direction=ds&range=1h")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert len(data) == 1
+
+    def test_invalid_range_param_is_rejected(self, client):
+        c, s = client
+        s.save_snapshot(_make_analysis())
+
+        resp = c.get("/api/channel-history?channel_id=1&direction=ds&range=4h")
+
+        assert resp.status_code == 400
+
 
 class TestChannelCompareEndpoint:
     def test_returns_multiple_channels(self, client):
@@ -329,6 +380,19 @@ class TestChannelCompareEndpoint:
         data = json.loads(resp.data)
         assert set(data.keys()) == {"1", "2", "3", "4", "5", "6", "7", "8"}
         assert data["8"][0]["power"] == 13.0
+
+    def test_range_param_supports_one_hour_window(self, client):
+        c, s = client
+        analysis = _make_analysis()
+        _insert_snapshot(s, analysis, _utc_ts(timedelta(hours=2)))
+        _insert_snapshot(s, analysis, _utc_ts(timedelta(minutes=20)))
+
+        resp = c.get("/api/channel-compare?channels=1,2&direction=ds&range=1h")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert len(data["1"]) == 1
+        assert len(data["2"]) == 1
 
     def test_rejects_more_than_64_channels(self, client):
         c, s = client

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -326,11 +326,55 @@ class TestCorrelationAPI:
         assert speedtest_entries[0].get("modem_health") == "good"
 
     def test_correlation_hours_clamped(self, client_with_storage):
-        """Hours parameter is clamped to 1-168."""
-        resp = client_with_storage.get("/api/correlation?hours=999")
+        """Hours parameter is clamped to 1-2160 (90d)."""
+        resp = client_with_storage.get("/api/correlation?hours=9999")
         assert resp.status_code == 200
         resp = client_with_storage.get("/api/correlation?hours=0")
         assert resp.status_code == 200
+
+    def test_correlation_supports_ninety_day_range(self, client_with_storage, storage, sample_analysis):
+        """Correlation API must honor 90d UI range instead of old 7d clamp."""
+        old_ts = utc_cutoff(days=80)
+        with sqlite3.connect(storage.db_path) as conn:
+            conn.execute(
+                "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?,?,?,?)",
+                (
+                    old_ts,
+                    json.dumps(sample_analysis["summary"]),
+                    json.dumps(sample_analysis["ds_channels"]),
+                    json.dumps(sample_analysis["us_channels"]),
+                ),
+            )
+
+        resp = client_with_storage.get("/api/correlation?hours=2160&sources=modem")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        old_date = old_ts[:10]
+        assert any(entry["source"] == "modem" and entry["timestamp"].startswith(old_date) for entry in data)
+
+    def test_correlation_clamps_above_ninety_days(self, client_with_storage, storage, sample_analysis):
+        inside_ts = utc_cutoff(days=80)
+        outside_ts = utc_cutoff(days=100)
+        with sqlite3.connect(storage.db_path) as conn:
+            for ts in (inside_ts, outside_ts):
+                conn.execute(
+                    "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?,?,?,?)",
+                    (
+                        ts,
+                        json.dumps(sample_analysis["summary"]),
+                        json.dumps(sample_analysis["ds_channels"]),
+                        json.dumps(sample_analysis["us_channels"]),
+                    ),
+                )
+
+        resp = client_with_storage.get("/api/correlation?hours=9999&sources=modem")
+
+        assert resp.status_code == 200
+        timestamps = {entry["timestamp"] for entry in json.loads(resp.data)}
+        timestamp_dates = {ts[:10] for ts in timestamps}
+        assert inside_ts[:10] in timestamp_dates
+        assert outside_ts[:10] not in timestamp_dates
 
     def test_correlation_segment_source_filter(self, client_with_storage, storage):
         """Segment source can be explicitly selected via API sources param."""

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,7 +107,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v32';" in sw_js
+    assert "var CACHE_VERSION = 'v33';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
@@ -183,6 +183,77 @@ def test_channels_controls_and_compare_titles_are_standardized():
     assert "{{ t.snr_db }}" in compare_charts
     assert "{{ t.power_history }}" not in compare_charts
     assert "{{ t.snr_history }}" not in compare_charts
+
+
+def test_chart_time_range_controls_use_normalized_existing_ranges():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    cm_template = (ROOT / "app" / "modules" / "connection_monitor" / "templates" / "connection_monitor_detail.html").read_text(encoding="utf-8")
+    expected_labels = ["1h", "6h", "1d", "2d", "3d", "7d", "30d", "90d"]
+    expected_values = ["1h", "6h", "1d", "2d", "3d", "7d", "30d", "90d"]
+    expected_seconds = ["3600", "21600", "86400", "172800", "259200", "604800", "2592000", "7776000"]
+
+    def block(source, start, end):
+        start_idx = source.index(start)
+        return source[start_idx : source.index(end, start_idx)]
+
+    def button_texts(html):
+        return re.findall(r"<button[^>]*>([^<{]+)</button>", html)
+
+    def data_values(html):
+        return re.findall(r"data-(?:range|value)=\"([^\"]+)\"", html)
+
+    controls = {
+        "trend": block(template, 'id="trend-tabs"', '</div>'),
+        "correlation": block(template, 'id="correlation-tabs"', '</div>'),
+        "channel": block(template, 'id="channel-time-tabs"', '</div>'),
+        "compare": block(template, 'id="compare-time-tabs"', '</div>'),
+    }
+    for name, html in controls.items():
+        assert button_texts(html) == expected_labels, name
+        assert data_values(html) == expected_values, name
+
+    cm_picker = block(cm_template, 'class="cm-range-picker', '</div>')
+    assert "trend-tabs" in cm_picker
+    assert button_texts(cm_picker) == expected_labels
+    assert re.findall(r"data-cm-range=\"([^\"]+)\"", cm_picker) == expected_seconds
+
+
+def test_channels_legacy_days_hashes_normalize_to_range_tabs():
+    channels_js = CHANNELS_JS.read_text(encoding="utf-8")
+
+    assert "function _normalizeChannelRangeValue" in channels_js
+    assert "if (/^\\d+$/.test(raw)) raw = raw + 'd';" in channels_js
+    assert "var allowed = ['1h', '6h', '1d', '2d', '3d', '7d', '30d', '90d'];" in channels_js
+    assert "return allowed.indexOf(raw) !== -1 ? raw : '1d';" in channels_js
+    assert "_normalizeChannelRangeValue(params.range || params.days || '1d')" in channels_js
+
+
+def test_trend_title_uses_rolling_range_without_stale_date_suffix():
+    trends_js = TRENDS_JS.read_text(encoding="utf-8")
+
+    assert "title.textContent = (T.signal_trends || 'Signal Trends') + ' (' + label + ')'" in trends_js
+    assert "formatDateDE(date)" not in trends_js
+    assert "&date=" not in trends_js
+
+
+def test_hero_chart_fetches_normalized_one_day_range():
+    hero_chart_js = (ROOT / "app" / "static" / "js" / "hero-chart.js").read_text(encoding="utf-8")
+
+    assert "fetch('/api/trends?range=1d')" in hero_chart_js
+    assert "fetch('/api/trends?range=week')" not in hero_chart_js
+
+
+def test_temperature_controls_are_consistently_after_time_range_controls_without_new_selectors():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    trend_header = template[template.index('id="view-trends"') : template.index('id="trend-no-data"')]
+    channel_controls = template[template.index('id="channel-timeline-controls"') : template.index('id="channel-compare-controls"')]
+    compare_controls = template[template.index('id="channel-compare-controls"') : template.index('id="channel-no-data"')]
+    correlation_header = template[template.index('id="view-correlation"') : template.index('id="correlation-loading"')]
+
+    assert trend_header.index('id="trend-tabs"') < trend_header.index('id="temp-toggle-btn"')
+    assert channel_controls.index('id="channel-time-tabs"') < channel_controls.index('id="channel-temp-toggle-btn"')
+    assert compare_controls.index('id="compare-time-tabs"') < compare_controls.index('id="compare-temp-toggle-btn"')
+    assert 'correlation-temp-toggle' not in correlation_header
 
 
 def test_chart_engine_has_configurable_axis_padding_for_long_qam_labels():

--- a/tests/test_trends_api.py
+++ b/tests/test_trends_api.py
@@ -1,0 +1,116 @@
+"""Tests for Signal Trends range normalization."""
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.config import ConfigManager
+from app.storage import SnapshotStorage
+from app.web import app, init_config, init_storage
+
+
+def _utc_ts(delta: timedelta) -> str:
+    return (datetime.now(timezone.utc) - delta).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _analysis(ds_power_avg: float):
+    return {
+        "summary": {
+            "ds_total": 1,
+            "us_total": 1,
+            "health": "good",
+            "health_issues": [],
+            "ds_power_avg": ds_power_avg,
+            "ds_snr_avg": 38.0,
+            "us_power_avg": 42.0,
+        },
+        "ds_channels": [],
+        "us_channels": [],
+    }
+
+
+def _insert_snapshot(storage, analysis, timestamp):
+    with sqlite3.connect(storage.db_path) as conn:
+        conn.execute(
+            "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?, ?, ?, ?)",
+            (
+                timestamp,
+                json.dumps(analysis["summary"]),
+                json.dumps(analysis["ds_channels"]),
+                json.dumps(analysis["us_channels"]),
+            ),
+        )
+
+
+@pytest.fixture
+def client(tmp_path):
+    db_path = str(tmp_path / "api.db")
+    storage = SnapshotStorage(db_path, max_days=120)
+    data_dir = str(tmp_path / "data")
+    manager = ConfigManager(data_dir)
+    manager.save({"modem_password": "test", "modem_type": "fritzbox"})
+    init_config(manager)
+    init_storage(storage)
+    app.config["TESTING"] = True
+    with app.test_client() as flask_client:
+        yield flask_client, storage
+
+
+class TestTrendsRangeEndpoint:
+    def test_range_param_supports_one_hour_window(self, client):
+        flask_client, storage = client
+        _insert_snapshot(storage, _analysis(1.0), _utc_ts(timedelta(hours=2)))
+        _insert_snapshot(storage, _analysis(2.0), _utc_ts(timedelta(minutes=20)))
+
+        resp = flask_client.get("/api/trends?range=1h")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert len(data) == 1
+        assert data[0]["ds_power_avg"] == 2.0
+
+    def test_range_param_supports_normalized_day_window(self, client):
+        flask_client, storage = client
+        _insert_snapshot(storage, _analysis(1.0), _utc_ts(timedelta(days=2)))
+        _insert_snapshot(storage, _analysis(2.0), _utc_ts(timedelta(hours=2)))
+
+        resp = flask_client.get("/api/trends?range=1d")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert len(data) == 1
+        assert data[0]["ds_power_avg"] == 2.0
+
+    def test_legacy_trend_ranges_still_work(self, client):
+        flask_client, storage = client
+        storage.save_snapshot(_analysis(2.0))
+
+        for range_name in ("day", "week", "month"):
+            resp = flask_client.get(f"/api/trends?range={range_name}")
+            assert resp.status_code == 200, range_name
+
+    def test_normalized_ranges_ignore_legacy_date_parameter(self, client):
+        flask_client, storage = client
+        storage.save_snapshot(_analysis(2.0))
+
+        resp = flask_client.get("/api/trends?range=1d&date=not-a-date")
+
+        assert resp.status_code == 200
+
+    def test_legacy_ranges_still_validate_date_parameter(self, client):
+        flask_client, storage = client
+        storage.save_snapshot(_analysis(2.0))
+
+        resp = flask_client.get("/api/trends?range=week&date=not-a-date")
+
+        assert resp.status_code == 400
+
+    def test_invalid_range_param_is_rejected(self, client):
+        flask_client, storage = client
+        storage.save_snapshot(_analysis(2.0))
+
+        resp = flask_client.get("/api/trends?range=4h")
+
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Normalize time range controls to `1h 6h 1d 2d 3d 7d 30d 90d` across Signal Trends, Channels, Correlation, and Connection Monitor.
- Keep existing temperature selectors consistently positioned after the time range controls without adding missing selectors.
- Preserve legacy API/hash compatibility while adding rolling normalized range handling and cache busting.

## Verification
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright pytest -q tests/e2e --tb=short`
- Independent final review: no blocking findings
