### PR TITLE
fix: restore OFDMA power KPI classification

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -164,14 +164,20 @@ def _assess_ds_modulation(modulation: str, docsis_ver: str) -> str:
 def _assess_us_modulation(ch, docsis_ver: str) -> str:
     """Return upstream modulation health, including OFDMA profile QAM."""
     modulation = ch.get("modulation") or ch.get("type") or ""
-    channel_type = (ch.get("type") or ch.get("multiplex") or modulation).upper().replace("-", "").strip()
     profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
-    assessment_modulation = profile_modulation if channel_type == "OFDMA" and profile_modulation else modulation
+    family = _classify_us_family({
+        "type": ch.get("type", ""),
+        "multiplex": ch.get("multiplex", ""),
+        "modulation": modulation,
+        "profile_modulation": profile_modulation,
+        "docsis_version": docsis_ver,
+    })
+    assessment_modulation = profile_modulation if family == "ofdma" and profile_modulation else modulation
     qam_order = _parse_qam_order(assessment_modulation)
     if qam_order is None:
         return "good"
 
-    if docsis_ver == "3.1" and channel_type == "OFDMA":
+    if docsis_ver == "3.1" and family == "ofdma":
         if qam_order <= 32:
             return "critical"
         if qam_order <= 64:
@@ -574,16 +580,13 @@ def _classify_us_family(channel):
         return "sc_qam"
     if "OFDMA" in modulation_text:
         return "ofdma"
-    if _parse_qam_order(modulation_text):
-        return "sc_qam"
-
-    # OFDMA profile modulation can be reduced to low QAM values; keep those
-    # profile-only DOCSIS 3.1 channels in the OFDMA lane instead of treating the
-    # profile QAM value as an SC-QAM channel modulation.
     if profile_text and is_docsis31_plus:
         return "ofdma"
     if is_docsis31_plus:
         return "ofdma"
+    if _parse_qam_order(modulation_text):
+        return "sc_qam"
+
     if "3.0" in docsis_version:
         return "sc_qam"
     return "unknown"
@@ -712,7 +715,18 @@ def _assess_us_channel(ch, docsis_ver="3.0"):
     raw_power = ch.get("powerLevel")
 
     modulation = ch.get("modulation") or ch.get("type") or ""
-    channel_type = (ch.get("type") or modulation).upper().replace("-", "").strip()
+    profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
+    channel_family = _classify_us_family({
+        "type": ch.get("type", ""),
+        "multiplex": ch.get("multiplex", ""),
+        "modulation": modulation,
+        "profile_modulation": profile_modulation,
+        "docsis_version": docsis_ver,
+    })
+    if channel_family == "ofdma":
+        channel_type = "OFDMA"
+    else:
+        channel_type = (ch.get("type") or ch.get("multiplex") or modulation).upper().replace("-", "").strip()
 
     if raw_power is not None:
         power = _parse_float(raw_power)

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1606,6 +1606,13 @@ body:has(#view-dashboard.active) .app-main {
   min-height: 22px;
 }
 
+.dashboard-view .metrics-grid .metric-modulation-row {
+  display: block;
+  clear: both;
+  width: 100%;
+  margin-top: 4px;
+}
+
 .dashboard-view .metrics-grid .metric-context {
   display: inline-flex;
   align-items: baseline;

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v33';
+var CACHE_VERSION = 'v34';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -724,7 +724,7 @@
     {% macro signal_family_card(card_id, label, family, metric_key, metric_unit, metric_label, spark_key, icon_class, icon_name, range_data=None, glossary_text=None, spark_color=None) -%}
         {% set metric = family.get(metric_key, {}) %}
         {% set modulation = family.get('modulation', {}) %}
-        {% set raw_health = metric.get('health', family.get('health', 'missing')) %}
+        {% set raw_health = range_data.health if range_data and range_data.health is defined else metric.get('health', family.get('health', 'missing')) %}
         {% set health_class = 'crit' if raw_health == 'critical' else ('warn' if raw_health == 'warning' else ('muted' if raw_health == 'missing' else raw_health)) %}
         {% set metric_value = metric.get('avg') %}
         <div class="metric-card glass" id="{{ card_id }}">

--- a/tests/analyzer/test_signal_metrics.py
+++ b/tests/analyzer/test_signal_metrics.py
@@ -381,6 +381,58 @@ class TestSignalFamilySummaries:
         assert result["us_channels"][0]["channel_family"] == "ofdma"
         assert upstream["ofdma"]["modulation"]["value"] == "64QAM"
 
+    def test_docsis31_upstream_qam_modulation_without_type_stays_ofdma(self):
+        """Some modems expose an OFDMA profile QAM value only as `modulation`."""
+        us_ofdma = {
+            "channelID": 41,
+            "frequency": "46.500 MHz",
+            "powerLevel": "50.5",
+            "modulation": "128QAM",
+        }
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us30=[
+                _make_us30(channel_id, power=power, modulation="64QAM")
+                for channel_id, power in [(1, 40.5), (2, 41.8), (3, 42.5), (4, 43.0)]
+            ],
+            us31=[us_ofdma],
+        )
+
+        result = analyze(data)
+
+        upstream = result["summary"]["signal_families"]["upstream"]["families"]
+        assert set(upstream) == {"sc_qam", "ofdma"}
+        assert result["us_channels"][-1]["channel_family"] == "ofdma"
+        assert result["us_channels"][-1]["power_health"] == "critical"
+        assert result["us_channels"][-1]["modulation_health"] == "tolerated"
+        assert upstream["sc_qam"]["count"] == 4
+        assert upstream["sc_qam"]["power"]["avg"] == 42.0
+        assert upstream["ofdma"]["count"] == 1
+        assert upstream["ofdma"]["power"]["avg"] == 50.5
+        assert result["summary"]["us_scqam_power_avg"] == 42.0
+        assert result["summary"]["us_ofdma_power_avg"] == 50.5
+
+    def test_docsis31_upstream_explicit_atdma_type_stays_sc_qam(self):
+        us_sc_qam = {
+            "channelID": 42,
+            "frequency": "46.500 MHz",
+            "powerLevel": "42.5",
+            "type": "ATDMA",
+            "modulation": "128QAM",
+        }
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us31=[us_sc_qam],
+        )
+
+        result = analyze(data)
+
+        upstream = result["summary"]["signal_families"]["upstream"]["families"]
+        assert set(upstream) == {"sc_qam"}
+        assert result["us_channels"][0]["channel_family"] == "sc_qam"
+        assert result["summary"]["us_scqam_power_avg"] == 42.5
+        assert result["summary"].get("us_ofdma_power_avg") is None
+
     def test_docsis31_profile_only_camel_case_profile_key_stays_ofdm(self):
         data = _make_data(
             ds31=[{

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -68,6 +68,33 @@ class TestDashboardSections:
         us = demo_page.locator(".dashboard-channel-panel .channel-title", has_text="Upstream")
         assert us.is_visible()
 
+    def test_signal_family_cards_show_ofdma_and_stack_modulation_below_status(self, demo_page):
+        ofdma_card = demo_page.locator("#metric-us-ofdma-card")
+        assert ofdma_card.is_visible()
+        assert "US POWER (OFDMA)" in ofdma_card.text_content()
+
+        geometry = demo_page.evaluate(
+            """
+            () => {
+                const card = document.querySelector('#metric-ds-sc-qam-power-card');
+                if (!card) throw new Error('DS SC-QAM power card not found');
+                const status = card.querySelector('.metric-status-row');
+                const modulation = card.querySelector('.metric-modulation-row');
+                if (!status || !modulation) throw new Error('status or modulation row not found');
+                const statusRect = status.getBoundingClientRect();
+                const modulationRect = modulation.getBoundingClientRect();
+                return {
+                    statusBottom: statusRect.bottom,
+                    modulationTop: modulationRect.top,
+                    modulationWidth: modulationRect.width,
+                    cardWidth: card.getBoundingClientRect().width,
+                };
+            }
+            """
+        )
+        assert geometry["modulationTop"] >= geometry["statusBottom"] - 1
+        assert geometry["modulationWidth"] >= geometry["cardWidth"] * 0.8
+
     def test_long_device_meta_values_keep_icons_visible_when_truncated(self, demo_page):
         demo_page.set_viewport_size({"width": 768, "height": 900})
         cases = [

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,7 +107,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v33';" in sw_js
+    assert "var CACHE_VERSION = 'v34';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
@@ -122,6 +122,16 @@ def test_home_signal_family_sparklines_use_data_keys():
     assert "data-spark-key=\"{{ spark_key }}\"" in template
     assert "querySelectorAll('canvas.metric-spark[data-spark-key]')" in sparklines_js
     assert "canvas.dataset.sparkKey" in sparklines_js
+
+
+def test_home_signal_family_modulation_rows_stack_below_status():
+    css = MAIN_CSS.read_text(encoding="utf-8")
+    start = css.index(".dashboard-view .metrics-grid .metric-modulation-row")
+    block = css[start : css.index(".dashboard-view .metrics-grid .metric-context", start)]
+
+    assert "display: block" in block
+    assert "clear: both" in block
+    assert "width: 100%" in block
 
 
 def test_channels_weather_overlay_contract_is_wired():

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -443,6 +443,22 @@ class TestIndexRoute:
         positions = [html.index(f'<span class="metric-label">{label}</span>') for label in labels]
         assert positions == sorted(positions)
 
+    def test_home_signal_family_card_status_uses_displayed_average_health(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        ofdm_power = sample_analysis["summary"]["signal_families"]["downstream"]["families"]["ofdm"]["power"]
+        ofdm_power.update({"avg": 0.6, "min": -7.8, "max": 9.0, "health": "critical"})
+        sample_analysis["summary"]["ds_ofdm_power_avg"] = 0.6
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        card = _element_by_id(resp.get_data(as_text=True), "metric-ds-ofdm-power-card")
+        assert "0.6<span class=\"unit\">dBmV</span>" in card
+        assert "badge badge-good" in card
+        assert "badge badge-critical" not in card
+        assert "--metric-range-accent: var(--good);" in card
+
     def test_home_signal_family_cards_show_metric_health_bars(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
         update_state(analysis=sample_analysis)


### PR DESCRIPTION
## Summary
- Restore OFDMA family classification for DOCSIS 3.1 upstream channels that expose only a QAM modulation value.
- Keep Home signal-family KPI badge and range colors aligned with the displayed average value.
- Stack the modulation context below the KPI status row and refresh the service-worker cache version.

## Test plan
- `git diff --check`
- `.venv313/bin/python scripts/i18n_check.py --validate`
- `ulimit -n 8192 && .venv313/bin/python -m pytest tests/ -q --ignore=tests/e2e`
- `ulimit -n 8192 && TZ=UTC .venv313/bin/python -m pytest -q tests/e2e --tb=short`
