### PR TITLE
Clarify signal family KPI averages

### DIFF
--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Ср.",
+  "metric_active_channel_singular": "активен канал",
+  "metric_active_channel_plural": "активни канала",
+  "signal_family_average_section_title": "Средни стойности по сигнални семейства",
+  "signal_family_average_section_hint": "Стойностите са осреднени за активните канали във всяко DOCSIS сигнално семейство."
 }

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Prům.",
+  "metric_active_channel_singular": "aktivní kanál",
+  "metric_active_channel_plural": "aktivní kanály",
+  "signal_family_average_section_title": "Průměry rodin signálu",
+  "signal_family_average_section_hint": "Hodnoty jsou průměrovány přes aktivní kanály v každé DOCSIS rodině signálu."
 }

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Gns.",
+  "metric_active_channel_singular": "aktiv kanal",
+  "metric_active_channel_plural": "aktive kanaler",
+  "signal_family_average_section_title": "Signalfamiliegennemsnit",
+  "signal_family_average_section_hint": "Værdierne beregnes som gennemsnit over aktive kanaler i hver DOCSIS-signalfamilie."
 }

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Nicht verfügbar"
+  "signal_family_unavailable": "Nicht verfügbar",
+  "metric_average_label": "Ø",
+  "metric_active_channel_singular": "aktiver Kanal",
+  "metric_active_channel_plural": "aktive Kanäle",
+  "signal_family_average_section_title": "Signalgruppen-Durchschnitte",
+  "signal_family_average_section_hint": "Werte werden über aktive Kanäle in jeder DOCSIS-Signalgruppe gemittelt."
 }

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Μ.Ο.",
+  "metric_active_channel_singular": "ενεργό κανάλι",
+  "metric_active_channel_plural": "ενεργά κανάλια",
+  "signal_family_average_section_title": "Μέσοι όροι οικογενειών σήματος",
+  "signal_family_average_section_hint": "Οι τιμές υπολογίζονται ως μέσος όρος των ενεργών καναλιών σε κάθε οικογένεια σήματος DOCSIS."
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Avg",
+  "metric_active_channel_singular": "active channel",
+  "metric_active_channel_plural": "active channels",
+  "signal_family_average_section_title": "Signal family averages",
+  "signal_family_average_section_hint": "Values are averaged across active channels in each DOCSIS signal family."
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1050,5 +1050,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Prom.",
+  "metric_active_channel_singular": "canal activo",
+  "metric_active_channel_plural": "canales activos",
+  "signal_family_average_section_title": "Promedios por familia de señal",
+  "signal_family_average_section_hint": "Los valores se promedian entre los canales activos de cada familia de señal DOCSIS."
 }

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Kesk.",
+  "metric_active_channel_singular": "aktiivne kanal",
+  "metric_active_channel_plural": "aktiivsed kanalid",
+  "signal_family_average_section_title": "Signaaliperekondade keskmised",
+  "signal_family_average_section_hint": "Väärtused on keskmistatud iga DOCSIS-signaaliperekonna aktiivsete kanalite lõikes."
 }

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Keskiarvo",
+  "metric_active_channel_singular": "aktiivinen kanava",
+  "metric_active_channel_plural": "aktiivista kanavaa",
+  "signal_family_average_section_title": "Signaaliperheiden keskiarvot",
+  "signal_family_average_section_hint": "Arvot ovat aktiivisten kanavien keskiarvoja kussakin DOCSIS-signaaliperheessä."
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -1047,5 +1047,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Moy.",
+  "metric_active_channel_singular": "canal actif",
+  "metric_active_channel_plural": "canaux actifs",
+  "signal_family_average_section_title": "Moyennes par famille de signal",
+  "signal_family_average_section_hint": "Les valeurs sont moyennées sur les canaux actifs de chaque famille de signal DOCSIS."
 }

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Meán",
+  "metric_active_channel_singular": "cainéal gníomhach",
+  "metric_active_channel_plural": "cainéil ghníomhacha",
+  "signal_family_average_section_title": "Meáin de réir teaghlaigh comhartha",
+  "signal_family_average_section_hint": "Ríomhtar na luachanna mar mheán thar chainéil ghníomhacha i ngach teaghlach comhartha DOCSIS."
 }

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Prosj.",
+  "metric_active_channel_singular": "aktivan kanal",
+  "metric_active_channel_plural": "aktivna kanala",
+  "signal_family_average_section_title": "Prosjeci po signalnim obiteljima",
+  "signal_family_average_section_hint": "Vrijednosti su prosjeci aktivnih kanala u svakoj DOCSIS signalnoj obitelji."
 }

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Átl.",
+  "metric_active_channel_singular": "aktív csatorna",
+  "metric_active_channel_plural": "aktív csatorna",
+  "signal_family_average_section_title": "Jelcsalád-átlagok",
+  "signal_family_average_section_hint": "Az értékek az egyes DOCSIS jelcsaládok aktív csatornáinak átlagai."
 }

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Media",
+  "metric_active_channel_singular": "canale attivo",
+  "metric_active_channel_plural": "canali attivi",
+  "signal_family_average_section_title": "Medie per famiglia di segnale",
+  "signal_family_average_section_hint": "I valori sono mediati sui canali attivi in ogni famiglia di segnale DOCSIS."
 }

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Vid.",
+  "metric_active_channel_singular": "aktyvus kanalas",
+  "metric_active_channel_plural": "aktyvūs kanalai",
+  "signal_family_average_section_title": "Signalų šeimų vidurkiai",
+  "signal_family_average_section_hint": "Reikšmės apskaičiuojamos kaip aktyvių kanalų vidurkis kiekvienoje DOCSIS signalų šeimoje."
 }

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Vid.",
+  "metric_active_channel_singular": "aktīvs kanāls",
+  "metric_active_channel_plural": "aktīvi kanāli",
+  "signal_family_average_section_title": "Signālu saimju vidējās vērtības",
+  "signal_family_average_section_hint": "Vērtības ir vidējotas pa aktīvajiem kanāliem katrā DOCSIS signālu saimē."
 }

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Snitt",
+  "metric_active_channel_singular": "aktiv kanal",
+  "metric_active_channel_plural": "aktive kanaler",
+  "signal_family_average_section_title": "Gjennomsnitt per signalfamilie",
+  "signal_family_average_section_hint": "Verdiene er gjennomsnitt over aktive kanaler i hver DOCSIS-signalfamilie."
 }

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Gem.",
+  "metric_active_channel_singular": "actief kanaal",
+  "metric_active_channel_plural": "actieve kanalen",
+  "signal_family_average_section_title": "Gemiddelden per signaalfamilie",
+  "signal_family_average_section_hint": "Waarden zijn gemiddeld over actieve kanalen in elke DOCSIS-signaalfamilie."
 }

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Śr.",
+  "metric_active_channel_singular": "aktywny kanał",
+  "metric_active_channel_plural": "aktywne kanały",
+  "signal_family_average_section_title": "Średnie rodzin sygnału",
+  "signal_family_average_section_hint": "Wartości są uśredniane dla aktywnych kanałów w każdej rodzinie sygnału DOCSIS."
 }

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Méd.",
+  "metric_active_channel_singular": "canal ativo",
+  "metric_active_channel_plural": "canais ativos",
+  "signal_family_average_section_title": "Médias por família de sinal",
+  "signal_family_average_section_hint": "Os valores são calculados como média dos canais ativos em cada família de sinal DOCSIS."
 }

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Med.",
+  "metric_active_channel_singular": "canal activ",
+  "metric_active_channel_plural": "canale active",
+  "signal_family_average_section_title": "Medii pe familii de semnal",
+  "signal_family_average_section_hint": "Valorile sunt mediate pe canalele active din fiecare familie de semnal DOCSIS."
 }

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Priem.",
+  "metric_active_channel_singular": "aktívny kanál",
+  "metric_active_channel_plural": "aktívne kanály",
+  "signal_family_average_section_title": "Priemery rodín signálu",
+  "signal_family_average_section_hint": "Hodnoty sú priemerované cez aktívne kanály v každej DOCSIS rodine signálu."
 }

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Povp.",
+  "metric_active_channel_singular": "aktiven kanal",
+  "metric_active_channel_plural": "aktivni kanali",
+  "signal_family_average_section_title": "Povprečja družin signalov",
+  "signal_family_average_section_hint": "Vrednosti so povprečene po aktivnih kanalih v vsaki družini signalov DOCSIS."
 }

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -1055,5 +1055,10 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
-  "signal_family_unavailable": "Unavailable"
+  "signal_family_unavailable": "Unavailable",
+  "metric_average_label": "Medel",
+  "metric_active_channel_singular": "aktiv kanal",
+  "metric_active_channel_plural": "aktiva kanaler",
+  "signal_family_average_section_title": "Medelvärden per signalfamilj",
+  "signal_family_average_section_hint": "Värdena är medelvärden över aktiva kanaler i varje DOCSIS-signalfamilj."
 }

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -900,5 +900,10 @@
   "signal_family_metric_snr": "",
   "signal_family_metric_mer": "",
   "signal_family_modulation_label": "",
-  "signal_family_unavailable": ""
+  "signal_family_unavailable": "",
+  "metric_average_label": "",
+  "metric_active_channel_singular": "",
+  "metric_active_channel_plural": "",
+  "signal_family_average_section_title": "",
+  "signal_family_average_section_hint": ""
 }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1507,6 +1507,23 @@ body:has(#view-dashboard.active) .app-main {
   text-align: right;
 }
 
+.dashboard-section-context {
+  display: grid;
+  gap: 2px;
+}
+
+.dashboard-section-context strong {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.dashboard-section-context span {
+  color: var(--text-muted);
+}
+
 .dashboard-section-kicker {
   display: block;
   margin-bottom: 2px;
@@ -1604,6 +1621,17 @@ body:has(#view-dashboard.active) .app-main {
 
 .dashboard-view .metrics-grid .metric-status-row {
   min-height: 22px;
+}
+
+.dashboard-view .metrics-grid .metric-average-row {
+  margin-top: 6px;
+  min-height: 18px;
+}
+
+.dashboard-view .metrics-grid .metric-average-copy {
+  color: var(--text-secondary);
+  font-size: 0.66rem;
+  letter-spacing: 0.01em;
 }
 
 .dashboard-view .metrics-grid .metric-modulation-row {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v34';
+var CACHE_VERSION = 'v35';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -727,6 +727,7 @@
         {% set raw_health = range_data.health if range_data and range_data.health is defined else metric.get('health', family.get('health', 'missing')) %}
         {% set health_class = 'crit' if raw_health == 'critical' else ('warn' if raw_health == 'warning' else ('muted' if raw_health == 'missing' else raw_health)) %}
         {% set metric_value = metric.get('avg') %}
+        {% set family_count = family.get('count', 0) %}
         <div class="metric-card glass" id="{{ card_id }}">
             {% if glossary_text %}<span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ glossary_text }}</div></span>{% endif %}
             <div class="metric-header">
@@ -737,6 +738,11 @@
                 <div class="metric-value" style="color:var(--{{ health_class }});">{% if metric_value is not none %}{{ metric_value }}<span class="unit">{% if metric_unit %}{{ metric_unit }}{% endif %}{% if metric_label %} {{ metric_label }}{% endif %}</span>{% else %}{{ t.get('signal_family_unavailable', 'Unavailable') }}<span class="unit">{% if metric_unit %}{{ metric_unit }}{% endif %}{% if metric_label %} {{ metric_label }}{% endif %}</span>{% endif %}</div>
                 <canvas class="metric-spark" id="spark-{{ card_id|replace('metric-', '') }}" data-spark-key="{{ spark_key }}"{% if spark_color %} data-spark-color="{{ spark_color }}"{% endif %} width="144" height="56" aria-hidden="true"></canvas>
             </div>
+            {% if metric_value is not none and family_count %}
+            <div class="metric-sub metric-average-row">
+                <span class="range metric-average-copy">{{ t.get('metric_average_label', 'Avg') }} · {{ family_count }} {{ t.get('metric_active_channel_singular', 'active channel') if family_count == 1 else t.get('metric_active_channel_plural', 'active channels') }}</span>
+            </div>
+            {% endif %}
             <div class="metric-sub metric-status-row">
                 <span class="metric-context">
                     <span class="metric-sub-label">{{ t.get('metric_status_label', 'Status') }}</span>
@@ -764,7 +770,14 @@
             <span class="dashboard-section-kicker">{{ t.get('dashboard_section_overview', 'Overview') }}</span>
             <h2>{{ t.get('dashboard_key_metrics', 'Key metrics') }}</h2>
         </div>
-        <span>{{ t.get('dashboard_key_metrics_hint', 'Live modem, throughput and monitoring signals') }}</span>
+        <span class="dashboard-section-context">
+            {% if has_signal_family_metric_cards %}
+            <strong>{{ t.get('signal_family_average_section_title', 'Signal family averages') }}</strong>
+            <span>{{ t.get('signal_family_average_section_hint', 'Values are averaged across active channels in each DOCSIS signal family.') }}</span>
+            {% else %}
+            {{ t.get('dashboard_key_metrics_hint', 'Live modem, throughput and monitoring signals') }}
+            {% endif %}
+        </span>
     </div>
     <div class="metrics-grid">
         {% if not has_signal_family_metric_cards %}

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,7 +107,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v34';" in sw_js
+    assert "var CACHE_VERSION = 'v35';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -443,6 +443,24 @@ class TestIndexRoute:
         positions = [html.index(f'<span class="metric-label">{label}</span>') for label in labels]
         assert positions == sorted(positions)
 
+    def test_home_signal_family_cards_explain_average_context_without_title_spam(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        sample_analysis["summary"]["signal_families"]["downstream"]["families"]["sc_qam"]["count"] = 2
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "Signal family averages" in html
+        assert "Values are averaged across active channels in each DOCSIS signal family." in html
+        scqam_power_card = _element_by_id(html, "metric-ds-sc-qam-power-card")
+        ofdm_power_card = _element_by_id(html, "metric-ds-ofdm-power-card")
+        assert "Avg · 2 active channels" in scqam_power_card
+        assert "Avg · 1 active channel" in ofdm_power_card
+        assert "DS POWER AVG" not in html
+        assert "US POWER AVG" not in html
+
     def test_home_signal_family_card_status_uses_displayed_average_health(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
         ofdm_power = sample_analysis["summary"]["signal_families"]["downstream"]["families"]["ofdm"]["power"]


### PR DESCRIPTION
## Summary
- keep signal-family KPI titles focused on metric and DOCSIS family instead of adding `AVG` to every title
- add a section-level `Signal family averages` hint for family-aware KPI cards
- add per-card `Avg · N active channel(s)` context below available averaged values
- localize the new context strings, update the template catalog, and bump the PWA cache to `v35`

## Verification
- `git diff --check`
- `.venv313/bin/python -m pytest tests/web/test_index.py -q`
- `.venv313/bin/python -m pytest tests/test_static_contracts.py -q`
- `.venv313/bin/python scripts/i18n_check.py --validate`
- `.venv313/bin/python -m pytest tests/ -q --ignore=tests/e2e`
- `TZ=UTC .venv313/bin/python -m pytest tests/e2e --collect-only -q` → 411 tests collected
- `TZ=UTC .venv313/bin/python -m pytest -q tests/e2e --tb=short`
