### PR TITLE
fix: polish home KPI layout

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1501,10 +1501,12 @@ body:has(#view-dashboard.active) .app-main {
 }
 
 .dashboard-section-header > span {
-  max-width: 38ch;
+  max-width: min(72ch, calc(100vw - 24rem));
+  min-width: 0;
   color: var(--text-muted);
   font-size: 0.78rem;
   text-align: right;
+  text-wrap: pretty;
 }
 
 .dashboard-section-context {
@@ -1542,6 +1544,8 @@ body:has(#view-dashboard.active) .app-main {
 }
 
 .dashboard-view .metrics-grid .metric-card.glass {
+  display: flex;
+  flex-direction: column;
   position: relative;
   min-width: 0;
   min-height: 128px;
@@ -1665,7 +1669,8 @@ body:has(#view-dashboard.active) .app-main {
   display: grid;
   gap: 6px;
   min-width: 0;
-  margin-top: 8px;
+  margin-top: auto;
+  padding-top: 8px;
 }
 
 .dashboard-view .metrics-grid .metric-range-caption {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v35';
+var CACHE_VERSION = 'v36';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -95,6 +95,43 @@ class TestDashboardSections:
         assert geometry["modulationTop"] >= geometry["statusBottom"] - 1
         assert geometry["modulationWidth"] >= geometry["cardWidth"] * 0.8
 
+    def test_metric_range_bars_align_on_wide_home_dashboard(self, demo_page):
+        demo_page.set_viewport_size({"width": 1280, "height": 720})
+        errors_card = demo_page.locator("#metric-errors-card")
+        us_scqam_card = demo_page.locator("#metric-us-sc-qam-card")
+        assert errors_card.is_visible()
+        assert us_scqam_card.is_visible()
+
+        geometry = demo_page.evaluate(
+            """
+            () => {
+                const errorsTrack = document.querySelector('#metric-errors-card .metric-range-track');
+                const usTrack = document.querySelector('#metric-us-sc-qam-card .metric-range-track');
+                if (!errorsTrack || !usTrack) throw new Error('range tracks not found');
+                const errorsRect = errorsTrack.getBoundingClientRect();
+                const usRect = usTrack.getBoundingClientRect();
+                return { errorsTop: errorsRect.top, usTop: usRect.top };
+            }
+            """
+        )
+        assert abs(geometry["errorsTop"] - geometry["usTop"]) <= 2
+
+    def test_signal_family_average_hint_uses_single_line_on_wide_dashboard(self, demo_page):
+        demo_page.set_viewport_size({"width": 1280, "height": 720})
+        hint = demo_page.locator(".dashboard-section-context > span")
+        assert hint.is_visible()
+
+        geometry = hint.evaluate(
+            """
+            el => {
+                const rect = el.getBoundingClientRect();
+                const lineHeight = Number.parseFloat(window.getComputedStyle(el).lineHeight);
+                return { height: rect.height, lineHeight };
+            }
+            """
+        )
+        assert geometry["height"] <= geometry["lineHeight"] * 1.5
+
     def test_long_device_meta_values_keep_icons_visible_when_truncated(self, demo_page):
         demo_page.set_viewport_size({"width": 768, "height": 900})
         cases = [

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -107,7 +107,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v35';" in sw_js
+    assert "var CACHE_VERSION = 'v36';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
@@ -132,6 +132,35 @@ def test_home_signal_family_modulation_rows_stack_below_status():
     assert "display: block" in block
     assert "clear: both" in block
     assert "width: 100%" in block
+
+
+def test_home_metric_range_bars_are_bottom_aligned_across_cards():
+    css = MAIN_CSS.read_text(encoding="utf-8")
+    card_block = css[
+        css.index(".dashboard-view .metrics-grid .metric-card.glass {") :
+        css.index(".dashboard-view .metrics-grid .metric-card.glass:hover")
+    ]
+    range_block = css[
+        css.index(".dashboard-view .metrics-grid .metric-range-viz {") :
+        css.index(".dashboard-view .metrics-grid .metric-range-caption", css.index(".dashboard-view .metrics-grid .metric-range-viz {"))
+    ]
+
+    assert "display: flex" in card_block
+    assert "flex-direction: column" in card_block
+    assert "margin-top: auto" in range_block
+    assert "padding-top: 8px" in range_block
+
+
+def test_home_signal_family_hint_uses_available_desktop_width():
+    css = MAIN_CSS.read_text(encoding="utf-8")
+    header_block = css[
+        css.index(".dashboard-section-header > span {") :
+        css.index(".dashboard-section-context", css.index(".dashboard-section-header > span {"))
+    ]
+
+    assert "max-width: min(72ch, calc(100vw - 24rem))" in header_block
+    assert "text-wrap: pretty" in header_block
+    assert "max-width: 38ch" not in header_block
 
 
 def test_channels_weather_overlay_contract_is_wired():


### PR DESCRIPTION
## Summary
- align the Errors KPI range bar with the other Home KPI range bars
- let the Signal family averages hint use wider desktop space before wrapping
- bump the service-worker cache version for the CSS change

## Test plan
- `git diff --check`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e`
