### PR TITLE
fix: hide unused channel controls

### DIFF
--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -198,6 +198,7 @@ function switchChannelMode() {
             _updateChannelInfoBar(cparts[0], cparts[1]);
         }
     }
+    _updateChannelSelectionControls();
     writeChannelHash();
 }
 window.switchChannelMode = switchChannelMode;
@@ -381,6 +382,19 @@ function _updateCompareTempToggle() {
     _updateTempToggleButton('compare-temp-toggle-btn', _lastCompareWeather);
 }
 
+function _updateChannelSelectionControls() {
+    var channelTimeTabs = document.getElementById('channel-time-tabs');
+    var channelSelect = document.getElementById('channel-select');
+    var hasTimelineSelection = !!(channelSelect && channelSelect.value);
+    if (channelTimeTabs) channelTimeTabs.style.display = hasTimelineSelection ? '' : 'none';
+
+    var hasCompareSelection = _compareChannels.length > 0;
+    var compareTimeTabs = document.getElementById('compare-time-tabs');
+    var compareClearBtn = document.getElementById('compare-clear-btn');
+    if (compareTimeTabs) compareTimeTabs.style.display = hasCompareSelection ? '' : 'none';
+    if (compareClearBtn) compareClearBtn.style.display = hasCompareSelection ? '' : 'none';
+}
+
 function toggleChannelTempOverlay() {
     _tempOverlayVisible = !_tempOverlayVisible;
     _updateChannelTempToggle();
@@ -540,6 +554,7 @@ function loadChannelTimeline() {
         noDataEl.style.display = 'none';
         loadingEl.style.display = 'none';
         if (infoBar) infoBar.style.display = 'none';
+        _updateChannelSelectionControls();
         _channelTimelineRequestSeq++;
         _lastChannelTimelineData = null;
         _lastChannelWeather = null;
@@ -550,6 +565,7 @@ function loadChannelTimeline() {
         return;
     }
     var parts = val.split('-');
+    _updateChannelSelectionControls();
     var direction = parts[0];
     var channelId = parts[1];
     var selectedOpt = sel.options[sel.selectedIndex];
@@ -813,6 +829,7 @@ window.removeCompareChannel = removeCompareChannel;
 function renderCompareChips() {
     var container = document.getElementById('compare-chips');
     container.innerHTML = '';
+    _updateChannelSelectionControls();
     if (_comparePreset === 'all' && _compareChannels.length > 0) {
         var presetChip = document.createElement('span');
         presetChip.className = 'compare-chip';

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v36';
+var CACHE_VERSION = 'v37';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1663,7 +1663,7 @@
             <select id="channel-select" class="channel-select-styled" onchange="loadChannelTimeline()">
                 <option value="">{{ t.select_channel }}</option>
             </select>
-            <div class="trend-tabs" id="channel-time-tabs">
+            <div class="trend-tabs" id="channel-time-tabs" style="display:none;">
                 <button class="trend-tab" data-value="1h" onclick="selectPill(this, loadChannelTimeline)">1h</button>
                 <button class="trend-tab" data-value="6h" onclick="selectPill(this, loadChannelTimeline)">6h</button>
                 <button class="trend-tab active" data-value="1d" onclick="selectPill(this, loadChannelTimeline)">1d</button>
@@ -1687,8 +1687,8 @@
             <select id="compare-channel-select" class="channel-select-styled"><option value="">{{ t.select_channel }}</option></select>
             <button id="compare-add-btn" class="compare-add-btn" onclick="addCompareChannel()">+ {{ t.add_channel }}</button>
             <button id="compare-add-all-btn" class="compare-add-btn" onclick="addAllCompareChannels()">{{ t.all_downstream }}</button>
-            <button id="compare-clear-btn" class="compare-add-btn" onclick="clearCompareChannels()">{{ t.clear_selection }}</button>
-            <div class="trend-tabs" id="compare-time-tabs">
+            <button id="compare-clear-btn" class="compare-add-btn" onclick="clearCompareChannels()" style="display:none;">{{ t.clear_selection }}</button>
+            <div class="trend-tabs" id="compare-time-tabs" style="display:none;">
                 <button class="trend-tab" data-value="1h" onclick="selectPill(this, loadCompareCharts)">1h</button>
                 <button class="trend-tab" data-value="6h" onclick="selectPill(this, loadCompareCharts)">6h</button>
                 <button class="trend-tab active" data-value="1d" onclick="selectPill(this, loadCompareCharts)">1d</button>

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -6,6 +6,7 @@ zoom modal, theme switching, responsive sizing, and crosshair sync.
 """
 
 import pytest
+from playwright.sync_api import expect
 
 
 # ── Helpers ──
@@ -253,6 +254,30 @@ class TestChartZoom:
 
 class TestChannelCharts:
     """Charts in the Channels > Timeline view."""
+
+    def test_channel_unused_controls_follow_selection_state(self, demo_page):
+        """Range and clear controls should only show after a usable channel selection."""
+        navigate_to_channels(demo_page)
+
+        expect(demo_page.locator("#channel-time-tabs")).not_to_be_visible()
+
+        demo_page.locator("#channel-select").select_option("ds-1")
+        expect(demo_page.locator("#channel-time-tabs")).to_be_visible()
+
+        demo_page.locator("#channel-select").select_option("")
+        expect(demo_page.locator("#channel-time-tabs")).not_to_be_visible()
+
+        demo_page.locator('#channel-mode-tabs .trend-tab[data-value="compare"]').click()
+        expect(demo_page.locator("#compare-time-tabs")).not_to_be_visible()
+        expect(demo_page.locator("#compare-clear-btn")).not_to_be_visible()
+
+        demo_page.locator("#compare-add-all-btn").click()
+        expect(demo_page.locator("#compare-time-tabs")).to_be_visible()
+        expect(demo_page.locator("#compare-clear-btn")).to_be_visible()
+
+        demo_page.locator("#compare-clear-btn").click()
+        expect(demo_page.locator("#compare-time-tabs")).not_to_be_visible()
+        expect(demo_page.locator("#compare-clear-btn")).not_to_be_visible()
 
     def test_channel_modulation_layout_preserves_long_labels_and_bounded_zoom_ticks(self, demo_page):
         """Long QAM labels and dense 7-day timestamps should get enough axis space."""

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -108,7 +108,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v36';" in sw_js
+    assert "var CACHE_VERSION = 'v37';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js


### PR DESCRIPTION
## Summary
- Hide Channel Timeline range tabs until a channel is selected.
- Hide Channel Compare range tabs and Clear Selection until compare channels exist.
- Add browser regression coverage and bump the service-worker cache version for the updated UI assets.

## Test plan
- `git diff --check`
- `.venv/bin/python -m pytest -q tests/e2e/test_charts.py::TestChannelCharts::test_channel_unused_controls_follow_selection_state tests/test_static_contracts.py::test_chart_time_range_controls_use_normalized_existing_ranges tests/test_static_contracts.py::test_static_cache_version_was_bumped_for_ui_followup_assets --tb=short`
- `ulimit -n 8192 && .venv311/bin/python -m pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC .venv311/bin/python -m pytest --collect-only -q tests/e2e`
- `ulimit -n 8192 && TZ=UTC .venv311/bin/python -m pytest -q tests/e2e --tb=short`

Closes #538
