### PR TITLE
Normalize chart axis time labels

### DIFF
--- a/app/modules/bqm/static/js/bqm-chart.js
+++ b/app/modules/bqm/static/js/bqm-chart.js
@@ -3,12 +3,7 @@ var BQMChart = (function() {
     'use strict';
 
     function formatTick(ts) {
-        var d = new Date(ts * 1000);
-        var day = String(d.getDate()).padStart(2, '0');
-        var month = String(d.getMonth() + 1).padStart(2, '0');
-        var hours = String(d.getHours()).padStart(2, '0');
-        var minutes = String(d.getMinutes()).padStart(2, '0');
-        return day + '.' + month + ' ' + hours + ':' + minutes;
+        return docsightFormatXAxisLabel(ts, 'bqm');
     }
 
     function toUnixSeries(timestamps) {

--- a/app/modules/comparison/static/main.js
+++ b/app/modules/comparison/static/main.js
@@ -142,6 +142,17 @@ function _cmpMapToLabels(normalized, hourLabels) {
     return hourLabels.map(function(h) { return map[h] || null; });
 }
 
+function _cmpBuildTimeLabels(hourLabels, period) {
+    var periodStartMs = new Date(period.from).getTime();
+    var periodEndMs = new Date(period.to).getTime();
+    var rangeSeconds = Math.max(Math.round((periodEndMs - periodStartMs) / 1000), 0);
+    // Before/after charts align both periods by relative offset. Axis text uses
+    // Period B's timeline as the visible time anchor so labels stay absolute.
+    return hourLabels.map(function(h) {
+        return docsightFormatXAxisLabel(periodStartMs + (h * 3600000), String(rangeSeconds) + 's');
+    });
+}
+
 /* ── Chart Rendering ── */
 function _cmpPeriodSupportsDocsisErrors(period) {
     if (!period) return false;
@@ -172,8 +183,7 @@ function _cmpRenderCharts(data) {
     var mappedA = _cmpMapToLabels(normA, hourLabels);
     var mappedB = _cmpMapToLabels(normB, hourLabels);
 
-    var hrsLabel = 'h';
-    var xLabels = hourLabels.map(function(h) { return h + hrsLabel; });
+    var xLabels = _cmpBuildTimeLabels(hourLabels, pb);
 
     if (pa.timeseries.length === 0 && pb.timeseries.length === 0) {
         var placeholder = document.getElementById('comparison-placeholder');

--- a/app/modules/connection_monitor/static/js/connection-monitor-charts.js
+++ b/app/modules/connection_monitor/static/js/connection-monitor-charts.js
@@ -144,8 +144,6 @@ var CMCharts = (function() {
         };
     }
 
-    function p2(n) { return n < 10 ? '0' + n : '' + n; }
-
     function sampleCountOf(sample) {
         return sample && sample.sample_count ? sample.sample_count : 1;
     }
@@ -162,8 +160,9 @@ var CMCharts = (function() {
      * Render combined PingPlotter-style chart with all targets overlaid.
      * @param {string} containerId - DOM element ID
      * @param {Array} allTargetData - [{target: {id, label, host}, samples: [...]}]
+     * @param {number|string} range - Selected range in seconds or a normalized range key.
      */
-    function renderCombinedChart(containerId, allTargetData) {
+    function renderCombinedChart(containerId, allTargetData, range) {
         if (!allTargetData || allTargetData.length === 0) return;
 
         // Build unified timeline from all targets' samples
@@ -178,15 +177,14 @@ var CMCharts = (function() {
         var tsIndex = {};
         for (var i = 0; i < timestamps.length; i++) tsIndex[timestamps[i]] = i;
 
-        // Format time labels - show date for ranges > 24h
         var rangeSeconds = timestamps[timestamps.length - 1] - timestamps[0];
-        var showDate = rangeSeconds > 86400;
-        var labels = timestamps.map(function(ts) {
-            var d = new Date(ts * 1000);
-            var time = p2(d.getHours()) + ':' + p2(d.getMinutes());
-            if (showDate) return p2(d.getDate()) + '.' + p2(d.getMonth() + 1) + ' ' + time;
-            return time;
-        });
+        var axisRange;
+        if (range !== undefined && range !== null) {
+            axisRange = /^\d+$/.test(String(range)) ? String(range) + 's' : range;
+        } else {
+            axisRange = String(Math.max(Math.round(rangeSeconds), 0)) + 's';
+        }
+        var labels = docsightFormatXAxisLabels(timestamps, axisRange);
 
         // Build datasets (one per target) and collect loss indices
         var datasets = [];

--- a/app/modules/connection_monitor/static/js/connection-monitor-detail.js
+++ b/app/modules/connection_monitor/static/js/connection-monitor-detail.js
@@ -298,7 +298,8 @@
                 hideNoData();
                 CMCharts.renderStatsCards('cm-stats-cards', allTargetData);
                 CMCharts.renderPerTargetStats('cm-per-target-stats', allTargetData);
-                CMCharts.renderCombinedChart('cm-combined-chart', allTargetData);
+                var chartRange = pinnedDayView ? 86400 : currentRange;
+                CMCharts.renderCombinedChart('cm-combined-chart', allTargetData, chartRange);
                 CMCharts.renderAvailabilityBand('cm-availability', allTargetData);
                 renderOutages(allOutageData);
                 renderExportLinks();

--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -1,6 +1,7 @@
 /* ── Channel Timeline + Compare ── */
 /* Extracted from IIFE – depends on: T, charts, renderChart, getPillValue,
-   DS_POWER_THRESHOLDS, DS_SNR_THRESHOLDS, US_POWER_THRESHOLDS */
+   docsightFormatXAxisLabels, DS_POWER_THRESHOLDS, DS_SNR_THRESHOLDS,
+   US_POWER_THRESHOLDS */
 
 /* ── Channel State URL Persistence ── */
 /* Hash format: #channels?mode=timeline&dir=ds&channel=42&range=1d
@@ -462,12 +463,7 @@ function _renderChannelTimelineCharts() {
     var docsisVersion = ctx.docsisVersion || '3.0';
     var days = ctx.days || '1d';
 
-    var xLabels = data.map(function(d) {
-        if (!d.timestamp) return '';
-        if (_channelRangeHours(days) <= 24) return d.timestamp.substring(11, 16);
-        if (_channelRangeDays(days) >= 30) return d.timestamp.substring(5, 10);
-        return d.timestamp.substring(5, 16).replace('T', ' ');
-    });
+    var xLabels = docsightFormatXAxisLabels(data.map(function(d) { return d.timestamp || ''; }), days);
     var tempOpts = _channelWeatherHasData(_lastChannelWeather) ? { tempData: _lastChannelWeather } : null;
     var tempByTimestamp = null;
     if (tempOpts) {
@@ -514,10 +510,7 @@ function _renderChannelTimelineCharts() {
         else { qamSteps = is31 ? dsQam31 : dsQam30; }
         var qamLabel = {}; qamSteps.forEach(function(v) { qamLabel[v] = v + 'QAM'; });
         var qamMap = {}; qamSteps.forEach(function(v, i) { qamMap[v + 'QAM'] = i; });
-        var modLabels = mods.map(function(d) {
-            if (_channelRangeDays(days) >= 30) return d.timestamp.substring(5, 10);
-            return d.timestamp.substring(5, 16).replace('T', ' ');
-        });
+        var modLabels = docsightFormatXAxisLabels(mods.map(function(d) { return d.timestamp; }), days);
         var modValues = mods.map(function(d) { return qamMap[d.modulation] !== undefined ? qamMap[d.modulation] : -1; });
         var tickValues = [];
         for (var qi = 0; qi < qamSteps.length; qi++) tickValues.push(qi);
@@ -534,6 +527,7 @@ function _renderChannelTimelineCharts() {
             yMax: qamSteps.length - 0.5,
             yAxisSize: 72,
             zoomYAxisSize: 80,
+            maxXTicks: 4,
             yAfterBuildTicks: function(axis) {
                 axis.ticks = tickValues.map(function(v) { return {value: v}; });
             }
@@ -855,11 +849,7 @@ function _renderCompareCharts() {
     var timestamps = ctx.timestamps;
     var days = ctx.days || '1d';
     var dir = ctx.dir || getCompareDirection();
-    var xLabels = timestamps.map(function(ts) {
-        if (_channelRangeHours(days) <= 24) return ts.substring(11, 16);
-        if (_channelRangeDays(days) >= 30) return ts.substring(5, 10);
-        return ts.substring(5, 16).replace('T', ' ');
-    });
+    var xLabels = docsightFormatXAxisLabels(timestamps, days);
     var tempOpts = _channelWeatherHasData(_lastCompareWeather) ? { tempData: _lastCompareWeather } : null;
 
     // Build lookup maps per channel: timestamp -> data point

--- a/app/static/js/chart-engine.js
+++ b/app/static/js/chart-engine.js
@@ -45,6 +45,50 @@ function formatDateDE(str) {
     return p[2] + '.' + p[1] + '.' + p[0];
 }
 
+function docsightRangeHours(range) {
+    if (range === null || range === undefined) return 24;
+    if (typeof range === 'number' && isFinite(range)) return range;
+    var raw = String(range || '1d').toLowerCase();
+    if (raw === 'bqm') return 24;
+    if (raw === 'all') return 24 * 90;
+    var secondsMatch = raw.match(/^(\d+)s$/);
+    if (secondsMatch) return parseInt(secondsMatch[1], 10) / 3600;
+    if (/^\d+$/.test(raw)) {
+        var numeric = parseInt(raw, 10);
+        return numeric;
+    }
+    var match = raw.match(/^(\d+)(h|d)$/);
+    if (!match) return 24;
+    var value = parseInt(match[1], 10);
+    return match[2] === 'h' ? value : value * 24;
+}
+
+function docsightTimestampDate(ts) {
+    if (ts instanceof Date) return ts;
+    if (typeof ts === 'number') {
+        return new Date(Math.abs(ts) < 100000000000 ? ts * 1000 : ts);
+    }
+    return new Date(ts);
+}
+
+function docsightFormatXAxisLabel(ts, range) {
+    var d = docsightTimestampDate(ts);
+    if (isNaN(d.getTime())) return '';
+    var hhmm = pad(d.getHours()) + ':' + pad(d.getMinutes());
+    if (String(range || '').toLowerCase() === 'bqm') return hhmm;
+    var mmdd = pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+    var hours = docsightRangeHours(range);
+    if (hours <= 24) return hhmm;
+    if (hours < 24 * 30) return mmdd + ' ' + hhmm;
+    return mmdd;
+}
+
+function docsightFormatXAxisLabels(timestamps, range) {
+    return (timestamps || []).map(function(ts) {
+        return ts !== null && ts !== undefined ? docsightFormatXAxisLabel(ts, range) : '';
+    });
+}
+
 function chartXRange(u) {
     var xData = u && u.data && u.data[0] ? u.data[0] : [];
     var edgePadding = u && u._docsightXEdgePadding ? u._docsightXEdgePadding : DEFAULT_X_EDGE_PADDING;

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -301,14 +301,8 @@ function renderCorrelationChart(data) {
     var labelCount = Math.min(8, Math.floor(plotW / 80));
     for (var i = 0; i <= labelCount; i++) {
         var t = tMin + (tMax - tMin) * i / labelCount;
-        var d = new Date(t);
-        var hours = getPillValue('correlation-tabs');
-        var label;
-        if (parseInt(hours) > 48) {
-            label = (d.getMonth() + 1) + '/' + d.getDate() + ' ' + String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
-        } else {
-            label = String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
-        }
+        var range = getPillValue('correlation-tabs') || '1d';
+        var label = docsightFormatXAxisLabel(t, range);
         ctx.fillText(label, xScale(t), H - pad.bottom + 18);
     }
 

--- a/app/static/js/segment-utilization.js
+++ b/app/static/js/segment-utilization.js
@@ -300,15 +300,7 @@ function _fritzCableRenderChart(containerId, samples, totalKey, ownKey) {
     var container = document.getElementById(containerId);
     if (!container || typeof renderChart === 'undefined') return;
 
-    var labels = samples.map(function(s) {
-        var d = new Date(s.timestamp);
-        var hh = (d.getHours() < 10 ? '0' : '') + d.getHours();
-        var mm = (d.getMinutes() < 10 ? '0' : '') + d.getMinutes();
-        if (_fritzCableRange === '24h') return hh + ':' + mm;
-        var dd = (d.getDate() < 10 ? '0' : '') + d.getDate();
-        var mo = ((d.getMonth() + 1) < 10 ? '0' : '') + (d.getMonth() + 1);
-        return dd + '.' + mo + ' ' + hh + ':' + mm;
-    });
+    var labels = docsightFormatXAxisLabels(samples.map(function(s) { return s.timestamp; }), _fritzCableRange);
 
     var datasets = [
         {

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -1,6 +1,6 @@
 /* ── Trend Charts ── */
 /* Extracted from IIFE – depends on: T, charts, renderChart, currentView,
-   todayStr, formatDateDE, DS_POWER_THRESHOLDS, DS_SNR_THRESHOLDS,
+   todayStr, docsightFormatXAxisLabels, DS_POWER_THRESHOLDS, DS_SNR_THRESHOLDS,
    US_POWER_THRESHOLDS, _tempOverlayVisible (chart-engine.js) */
 
 var _trendRange = '1d';
@@ -99,12 +99,8 @@ function _renderTrendCharts() {
     var data = _lastTrendData;
     var range = _lastTrendRange;
     if (!data || data.length === 0) return;
-    var xLabels = data.map(function(d) {
-        if (!d.timestamp) return '';
-        if (_trendRangeHours(range) <= 24) return d.timestamp.substring(11, 16);
-        if (_trendRangeHours(range) < 24 * 30) return d.timestamp.substring(5, 16).replace('T', ' ');
-        return d.date ? formatDateDE(d.date) : formatDateDE(d.timestamp.substring(0, 10));
-    });
+    var timestamps = data.map(function(d) { return d.timestamp || ''; });
+    var xLabels = docsightFormatXAxisLabels(timestamps, range);
     var tempOpts = (_lastTrendWeather && _lastTrendWeather.length > 0) ? { tempData: _lastTrendWeather } : null;
     renderChart('chart-ds-power', xLabels,
         [{label: 'DS Power Avg', data: data.map(function(d){ return d.ds_power_avg; }), color: '#a855f7', fill: POWER_TREND_FILL, fillTo: fillToScaleMin}],

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v37';
+var CACHE_VERSION = 'v38';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -1,7 +1,9 @@
 """Static UI/CSS contract tests."""
 
 import json
+import os
 import re
+import subprocess
 from collections import Counter
 from pathlib import Path
 
@@ -33,6 +35,9 @@ CM_CSS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "style.css
 CM_DETAIL_JS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "js" / "connection-monitor-detail.js"
 CM_CHARTS_JS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "js" / "connection-monitor-charts.js"
 CM_CARD_JS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "js" / "connection-monitor-card.js"
+SEGMENT_UTILIZATION_JS = ROOT / "app" / "static" / "js" / "segment-utilization.js"
+BQM_CHART_JS = ROOT / "app" / "modules" / "bqm" / "static" / "js" / "bqm-chart.js"
+COMPARISON_MAIN_JS = ROOT / "app" / "modules" / "comparison" / "static" / "main.js"
 
 
 def test_correlation_timeline_sticky_header_uses_opaque_surface():
@@ -108,7 +113,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v37';" in sw_js
+    assert "var CACHE_VERSION = 'v38';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
@@ -258,6 +263,88 @@ def test_chart_time_range_controls_use_normalized_existing_ranges():
     assert re.findall(r"data-cm-range=\"([^\"]+)\"", cm_picker) == expected_seconds
 
 
+def test_chart_axis_label_formatter_contract_is_range_normalized():
+    script = f"""
+const fs = require('fs');
+const vm = require('vm');
+const code = fs.readFileSync({str(CHART_ENGINE_JS)!r}, 'utf8');
+const context = {{ console: console, window: {{ devicePixelRatio: 1 }} }};
+vm.createContext(context);
+vm.runInContext(code, context);
+const fmt = context.docsightFormatXAxisLabel;
+if (typeof fmt !== 'function') {{
+  throw new Error('docsightFormatXAxisLabel is not defined');
+}}
+const tsMs = Date.UTC(2026, 0, 2, 3, 4, 0);
+const tsSec = Math.floor(tsMs / 1000);
+const cases = [
+  [tsMs, '1h', '03:04'],
+  [tsMs, '6h', '03:04'],
+  [tsMs, '1d', '03:04'],
+  [tsMs, '2d', '01-02 03:04'],
+  [tsMs, '3d', '01-02 03:04'],
+  [tsMs, '7d', '01-02 03:04'],
+  [tsMs, '30d', '01-02'],
+  [tsMs, '90d', '01-02'],
+  [tsMs, 'bqm', '03:04'],
+  [tsSec, 24, '03:04'],
+  [tsSec, 168, '01-02 03:04'],
+  [tsSec, 720, '01-02'],
+  [tsSec, '168', '01-02 03:04'],
+  [tsSec, '720', '01-02'],
+  [tsSec, '86400s', '03:04'],
+  [tsSec, '604800s', '01-02 03:04'],
+  [tsSec, '2592000s', '01-02'],
+  [tsSec, 2160, '01-02'],
+];
+for (const [ts, range, expected] of cases) {{
+  const actual = fmt(ts, range);
+  if (actual !== expected) {{
+    throw new Error(`${{range}} expected ${{expected}} but got ${{actual}}`);
+  }}
+}}
+"""
+    env = os.environ.copy()
+    env["TZ"] = "UTC"
+    result = subprocess.run(["node", "-e", script], cwd=ROOT, env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_chart_axis_labels_use_shared_formatter_across_graphs():
+    chart_engine = CHART_ENGINE_JS.read_text(encoding="utf-8")
+    graph_sources = {
+        "trends": TRENDS_JS,
+        "channels": CHANNELS_JS,
+        "correlation": CORRELATION_JS,
+        "connection_monitor": CM_CHARTS_JS,
+        "segment_utilization": SEGMENT_UTILIZATION_JS,
+        "bqm": BQM_CHART_JS,
+        "comparison": COMPARISON_MAIN_JS,
+    }
+
+    assert "function docsightFormatXAxisLabel" in chart_engine
+    assert "function docsightFormatXAxisLabels" in chart_engine
+    for name, path in graph_sources.items():
+        js = path.read_text(encoding="utf-8")
+        assert "docsightFormatXAxisLabel" in js or "docsightFormatXAxisLabels" in js, name
+
+    legacy_patterns = {
+        "DD.MM axis labels": r"return dd \+ '\\.' \+ mo|return day \+ '\\.' \+ month|p2\(d\.getDate\(\)\) \+ '\\.'",
+        "slash date axis labels": r"getMonth\(\) \+ 1\) \+ '/' \+ d\.getDate",
+        "manual ISO axis labels": r"substring\(5, 16\)\.replace\('T', ' '\)|substring\(11, 16\)|formatDateDE\(d\.date\)",
+        "relative comparison hour labels": r"hourLabels\.map\(function\(h\) \{ return h \+ hrsLabel; \}\)",
+    }
+    offenders = []
+    for name, path in graph_sources.items():
+        js = path.read_text(encoding="utf-8")
+        for label, pattern in legacy_patterns.items():
+            if re.search(pattern, js):
+                offenders.append(f"{name}: {label}")
+
+    assert offenders == []
+
+
 def test_modulation_range_control_uses_normalized_labels_while_preserving_today():
     template = MODULATION_TEMPLATE.read_text(encoding="utf-8")
     range_tabs = template[template.index('id="modulation-range-tabs"') : template.index('</div>', template.index('id="modulation-range-tabs"'))]
@@ -326,6 +413,7 @@ def test_chart_engine_has_configurable_axis_padding_for_long_qam_labels():
     assert "calculateMaxXTicks(labels, width, yAxisSize" in js
     assert "yAxisSize: 72" in channels_js
     assert "zoomYAxisSize: 80" in channels_js
+    assert "maxXTicks: 4" in channels_js
 
 
 def test_chart_zoom_uses_bounded_index_ticks_instead_of_all_samples():


### PR DESCRIPTION
## Summary
- normalize chart x-axis labels with one shared range-aware formatter
- apply the same labels to normal and zoomed chart views across Channels, Signal Trends, Correlation, Connection Monitor, Before/After Comparison, and BQM
- bump the service worker cache for the updated static assets

Closes #540

## Tests
- `pytest -q tests/test_static_contracts.py --tb=short`
- `pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC pytest -q tests/e2e --tb=short`
- `node --check` on changed JavaScript assets
- `git diff --check`
