### PR TITLE
fix: preserve customer details in complaint PDFs

### DIFF
--- a/app/modules/reports/report.py
+++ b/app/modules/reports/report.py
@@ -493,7 +493,35 @@ def _format_comparison_evidence(comparison_data, s):
     return "\n".join(lines)
 
 
-def generate_report(snapshots, current_analysis, config=None, connection_info=None, lang="en", comparison_data=None):
+def _localized_closing_placeholder(s, line_index, fallback):
+    closing = s.get("complaint_closing", "")
+    lines = closing.splitlines() if isinstance(closing, str) else []
+    if len(lines) > line_index and lines[line_index].strip():
+        return lines[line_index].strip()
+    return fallback
+
+
+def _format_customer_closing(s, customer_name="", customer_number="", customer_address=""):
+    """Build a localized complaint closing with provided customer details."""
+    label = s.get("complaint_closing_label") or _localized_closing_placeholder(s, 0, "Sincerely,")
+    name = (customer_name or "").strip() or _localized_closing_placeholder(s, 1, "[Your Name]")
+    number = (customer_number or "").strip() or _localized_closing_placeholder(s, 2, "[Customer Number]")
+    address = (customer_address or "").strip()
+    address_lines = address.splitlines() if address else [_localized_closing_placeholder(s, 3, "[Address]")]
+    return "\n".join([label, name, number, *address_lines])
+
+
+def generate_report(
+    snapshots,
+    current_analysis,
+    config=None,
+    connection_info=None,
+    lang="en",
+    comparison_data=None,
+    customer_name="",
+    customer_number="",
+    customer_address="",
+):
     """Generate a PDF incident report.
 
     Args:
@@ -503,6 +531,9 @@ def generate_report(snapshots, current_analysis, config=None, connection_info=No
         connection_info: Connection info dict (speeds, etc.)
         lang: Language code
         comparison_data: Optional before/after comparison payload
+        customer_name: Customer name for the embedded complaint letter
+        customer_number: Customer/contract number for the embedded complaint letter
+        customer_address: Customer address for the embedded complaint letter
 
     Returns:
         bytes: PDF file content
@@ -695,6 +726,7 @@ def generate_report(snapshots, current_analysis, config=None, connection_info=No
             _build_diagnostic_notes(current_analysis), s
         )
     comparison_section = _format_comparison_evidence(comparison_data, s)
+    complaint_closing = _format_customer_closing(s, customer_name, customer_number, customer_address)
 
     if snapshots:
         worst = _compute_worst_values(snapshots)
@@ -719,14 +751,14 @@ def generate_report(snapshots, current_analysis, config=None, connection_info=No
             f"2. {s['complaint_req2']}\n"
             f"3. {s['complaint_req3']}\n\n"
             f"{s['complaint_escalation']}\n\n"
-            f"{s['complaint_closing']}"
+            f"{complaint_closing}"
         )
     else:
         complaint = (
             f"{s['complaint_short_subject']}\n\n"
             f"{s['complaint_short_greeting']}\n\n"
             f"{s['complaint_short_body']}\n\n"
-            f"{s['complaint_short_closing']}"
+            f"{complaint_closing}"
         )
 
     pdf.multi_cell(0, 4, complaint)

--- a/app/modules/reports/routes.py
+++ b/app/modules/reports/routes.py
@@ -64,8 +64,21 @@ def api_report():
     conn_info = state.get("connection_info") or {}
     lang = request.args.get("lang", _get_lang())
     comparison_data = _get_comparison_data(_storage)
+    customer_name = request.args.get("name", "")
+    customer_number = request.args.get("number", "")
+    customer_address = request.args.get("address", "")
 
-    pdf_bytes = generate_report(snapshots, analysis, config, conn_info, lang, comparison_data=comparison_data)
+    pdf_bytes = generate_report(
+        snapshots,
+        analysis,
+        config,
+        conn_info,
+        lang,
+        comparison_data=comparison_data,
+        customer_name=customer_name,
+        customer_number=customer_number,
+        customer_address=customer_address,
+    )
 
     response = make_response(pdf_bytes)
     response.headers["Content-Type"] = "application/pdf"

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -285,19 +285,21 @@ function copyComplaint() {
     }
 }
 function downloadReport() {
-    var days = document.getElementById('report-days').value;
-    var lang = document.getElementById('report-lang').value;
-    var comparisonParam = '';
+    var params = new URLSearchParams();
+    params.set('days', document.getElementById('report-days').value);
+    params.set('lang', document.getElementById('report-lang').value);
+    params.set('name', document.getElementById('report-name').value);
+    params.set('number', document.getElementById('report-number').value);
+    params.set('address', document.getElementById('report-address').value);
     var includeComparison = document.getElementById('report-include-comparison');
     if (includeComparison && includeComparison.checked && window.__docsightComparisonResult) {
         var cmp = window.__docsightComparisonResult;
-        comparisonParam =
-            '&comparison_from_a=' + encodeURIComponent(cmp.period_a.from) +
-            '&comparison_to_a=' + encodeURIComponent(cmp.period_a.to) +
-            '&comparison_from_b=' + encodeURIComponent(cmp.period_b.from) +
-            '&comparison_to_b=' + encodeURIComponent(cmp.period_b.to);
+        params.set('comparison_from_a', cmp.period_a.from);
+        params.set('comparison_to_a', cmp.period_a.to);
+        params.set('comparison_from_b', cmp.period_b.from);
+        params.set('comparison_to_b', cmp.period_b.to);
     }
-    window.location.href = '/api/report?days=' + days + '&lang=' + lang + comparisonParam;
+    window.location.href = '/api/report?' + params.toString();
 }
 function copyExport() {
     var textarea = document.getElementById('export-text');

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v38';
+var CACHE_VERSION = 'v39';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -1,5 +1,7 @@
 """E2E coverage for DOCSight modal behavior."""
 
+from urllib.parse import parse_qs, urlparse
+
 from playwright.sync_api import expect
 
 
@@ -180,6 +182,42 @@ def test_report_modal_frames_isp_ready_evidence_builder(demo_page):
     expect(modal).to_contain_text("BQM, SmokePing, and Speedtest evidence when available")
     expect(modal).to_contain_text("Generated locally")
     expect(modal.get_by_role("button", name="Build evidence package")).to_be_visible()
+
+
+def test_report_pdf_download_preserves_customer_details_e2e(demo_page):
+    """PDF download keeps the customer fields entered in the report builder."""
+    demo_page.route(
+        "**/api/complaint?**",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"text":"Subject: DOCSIS Signal Quality Issues\\n\\nEvidence summary ready."}',
+        ),
+    )
+    demo_page.route(
+        "**/api/report?**",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/pdf",
+            body="%PDF-1.4\n%%EOF",
+        ),
+    )
+
+    demo_page.locator("#report-link").click()
+    modal = demo_page.locator("#report-modal")
+    modal.locator("#report-name").fill("Max Mustermann")
+    modal.locator("#report-number").fill("KD-123456")
+    modal.locator("#report-address").fill("Musterstraße 1, 12345 Musterstadt")
+    modal.get_by_role("button", name="Build evidence package").click()
+    expect(modal.get_by_role("button", name="Download PDF package")).to_be_visible()
+
+    with demo_page.expect_request("**/api/report?**") as report_request:
+        modal.get_by_role("button", name="Download PDF package").click()
+
+    params = parse_qs(urlparse(report_request.value.url).query)
+    assert params["name"] == ["Max Mustermann"]
+    assert params["number"] == ["KD-123456"]
+    assert params["address"] == ["Musterstraße 1, 12345 Musterstadt"]
 
 
 def test_report_modal_shows_generation_success_and_error_states(demo_page):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,10 @@
 """Tests for incident report generation."""
 
+import io
 import sys
 import os
+
+from pypdf import PdfReader
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -245,3 +248,25 @@ def test_generate_report_accepts_comparison_evidence():
 
     assert pdf[:5] == b"%PDF-"
     assert len(pdf) > 1000
+
+def test_generate_report_embeds_customer_details_in_complaint_closing():
+    pdf = generate_report(
+        MOCK_SNAPSHOTS,
+        MOCK_ANALYSIS,
+        lang="de",
+        customer_name="Max Mustermann",
+        customer_number="KD-123456",
+        customer_address="Musterstraße 1\n12345 Musterstadt",
+    )
+    text = "\n".join(
+        page.extract_text() or ""
+        for page in PdfReader(io.BytesIO(pdf)).pages
+    )
+
+    assert "Max Mustermann" in text
+    assert "KD-123456" in text
+    assert "Musterstraße 1" in text
+    assert "12345 Musterstadt" in text
+    assert "[Ihr Name]" not in text
+    assert "[Kundennummer]" not in text
+    assert "[Adresse]" not in text

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -38,6 +38,18 @@ CM_CARD_JS = ROOT / "app" / "modules" / "connection_monitor" / "static" / "js" /
 SEGMENT_UTILIZATION_JS = ROOT / "app" / "static" / "js" / "segment-utilization.js"
 BQM_CHART_JS = ROOT / "app" / "modules" / "bqm" / "static" / "js" / "bqm-chart.js"
 COMPARISON_MAIN_JS = ROOT / "app" / "modules" / "comparison" / "static" / "main.js"
+UTILS_JS = ROOT / "app" / "static" / "js" / "utils.js"
+
+
+def test_report_pdf_download_preserves_customer_detail_params():
+    js = UTILS_JS.read_text(encoding="utf-8")
+    download_block = js[js.index("function downloadReport()") : js.index("function copyExport()")]
+
+    assert "params.set('name', document.getElementById('report-name').value)" in download_block
+    assert "params.set('number', document.getElementById('report-number').value)" in download_block
+    assert "params.set('address', document.getElementById('report-address').value)" in download_block
+    assert "new URLSearchParams()" in download_block
+    assert "params.toString()" in download_block
 
 
 def test_correlation_timeline_sticky_header_uses_opaque_surface():
@@ -113,9 +125,10 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v38';" in sw_js
+    assert "var CACHE_VERSION = 'v39';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
+    assert "/static/js/utils.js" in sw_js
     assert "/modules/docsight.connection_monitor/static/style.css" in sw_js
     assert "/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js" in sw_js
     assert "/modules/docsight.modulation/static/main.js" in sw_js

--- a/tests/web/test_reports.py
+++ b/tests/web/test_reports.py
@@ -1,6 +1,6 @@
 """Tests for report/comparison helpers exposed through web routes."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from app.web import app
 
 
@@ -71,6 +71,38 @@ class TestReportHelpers:
 
 
 class TestComplaintRoutes:
+    def test_api_report_passes_customer_details_to_pdf_generator(self):
+        from app.modules.reports import routes
+
+        storage = Mock()
+        storage.get_range_data.return_value = [{"timestamp": "2026-05-01T00:00:00Z", "summary": {}}]
+        config_manager = Mock()
+        config_manager.get.side_effect = lambda key, default="": {
+            "isp_name": "Example ISP",
+            "modem_type": "Example Modem",
+        }.get(key, default)
+        analysis = {"summary": {"health": "critical"}, "ds_channels": [], "us_channels": []}
+        pdf_bytes = b"%PDF-1.4\ncustomer-data\n"
+
+        with app.test_request_context(
+            "/api/report?days=7&lang=de"
+            "&name=Max%20Mustermann"
+            "&number=KD-123456"
+            "&address=Musterstra%C3%9Fe%201%0A12345%20Musterstadt"
+        ):
+            with patch.object(routes, "get_storage", return_value=storage), \
+                 patch.object(routes, "get_config_manager", return_value=config_manager), \
+                 patch.object(routes, "get_state", return_value={"analysis": analysis, "connection_info": {}}), \
+                 patch.object(routes, "generate_report", return_value=pdf_bytes) as generate_report:
+                response = getattr(routes.api_report, "__wrapped__")()
+
+        assert response.status_code == 200
+        assert response.data == pdf_bytes
+        generate_report.assert_called_once()
+        assert generate_report.call_args.kwargs["customer_name"] == "Max Mustermann"
+        assert generate_report.call_args.kwargs["customer_number"] == "KD-123456"
+        assert generate_report.call_args.kwargs["customer_address"] == "Musterstraße 1\n12345 Musterstadt"
+
     def test_get_comparison_data_helper(self):
         from app.modules.reports.routes import _get_comparison_data
 


### PR DESCRIPTION
## Summary
- Preserve File Complaint customer details when downloading the PDF report
- Replace the embedded complaint-letter placeholders with the entered name, customer number, and address
- Refresh the service-worker cache version for the updated frontend download flow

## Validation
- Targeted report/static/web regression tests pass
- Full non-E2E test suite passes
- Browser E2E suite passes
- Static security and public-copy hygiene scans are clean
