### PR TITLE
Align KPI family health with modulation

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Literal
 
-from .types import AnalysisResult, DocsisData
+from .types import AnalysisResult, DocsisData, SignalFamilyHealthCause
 from .tz import utc_now, _parse_utc
 
 log = logging.getLogger("docsis.analyzer")
@@ -595,7 +596,7 @@ def _classify_us_family(channel):
 def _family_summary(family, channels, *, direction):
     # The analyzer normalizes downstream OFDM MER into the per-channel `snr` slot;
     # expose it as `mer` at the family-summary boundary so Home labels stay honest.
-    quality_key = "mer" if direction == "downstream" and family == "ofdm" else "snr"
+    quality_key: Literal["snr", "mer"] = "mer" if direction == "downstream" and family == "ofdm" else "snr"
     prefer_profile = family in {"ofdm", "ofdma"}
     power = _stats([channel.get("power") for channel in channels])
     quality = _stats([channel.get("snr") for channel in channels]) if direction == "downstream" else None
@@ -618,10 +619,24 @@ def _family_summary(family, channels, *, direction):
     if direction == "downstream":
         metrics.append(quality_health)
 
+    family_health = _worst_health(metrics)
+    # Surface the most useful hidden cause first: modulation degradations are
+    # otherwise easy to miss on power/SNR/MER cards, followed by power, then
+    # downstream quality.
+    health_cause: SignalFamilyHealthCause | None = None
+    if family_health not in {"good", "missing"}:
+        if modulation_health == family_health:
+            health_cause = "modulation"
+        elif power_health == family_health:
+            health_cause = "power"
+        elif direction == "downstream" and quality_health == family_health:
+            health_cause = quality_key
+
     result = {
         "family": family,
         "count": len(channels),
-        "health": _worst_health(metrics),
+        "health": family_health,
+        "health_cause": health_cause,
         "power": {**power, "health": power_health},
         "modulation": {
             "available": bool(modulation_values),

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1627,6 +1627,13 @@ body:has(#view-dashboard.active) .app-main {
   min-height: 22px;
 }
 
+.dashboard-view .metrics-grid .metric-status-cause {
+  color: var(--text-muted);
+  font-size: 0.66rem;
+  line-height: 1;
+  margin-left: 4px;
+}
+
 .dashboard-view .metrics-grid .metric-average-row {
   margin-top: 6px;
   min-height: 18px;
@@ -1639,7 +1646,9 @@ body:has(#view-dashboard.active) .app-main {
 }
 
 .dashboard-view .metrics-grid .metric-modulation-row {
-  display: block;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
   clear: both;
   width: 100%;
   margin-top: 4px;

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v39';
+var CACHE_VERSION = 'v40';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -724,8 +724,23 @@
     {% macro signal_family_card(card_id, label, family, metric_key, metric_unit, metric_label, spark_key, icon_class, icon_name, range_data=None, glossary_text=None, spark_color=None) -%}
         {% set metric = family.get(metric_key, {}) %}
         {% set modulation = family.get('modulation', {}) %}
-        {% set raw_health = range_data.health if range_data and range_data.health is defined else metric.get('health', family.get('health', 'missing')) %}
+        {% set raw_health = family.get('health', metric.get('health', 'missing')) %}
         {% set health_class = 'crit' if raw_health == 'critical' else ('warn' if raw_health == 'warning' else ('muted' if raw_health == 'missing' else raw_health)) %}
+        {% set metric_raw_health = range_data.health if range_data and range_data.health is defined else metric.get('health', raw_health) %}
+        {% set metric_health_class = 'crit' if metric_raw_health == 'critical' else ('warn' if metric_raw_health == 'warning' else ('muted' if metric_raw_health == 'missing' else metric_raw_health)) %}
+        {% set modulation_raw_health = modulation.get('health', 'missing') %}
+        {% set modulation_health_class = 'crit' if modulation_raw_health == 'critical' else ('warn' if modulation_raw_health == 'warning' else ('muted' if modulation_raw_health == 'missing' else modulation_raw_health)) %}
+        {% set health_cause = family.get('health_cause') %}
+        {% set health_cause_label = none %}
+        {% if health_cause == 'modulation' and metric_key != 'modulation' %}
+            {% set health_cause_label = t.get('signal_family_modulation_label', 'Modulation') %}
+        {% elif health_cause == 'power' and metric_key != 'power' %}
+            {% set health_cause_label = t.get('signal_family_metric_power', 'Power') %}
+        {% elif health_cause == 'snr' and metric_key != 'snr' %}
+            {% set health_cause_label = t.get('signal_family_metric_snr', 'SNR') %}
+        {% elif health_cause == 'mer' and metric_key != 'mer' %}
+            {% set health_cause_label = t.get('signal_family_metric_mer', 'MER') %}
+        {% endif %}
         {% set metric_value = metric.get('avg') %}
         {% set family_count = family.get('count', 0) %}
         <div class="metric-card glass" id="{{ card_id }}">
@@ -735,7 +750,7 @@
                 <div class="metric-icon {{ icon_class }}"><i data-lucide="{{ icon_name }}"></i></div>
             </div>
             <div class="metric-value-row">
-                <div class="metric-value" style="color:var(--{{ health_class }});">{% if metric_value is not none %}{{ metric_value }}<span class="unit">{% if metric_unit %}{{ metric_unit }}{% endif %}{% if metric_label %} {{ metric_label }}{% endif %}</span>{% else %}{{ t.get('signal_family_unavailable', 'Unavailable') }}<span class="unit">{% if metric_unit %}{{ metric_unit }}{% endif %}{% if metric_label %} {{ metric_label }}{% endif %}</span>{% endif %}</div>
+                <div class="metric-value" style="color:var(--{{ metric_health_class }});">{% if metric_value is not none %}{{ metric_value }}<span class="unit">{% if metric_unit %}{{ metric_unit }}{% endif %}{% if metric_label %} {{ metric_label }}{% endif %}</span>{% else %}{{ t.get('signal_family_unavailable', 'Unavailable') }}<span class="unit">{% if metric_unit %}{{ metric_unit }}{% endif %}{% if metric_label %} {{ metric_label }}{% endif %}</span>{% endif %}</div>
                 <canvas class="metric-spark" id="spark-{{ card_id|replace('metric-', '') }}" data-spark-key="{{ spark_key }}"{% if spark_color %} data-spark-color="{{ spark_color }}"{% endif %} width="144" height="56" aria-hidden="true"></canvas>
             </div>
             {% if metric_value is not none and family_count %}
@@ -747,17 +762,19 @@
                 <span class="metric-context">
                     <span class="metric-sub-label">{{ t.get('metric_status_label', 'Status') }}</span>
                     <span class="badge badge-{{ raw_health }} badge-{{ health_class }}">{{ health_labels.get(raw_health, health_labels.get(health_class, raw_health|title)) }}</span>
+                    {% if health_cause_label %}<span class="metric-status-cause">· {{ health_cause_label }}</span>{% endif %}
                 </span>
             </div>
             {% if modulation.get('value') %}
             <div class="metric-sub metric-modulation-row">
-                <span class="range">{{ t.get('signal_family_modulation_label', 'Modulation') }}: {{ modulation.get('value') }}{% if modulation.get('secondary') %} — {{ modulation.get('secondary') }}{% endif %}</span>
+                <span class="range" style="color:var(--{{ modulation_health_class }});">{{ t.get('signal_family_modulation_label', 'Modulation') }}: {{ modulation.get('value') }}{% if modulation.get('secondary') %} — {{ modulation.get('secondary') }}{% endif %}</span>
+                <span class="badge badge-{{ modulation_raw_health }} badge-{{ modulation_health_class }}">{{ health_labels.get(modulation_raw_health, health_labels.get(modulation_health_class, modulation_raw_health|title)) }}</span>
             </div>
             {% endif %}
             {% if metric_value is not none and range_data %}
             {% set metric_min = metric.get('min') if metric.get('min') is not none else metric_value %}
             {% set metric_max = metric.get('max') if metric.get('max') is not none else metric_value %}
-            {{ metric_range_viz(range_data, range_data.health if range_data.health is defined else health_class, health_labels.good, t.get('metric_channel_span', 'Channel min-max'), metric_min ~ ' — ' ~ metric_max) }}
+            {{ metric_range_viz(range_data, range_data.health if range_data.health is defined else metric_health_class, health_labels.good, t.get('metric_channel_span', 'Channel min-max'), metric_min ~ ' — ' ~ metric_max) }}
             {% endif %}
         </div>
     {%- endmacro %}

--- a/app/types.py
+++ b/app/types.py
@@ -9,7 +9,7 @@ and do not change any public API, config key, DB schema, or wire format.
 
 from __future__ import annotations
 
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 # ── Raw DOCSIS Channel (driver output, pre-analysis) ────────────
@@ -159,12 +159,16 @@ class SignalFamilyModulation(TypedDict):
     health: str
 
 
+SignalFamilyHealthCause = Literal["power", "snr", "mer", "modulation"]
+
+
 class SignalFamilySummary(TypedDict, total=False):
     """Summary for one DOCSIS signal family on the Home dashboard."""
 
     family: str
     count: int
     health: str
+    health_cause: SignalFamilyHealthCause | None
     power: SignalFamilyMetric
     snr: SignalFamilyMetric
     mer: SignalFamilyMetric

--- a/tests/analyzer/test_signal_metrics.py
+++ b/tests/analyzer/test_signal_metrics.py
@@ -483,6 +483,69 @@ class TestSignalFamilySummaries:
         assert upstream["ofdma"]["modulation"]["value"] == "64QAM"
         assert upstream["ofdma"]["modulation"]["health"] == "warning"
 
+    def test_upstream_ofdma_family_health_surfaces_critical_modulation_cause(self):
+        us_ofdma = {
+            "channelID": 5,
+            "frequency": "30-65 MHz",
+            "type": "OFDMA",
+            "powerLevel": "49.5",
+            "profile_modulation": "32QAM",
+        }
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us31=[us_ofdma],
+        )
+
+        result = analyze(data)
+
+        ofdma = result["summary"]["signal_families"]["upstream"]["families"]["ofdma"]
+        assert ofdma["power"]["health"] == "warning"
+        assert ofdma["modulation"]["health"] == "critical"
+        assert ofdma["health"] == "critical"
+        assert ofdma["health_cause"] == "modulation"
+
+    def test_downstream_family_health_cause_is_none_when_all_metrics_are_good(self):
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us30=[_make_us30(1, power=42.0)],
+        )
+
+        result = analyze(data)
+
+        sc_qam = result["summary"]["signal_families"]["downstream"]["families"]["sc_qam"]
+        assert sc_qam["health"] == "good"
+        assert sc_qam["health_cause"] is None
+
+    def test_downstream_sc_qam_family_health_surfaces_snr_cause(self):
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-25")],
+            us30=[_make_us30(1, power=42.0)],
+        )
+
+        result = analyze(data)
+
+        sc_qam = result["summary"]["signal_families"]["downstream"]["families"]["sc_qam"]
+        assert sc_qam["power"]["health"] == "good"
+        assert sc_qam["snr"]["health"] == "critical"
+        assert sc_qam["modulation"]["health"] == "good"
+        assert sc_qam["health"] == "critical"
+        assert sc_qam["health_cause"] == "snr"
+
+    def test_downstream_ofdm_family_health_surfaces_mer_cause(self):
+        data = _make_data(
+            ds31=[_make_ds31(100, power=5.0, mer="35.0")],
+            us30=[_make_us30(1, power=42.0)],
+        )
+
+        result = analyze(data)
+
+        ofdm = result["summary"]["signal_families"]["downstream"]["families"]["ofdm"]
+        assert ofdm["power"]["health"] == "good"
+        assert ofdm["mer"]["health"] == "critical"
+        assert ofdm["modulation"]["health"] == "good"
+        assert ofdm["health"] == "critical"
+        assert ofdm["health_cause"] == "mer"
+
 
 # -- Upstream bitrate calculation --
 

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -125,7 +125,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v39';" in sw_js
+    assert "var CACHE_VERSION = 'v40';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -148,7 +148,9 @@ def test_home_signal_family_modulation_rows_stack_below_status():
     start = css.index(".dashboard-view .metrics-grid .metric-modulation-row")
     block = css[start : css.index(".dashboard-view .metrics-grid .metric-context", start)]
 
-    assert "display: block" in block
+    assert "display: flex" in block
+    assert "align-items: baseline" in block
+    assert "gap: 6px" in block
     assert "clear: both" in block
     assert "width: 100%" in block
 

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -461,21 +461,63 @@ class TestIndexRoute:
         assert "DS POWER AVG" not in html
         assert "US POWER AVG" not in html
 
-    def test_home_signal_family_card_status_uses_displayed_average_health(self, client, sample_analysis):
+    def test_home_signal_family_card_status_uses_composite_health_with_hidden_cause(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
-        ofdm_power = sample_analysis["summary"]["signal_families"]["downstream"]["families"]["ofdm"]["power"]
-        ofdm_power.update({"avg": 0.6, "min": -7.8, "max": 9.0, "health": "critical"})
-        sample_analysis["summary"]["ds_ofdm_power_avg"] = 0.6
+        ofdma = sample_analysis["summary"]["signal_families"]["upstream"]["families"]["ofdma"]
+        ofdma["health"] = "critical"
+        ofdma["health_cause"] = "modulation"
+        ofdma["power"].update({"available": True, "avg": 49.5, "min": 49.5, "max": 49.5, "health": "warning"})
+        ofdma["modulation"].update({"value": "32QAM", "distinct": ["32QAM"], "health": "critical"})
+        sample_analysis["summary"]["us_ofdma_power_avg"] = 49.5
         update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
         assert resp.status_code == 200
-        card = _element_by_id(resp.get_data(as_text=True), "metric-ds-ofdm-power-card")
-        assert "0.6<span class=\"unit\">dBmV</span>" in card
-        assert "badge badge-good" in card
-        assert "badge badge-critical" not in card
-        assert "--metric-range-accent: var(--good);" in card
+        card = _element_by_id(resp.get_data(as_text=True), "metric-us-ofdma-card")
+        assert "49.5<span class=\"unit\">dBmV</span>" in card
+        assert "style=\"color:var(--warn);\"" in card
+        status_row = card[card.index('<div class="metric-sub metric-status-row">'):]
+        status_row = status_row[:status_row.index("</div>")]
+        assert "badge badge-critical" in status_row
+        assert "Modulation" in status_row
+        assert "--metric-range-accent: var(--warn);" in card
+
+    def test_home_signal_family_modulation_row_shows_own_health(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        ofdma = sample_analysis["summary"]["signal_families"]["upstream"]["families"]["ofdma"]
+        ofdma["health"] = "critical"
+        ofdma["health_cause"] = "modulation"
+        ofdma["power"].update({"available": True, "avg": 49.5, "min": 49.5, "max": 49.5, "health": "warning"})
+        ofdma["modulation"].update({"value": "32QAM", "distinct": ["32QAM"], "health": "critical"})
+        sample_analysis["summary"]["us_ofdma_power_avg"] = 49.5
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        card = _element_by_id(resp.get_data(as_text=True), "metric-us-ofdma-card")
+        modulation_row = card[card.index('<div class="metric-sub metric-modulation-row">'):]
+        modulation_row = modulation_row[:modulation_row.index("</div>")]
+        assert "Modulation: 32QAM" in modulation_row
+        assert "badge badge-critical" in modulation_row
+        assert "style=\"color:var(--crit);\"" in modulation_row
+
+    def test_home_signal_family_card_omits_cause_when_status_matches_visible_metric(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        ofdm = sample_analysis["summary"]["signal_families"]["downstream"]["families"]["ofdm"]
+        ofdm["health"] = "warning"
+        ofdm["health_cause"] = "mer"
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        card = _element_by_id(resp.get_data(as_text=True), "metric-ds-ofdm-mer-card")
+        status_row = card[card.index('<div class="metric-sub metric-status-row">'):]
+        status_row = status_row[:status_row.index("</div>")]
+        assert "badge badge-warning" in status_row
+        assert "MER" not in status_row
 
     def test_home_signal_family_cards_show_metric_health_bars(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
@@ -529,7 +571,7 @@ class TestIndexRoute:
         assert "64QAM" in scqam_card
         assert "US POWER (OFDMA)" in ofdma_card
         assert "Unavailable<span class=\"unit\">dBmV</span>" in ofdma_card
-        assert "badge badge-missing" in ofdma_card
+        assert "badge badge-warning" in ofdma_card
 
     def test_home_family_cards_expose_family_sparkline_keys(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)


### PR DESCRIPTION
## Summary
- Make Home signal-family KPI status reflect composite family health, including modulation
- Keep the primary KPI value and range bar tied to the displayed power/SNR/MER metric
- Color-code modulation rows with their own health badge and surface hidden health causes when needed
- Add analyzer, web, and static regressions; bump the service-worker cache for the CSS/template update

## Tests
- `git diff --check`
- `python -m py_compile app/analyzer.py app/types.py`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e` in resource-safe batches, 415/415 passed

Closes #545
