### PR TITLE
fix: unwrap DOCSIS counter rollovers

### DIFF
--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -4,6 +4,10 @@ import json
 import sqlite3
 
 from ..tz import utc_cutoff
+from .error_counters import unwrap_uint32_counter_series
+
+
+_CHANNEL_ERROR_KEYS = ("correctable_errors", "uncorrectable_errors")
 
 
 class AnalysisMixin:
@@ -199,6 +203,7 @@ class AnalysisMixin:
                         "health": ch.get("health", ""),
                     })
                     break
+        unwrap_uint32_counter_series(results, _CHANNEL_ERROR_KEYS)
         return results
 
     def get_multi_channel_history(self, channel_ids, direction, days=7, hours=None):
@@ -231,4 +236,6 @@ class AnalysisMixin:
                         "modulation": ch.get("modulation", ""),
                         "frequency": ch.get("frequency", ""),
                     })
+        for rows_for_channel in results.values():
+            unwrap_uint32_counter_series(rows_for_channel, _CHANNEL_ERROR_KEYS)
         return results

--- a/app/storage/error_counters.py
+++ b/app/storage/error_counters.py
@@ -1,0 +1,75 @@
+"""Helpers for presenting DOCSIS hardware error counters as time series."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, MutableMapping
+from typing import Any
+
+UINT32_COUNTER_SIZE = 2**32
+_UINT32_WRAP_PREVIOUS_MIN = int(UINT32_COUNTER_SIZE * 0.75)
+_UINT32_WRAP_CURRENT_MAX = int(UINT32_COUNTER_SIZE * 0.25)
+
+
+def _coerce_counter(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _looks_like_uint32_wrap(previous_raw: int, current_raw: int) -> bool:
+    """Return True when a raw counter drop matches an unsigned 32-bit rollover."""
+    if current_raw >= previous_raw:
+        return False
+    previous_mod = previous_raw % UINT32_COUNTER_SIZE
+    current_mod = current_raw % UINT32_COUNTER_SIZE
+    return (
+        previous_mod >= _UINT32_WRAP_PREVIOUS_MIN
+        and current_mod <= _UINT32_WRAP_CURRENT_MAX
+    )
+
+
+def unwrap_uint32_counter_series(
+    rows: Iterable[MutableMapping[str, Any]],
+    keys: Iterable[str],
+) -> None:
+    """Unwrap unsigned 32-bit counter rollovers in-place for presentation rows.
+
+    DOCSIS drivers can expose hardware counters as raw uint32 values. Persisting
+    those raw values is useful, but charts should not show a sawtooth when a
+    counter rolls from 4,294,967,295 back to 0. This helper only adjusts returned
+    API/storage series rows; it does not mutate stored snapshots.
+
+    Rows must be ordered oldest-to-newest. Missing/null counters remain
+    missing/null, and ordinary low-value decreases are treated as resets rather
+    than wraps. A real hardware reset from a value near uint32 max to a low value
+    is indistinguishable from a rollover in this presentation-layer heuristic.
+    """
+    state = {
+        key: {"offset": 0, "previous_raw": None, "previous_unwrapped": None}
+        for key in keys
+    }
+    for row in rows:
+        for key, key_state in state.items():
+            if key not in row:
+                continue
+            raw = _coerce_counter(row.get(key))
+            if raw is None:
+                continue
+
+            previous_raw = key_state["previous_raw"]
+            previous_unwrapped = key_state["previous_unwrapped"]
+            if isinstance(previous_raw, int) and isinstance(previous_unwrapped, int):
+                if _looks_like_uint32_wrap(previous_raw, raw):
+                    key_state["offset"] += UINT32_COUNTER_SIZE
+                    while raw + key_state["offset"] <= previous_unwrapped:
+                        key_state["offset"] += UINT32_COUNTER_SIZE
+                elif raw < previous_raw:
+                    key_state["offset"] = 0
+
+            unwrapped = raw + key_state["offset"]
+            row[key] = unwrapped
+            key_state["previous_raw"] = raw
+            key_state["previous_unwrapped"] = unwrapped

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -9,6 +9,10 @@ from typing import cast
 
 from ..types import AnalysisResult
 from ..tz import local_date_to_utc_range, utc_cutoff, utc_now
+from .error_counters import unwrap_uint32_counter_series
+
+
+_SUMMARY_ERROR_KEYS = ("ds_correctable_errors", "ds_uncorrectable_errors")
 
 log = logging.getLogger("docsis.storage")
 
@@ -98,6 +102,10 @@ class SnapshotMixin:
                 "us_channels": json.loads(row[3]),
             }
             results.append(entry)
+        unwrap_uint32_counter_series(
+            (entry["summary"] for entry in results),
+            _SUMMARY_ERROR_KEYS,
+        )
         return results
 
     def get_intraday_data(self, date):
@@ -117,6 +125,7 @@ class SnapshotMixin:
             entry = {"timestamp": row[0]}
             entry.update(_normalize_summary_errors(json.loads(row[1])))
             results.append(entry)
+        unwrap_uint32_counter_series(results, _SUMMARY_ERROR_KEYS)
         return results
 
     def _summary_rows_to_entries(self, rows):
@@ -125,6 +134,7 @@ class SnapshotMixin:
             entry = {"timestamp": row[0]}
             entry.update(_normalize_summary_errors(json.loads(row[1])))
             results.append(entry)
+        unwrap_uint32_counter_series(results, _SUMMARY_ERROR_KEYS)
         return results
 
     def get_summary_since(self, hours):

--- a/tests/test_channel_timeline.py
+++ b/tests/test_channel_timeline.py
@@ -204,6 +204,61 @@ class TestGetChannelHistory:
         assert result[1][0]["correctable_errors"] is None
         assert result[1][0]["uncorrectable_errors"] is None
 
+    def test_unwraps_32bit_downstream_error_counter_wrap(self, storage):
+        ds_near_wrap = [
+            {"channel_id": 1, "frequency": "114.0 MHz", "power": 5.2,
+             "modulation": "OFDM", "snr": 38.1, "correctable_errors": 4_294_495_351,
+             "uncorrectable_errors": 0, "docsis_version": "3.1",
+             "health": "good", "health_detail": ""},
+        ]
+        ds_after_wrap = [
+            {"channel_id": 1, "frequency": "114.0 MHz", "power": 5.2,
+             "modulation": "OFDM", "snr": 38.1, "correctable_errors": 692_254,
+             "uncorrectable_errors": 0, "docsis_version": "3.1",
+             "health": "good", "health_detail": ""},
+        ]
+        _insert_snapshot(storage, _make_analysis(ds_channels=ds_near_wrap), _utc_ts(timedelta(minutes=2)))
+        _insert_snapshot(storage, _make_analysis(ds_channels=ds_after_wrap), _utc_ts(timedelta(minutes=1)))
+
+        result = storage.get_channel_history(1, "ds", days=7)
+
+        assert [row["correctable_errors"] for row in result] == [
+            4_294_495_351,
+            4_295_659_550,
+        ]
+
+    def test_multi_channel_unwraps_error_counters_per_channel(self, storage):
+        first = [
+            {"channel_id": 1, "frequency": "114.0 MHz", "power": 5.2,
+             "modulation": "OFDM", "snr": 38.1, "correctable_errors": 4_294_495_351,
+             "uncorrectable_errors": 10, "docsis_version": "3.1",
+             "health": "good", "health_detail": ""},
+            {"channel_id": 2, "frequency": "130.0 MHz", "power": 4.8,
+             "modulation": "256QAM", "snr": 37.5, "correctable_errors": 20,
+             "uncorrectable_errors": 0, "docsis_version": "3.0",
+             "health": "good", "health_detail": ""},
+        ]
+        second = [
+            {"channel_id": 1, "frequency": "114.0 MHz", "power": 5.2,
+             "modulation": "OFDM", "snr": 38.1, "correctable_errors": 692_254,
+             "uncorrectable_errors": 11, "docsis_version": "3.1",
+             "health": "good", "health_detail": ""},
+            {"channel_id": 2, "frequency": "130.0 MHz", "power": 4.8,
+             "modulation": "256QAM", "snr": 37.5, "correctable_errors": 25,
+             "uncorrectable_errors": 0, "docsis_version": "3.0",
+             "health": "good", "health_detail": ""},
+        ]
+        _insert_snapshot(storage, _make_analysis(ds_channels=first), _utc_ts(timedelta(minutes=2)))
+        _insert_snapshot(storage, _make_analysis(ds_channels=second), _utc_ts(timedelta(minutes=1)))
+
+        result = storage.get_multi_channel_history([1, 2], "ds", days=7)
+
+        assert [row["correctable_errors"] for row in result[1]] == [
+            4_294_495_351,
+            4_295_659_550,
+        ]
+        assert [row["correctable_errors"] for row in result[2]] == [20, 25]
+
     def test_string_channel_id_matches(self, storage):
         """Drivers like Vodafone Station store channelID as string.
         Ensure channel history still matches when channel_id is stored as str."""

--- a/tests/test_error_counter_unwrap.py
+++ b/tests/test_error_counter_unwrap.py
@@ -1,0 +1,33 @@
+from app.storage.error_counters import unwrap_uint32_counter_series
+
+
+def test_unwrap_uint32_counter_series_preserves_null_gap_for_wrap_detection():
+    rows = [
+        {"errors": 4_294_495_351},
+        {"errors": None},
+        {"errors": 692_254},
+    ]
+
+    unwrap_uint32_counter_series(rows, ["errors"])
+
+    assert [row["errors"] for row in rows] == [
+        4_294_495_351,
+        None,
+        4_295_659_550,
+    ]
+
+
+def test_unwrap_uint32_counter_series_treats_low_drop_as_reset_after_wrap():
+    rows = [
+        {"errors": 4_294_495_351},
+        {"errors": 692_254},
+        {"errors": 10_000},
+    ]
+
+    unwrap_uint32_counter_series(rows, ["errors"])
+
+    assert [row["errors"] for row in rows] == [
+        4_294_495_351,
+        4_295_659_550,
+        10_000,
+    ]

--- a/tests/test_trends_api.py
+++ b/tests/test_trends_api.py
@@ -15,17 +15,27 @@ def _utc_ts(delta: timedelta) -> str:
     return (datetime.now(timezone.utc) - delta).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _analysis(ds_power_avg: float):
+def _analysis(
+    ds_power_avg: float,
+    *,
+    ds_correctable_errors: int | None = None,
+    ds_uncorrectable_errors: int | None = None,
+):
+    summary = {
+        "ds_total": 1,
+        "us_total": 1,
+        "health": "good",
+        "health_issues": [],
+        "ds_power_avg": ds_power_avg,
+        "ds_snr_avg": 38.0,
+        "us_power_avg": 42.0,
+    }
+    if ds_correctable_errors is not None:
+        summary["ds_correctable_errors"] = ds_correctable_errors
+    if ds_uncorrectable_errors is not None:
+        summary["ds_uncorrectable_errors"] = ds_uncorrectable_errors
     return {
-        "summary": {
-            "ds_total": 1,
-            "us_total": 1,
-            "health": "good",
-            "health_issues": [],
-            "ds_power_avg": ds_power_avg,
-            "ds_snr_avg": 38.0,
-            "us_power_avg": 42.0,
-        },
+        "summary": summary,
         "ds_channels": [],
         "us_channels": [],
     }
@@ -114,3 +124,33 @@ class TestTrendsRangeEndpoint:
         resp = flask_client.get("/api/trends?range=4h")
 
         assert resp.status_code == 400
+
+    def test_trends_unwrap_32bit_error_counter_rollover(self, client):
+        flask_client, storage = client
+        _insert_snapshot(
+            storage,
+            _analysis(
+                1.0,
+                ds_correctable_errors=4_294_495_351,
+                ds_uncorrectable_errors=0,
+            ),
+            _utc_ts(timedelta(minutes=2)),
+        )
+        _insert_snapshot(
+            storage,
+            _analysis(
+                2.0,
+                ds_correctable_errors=692_254,
+                ds_uncorrectable_errors=0,
+            ),
+            _utc_ts(timedelta(minutes=1)),
+        )
+
+        resp = flask_client.get("/api/trends?range=1d")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert [row["ds_correctable_errors"] for row in data] == [
+            4_294_495_351,
+            4_295_659_550,
+        ]


### PR DESCRIPTION
## Summary
- Unwraps unsigned 32-bit DOCSIS error counter rollovers in returned time-series data.
- Keeps persisted modem snapshots/raw counter values unchanged.
- Preserves missing/null counter semantics for unsupported telemetry.

## Test plan
- `git diff --check`
- `.venv311/bin/python -m pytest -q tests/test_error_counter_unwrap.py tests/test_channel_timeline.py::TestGetChannelHistory::test_unwraps_32bit_downstream_error_counter_wrap tests/test_channel_timeline.py::TestGetChannelHistory::test_multi_channel_unwraps_error_counters_per_channel tests/test_trends_api.py::TestTrendsRangeEndpoint::test_trends_unwrap_32bit_error_counter_rollover --tb=short`
- `.venv311/bin/python -m pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC .venv311/bin/python -m pytest -q tests/e2e --tb=short`
