### PR TITLE
fix: simplify KPI modulation labels

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -728,19 +728,8 @@
         {% set health_class = 'crit' if raw_health == 'critical' else ('warn' if raw_health == 'warning' else ('muted' if raw_health == 'missing' else raw_health)) %}
         {% set metric_raw_health = range_data.health if range_data and range_data.health is defined else metric.get('health', raw_health) %}
         {% set metric_health_class = 'crit' if metric_raw_health == 'critical' else ('warn' if metric_raw_health == 'warning' else ('muted' if metric_raw_health == 'missing' else metric_raw_health)) %}
-        {% set modulation_raw_health = modulation.get('health', 'missing') %}
-        {% set modulation_health_class = 'crit' if modulation_raw_health == 'critical' else ('warn' if modulation_raw_health == 'warning' else ('muted' if modulation_raw_health == 'missing' else modulation_raw_health)) %}
-        {% set health_cause = family.get('health_cause') %}
-        {% set health_cause_label = none %}
-        {% if health_cause == 'modulation' and metric_key != 'modulation' %}
-            {% set health_cause_label = t.get('signal_family_modulation_label', 'Modulation') %}
-        {% elif health_cause == 'power' and metric_key != 'power' %}
-            {% set health_cause_label = t.get('signal_family_metric_power', 'Power') %}
-        {% elif health_cause == 'snr' and metric_key != 'snr' %}
-            {% set health_cause_label = t.get('signal_family_metric_snr', 'SNR') %}
-        {% elif health_cause == 'mer' and metric_key != 'mer' %}
-            {% set health_cause_label = t.get('signal_family_metric_mer', 'MER') %}
-        {% endif %}
+        {% set modulation_health = modulation.get('health', 'missing') %}
+        {% set modulation_health_class = 'crit' if modulation_health == 'critical' else ('warn' if modulation_health == 'warning' else ('muted' if modulation_health == 'missing' else modulation_health)) %}
         {% set metric_value = metric.get('avg') %}
         {% set family_count = family.get('count', 0) %}
         <div class="metric-card glass" id="{{ card_id }}">
@@ -762,13 +751,11 @@
                 <span class="metric-context">
                     <span class="metric-sub-label">{{ t.get('metric_status_label', 'Status') }}</span>
                     <span class="badge badge-{{ raw_health }} badge-{{ health_class }}">{{ health_labels.get(raw_health, health_labels.get(health_class, raw_health|title)) }}</span>
-                    {% if health_cause_label %}<span class="metric-status-cause">· {{ health_cause_label }}</span>{% endif %}
                 </span>
             </div>
             {% if modulation.get('value') %}
             <div class="metric-sub metric-modulation-row">
-                <span class="range" style="color:var(--{{ modulation_health_class }});">{{ t.get('signal_family_modulation_label', 'Modulation') }}: {{ modulation.get('value') }}{% if modulation.get('secondary') %} — {{ modulation.get('secondary') }}{% endif %}</span>
-                <span class="badge badge-{{ modulation_raw_health }} badge-{{ modulation_health_class }}">{{ health_labels.get(modulation_raw_health, health_labels.get(modulation_health_class, modulation_raw_health|title)) }}</span>
+                <span class="range" style="color:var(--{{ modulation_health_class }});">{{ modulation.get('value') }}{% if modulation.get('secondary') %} — {{ modulation.get('secondary') }}{% endif %}</span>
             </div>
             {% endif %}
             {% if metric_value is not none and range_data %}

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -68,7 +68,10 @@ class TestModulationNavigation:
             card = demo_page.locator(f"#{card_id}")
             expect(card).to_be_visible()
             expect(card).to_contain_text(label)
-            expect(card).to_contain_text("Modulation:")
+            modulation_row = card.locator(".metric-modulation-row")
+            expect(modulation_row).to_be_visible()
+            expect(modulation_row.locator(".badge")).to_have_count(0)
+            expect(modulation_row).not_to_contain_text("Modulation:")
 
     def test_home_family_kpis_share_hero_without_modulation_card(self, page, live_server):
         page.set_viewport_size({"width": 1280, "height": 900})

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -461,7 +461,7 @@ class TestIndexRoute:
         assert "DS POWER AVG" not in html
         assert "US POWER AVG" not in html
 
-    def test_home_signal_family_card_status_uses_composite_health_with_hidden_cause(self, client, sample_analysis):
+    def test_home_signal_family_card_status_uses_composite_health_without_cause_suffix(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
         ofdma = sample_analysis["summary"]["signal_families"]["upstream"]["families"]["ofdma"]
         ofdma["health"] = "critical"
@@ -480,16 +480,17 @@ class TestIndexRoute:
         status_row = card[card.index('<div class="metric-sub metric-status-row">'):]
         status_row = status_row[:status_row.index("</div>")]
         assert "badge badge-critical" in status_row
-        assert "Modulation" in status_row
+        assert "metric-status-cause" not in status_row
+        assert "Modulation" not in status_row
         assert "--metric-range-accent: var(--warn);" in card
 
-    def test_home_signal_family_modulation_row_shows_own_health(self, client, sample_analysis):
+    def test_home_signal_family_modulation_row_shows_values_without_label_or_second_status_pill(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
         ofdma = sample_analysis["summary"]["signal_families"]["upstream"]["families"]["ofdma"]
         ofdma["health"] = "critical"
         ofdma["health_cause"] = "modulation"
         ofdma["power"].update({"available": True, "avg": 49.5, "min": 49.5, "max": 49.5, "health": "warning"})
-        ofdma["modulation"].update({"value": "32QAM", "distinct": ["32QAM"], "health": "critical"})
+        ofdma["modulation"].update({"value": "32QAM", "secondary": "16QAM", "distinct": ["32QAM", "16QAM"], "health": "critical"})
         sample_analysis["summary"]["us_ofdma_power_avg"] = 49.5
         update_state(analysis=sample_analysis)
 
@@ -499,8 +500,9 @@ class TestIndexRoute:
         card = _element_by_id(resp.get_data(as_text=True), "metric-us-ofdma-card")
         modulation_row = card[card.index('<div class="metric-sub metric-modulation-row">'):]
         modulation_row = modulation_row[:modulation_row.index("</div>")]
-        assert "Modulation: 32QAM" in modulation_row
-        assert "badge badge-critical" in modulation_row
+        assert "32QAM — 16QAM" in modulation_row
+        assert "Modulation:" not in modulation_row
+        assert "badge badge-critical" not in modulation_row
         assert "style=\"color:var(--crit);\"" in modulation_row
 
     def test_home_signal_family_card_omits_cause_when_status_matches_visible_metric(self, client, sample_analysis):


### PR DESCRIPTION
## Summary
- Removes the status-cause suffix from signal-family KPI cards.
- Shows modulation values without the `Modulation:` prefix.
- Removes the second status pill from the modulation row.

## Test plan
- `git diff --check`
- `.venv311/bin/python -m pytest -q tests/web/test_index.py::TestIndexRoute::test_home_signal_family_card_status_uses_composite_health_without_cause_suffix tests/web/test_index.py::TestIndexRoute::test_home_signal_family_modulation_row_shows_values_without_label_or_second_status_pill tests/test_static_contracts.py::test_home_signal_family_modulation_rows_stack_below_status --tb=short`
- `.venv311/bin/python -m pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC .venv311/bin/python -m pytest -q tests/e2e --tb=short`
