### PR TITLE
fix: restore plain modulation prefix

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -755,6 +755,7 @@
             </div>
             {% if modulation.get('value') %}
             <div class="metric-sub metric-modulation-row">
+                <span class="metric-sub-label">{{ t.get('signal_family_modulation_label', 'Modulation') }}:</span>
                 <span class="range" style="color:var(--{{ modulation_health_class }});">{{ modulation.get('value') }}{% if modulation.get('secondary') %} — {{ modulation.get('secondary') }}{% endif %}</span>
             </div>
             {% endif %}

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -71,7 +71,10 @@ class TestModulationNavigation:
             modulation_row = card.locator(".metric-modulation-row")
             expect(modulation_row).to_be_visible()
             expect(modulation_row.locator(".badge")).to_have_count(0)
-            expect(modulation_row).not_to_contain_text("Modulation:")
+            expect(modulation_row.locator(".metric-sub-label")).to_have_text("Modulation:")
+            value = modulation_row.locator(".range")
+            expect(value).to_contain_text("QAM")
+            expect(value).not_to_contain_text("Modulation:")
 
     def test_home_family_kpis_share_hero_without_modulation_card(self, page, live_server):
         page.set_viewport_size({"width": 1280, "height": 900})

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -484,7 +484,7 @@ class TestIndexRoute:
         assert "Modulation" not in status_row
         assert "--metric-range-accent: var(--warn);" in card
 
-    def test_home_signal_family_modulation_row_shows_values_without_label_or_second_status_pill(self, client, sample_analysis):
+    def test_home_signal_family_modulation_row_shows_plain_label_and_colored_values_without_second_status_pill(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
         ofdma = sample_analysis["summary"]["signal_families"]["upstream"]["families"]["ofdma"]
         ofdma["health"] = "critical"
@@ -500,10 +500,10 @@ class TestIndexRoute:
         card = _element_by_id(resp.get_data(as_text=True), "metric-us-ofdma-card")
         modulation_row = card[card.index('<div class="metric-sub metric-modulation-row">'):]
         modulation_row = modulation_row[:modulation_row.index("</div>")]
-        assert "32QAM — 16QAM" in modulation_row
-        assert "Modulation:" not in modulation_row
+        assert '<span class="metric-sub-label">Modulation:</span>' in modulation_row
+        assert '<span class="range" style="color:var(--crit);">32QAM — 16QAM</span>' in modulation_row
+        assert '<span class="range" style="color:var(--crit);">Modulation:' not in modulation_row
         assert "badge badge-critical" not in modulation_row
-        assert "style=\"color:var(--crit);\"" in modulation_row
 
     def test_home_signal_family_card_omits_cause_when_status_matches_visible_metric(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)


### PR DESCRIPTION
## Summary
- Restores the `Modulation:` prefix on signal-family KPI modulation rows
- Keeps the prefix plain while only the QAM value span carries health coloring
- Keeps the duplicate status pill out of the modulation row

## Test plan
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/web/test_index.py -q`
- `TZ=UTC uv run --with-requirements requirements.txt --with-requirements requirements-test.txt --with pytest-playwright --with playwright python -m pytest tests/e2e/test_modulation.py -q`
- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest -q tests --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements.txt --with-requirements requirements-test.txt --with pytest-playwright --with playwright python -m pytest -q tests/e2e --tb=short`
