### PR TITLE
Color modulation values individually

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -515,16 +515,31 @@ def _stats(values):
     }
 
 
-def _distinct_modulations(channels, *, prefer_profile=False):
-    values = []
+def _channel_modulation_value(channel, *, prefer_profile=False):
+    if prefer_profile:
+        return channel.get("profile_modulation") or channel.get("modulation")
+    return channel.get("modulation") or channel.get("profile_modulation")
+
+
+def _modulation_sort_key(value):
+    return _parse_qam_order(value) or 0, value
+
+
+def _distinct_modulation_healths(channels, *, prefer_profile=False):
+    health_by_value = {}
     for channel in channels:
-        if prefer_profile:
-            value = channel.get("profile_modulation") or channel.get("modulation")
-        else:
-            value = channel.get("modulation") or channel.get("profile_modulation")
-        if value:
-            values.append(str(value))
-    return sorted(set(values), key=lambda value: (_parse_qam_order(value) or 0, value))
+        value = _channel_modulation_value(channel, prefer_profile=prefer_profile)
+        if not value:
+            continue
+        value = str(value)
+        health = channel.get("modulation_health", "good")
+        if value in health_by_value:
+            health = _worst_health([health_by_value[value], health])
+        health_by_value[value] = health
+    return [
+        {"value": value, "health": health_by_value[value]}
+        for value in sorted(health_by_value, key=_modulation_sort_key)
+    ]
 
 
 def _channel_text(channel, *keys):
@@ -600,7 +615,8 @@ def _family_summary(family, channels, *, direction):
     prefer_profile = family in {"ofdm", "ofdma"}
     power = _stats([channel.get("power") for channel in channels])
     quality = _stats([channel.get("snr") for channel in channels]) if direction == "downstream" else None
-    modulation_values = _distinct_modulations(channels, prefer_profile=prefer_profile)
+    modulation_value_healths = _distinct_modulation_healths(channels, prefer_profile=prefer_profile)
+    modulation_values = [entry["value"] for entry in modulation_value_healths]
     power_health = _worst_health(
         channel.get("power_health", "good") for channel in channels if channel.get("power") is not None
     )
@@ -609,11 +625,7 @@ def _family_summary(family, channels, *, direction):
         if direction == "downstream"
         else "missing"
     )
-    modulation_health = _worst_health(
-        channel.get("modulation_health", "good")
-        for channel in channels
-        if channel.get("modulation") or channel.get("profile_modulation")
-    )
+    modulation_health = _worst_health(entry["health"] for entry in modulation_value_healths)
 
     metrics = [power_health, modulation_health]
     if direction == "downstream":
@@ -643,6 +655,7 @@ def _family_summary(family, channels, *, direction):
             "value": modulation_values[0] if modulation_values else None,
             "secondary": modulation_values[-1] if len(modulation_values) > 1 else None,
             "distinct": modulation_values,
+            "values": modulation_value_healths,
             "health": modulation_health,
         },
     }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -730,6 +730,7 @@
         {% set metric_health_class = 'crit' if metric_raw_health == 'critical' else ('warn' if metric_raw_health == 'warning' else ('muted' if metric_raw_health == 'missing' else metric_raw_health)) %}
         {% set modulation_health = modulation.get('health', 'missing') %}
         {% set modulation_health_class = 'crit' if modulation_health == 'critical' else ('warn' if modulation_health == 'warning' else ('muted' if modulation_health == 'missing' else modulation_health)) %}
+        {% set modulation_values = modulation.get('values') %}
         {% set metric_value = metric.get('avg') %}
         {% set family_count = family.get('count', 0) %}
         <div class="metric-card glass" id="{{ card_id }}">
@@ -756,7 +757,18 @@
             {% if modulation.get('value') %}
             <div class="metric-sub metric-modulation-row">
                 <span class="metric-sub-label">{{ t.get('signal_family_modulation_label', 'Modulation') }}:</span>
-                <span class="range" style="color:var(--{{ modulation_health_class }});">{{ modulation.get('value') }}{% if modulation.get('secondary') %} — {{ modulation.get('secondary') }}{% endif %}</span>
+                {% if modulation_values %}
+                    {% for modulation_value in modulation_values %}
+                        {% set value_raw_health = modulation_value.get('health', modulation_health) %}
+                        {% set value_health_class = 'crit' if value_raw_health == 'critical' else ('warn' if value_raw_health == 'warning' else ('muted' if value_raw_health == 'missing' else value_raw_health)) %}
+                        {% if not loop.first %}<span class="metric-sub-label metric-modulation-separator">—</span>{% endif %}
+                        <span class="range metric-modulation-value" style="color:var(--{{ value_health_class }});">{{ modulation_value.get('value') }}</span>
+                    {% endfor %}
+                {% else %}
+                    <span class="range metric-modulation-value" style="color:var(--{{ modulation_health_class }});">{{ modulation.get('value') }}</span>{% if modulation.get('secondary') %}
+                    <span class="metric-sub-label metric-modulation-separator">—</span>
+                    <span class="range metric-modulation-value" style="color:var(--{{ modulation_health_class }});">{{ modulation.get('secondary') }}</span>{% endif %}
+                {% endif %}
             </div>
             {% endif %}
             {% if metric_value is not none and range_data %}

--- a/app/types.py
+++ b/app/types.py
@@ -149,6 +149,13 @@ class SignalFamilyMetric(TypedDict):
     health: str
 
 
+class SignalFamilyModulationValue(TypedDict):
+    """One distinct modulation/profile value with its own health."""
+
+    value: str
+    health: str
+
+
 class SignalFamilyModulation(TypedDict):
     """Aggregated modulation/profile values for a DOCSIS signal family."""
 
@@ -156,6 +163,7 @@ class SignalFamilyModulation(TypedDict):
     value: str | None
     secondary: str | None
     distinct: list[str]
+    values: list[SignalFamilyModulationValue]
     health: str
 
 

--- a/tests/analyzer/test_signal_metrics.py
+++ b/tests/analyzer/test_signal_metrics.py
@@ -504,6 +504,66 @@ class TestSignalFamilySummaries:
         assert ofdma["health"] == "critical"
         assert ofdma["health_cause"] == "modulation"
 
+    def test_upstream_sc_qam_family_keeps_health_per_distinct_modulation_value(self):
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us30=[
+                _make_us30(1, power=42.0, modulation="4QAM"),
+                _make_us30(2, power=42.0, modulation="64QAM"),
+            ],
+        )
+
+        result = analyze(data)
+
+        sc_qam = result["summary"]["signal_families"]["upstream"]["families"]["sc_qam"]
+        assert sc_qam["modulation"]["value"] == "4QAM"
+        assert sc_qam["modulation"]["secondary"] == "64QAM"
+        assert sc_qam["modulation"]["health"] == "critical"
+        assert sc_qam["modulation"]["values"] == [
+            {"value": "4QAM", "health": "critical"},
+            {"value": "64QAM", "health": "good"},
+        ]
+
+    def test_modulation_value_healths_keep_worst_health_for_duplicate_values(self):
+        channels = [
+            {"modulation": "64QAM", "modulation_health": "good"},
+            {"modulation": "64QAM", "modulation_health": "warning"},
+        ]
+
+        values = analyzer._distinct_modulation_healths(channels)
+
+        assert values == [{"value": "64QAM", "health": "warning"}]
+
+    def test_upstream_ofdma_family_keeps_health_per_distinct_profile_modulation_value(self):
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us31=[
+                {
+                    "channelID": 5,
+                    "frequency": "30-65 MHz",
+                    "type": "OFDMA",
+                    "powerLevel": "49.5",
+                    "profile_modulation": "32QAM",
+                },
+                {
+                    "channelID": 6,
+                    "frequency": "65-85 MHz",
+                    "type": "OFDMA",
+                    "powerLevel": "49.0",
+                    "profile_modulation": "256QAM",
+                },
+            ],
+        )
+
+        result = analyze(data)
+
+        ofdma = result["summary"]["signal_families"]["upstream"]["families"]["ofdma"]
+        assert ofdma["modulation"]["health"] == "critical"
+        assert ofdma["modulation"]["values"] == [
+            {"value": "32QAM", "health": "critical"},
+            {"value": "256QAM", "health": "good"},
+        ]
+
     def test_downstream_family_health_cause_is_none_when_all_metrics_are_good(self):
         data = _make_data(
             ds30=[_make_ds30(1, power=2.0, mse="-35")],

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -490,7 +490,16 @@ class TestIndexRoute:
         ofdma["health"] = "critical"
         ofdma["health_cause"] = "modulation"
         ofdma["power"].update({"available": True, "avg": 49.5, "min": 49.5, "max": 49.5, "health": "warning"})
-        ofdma["modulation"].update({"value": "32QAM", "secondary": "16QAM", "distinct": ["32QAM", "16QAM"], "health": "critical"})
+        ofdma["modulation"].update({
+            "value": "4QAM",
+            "secondary": "64QAM",
+            "distinct": ["4QAM", "64QAM"],
+            "values": [
+                {"value": "4QAM", "health": "critical"},
+                {"value": "64QAM", "health": "good"},
+            ],
+            "health": "critical",
+        })
         sample_analysis["summary"]["us_ofdma_power_avg"] = 49.5
         update_state(analysis=sample_analysis)
 
@@ -501,9 +510,35 @@ class TestIndexRoute:
         modulation_row = card[card.index('<div class="metric-sub metric-modulation-row">'):]
         modulation_row = modulation_row[:modulation_row.index("</div>")]
         assert '<span class="metric-sub-label">Modulation:</span>' in modulation_row
-        assert '<span class="range" style="color:var(--crit);">32QAM — 16QAM</span>' in modulation_row
-        assert '<span class="range" style="color:var(--crit);">Modulation:' not in modulation_row
+        assert '<span class="range metric-modulation-value" style="color:var(--crit);">4QAM</span>' in modulation_row
+        assert '<span class="metric-sub-label metric-modulation-separator">—</span>' in modulation_row
+        assert '<span class="range metric-modulation-value" style="color:var(--good);">64QAM</span>' in modulation_row
+        assert '<span class="range metric-modulation-value" style="color:var(--crit);">4QAM — 64QAM</span>' not in modulation_row
+        assert '<span class="range metric-modulation-value" style="color:var(--crit);">—</span>' not in modulation_row
+        assert '<span class="range metric-modulation-value" style="color:var(--crit);">Modulation:' not in modulation_row
         assert "badge badge-critical" not in modulation_row
+
+    def test_home_signal_family_modulation_row_renders_single_value_without_separator(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        sc_qam = sample_analysis["summary"]["signal_families"]["upstream"]["families"]["sc_qam"]
+        sc_qam["modulation"].update({
+            "value": "64QAM",
+            "secondary": None,
+            "distinct": ["64QAM"],
+            "values": [{"value": "64QAM", "health": "good"}],
+            "health": "good",
+        })
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        card = _element_by_id(resp.get_data(as_text=True), "metric-us-sc-qam-card")
+        modulation_row = card[card.index('<div class="metric-sub metric-modulation-row">'):]
+        modulation_row = modulation_row[:modulation_row.index("</div>")]
+        assert '<span class="metric-sub-label">Modulation:</span>' in modulation_row
+        assert '<span class="range metric-modulation-value" style="color:var(--good);">64QAM</span>' in modulation_row
+        assert "metric-modulation-separator" not in modulation_row
 
     def test_home_signal_family_card_omits_cause_when_status_matches_visible_metric(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)


### PR DESCRIPTION
## Summary
- add per-value health metadata for signal-family modulation values
- render each modulation value with its own health color while keeping the label and separator plain
- cover mixed values, duplicate-value worst-health aggregation, OFDMA profile modulation, and single-value rows

## Tests
- `uv run --with-requirements requirements-test.txt python -m pytest tests/analyzer/test_signal_metrics.py tests/web/test_index.py -q`
- `uv run --with-requirements requirements-test.txt python -m pytest -q --ignore=tests/e2e`
- `uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q tests/e2e/test_modulation.py tests/e2e/test_modulation_visual.py --tb=short`
- `uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q tests/e2e --tb=short`

Note: a plain full-suite run without Playwright extras fails during E2E collection because `playwright` is not installed by `requirements-test.txt`; rerunning with the documented Playwright packages passes.