### PR TITLE
Fix incident report customer details

### DIFF
--- a/app/modules/journal/routes.py
+++ b/app/modules/journal/routes.py
@@ -655,10 +655,16 @@ def api_incident_report(incident_id):
 
     conn_info = get_state().get("connection_info") or {}
     lang = _get_lang()
+    customer_name = request.args.get("name", "")
+    customer_number = request.args.get("number", "")
+    customer_address = request.args.get("address", "")
 
     pdf_bytes = generate_incident_report(
         incident, entries, snapshots, speedtests, bnetz,
         config, conn_info, lang,
+        customer_name=customer_name,
+        customer_number=customer_number,
+        customer_address=customer_address,
         attachment_loader=_storage.get_attachment,
     )
 

--- a/app/modules/reports/report.py
+++ b/app/modules/reports/report.py
@@ -771,6 +771,7 @@ def generate_report(
 
 def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_list,
                               config=None, connection_info=None, lang="en",
+                              customer_name="", customer_number="", customer_address="",
                               attachment_loader=None):
     """Generate PDF complaint report scoped to a specific incident.
 
@@ -783,6 +784,9 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
         config: Config dict (isp_name, modem_type)
         connection_info: Connection info dict
         lang: Language code
+        customer_name: Customer name for the embedded complaint letter
+        customer_number: Customer/contract number for the embedded complaint letter
+        customer_address: Customer address for the embedded complaint letter
         attachment_loader: Optional callable(attachment_id) -> dict with 'data', 'mime_type'
 
     Returns:
@@ -1075,7 +1079,8 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
         if has_dev:
             complaint += s.get("complaint_bnetz_legal", "") + "\n\n"
 
-    complaint += f"{s['complaint_escalation']}\n\n{s['complaint_closing']}"
+    complaint_closing = _format_customer_closing(s, customer_name, customer_number, customer_address)
+    complaint += f"{s['complaint_escalation']}\n\n{complaint_closing}"
 
     pdf.multi_cell(0, 4, complaint)
 

--- a/app/static/js/journal.js
+++ b/app/static/js/journal.js
@@ -1010,8 +1010,17 @@ window.closeIncidentTimeline = function() {
 window.downloadIncidentPdf = function(incidentId, incidentName) {
     var btn = document.querySelector('.incident-timeline-pdf-btn');
     var origHtml = btn ? btn.innerHTML : '';
+    var params = new URLSearchParams();
+    var langInput = document.getElementById('report-lang');
+    var nameInput = document.getElementById('report-name');
+    var numberInput = document.getElementById('report-number');
+    var addressInput = document.getElementById('report-address');
+    if (langInput) params.set('lang', langInput.value);
+    if (nameInput) params.set('name', nameInput.value);
+    if (numberInput) params.set('number', numberInput.value);
+    if (addressInput) params.set('address', addressInput.value);
     if (btn) { btn.disabled = true; btn.textContent = '\u23F3'; }
-    fetch('/api/incidents/' + incidentId + '/report')
+    fetch('/api/incidents/' + incidentId + '/report?' + params.toString())
         .then(function(r) {
             if (!r.ok) throw new Error('Failed');
             return r.blob();

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v40';
+var CACHE_VERSION = 'v41';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_modals.py
+++ b/tests/e2e/test_modals.py
@@ -169,6 +169,32 @@ def test_incident_modal_and_summary_offer_report_path(demo_page):
     expect(summary.get_by_role("button", name="Build report")).to_be_visible()
 
 
+def test_incident_report_pdf_download_preserves_customer_details_e2e(demo_page):
+    """Incident PDF download keeps customer fields entered in the report builder."""
+    demo_page.route(
+        "**/api/incidents/381/report?**",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/pdf",
+            body="%PDF-1.4\n%%EOF",
+        ),
+    )
+
+    demo_page.locator("#report-link").click()
+    modal = demo_page.locator("#report-modal")
+    modal.locator("#report-name").fill("Max Mustermann")
+    modal.locator("#report-number").fill("KD-123456")
+    modal.locator("#report-address").fill("Musterstraße 1, 12345 Musterstadt")
+
+    with demo_page.expect_request("**/api/incidents/381/report?**") as report_request:
+        demo_page.evaluate("downloadIncidentPdf(381, 'Packet loss evening window')")
+
+    params = parse_qs(urlparse(report_request.value.url).query)
+    assert params["name"] == ["Max Mustermann"]
+    assert params["number"] == ["KD-123456"]
+    assert params["address"] == ["Musterstraße 1, 12345 Musterstadt"]
+
+
 def test_report_modal_frames_isp_ready_evidence_builder(demo_page):
     """The report modal previews evidence contents, privacy expectations, and output actions before generation."""
     demo_page.locator("#report-link").click()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -9,7 +9,7 @@ from pypdf import PdfReader
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app.modules.reports.report import (
-    generate_report, generate_complaint_text,
+    generate_report, generate_incident_report, generate_complaint_text,
     _compute_worst_values, _find_worst_channels,
     _format_threshold_table, _default_warn_thresholds,
 )
@@ -253,6 +253,41 @@ def test_generate_report_embeds_customer_details_in_complaint_closing():
     pdf = generate_report(
         MOCK_SNAPSHOTS,
         MOCK_ANALYSIS,
+        lang="de",
+        customer_name="Max Mustermann",
+        customer_number="KD-123456",
+        customer_address="Musterstraße 1\n12345 Musterstadt",
+    )
+    text = "\n".join(
+        page.extract_text() or ""
+        for page in PdfReader(io.BytesIO(pdf)).pages
+    )
+
+    assert "Max Mustermann" in text
+    assert "KD-123456" in text
+    assert "Musterstraße 1" in text
+    assert "12345 Musterstadt" in text
+    assert "[Ihr Name]" not in text
+    assert "[Kundennummer]" not in text
+    assert "[Adresse]" not in text
+
+
+def test_generate_incident_report_embeds_customer_details_in_complaint_closing():
+    incident = {
+        "name": "Repeated outages",
+        "status": "open",
+        "description": "Recurring signal loss during the evening.",
+        "start_date": "2026-05-01",
+        "end_date": "2026-05-03",
+    }
+    pdf = generate_incident_report(
+        incident,
+        entries=[],
+        snapshots=MOCK_SNAPSHOTS,
+        speedtests=[],
+        bnetz_list=[],
+        config={"isp_name": "Vodafone", "modem_type": "FRITZ!Box 6690"},
+        connection_info={"max_downstream_kbps": 1000000, "max_upstream_kbps": 50000},
         lang="de",
         customer_name="Max Mustermann",
         customer_number="KD-123456",

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -39,6 +39,7 @@ SEGMENT_UTILIZATION_JS = ROOT / "app" / "static" / "js" / "segment-utilization.j
 BQM_CHART_JS = ROOT / "app" / "modules" / "bqm" / "static" / "js" / "bqm-chart.js"
 COMPARISON_MAIN_JS = ROOT / "app" / "modules" / "comparison" / "static" / "main.js"
 UTILS_JS = ROOT / "app" / "static" / "js" / "utils.js"
+JOURNAL_JS = ROOT / "app" / "static" / "js" / "journal.js"
 
 
 def test_report_pdf_download_preserves_customer_detail_params():
@@ -50,6 +51,17 @@ def test_report_pdf_download_preserves_customer_detail_params():
     assert "params.set('address', document.getElementById('report-address').value)" in download_block
     assert "new URLSearchParams()" in download_block
     assert "params.toString()" in download_block
+
+
+def test_incident_pdf_download_preserves_customer_detail_params():
+    js = JOURNAL_JS.read_text(encoding="utf-8")
+    download_block = js[js.index("window.downloadIncidentPdf") : js.index("function renderIncidentTimeline")]
+
+    assert "new URLSearchParams()" in download_block
+    assert "params.set('name', nameInput.value)" in download_block
+    assert "params.set('number', numberInput.value)" in download_block
+    assert "params.set('address', addressInput.value)" in download_block
+    assert "'/api/incidents/' + incidentId + '/report?' + params.toString()" in download_block
 
 
 def test_correlation_timeline_sticky_header_uses_opaque_surface():
@@ -125,7 +137,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v40';" in sw_js
+    assert "var CACHE_VERSION = 'v41';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js

--- a/tests/web/test_reports.py
+++ b/tests/web/test_reports.py
@@ -103,6 +103,44 @@ class TestComplaintRoutes:
         assert generate_report.call_args.kwargs["customer_number"] == "KD-123456"
         assert generate_report.call_args.kwargs["customer_address"] == "Musterstraße 1\n12345 Musterstadt"
 
+    def test_api_incident_report_passes_customer_details_to_pdf_generator(self):
+        from app.modules.journal import routes
+
+        storage = Mock()
+        storage.get_incident.return_value = {
+            "id": 7,
+            "name": "Repeated outages",
+            "status": "open",
+            "description": "Recurring signal loss.",
+        }
+        storage.get_entries.return_value = []
+        storage.get_attachment.return_value = None
+        config_manager = Mock()
+        config_manager.get.side_effect = lambda key, default="": {
+            "isp_name": "Example ISP",
+            "modem_type": "Example Modem",
+        }.get(key, default)
+        pdf_bytes = b"%PDF-1.4\nincident-customer-data\n"
+
+        with app.test_request_context(
+            "/api/incidents/7/report?lang=de"
+            "&name=Max%20Mustermann"
+            "&number=KD-123456"
+            "&address=Musterstra%C3%9Fe%201%0A12345%20Musterstadt"
+        ):
+            with patch.object(routes, "_get_journal_storage", return_value=storage), \
+                 patch.object(routes, "get_config_manager", return_value=config_manager), \
+                 patch.object(routes, "get_state", return_value={"connection_info": {}}), \
+                 patch("app.modules.reports.report.generate_incident_report", return_value=pdf_bytes) as generate_incident_report:
+                response = getattr(routes.api_incident_report, "__wrapped__")(7)
+
+        assert response.status_code == 200
+        assert response.data == pdf_bytes
+        generate_incident_report.assert_called_once()
+        assert generate_incident_report.call_args.kwargs["customer_name"] == "Max Mustermann"
+        assert generate_incident_report.call_args.kwargs["customer_number"] == "KD-123456"
+        assert generate_incident_report.call_args.kwargs["customer_address"] == "Musterstraße 1\n12345 Musterstadt"
+
     def test_get_comparison_data_helper(self):
         from app.modules.reports.routes import _get_comparison_data
 


### PR DESCRIPTION
## Summary
- Passes report builder customer details through the Incident Journal PDF download path.
- Uses the shared PDF closing formatter for incident reports so customer name, number, and address replace localized placeholders when provided.
- Bumps the service-worker cache version for the updated journal JavaScript.

## Validation
- `git diff --check`
- Targeted incident PDF regression tests
- `pytest -q tests --ignore=tests/e2e`
- `pytest -q tests/e2e` in resource-safe batches, 416 collected / 416 passed

Closes #552
