### PR TITLE
Add Hitron CODA-4680 driver

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -410,6 +410,7 @@ class ModemDriver(ABC):
 | `cm3000` | `cm3000.py` | Netgear CM3000 | HTTP Basic Auth |
 | `surfboard` | `surfboard.py` | Arris SURFboard S33/S34/SB8200 | HNAP1 HMAC-SHA256 |
 | `cm8200` | `cm8200.py` | Arris Touchstone CM8200A | Base64 query string |
+| `hitron_coda_4680` | `hitron_coda_4680.py` | Hitron CODA-4680 | Form POST (`/1/Device/Users/Login`) |
 | `generic` | `generic.py` | Generic Router (no DOCSIS) | None |
 
 ### Driver Registry (`app/drivers/__init__.py`)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 </p>
 
 <p align="center">
-  <strong>Self-hosted</strong> • <strong>Local data</strong> • <strong>Demo</strong> • <strong>Reports</strong> • <strong>16 modem families</strong> • <strong>MIT</strong>
+  <strong>Self-hosted</strong> • <strong>Local data</strong> • <strong>Demo</strong> • <strong>Reports</strong> • <strong>17 modem families</strong> • <strong>MIT</strong>
 </p>
 
 <p align="center">
@@ -266,7 +266,7 @@ More views from the product:
 
 ## Supported Hardware
 
-DOCSight supports **16 modem families** out of the box and also offers **Generic Router mode** for fiber, DSL, and satellite connections.
+DOCSight supports **17 modem families** out of the box and also offers **Generic Router mode** for fiber, DSL, and satellite connections.
 
 ### Common setups
 
@@ -277,7 +277,7 @@ DOCSight supports **16 modem families** out of the box and also offers **Generic
 - **Sagemcom F@st 3896:** JSON-RPC API
 - **Technicolor TC4400**
 - **Arris SURFboard** (S33, S34, SB8200): HNAP1 API
-- **Hitron CODA-56**
+- **Hitron CODA-56 and CODA-4680**
 - **Netgear CM3000**
 - **Generic Router mode:** no DOCSIS signal pages, but still supports speed tracking, latency monitoring, incident logging, reports, and modules
 

--- a/app/drivers/__init__.py
+++ b/app/drivers/__init__.py
@@ -36,6 +36,9 @@ driver_registry.register_builtin("cm8200", "app.drivers.cm8200.CM8200Driver",
 driver_registry.register_builtin("hitron", "app.drivers.hitron.HitronDriver",
                                  "Hitron CODA-56",
                                  hints={"default_url": "http://192.168.100.1", "credentials_required": False})
+driver_registry.register_builtin("hitron_coda_4680", "app.drivers.hitron_coda_4680.HitronCoda4680Driver",
+                                 "Hitron CODA-4680",
+                                 hints={"default_url": "http://192.168.100.1", "default_user": "admin"})
 driver_registry.register_builtin("sagemcom", "app.drivers.sagemcom.SagemcomDriver",
                                  "Sagemcom F@st 3896",
                                  hints={"default_url": "http://192.168.100.1", "default_user": "admin"})

--- a/app/drivers/hitron_coda_4680.py
+++ b/app/drivers/hitron_coda_4680.py
@@ -1,0 +1,252 @@
+"""Authenticated Hitron CODA-4680 modem driver for DOCSight.
+
+The CODA-4680 web UI uses Backbone endpoints under ``/1/Device/CM`` and
+requires a simple form login before DOCSIS data is available.  Unlike the
+CODA-56-style Hitron driver, this UI returns object payloads whose channel
+lists live under ``Freq_List``, ``OFDMs_List``, and ``OFDMAs_List``.
+
+DOCSIS Event pages are intentionally not collected here. DOCSight currently
+normalizes modem signal data and generates its own analyzer events; it does
+not import vendor modem event logs for other drivers either.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+import requests
+
+from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
+from .base import ModemDriver
+from .utils import hz_to_mhz, make_legacy_tls_adapter, normalize_modulation
+
+log = logging.getLogger("docsis.driver.hitron_coda_4680")
+
+
+class HitronCoda4680Driver(ModemDriver):
+    """Driver for authenticated Hitron CODA-4680 modem/router UIs."""
+
+    def __init__(self, url: str, user: str, password: str):
+        super().__init__(url.rstrip("/"), user, password)
+        self._session = requests.Session()
+        self._session.verify = False
+        self._session.headers.update({
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "Referer": f"{self._url}/webpages/index.html",
+        })
+        self._session.mount("https://", make_legacy_tls_adapter(sec_level=1))
+        self._device_info_cache: DeviceInfo | None = None
+
+    def login(self) -> None:
+        """Authenticate with the CODA-4680 web UI."""
+        payload = {
+            "model": json.dumps({"username": self._user, "password": self._password}),
+        }
+        try:
+            resp = self._session.post(
+                f"{self._url}/1/Device/Users/Login",
+                data=payload,
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Hitron CODA-4680 login failed: {exc}") from exc
+
+        body = self._json_body(resp)
+        if body:
+            self._ensure_ok(body, "login")
+
+        # The login response can be an empty 200. Verify that the authenticated
+        # session can read a protected endpoint before reporting success.
+        self._device_info_cache = self._parse_device_info(
+            self._fetch_payload("/1/Device/CM/Version", raise_on_error=True)
+        )
+        log.info("Hitron CODA-4680 login OK")
+
+    def get_docsis_data(self) -> DocsisData:
+        """Retrieve DOCSIS channel data from the CODA-4680 CM endpoints."""
+        ds_info = self._fetch_payload("/1/Device/CM/DsInfo")
+        us_info = self._fetch_payload("/1/Device/CM/UsInfo")
+        ds_ofdm = self._fetch_payload("/1/Device/CM/DsOfdm")
+        us_ofdma = self._fetch_payload("/1/Device/CM/UsOfdm")
+
+        return {
+            "channelDs": {
+                "docsis30": self._parse_ds_scqam(ds_info.get("Freq_List", [])),
+                "docsis31": self._parse_ds_ofdm(ds_ofdm.get("OFDMs_List", [])),
+            },
+            "channelUs": {
+                "docsis30": self._parse_us_scqam(us_info.get("Freq_List", [])),
+                "docsis31": self._parse_us_ofdma(us_ofdma.get("OFDMAs_List", [])),
+            },
+        }
+
+    def get_device_info(self) -> DeviceInfo:
+        """Retrieve model and firmware from the version endpoint."""
+        if self._device_info_cache is not None:
+            return self._device_info_cache
+        self._device_info_cache = self._parse_device_info(self._fetch_payload("/1/Device/CM/Version"))
+        return self._device_info_cache
+
+    def get_connection_info(self) -> ConnectionInfo:
+        """Retrieve basic DOCSIS WAN state from SysInfo."""
+        payload = self._fetch_payload("/1/Device/CM/SysInfo")
+        if not payload:
+            return {}
+        ip_values = payload.get("ip")
+        wan_ip = ""
+        if isinstance(ip_values, list) and ip_values:
+            wan_ip = str(ip_values[0])
+        return {
+            "connection_type": "DOCSIS",
+            "status": str(payload.get("ntAccess") or ""),
+            "wan_ip": wan_ip,
+            "max_downstream_kbps": self._parse_rate_kbps(payload.get("DsDataRate")),
+            "max_upstream_kbps": self._parse_rate_kbps(payload.get("UsDataRate")),
+        }
+
+    def _fetch_payload(self, path: str, *, raise_on_error: bool = False) -> dict[str, Any]:
+        """Fetch and validate a JSON object endpoint."""
+        try:
+            resp = self._session.get(
+                f"{self._url}{path}?_={self._cache_bust()}",
+                timeout=30,
+            )
+            resp.raise_for_status()
+            payload = self._json_body(resp)
+        except requests.RequestException as exc:
+            if raise_on_error:
+                raise RuntimeError(f"Hitron CODA-4680 fetch {path} failed: {exc}") from exc
+            log.warning("Hitron CODA-4680 fetch %s failed: %s", path, exc)
+            return {}
+
+        if not isinstance(payload, dict):
+            if raise_on_error:
+                raise RuntimeError(f"Hitron CODA-4680 fetch {path} returned invalid JSON payload")
+            log.warning("Hitron CODA-4680 fetch %s returned non-object payload", path)
+            return {}
+        if not self._ensure_ok(payload, path, raise_on_error=raise_on_error):
+            return {}
+        return payload
+
+    @staticmethod
+    def _json_body(resp: requests.Response) -> Any:
+        try:
+            return resp.json()
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _ensure_ok(payload: dict[str, Any], context: str, *, raise_on_error: bool = True) -> bool:
+        code = str(payload.get("errCode", "000"))
+        if code == "000":
+            return True
+        message = str(payload.get("errMsg") or f"errCode {code}")
+        if raise_on_error:
+            raise RuntimeError(f"Hitron CODA-4680 {context} failed: {message}")
+        log.warning("Hitron CODA-4680 %s failed: %s", context, message)
+        return False
+
+    @staticmethod
+    def _parse_device_info(payload: dict[str, Any]) -> DeviceInfo:
+        return {
+            "manufacturer": str(payload.get("vendorName") or "Hitron Technologies"),
+            "model": str(payload.get("ModelReport") or payload.get("modelName") or "CODA-4680"),
+            "sw_version": str(payload.get("SoftwareVersion") or ""),
+        }
+
+    def _parse_ds_scqam(self, rows: list[dict[str, Any]]) -> list[RawChannel]:
+        channels: list[RawChannel] = []
+        for row in rows:
+            try:
+                snr = float(row["snr"])
+                channels.append({
+                    "channelID": int(row["channelId"]),
+                    "frequency": hz_to_mhz(row["frequency"]),
+                    "powerLevel": float(row["signalStrength"]),
+                    "modulation": normalize_modulation(row.get("modulation", "")),
+                    "mer": snr,
+                    "mse": -snr,
+                    "corrErrors": int(row["correcteds"]),
+                    "nonCorrErrors": int(row["uncorrect"]),
+                })
+            except (KeyError, TypeError, ValueError) as exc:
+                log.warning("Failed to parse Hitron CODA-4680 DS row: %s", exc)
+        return channels
+
+    def _parse_us_scqam(self, rows: list[dict[str, Any]]) -> list[RawChannel]:
+        channels: list[RawChannel] = []
+        for row in rows:
+            try:
+                modulation = normalize_modulation(row.get("modulationType") or row.get("modtype") or "")
+                channel: RawChannel = {
+                    "channelID": int(row["channelId"]),
+                    "frequency": hz_to_mhz(row["frequency"]),
+                    "powerLevel": float(row["signalStrength"]),
+                    "modulation": modulation,
+                    # CODA-4680 does not expose scdmaMode in the captured API;
+                    # ATDMA is the SC-QAM upstream lane DOCSight should score.
+                    "multiplex": "ATDMA",
+                }
+                symbol_rate = row.get("symbolrate")
+                if symbol_rate is not None:
+                    channel["symbolRate"] = int(symbol_rate)
+                channels.append(channel)
+            except (KeyError, TypeError, ValueError) as exc:
+                log.warning("Failed to parse Hitron CODA-4680 US row: %s", exc)
+        return channels
+
+    def _parse_ds_ofdm(self, rows: list[dict[str, Any]]) -> list[RawChannel]:
+        channels: list[RawChannel] = []
+        for row in rows:
+            try:
+                if str(row.get("plclock", "")).strip().upper() != "YES":
+                    continue
+                channels.append({
+                    "channelID": int(row["receive"]),
+                    "type": "OFDM",
+                    "frequency": hz_to_mhz(row.get("Subcarr0freqFreq", "")),
+                    "powerLevel": float(row["plcpower"]),
+                    "modulation": "OFDM",
+                    "mer": None,
+                    "mse": None,
+                    "corrErrors": None,
+                    "nonCorrErrors": None,
+                })
+            except (KeyError, TypeError, ValueError) as exc:
+                log.warning("Failed to parse Hitron CODA-4680 DS OFDM row: %s", exc)
+        return channels
+
+    def _parse_us_ofdma(self, rows: list[dict[str, Any]]) -> list[RawChannel]:
+        channels: list[RawChannel] = []
+        for row in rows:
+            try:
+                if str(row.get("state", "")).strip().upper() != "OPERATE":
+                    continue
+                channels.append({
+                    "channelID": int(row["uschindex"]),
+                    "type": "OFDMA",
+                    # The captured CODA-4680 OFDMA API does not expose center
+                    # frequency. Preserve unsupported as blank instead of 0 MHz.
+                    "frequency": "",
+                    "powerLevel": float(row["repPower"]),
+                    "modulation": "OFDMA",
+                    "multiplex": "OFDMA",
+                })
+            except (KeyError, TypeError, ValueError) as exc:
+                log.warning("Failed to parse Hitron CODA-4680 US OFDMA row: %s", exc)
+        return channels
+
+    @staticmethod
+    def _parse_rate_kbps(value: Any) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _cache_bust() -> str:
+        return str(int(time.time() * 1000))

--- a/tests/test_hitron_coda_4680_driver.py
+++ b/tests/test_hitron_coda_4680_driver.py
@@ -1,0 +1,274 @@
+"""Tests for authenticated Hitron CODA-4680 modem driver."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.analyzer import analyze
+from app.drivers import driver_registry
+from app.drivers.hitron_coda_4680 import HitronCoda4680Driver
+
+
+DS_INFO = {
+    "errCode": "000",
+    "errMsg": "",
+    "Freq_List": [
+        {
+            "portId": "1",
+            "frequency": "663000000",
+            "modulation": "QAM256",
+            "signalStrength": "5.099",
+            "snr": "40.946",
+            "channelId": "18",
+            "dsoctets": "1591166190",
+            "correcteds": "5",
+            "uncorrect": "33",
+        },
+        {
+            "portId": "2",
+            "frequency": "591000000",
+            "modulation": "QAM256",
+            "signalStrength": "4.099",
+            "snr": "43.376",
+            "channelId": "7",
+            "dsoctets": "116416",
+            "correcteds": "0",
+            "uncorrect": "0",
+        },
+    ],
+}
+
+US_INFO = {
+    "errCode": "000",
+    "errMsg": "",
+    "Freq_List": [
+        {
+            "portId": "1",
+            "frequency": "32300000",
+            "modulationType": "64QAM",
+            "signalStrength": "42.770",
+            "bandwidth": "6400000",
+            "channelId": "3",
+            "symbolrate": 5120,
+            "preEq": [8, 1, 24, 0],
+        }
+    ],
+}
+
+DS_OFDM = {
+    "errCode": "000",
+    "errMsg": "",
+    "OFDMs_List": [
+        {
+            "receive": 0,
+            "ffttype": "4K",
+            "Subcarr0freqFreq": " 275600000",
+            "plclock": "YES",
+            "ncplock": "YES",
+            "mdc1lock": "YES",
+            "plclocation": "1544",
+            "occupiedbw": "283 ~ 472.95",
+            "datasubcarriers": "3736",
+            "plcpower": "  3.000000",
+        }
+    ],
+}
+
+US_OFDMA = {
+    "errCode": "000",
+    "errMsg": "",
+    "OFDMAs_List": [
+        {
+            "uschindex": "0",
+            "state": "OPERATE",
+            "digAtten": "0.1659",
+            "digAttenBo": "6.5838",
+            "channelBw": "39.2000",
+            "repPower": "52.6417",
+            "repPower1_6": "38.7500",
+            "fftVal": "2K",
+        },
+        {
+            "uschindex": "1",
+            "state": "DISABLED",
+            "digAtten": "0.0000",
+            "digAttenBo": "0.0000",
+            "channelBw": "0.0000",
+            "repPower": "0.0000",
+            "repPower1_6": "0.0000",
+            "fftVal": "2K",
+        },
+    ],
+}
+
+VERSION = {
+    "errCode": "000",
+    "errMsg": "",
+    "modelName": "CODA-4680-TPIA",
+    "vendorName": "Hitron Technologies",
+    "SerialNum": "REDACTED",
+    "HwVersion": "1A",
+    "ApiVersion": "1.12.1",
+    "SoftwareVersion": "7.2.4.5.2b8",
+    "Model": "CODA-4680-TPIA (1A)",
+    "ModelReport": "CODA-4680-TPIA",
+}
+
+SYS_INFO = {
+    "errCode": "000",
+    "errMsg": "",
+    "ntAccess": "Permitted",
+    "macAddr": "00:00:00:00:00:00",
+    "ip": ["0.0.0.0"],
+    "subMask": "255.255.255.192",
+    "gw": "10.78.158.1",
+    "lease": "D: 7 H: 00 M: 00 S: 00",
+    "Configname": "bac10a000106b0f530913980",
+    "DsDataRate": "0",
+    "UsDataRate": "0",
+}
+
+
+def make_response(payload=None):
+    resp = MagicMock(status_code=200)
+    resp.raise_for_status = MagicMock()
+    if payload is None:
+        resp.text = ""
+        resp.json.side_effect = ValueError("empty body")
+    else:
+        resp.text = json.dumps(payload)
+        resp.json.return_value = payload
+    return resp
+
+
+@pytest.fixture
+def driver():
+    return HitronCoda4680Driver("http://192.168.100.1", "username", "secret")
+
+
+class TestLogin:
+    def test_login_posts_json_model_credentials_and_accepts_empty_body(self, driver):
+        with patch.object(driver._session, "post", return_value=make_response(None)) as post:
+            with patch.object(driver, "_fetch_payload", return_value=VERSION) as fetch:
+                driver.login()
+
+        post.assert_called_once()
+        url = post.call_args.args[0]
+        assert url == "http://192.168.100.1/1/Device/Users/Login"
+        assert json.loads(post.call_args.kwargs["data"]["model"]) == {
+            "username": "username",
+            "password": "secret",
+        }
+        fetch.assert_called_once_with("/1/Device/CM/Version", raise_on_error=True)
+
+    def test_login_fails_when_post_login_version_check_fails(self, driver):
+        with patch.object(driver._session, "post", return_value=make_response(None)):
+            with patch.object(driver, "_fetch_payload", side_effect=RuntimeError("unauthorized")):
+                with pytest.raises(RuntimeError, match="unauthorized"):
+                    driver.login()
+
+    def test_login_rejects_json_error_response(self, driver):
+        with patch.object(driver._session, "post", return_value=make_response({"errCode": "101", "errMsg": "bad login"})):
+            with pytest.raises(RuntimeError, match="bad login"):
+                driver.login()
+
+
+class TestDeviceInfo:
+    def test_get_device_info_reads_version_endpoint(self, driver):
+        with patch.object(driver, "_fetch_payload", return_value=VERSION):
+            info = driver.get_device_info()
+
+        assert info["manufacturer"] == "Hitron Technologies"
+        assert info["model"] == "CODA-4680-TPIA"
+        assert info["sw_version"] == "7.2.4.5.2b8"
+
+
+class TestDocsisData:
+    def test_parses_coda_4680_channel_payloads(self, driver):
+        payloads = {
+            "/1/Device/CM/DsInfo": DS_INFO,
+            "/1/Device/CM/UsInfo": US_INFO,
+            "/1/Device/CM/DsOfdm": DS_OFDM,
+            "/1/Device/CM/UsOfdm": US_OFDMA,
+        }
+        with patch.object(driver, "_fetch_payload", side_effect=lambda path: payloads[path]):
+            data = driver.get_docsis_data()
+
+        assert len(data["channelDs"]["docsis30"]) == 2
+        assert len(data["channelDs"]["docsis31"]) == 1
+        assert len(data["channelUs"]["docsis30"]) == 1
+        assert len(data["channelUs"]["docsis31"]) == 1
+
+        ds = data["channelDs"]["docsis30"][0]
+        assert ds == {
+            "channelID": 18,
+            "frequency": "663 MHz",
+            "powerLevel": 5.099,
+            "modulation": "256QAM",
+            "mer": 40.946,
+            "mse": -40.946,
+            "corrErrors": 5,
+            "nonCorrErrors": 33,
+        }
+
+        us = data["channelUs"]["docsis30"][0]
+        assert us["channelID"] == 3
+        assert us["frequency"] == "32.3 MHz"
+        assert us["powerLevel"] == 42.77
+        assert us["modulation"] == "64QAM"
+        assert us["multiplex"] == "ATDMA"
+        assert us["symbolRate"] == 5120
+
+        ds_ofdm = data["channelDs"]["docsis31"][0]
+        assert ds_ofdm["channelID"] == 0
+        assert ds_ofdm["type"] == "OFDM"
+        assert ds_ofdm["frequency"] == "275.6 MHz"
+        assert ds_ofdm["powerLevel"] == 3.0
+        assert ds_ofdm["mer"] is None
+        assert ds_ofdm["corrErrors"] is None
+        assert ds_ofdm["nonCorrErrors"] is None
+
+        us_ofdma = data["channelUs"]["docsis31"][0]
+        assert us_ofdma["channelID"] == 0
+        assert us_ofdma["type"] == "OFDMA"
+        assert us_ofdma["frequency"] == ""
+        assert us_ofdma["powerLevel"] == pytest.approx(52.6417)
+        assert us_ofdma["multiplex"] == "OFDMA"
+
+    def test_analyzer_accepts_coda_4680_null_counter_payload(self, driver):
+        payloads = {
+            "/1/Device/CM/DsInfo": DS_INFO,
+            "/1/Device/CM/UsInfo": US_INFO,
+            "/1/Device/CM/DsOfdm": DS_OFDM,
+            "/1/Device/CM/UsOfdm": US_OFDMA,
+        }
+        with patch.object(driver, "_fetch_payload", side_effect=lambda path: payloads[path]):
+            analysis = analyze(driver.get_docsis_data())
+
+        ofdm = next(ch for ch in analysis["ds_channels"] if ch["channel_family"] == "ofdm")
+        ofdma = next(ch for ch in analysis["us_channels"] if ch["channel_family"] == "ofdma")
+        assert ofdm["correctable_errors"] is None
+        assert ofdm["uncorrectable_errors"] is None
+        assert ofdm["snr"] is None
+        assert ofdma["frequency"] == ""
+
+
+class TestConnectionInfo:
+    def test_get_connection_info_reads_docsis_sysinfo_when_available(self, driver):
+        with patch.object(driver, "_fetch_payload", return_value=SYS_INFO):
+            info = driver.get_connection_info()
+
+        assert info["connection_type"] == "DOCSIS"
+        assert info["status"] == "Permitted"
+        assert info["wan_ip"] == "0.0.0.0"
+        assert info["max_downstream_kbps"] == 0
+        assert info["max_upstream_kbps"] == 0
+
+
+class TestRegistry:
+    def test_coda_4680_driver_is_registered_separately_from_coda_56_driver(self):
+        assert driver_registry.has_driver("hitron_coda_4680")
+        drivers = dict(driver_registry.get_available_drivers())
+        assert drivers["hitron_coda_4680"] == "Hitron CODA-4680"
+        assert drivers["hitron"] == "Hitron CODA-56"


### PR DESCRIPTION
## Summary
- add a dedicated authenticated Hitron CODA-4680 driver for the `/1/Device/CM/*` API
- parse downstream SC-QAM, upstream SC-QAM, downstream OFDM, and upstream OFDMA signal data from the captured endpoint shapes
- keep modem-internal DOCSIS event logs out of scope, matching the existing driver model
- document CODA-4680 as a supported Hitron family

Refs #557

## Test plan
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/test_hitron_coda_4680_driver.py tests/test_hitron_driver.py tests/test_driver_registry.py tests/collectors/test_builtin_drivers.py tests/test_static_contracts.py -q`
- `uv run --with-requirements requirements-test.txt python -m pytest tests -q --ignore=tests/e2e`
- `uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest --collect-only -q tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q --browser chromium --tb=short tests/e2e/test_auth.py tests/e2e/test_channels.py tests/e2e/test_dashboard.py tests/e2e/test_events.py tests/e2e/test_i18n.py tests/e2e/test_responsive.py tests/e2e/test_security.py tests/e2e/test_theme.py tests/e2e/test_settings.py tests/e2e/test_setup.py tests/e2e/test_pwa_gate.py`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q --browser chromium --tb=short tests/e2e/test_charts.py tests/e2e/test_comparison.py tests/e2e/test_correlation_ui.py tests/e2e/test_event_log_redesign.py tests/e2e/test_glossary.py tests/e2e/test_glossary_visual.py tests/e2e/test_mobile_quality_gate.py tests/e2e/test_modals.py tests/e2e/test_modulation.py tests/e2e/test_modulation_visual.py tests/e2e/test_segment_utilization.py`
