### PR TITLE
Harden CODA-4680 reauth handling

### DIFF
--- a/app/drivers/hitron_coda_4680.py
+++ b/app/drivers/hitron_coda_4680.py
@@ -56,13 +56,15 @@ class HitronCoda4680Driver(ModemDriver):
             raise RuntimeError(f"Hitron CODA-4680 login failed: {exc}") from exc
 
         body = self._json_body(resp)
-        if body:
+        if body is not None:
+            if not isinstance(body, dict):
+                raise RuntimeError("Hitron CODA-4680 login returned invalid JSON payload")
             self._ensure_ok(body, "login")
 
         # The login response can be an empty 200. Verify that the authenticated
         # session can read a protected endpoint before reporting success.
         self._device_info_cache = self._parse_device_info(
-            self._fetch_payload("/1/Device/CM/Version", raise_on_error=True)
+            self._fetch_payload("/1/Device/CM/Version", raise_on_error=True, allow_reauth=False)
         )
         log.info("Hitron CODA-4680 login OK")
 
@@ -108,7 +110,13 @@ class HitronCoda4680Driver(ModemDriver):
             "max_upstream_kbps": self._parse_rate_kbps(payload.get("UsDataRate")),
         }
 
-    def _fetch_payload(self, path: str, *, raise_on_error: bool = False) -> dict[str, Any]:
+    def _fetch_payload(
+        self,
+        path: str,
+        *,
+        raise_on_error: bool = False,
+        allow_reauth: bool = True,
+    ) -> dict[str, Any]:
         """Fetch and validate a JSON object endpoint."""
         try:
             resp = self._session.get(
@@ -117,6 +125,14 @@ class HitronCoda4680Driver(ModemDriver):
             )
             resp.raise_for_status()
             payload = self._json_body(resp)
+        except requests.HTTPError as exc:
+            if allow_reauth and self._is_auth_error(exc):
+                log.info("Hitron CODA-4680 session expired while fetching %s; retrying after login", path)
+                return self._retry_after_reauth(path, raise_on_error=raise_on_error)
+            if raise_on_error:
+                raise RuntimeError(f"Hitron CODA-4680 fetch {path} failed: {exc}") from exc
+            log.warning("Hitron CODA-4680 fetch %s failed: %s", path, exc)
+            return {}
         except requests.RequestException as exc:
             if raise_on_error:
                 raise RuntimeError(f"Hitron CODA-4680 fetch {path} failed: {exc}") from exc
@@ -128,9 +144,31 @@ class HitronCoda4680Driver(ModemDriver):
                 raise RuntimeError(f"Hitron CODA-4680 fetch {path} returned invalid JSON payload")
             log.warning("Hitron CODA-4680 fetch %s returned non-object payload", path)
             return {}
+        if allow_reauth and self._is_auth_payload(payload):
+            log.info("Hitron CODA-4680 endpoint %s returned an auth error; retrying after login", path)
+            return self._retry_after_reauth(path, raise_on_error=raise_on_error)
         if not self._ensure_ok(payload, path, raise_on_error=raise_on_error):
             return {}
         return payload
+
+    def _retry_after_reauth(self, path: str, *, raise_on_error: bool) -> dict[str, Any]:
+        try:
+            self.login()
+        except RuntimeError as exc:
+            if raise_on_error:
+                raise RuntimeError(f"Hitron CODA-4680 re-login before fetching {path} failed: {exc}") from exc
+            log.warning("Hitron CODA-4680 re-login before fetching %s failed: %s", path, exc)
+            return {}
+        return self._fetch_payload(path, raise_on_error=raise_on_error, allow_reauth=False)
+
+    @staticmethod
+    def _is_auth_error(exc: requests.HTTPError) -> bool:
+        response = getattr(exc, "response", None)
+        return getattr(response, "status_code", None) in {401, 403}
+
+    @staticmethod
+    def _is_auth_payload(payload: Any) -> bool:
+        return isinstance(payload, dict) and str(payload.get("errCode", "")) in {"401", "403"}
 
     @staticmethod
     def _json_body(resp: requests.Response) -> Any:

--- a/tests/test_hitron_coda_4680_driver.py
+++ b/tests/test_hitron_coda_4680_driver.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from app.analyzer import analyze
 from app.drivers import driver_registry
@@ -142,6 +143,14 @@ def make_response(payload=None):
     return resp
 
 
+def make_http_error_response(status_code=403):
+    resp = MagicMock(status_code=status_code)
+    error = requests.HTTPError(f"{status_code} Client Error")
+    error.response = resp
+    resp.raise_for_status.side_effect = error
+    return resp
+
+
 @pytest.fixture
 def driver():
     return HitronCoda4680Driver("http://192.168.100.1", "username", "secret")
@@ -160,7 +169,14 @@ class TestLogin:
             "username": "username",
             "password": "secret",
         }
-        fetch.assert_called_once_with("/1/Device/CM/Version", raise_on_error=True)
+        fetch.assert_called_once_with("/1/Device/CM/Version", raise_on_error=True, allow_reauth=False)
+
+    def test_login_accepts_empty_object_body_after_version_check(self, driver):
+        with patch.object(driver._session, "post", return_value=make_response({})):
+            with patch.object(driver, "_fetch_payload", return_value=VERSION) as fetch:
+                driver.login()
+
+        fetch.assert_called_once_with("/1/Device/CM/Version", raise_on_error=True, allow_reauth=False)
 
     def test_login_fails_when_post_login_version_check_fails(self, driver):
         with patch.object(driver._session, "post", return_value=make_response(None)):
@@ -171,6 +187,11 @@ class TestLogin:
     def test_login_rejects_json_error_response(self, driver):
         with patch.object(driver._session, "post", return_value=make_response({"errCode": "101", "errMsg": "bad login"})):
             with pytest.raises(RuntimeError, match="bad login"):
+                driver.login()
+
+    def test_login_rejects_non_object_json_response(self, driver):
+        with patch.object(driver._session, "post", return_value=make_response(["not", "an", "object"])):
+            with pytest.raises(RuntimeError, match="login returned invalid JSON payload"):
                 driver.login()
 
 
@@ -235,6 +256,132 @@ class TestDocsisData:
         assert us_ofdma["frequency"] == ""
         assert us_ofdma["powerLevel"] == pytest.approx(52.6417)
         assert us_ofdma["multiplex"] == "OFDMA"
+
+    def test_ds_ofdm_unlocked_rows_are_ignored(self, driver):
+        rows = [
+            dict(DS_OFDM["OFDMs_List"][0], receive=0, plclock="NO"),
+            dict(DS_OFDM["OFDMs_List"][0], receive=1, plclock="YES"),
+        ]
+
+        channels = driver._parse_ds_ofdm(rows)
+
+        assert [channel["channelID"] for channel in channels] == [1]
+
+    def test_fetch_payload_returns_empty_for_non_object_json(self, driver):
+        with patch.object(driver._session, "get", return_value=make_response(["not", "an", "object"])):
+            assert driver._fetch_payload("/1/Device/CM/DsInfo") == {}
+
+    def test_fetch_payload_returns_empty_for_modem_error_code(self, driver):
+        with patch.object(
+            driver._session,
+            "get",
+            return_value=make_response({"errCode": "999", "errMsg": "temporary unavailable"}),
+        ):
+            assert driver._fetch_payload("/1/Device/CM/DsInfo") == {}
+
+    @pytest.mark.parametrize("err_code", ["401", "403"])
+    def test_fetch_payload_reauthenticates_once_after_auth_error_payload(self, driver, err_code):
+        with patch.object(
+            driver._session,
+            "get",
+            side_effect=[make_response({"errCode": err_code, "errMsg": "session expired"}), make_response(DS_INFO)],
+        ) as get:
+            with patch.object(driver, "login") as login:
+                payload = driver._fetch_payload("/1/Device/CM/DsInfo")
+
+        assert payload == DS_INFO
+        login.assert_called_once_with()
+        assert get.call_count == 2
+
+    def test_fetch_payload_does_not_loop_when_auth_error_payload_retry_also_expires(self, driver):
+        with patch.object(
+            driver._session,
+            "get",
+            side_effect=[
+                make_response({"errCode": "401", "errMsg": "session expired"}),
+                make_response({"errCode": "401", "errMsg": "session expired"}),
+            ],
+        ) as get:
+            with patch.object(driver, "login") as login:
+                payload = driver._fetch_payload("/1/Device/CM/DsInfo")
+
+        assert payload == {}
+        login.assert_called_once_with()
+        assert get.call_count == 2
+
+    def test_fetch_payload_strict_mode_raises_when_auth_error_payload_retry_also_expires(self, driver):
+        with patch.object(
+            driver._session,
+            "get",
+            side_effect=[
+                make_response({"errCode": "401", "errMsg": "session expired"}),
+                make_response({"errCode": "401", "errMsg": "session expired"}),
+            ],
+        ) as get:
+            with patch.object(driver, "login") as login:
+                with pytest.raises(RuntimeError, match="/1/Device/CM/Version failed: session expired"):
+                    driver._fetch_payload("/1/Device/CM/Version", raise_on_error=True)
+
+        login.assert_called_once_with()
+        assert get.call_count == 2
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    def test_fetch_payload_reauthenticates_once_after_session_expiry(self, driver, status_code):
+        with patch.object(
+            driver._session,
+            "get",
+            side_effect=[make_http_error_response(status_code), make_response(DS_INFO)],
+        ) as get:
+            with patch.object(driver, "login") as login:
+                payload = driver._fetch_payload("/1/Device/CM/DsInfo")
+
+        assert payload == DS_INFO
+        login.assert_called_once_with()
+        assert get.call_count == 2
+
+    def test_fetch_payload_does_not_loop_when_reauth_retry_also_expires(self, driver):
+        with patch.object(
+            driver._session,
+            "get",
+            side_effect=[make_http_error_response(403), make_http_error_response(403)],
+        ) as get:
+            with patch.object(driver, "login") as login:
+                payload = driver._fetch_payload("/1/Device/CM/DsInfo")
+
+        assert payload == {}
+        login.assert_called_once_with()
+        assert get.call_count == 2
+
+    def test_fetch_payload_strict_mode_raises_when_reauth_retry_also_expires(self, driver):
+        with patch.object(
+            driver._session,
+            "get",
+            side_effect=[make_http_error_response(403), make_http_error_response(403)],
+        ) as get:
+            with patch.object(driver, "login") as login:
+                with pytest.raises(RuntimeError, match="fetch /1/Device/CM/Version failed"):
+                    driver._fetch_payload("/1/Device/CM/Version", raise_on_error=True)
+
+        login.assert_called_once_with()
+        assert get.call_count == 2
+
+    def test_fetch_payload_returns_empty_when_reauth_login_fails(self, driver):
+        with patch.object(driver._session, "get", return_value=make_http_error_response(403)) as get:
+            with patch.object(driver, "login", side_effect=RuntimeError("bad credentials")) as login:
+                payload = driver._fetch_payload("/1/Device/CM/DsInfo")
+
+        assert payload == {}
+        login.assert_called_once_with()
+        get.assert_called_once()
+
+    def test_fetch_payload_strict_mode_raises_when_reauth_login_fails(self, driver):
+        with patch.object(driver._session, "get", return_value=make_http_error_response(403)) as get:
+            with patch.object(driver, "login", side_effect=RuntimeError("bad credentials")) as login:
+                with pytest.raises(RuntimeError, match="re-login before fetching /1/Device/CM/Version failed"):
+                    driver._fetch_payload("/1/Device/CM/Version", raise_on_error=True)
+
+        login.assert_called_once_with()
+        get.assert_called_once()
 
     def test_analyzer_accepts_coda_4680_null_counter_payload(self, driver):
         payloads = {


### PR DESCRIPTION
## Summary
- harden CODA-4680 login handling for unexpected JSON response shapes
- retry once after expired sessions reported by HTTP 401/403 or endpoint `errCode` 401/403
- keep best-effort polling tolerant when re-login fails while preserving strict-mode errors
- add regression coverage for OFDM lock filtering and CODA-4680 auth/error edge cases

Refs #557

## Test plan
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/test_hitron_coda_4680_driver.py tests/test_hitron_driver.py tests/test_driver_registry.py tests/collectors/test_builtin_drivers.py tests/test_static_contracts.py -q`
- `uv run --with-requirements requirements-test.txt python -m pytest tests -q --ignore=tests/e2e`
- `uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest --collect-only -q tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q --browser chromium --tb=short tests/e2e/test_auth.py tests/e2e/test_channels.py tests/e2e/test_dashboard.py tests/e2e/test_events.py tests/e2e/test_i18n.py tests/e2e/test_responsive.py tests/e2e/test_security.py tests/e2e/test_theme.py tests/e2e/test_settings.py tests/e2e/test_setup.py tests/e2e/test_pwa_gate.py`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q --browser chromium --tb=short tests/e2e/test_charts.py tests/e2e/test_comparison.py tests/e2e/test_correlation_ui.py tests/e2e/test_event_log_redesign.py tests/e2e/test_glossary.py tests/e2e/test_glossary_visual.py tests/e2e/test_mobile_quality_gate.py tests/e2e/test_modals.py tests/e2e/test_modulation.py tests/e2e/test_modulation_visual.py tests/e2e/test_segment_utilization.py`
