### PR TITLE
Unwrap aggregate counter wraps in trends

### DIFF
--- a/app/storage/error_counters.py
+++ b/app/storage/error_counters.py
@@ -8,6 +8,7 @@ from typing import Any
 UINT32_COUNTER_SIZE = 2**32
 _UINT32_WRAP_PREVIOUS_MIN = int(UINT32_COUNTER_SIZE * 0.75)
 _UINT32_WRAP_CURRENT_MAX = int(UINT32_COUNTER_SIZE * 0.25)
+_UINT32_WRAP_AGGREGATE_DROP_MIN = _UINT32_WRAP_PREVIOUS_MIN
 
 
 def _coerce_counter(value: Any) -> int | None:
@@ -19,21 +20,37 @@ def _coerce_counter(value: Any) -> int | None:
         return None
 
 
-def _looks_like_uint32_wrap(previous_raw: int, current_raw: int) -> bool:
+def _looks_like_uint32_wrap(
+    previous_raw: int,
+    current_raw: int,
+    *,
+    allow_aggregate_wrap: bool = False,
+) -> bool:
     """Return True when a raw counter drop matches an unsigned 32-bit rollover."""
     if current_raw >= previous_raw:
         return False
     previous_mod = previous_raw % UINT32_COUNTER_SIZE
     current_mod = current_raw % UINT32_COUNTER_SIZE
-    return (
+    if (
         previous_mod >= _UINT32_WRAP_PREVIOUS_MIN
         and current_mod <= _UINT32_WRAP_CURRENT_MAX
-    )
+    ):
+        return True
+    if not allow_aggregate_wrap:
+        return False
+
+    # Aggregates can drop by one or more exact uint32 periods when any summed
+    # channel rolls over. The modulo remainder is the observed growth after
+    # removing those periods; a wrap-like drop leaves that remainder near uint32.
+    drop_mod = (previous_raw - current_raw) % UINT32_COUNTER_SIZE
+    return drop_mod >= _UINT32_WRAP_AGGREGATE_DROP_MIN
 
 
 def unwrap_uint32_counter_series(
     rows: Iterable[MutableMapping[str, Any]],
     keys: Iterable[str],
+    *,
+    allow_aggregate_wrap: bool = False,
 ) -> None:
     """Unwrap unsigned 32-bit counter rollovers in-place for presentation rows.
 
@@ -44,8 +61,11 @@ def unwrap_uint32_counter_series(
 
     Rows must be ordered oldest-to-newest. Missing/null counters remain
     missing/null, and ordinary low-value decreases are treated as resets rather
-    than wraps. A real hardware reset from a value near uint32 max to a low value
-    is indistinguishable from a rollover in this presentation-layer heuristic.
+    than wraps. Summary rows can aggregate many raw 32-bit channel counters, so
+    allow_aggregate_wrap also accepts drops that are just below a multiple of
+    uint32 even when the aggregate value itself is not near the uint32 boundary.
+    A real hardware reset from a value near uint32 max to a low value is
+    indistinguishable from a rollover in this presentation-layer heuristic.
     """
     state = {
         key: {"offset": 0, "previous_raw": None, "previous_unwrapped": None}
@@ -62,7 +82,11 @@ def unwrap_uint32_counter_series(
             previous_raw = key_state["previous_raw"]
             previous_unwrapped = key_state["previous_unwrapped"]
             if isinstance(previous_raw, int) and isinstance(previous_unwrapped, int):
-                if _looks_like_uint32_wrap(previous_raw, raw):
+                if _looks_like_uint32_wrap(
+                    previous_raw,
+                    raw,
+                    allow_aggregate_wrap=allow_aggregate_wrap,
+                ):
                     key_state["offset"] += UINT32_COUNTER_SIZE
                     while raw + key_state["offset"] <= previous_unwrapped:
                         key_state["offset"] += UINT32_COUNTER_SIZE

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -105,6 +105,7 @@ class SnapshotMixin:
         unwrap_uint32_counter_series(
             (entry["summary"] for entry in results),
             _SUMMARY_ERROR_KEYS,
+            allow_aggregate_wrap=True,
         )
         return results
 
@@ -125,7 +126,11 @@ class SnapshotMixin:
             entry = {"timestamp": row[0]}
             entry.update(_normalize_summary_errors(json.loads(row[1])))
             results.append(entry)
-        unwrap_uint32_counter_series(results, _SUMMARY_ERROR_KEYS)
+        unwrap_uint32_counter_series(
+            results,
+            _SUMMARY_ERROR_KEYS,
+            allow_aggregate_wrap=True,
+        )
         return results
 
     def _summary_rows_to_entries(self, rows):
@@ -134,7 +139,11 @@ class SnapshotMixin:
             entry = {"timestamp": row[0]}
             entry.update(_normalize_summary_errors(json.loads(row[1])))
             results.append(entry)
-        unwrap_uint32_counter_series(results, _SUMMARY_ERROR_KEYS)
+        unwrap_uint32_counter_series(
+            results,
+            _SUMMARY_ERROR_KEYS,
+            allow_aggregate_wrap=True,
+        )
         return results
 
     def get_summary_since(self, hours):

--- a/tests/test_error_counter_unwrap.py
+++ b/tests/test_error_counter_unwrap.py
@@ -31,3 +31,63 @@ def test_unwrap_uint32_counter_series_treats_low_drop_as_reset_after_wrap():
         4_295_659_550,
         10_000,
     ]
+
+
+def test_unwrap_uint32_counter_series_handles_aggregate_drop_near_uint32_wrap():
+    other_channels_total = 332_000_000
+    rows = [
+        {"errors": other_channels_total + 4_294_495_351},
+        {"errors": other_channels_total + 692_254},
+        {"errors": other_channels_total + 1_958_096},
+    ]
+
+    unwrap_uint32_counter_series(rows, ["errors"], allow_aggregate_wrap=True)
+
+    assert [row["errors"] for row in rows] == [
+        4_626_495_351,
+        4_627_659_550,
+        4_628_925_392,
+    ]
+
+
+def test_unwrap_uint32_counter_series_gates_aggregate_detection_by_default():
+    other_channels_total = 332_000_000
+    rows = [
+        {"errors": other_channels_total + 4_294_495_351},
+        {"errors": other_channels_total + 692_254},
+    ]
+
+    unwrap_uint32_counter_series(rows, ["errors"])
+
+    assert [row["errors"] for row in rows] == [
+        4_626_495_351,
+        332_692_254,
+    ]
+
+
+def test_unwrap_uint32_counter_series_keeps_non_wrap_aggregate_drop_as_reset():
+    rows = [
+        {"errors": 2_000_000_000},
+        {"errors": 1_500_000_000},
+    ]
+
+    unwrap_uint32_counter_series(rows, ["errors"], allow_aggregate_wrap=True)
+
+    assert [row["errors"] for row in rows] == [
+        2_000_000_000,
+        1_500_000_000,
+    ]
+
+
+def test_unwrap_uint32_counter_series_handles_multiple_aggregate_wraps_between_rows():
+    rows = [
+        {"errors": 9_000_000_000},
+        {"errors": 500_000_000},
+    ]
+
+    unwrap_uint32_counter_series(rows, ["errors"], allow_aggregate_wrap=True)
+
+    assert [row["errors"] for row in rows] == [
+        9_000_000_000,
+        9_089_934_592,
+    ]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,8 @@
 """Tests for SQLite snapshot storage."""
 
+import json
+import sqlite3
+
 import pytest
 from app.storage import SnapshotStorage
 from app.modules.bnetz.storage import BnetzStorage
@@ -91,6 +94,45 @@ class TestSnapshotStorage:
 
         assert intraday[0]["ds_correctable_errors"] == 0
         assert intraday[0]["ds_uncorrectable_errors"] == 0
+
+    def test_summary_trends_unwrap_aggregate_uint32_counter_wrap(self, storage):
+        summaries = [
+            ("2026-06-01T10:00:00Z", 4_626_495_351),
+            ("2026-06-01T10:01:00Z", 332_692_254),
+            ("2026-06-01T10:02:00Z", 333_958_096),
+        ]
+        with sqlite3.connect(storage.db_path) as conn:
+            for ts, correctable_errors in summaries:
+                conn.execute(
+                    "INSERT INTO snapshots "
+                    "(timestamp, summary_json, ds_channels_json, us_channels_json) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        ts,
+                        json.dumps({
+                            "errors_supported": True,
+                            "ds_correctable_errors": correctable_errors,
+                            "ds_uncorrectable_errors": 0,
+                        }),
+                        "[]",
+                        "[]",
+                    ),
+                )
+
+        intraday = storage.get_intraday_data("2026-06-01")
+        summary_range = storage.get_summary_range("2026-06-01", "2026-06-01")
+        range_data = storage.get_range_data(
+            "2026-06-01T10:00:00Z",
+            "2026-06-01T10:02:00Z",
+        )
+
+        expected = [4_626_495_351, 4_627_659_550, 4_628_925_392]
+        assert [row["ds_correctable_errors"] for row in intraday] == expected
+        assert [row["ds_uncorrectable_errors"] for row in intraday] == [0, 0, 0]
+        assert [row["ds_correctable_errors"] for row in summary_range] == expected
+        assert [row["ds_uncorrectable_errors"] for row in summary_range] == [0, 0, 0]
+        assert [row["summary"]["ds_correctable_errors"] for row in range_data] == expected
+        assert [row["summary"]["ds_uncorrectable_errors"] for row in range_data] == [0, 0, 0]
 
     def test_empty_storage(self, storage):
         assert storage.get_snapshot_list() == []


### PR DESCRIPTION
## Summary
- unwrap aggregate DOCSIS error-counter drops in trend/summary rows when the drop matches a uint32 rollover
- keep the wider aggregate heuristic opt-in so per-channel timelines retain the stricter single-counter behavior
- add regression coverage for the reported aggregate sawtooth shape, default gating, multi-wrap intervals, and storage trend APIs

Refs #546

## Tests
- `uv run --with-requirements requirements-test.txt python -m pytest tests/test_error_counter_unwrap.py tests/test_storage.py tests/test_channel_timeline.py -q` → `55 passed` before polish
- `uv run --with-requirements requirements-test.txt python -m pytest tests/test_error_counter_unwrap.py tests/test_storage.py::TestSnapshotStorage::test_summary_trends_unwrap_aggregate_uint32_counter_wrap tests/test_channel_timeline.py -q` → `39 passed`
- `uv run --with-requirements requirements-test.txt python -m pytest tests -q --ignore=tests/e2e` → `2532 passed, 11 skipped, 1 warning`
- `uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest --collect-only -q tests/e2e | tail -1` → `416 tests collected`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q --browser chromium --tb=short tests/e2e/test_auth.py tests/e2e/test_channels.py tests/e2e/test_comparison.py tests/e2e/test_correlation_ui.py tests/e2e/test_dashboard.py tests/e2e/test_event_log_redesign.py tests/e2e/test_events.py tests/e2e/test_glossary.py tests/e2e/test_glossary_visual.py tests/e2e/test_i18n.py tests/e2e/test_mobile_quality_gate.py tests/e2e/test_modals.py` → `109 passed`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q --browser chromium --tb=short tests/e2e/test_modulation.py tests/e2e/test_modulation_visual.py tests/e2e/test_pwa_gate.py tests/e2e/test_responsive.py tests/e2e/test_security.py tests/e2e/test_segment_utilization.py tests/e2e/test_settings.py tests/e2e/test_setup.py tests/e2e/test_theme.py tests/e2e/test_charts.py` → `307 passed`
