### PR TITLE
Add Sercom DM1000 modem driver

### DIFF
--- a/app/drivers/__init__.py
+++ b/app/drivers/__init__.py
@@ -42,6 +42,9 @@ driver_registry.register_builtin("hitron_coda_4680", "app.drivers.hitron_coda_46
 driver_registry.register_builtin("sagemcom", "app.drivers.sagemcom.SagemcomDriver",
                                  "Sagemcom F@st 3896",
                                  hints={"default_url": "http://192.168.100.1", "default_user": "admin"})
+driver_registry.register_builtin("sercom_dm1000", "app.drivers.sercom_dm1000.SercomDM1000Driver",
+                                 "Sercom DM1000",
+                                 hints={"default_url": "http://192.168.100.1", "default_user": "technician"})
 driver_registry.register_builtin("cgm4981", "app.drivers.cgm4981.CGM4981Driver",
                                  "Technicolor CGM4981COM (Cox Panoramic Gateway PM8 / XB8)",
                                  hints={"default_url": "http://192.168.0.1", "default_user": "admin"})

--- a/app/drivers/sercom_dm1000.py
+++ b/app/drivers/sercom_dm1000.py
@@ -1,0 +1,394 @@
+"""Authenticated Sercom DM1000 modem driver for DOCSight.
+
+The DM1000 web UI uses a classic ``/setup.cgi`` form login and exposes
+DOCSIS signal tables through JSON endpoints selected by a ``todo`` query
+parameter. The captured UI labels the JSON MIME type as ``applation/json``;
+this driver parses the response body directly through ``requests`` instead of
+relying on the header.
+
+The reporter-provided capture covers signal data only. Vendor modem event logs
+are intentionally out of scope here, matching DOCSight's other modem drivers.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import requests
+
+from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
+from .base import ModemDriver
+from .utils import hz_to_mhz, normalize_modulation
+
+log = logging.getLogger("docsis.driver.sercom_dm1000")
+
+_AUTH_STATUSES = {401, 403}
+
+
+class SercomDM1000Driver(ModemDriver):
+    """Driver for authenticated Sercom DM1000 cable modem UIs."""
+
+    def __init__(self, url: str, user: str, password: str):
+        super().__init__(url.rstrip("/"), user, password)
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "X-Requested-With": "XMLHttpRequest",
+            "Referer": f"{self._url}/status.html",
+        })
+
+    def login(self) -> None:
+        """Authenticate with the Sercom form and verify a protected endpoint."""
+        payload = {
+            "login_user": self._user,
+            # The captured login form sends both names with the same password
+            # value; firmware variants may read either field. Keep both until
+            # a live modem confirms which field this firmware validates.
+            "pws": self._password,
+            "submit": "Apply",
+            "is_parent_window": "1",
+            "todo": "login",
+            "this_file": "login.html",
+            "next_file": "",
+            "language": "en",
+            "message": "",
+            "passwd": self._password,
+            "cur_passwd": "",
+        }
+        try:
+            resp = self._session.post(f"{self._url}/setup.cgi", data=payload, timeout=15)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Sercom DM1000 login failed: {exc}") from exc
+
+        # A Sercom login can return 200 + HTML even when authentication failed.
+        # Probe a protected JSON endpoint before reporting success.
+        self._fetch_payload("RF_DS_param", raise_on_error=True, allow_reauth=False)
+        log.info("Sercom DM1000 login OK")
+
+    def get_docsis_data(self) -> DocsisData:
+        """Retrieve DOCSIS channel data from the captured Sercom endpoints."""
+        ds_info = self._fetch_payload("RF_DS_param")
+        ds_ofdm = self._fetch_payload("RF_DS_31_param")
+        us_info = self._fetch_payload("RF_US_param")
+        us_ofdma = self._fetch_payload("RF_US_31_param")
+
+        return {
+            "channelDs": {
+                "docsis30": self._parse_ds_scqam(self._nodes(ds_info)),
+                "docsis31": self._parse_ds_ofdm(self._nodes(ds_ofdm)),
+            },
+            "channelUs": {
+                "docsis30": self._parse_us_scqam(self._nodes(us_info)),
+                "docsis31": self._parse_us_ofdma(self._nodes(us_ofdma)),
+            },
+        }
+
+    def get_device_info(self) -> DeviceInfo:
+        """Return model metadata, using safe static fallback when Pd_info is absent."""
+        payload = self._fetch_payload("Pd_info")
+        model = self._first_text(payload, "model", "Model", "ModelName", "ProductName") or "DM1000"
+        sw_version = self._first_text(payload, "sw_version", "SoftwareVersion", "firmware", "FirmwareVersion")
+        return {"manufacturer": "Sercom", "model": model, "sw_version": sw_version}
+
+    def get_connection_info(self) -> ConnectionInfo:
+        """Retrieve basic interface state when exposed by the modem."""
+        payload = self._fetch_payload("Interface_param")
+        nodes = self._nodes(payload)
+        wan = next((row for row in nodes if str(row.get("name", "")).lower() == "wan0"), None)
+        if not wan:
+            return {}
+        return {
+            "connection_type": "DOCSIS",
+            "status": str(wan.get("state") or ""),
+        }
+
+    def _fetch_payload(
+        self,
+        todo: str,
+        *,
+        raise_on_error: bool = False,
+        allow_reauth: bool = True,
+    ) -> dict[str, Any]:
+        """Fetch a ``/setup.cgi?todo=...`` JSON object with one reauth retry."""
+        try:
+            resp = self._session.get(f"{self._url}/setup.cgi", params={"todo": todo}, timeout=30)
+            resp.raise_for_status()
+        except requests.HTTPError as exc:
+            if allow_reauth and self._is_auth_error(exc):
+                log.info("Sercom DM1000 session expired while fetching %s; retrying after login", todo)
+                return self._retry_after_reauth(todo, raise_on_error=raise_on_error)
+            if raise_on_error:
+                raise RuntimeError(f"Sercom DM1000 fetch {todo} failed: {exc}") from exc
+            log.warning("Sercom DM1000 fetch %s failed: %s", todo, exc)
+            return {}
+        except requests.RequestException as exc:
+            if raise_on_error:
+                raise RuntimeError(f"Sercom DM1000 fetch {todo} failed: {exc}") from exc
+            log.warning("Sercom DM1000 fetch %s failed: %s", todo, exc)
+            return {}
+
+        if self._looks_like_html(resp):
+            message = f"Sercom DM1000 fetch {todo} returned an HTML login page"
+            if allow_reauth:
+                log.info("%s; retrying after login", message)
+                return self._retry_after_reauth(todo, raise_on_error=raise_on_error)
+            if raise_on_error:
+                raise RuntimeError(message)
+            log.warning(message)
+            return {}
+
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            if raise_on_error:
+                raise RuntimeError(f"Sercom DM1000 fetch {todo} returned invalid JSON payload") from exc
+            log.warning("Sercom DM1000 fetch %s returned invalid JSON payload", todo)
+            return {}
+
+        if not isinstance(payload, dict):
+            if raise_on_error:
+                raise RuntimeError(f"Sercom DM1000 fetch {todo} returned non-object JSON payload")
+            log.warning("Sercom DM1000 fetch %s returned non-object JSON payload", todo)
+            return {}
+
+        if not self._ensure_ok(payload, todo, raise_on_error=raise_on_error):
+            return {}
+        return payload
+
+    def _retry_after_reauth(self, todo: str, *, raise_on_error: bool) -> dict[str, Any]:
+        try:
+            self.login()
+        except RuntimeError as exc:
+            if raise_on_error:
+                raise RuntimeError(f"Sercom DM1000 re-login before fetching {todo} failed: {exc}") from exc
+            log.warning("Sercom DM1000 re-login before fetching %s failed: %s", todo, exc)
+            return {}
+        return self._fetch_payload(todo, raise_on_error=raise_on_error, allow_reauth=False)
+
+    @staticmethod
+    def _is_auth_error(exc: requests.HTTPError) -> bool:
+        response = getattr(exc, "response", None)
+        return getattr(response, "status_code", None) in _AUTH_STATUSES
+
+    @staticmethod
+    def _looks_like_html(resp: requests.Response) -> bool:
+        content_type = str(resp.headers.get("Content-Type", "")).lower()
+        text = str(getattr(resp, "text", "") or "").lstrip().lower()
+        return "text/html" in content_type or text.startswith(("<html", "<!doctype html"))
+
+    @staticmethod
+    def _ensure_ok(payload: dict[str, Any], context: str, *, raise_on_error: bool = False) -> bool:
+        code = payload.get("errCode")
+        if code is None or str(code) == "000":
+            return True
+        message = str(payload.get("errMsg") or f"errCode {code}")
+        if raise_on_error:
+            raise RuntimeError(f"Sercom DM1000 {context} failed: {message}")
+        log.warning("Sercom DM1000 %s failed: %s", context, message)
+        return False
+
+    @staticmethod
+    def _nodes(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        nodes = payload.get("nodes") if isinstance(payload, dict) else None
+        if not isinstance(nodes, list):
+            return []
+        return [row for row in nodes if isinstance(row, dict)]
+
+    @staticmethod
+    def _first_text(payload: dict[str, Any], *keys: str) -> str:
+        for key in keys:
+            value = payload.get(key)
+            if value is not None and str(value).strip():
+                return str(value).strip()
+        for row in SercomDM1000Driver._nodes(payload):
+            name = str(row.get("name") or row.get("key") or "").lower()
+            for key in keys:
+                if name == key.lower():
+                    value = row.get("value") or row.get("text") or row.get("index1")
+                    if value is not None and str(value).strip():
+                        return str(value).strip()
+        return ""
+
+    def _parse_ds_scqam(self, rows: list[dict[str, Any]]) -> list[RawChannel]:
+        channels: list[RawChannel] = []
+        for row in rows:
+            try:
+                modulation = normalize_modulation(row.get("qamD", ""))
+                if not modulation or modulation in {"QAM_NONE", "NONE"}:
+                    continue
+                snr = float(row["SNRD"])
+                channels.append({
+                    "channelID": int(row["DCIDD"]),
+                    "frequency": hz_to_mhz(row.get("FreqD", "")),
+                    "powerLevel": float(row["PowerD"]),
+                    "modulation": modulation,
+                    "mer": snr,
+                    # Keep the long-standing DOCSight raw-channel convention:
+                    # drivers expose MSE as the inverse of SNR/MER when the
+                    # modem does not provide a separate MSE counter.
+                    "mse": -snr,
+                    "corrErrors": int(row["correctedsD"]),
+                    "nonCorrErrors": int(row["uncorrectedsD"]),
+                })
+            except (KeyError, TypeError, ValueError) as exc:
+                log.warning("Failed to parse Sercom DM1000 DS row: %s", exc)
+        return channels
+
+    def _parse_ds_ofdm(self, rows: list[dict[str, Any]]) -> list[RawChannel]:
+        channels: list[RawChannel] = []
+        for row in rows:
+            try:
+                if str(row.get("PLC", "")).strip().upper() != "YES":
+                    continue
+                if str(row.get("MDC1", "")).strip().upper() != "YES":
+                    continue
+                mer = self._optional_float(row.get("AV_Data"))
+                if mer is None:
+                    mer = self._optional_float(row.get("AV_PLC"))
+                if mer is None:
+                    continue
+                channels.append({
+                    "channelID": int(row["num"]),
+                    "type": "OFDM",
+                    "frequency": hz_to_mhz(row.get("OFDMFreq", "")),
+                    "powerLevel": float(row["PLC_power"]),
+                    "modulation": "OFDM",
+                    # The Sercom UI labels these as average OFDM values; use
+                    # data-subcarrier MER first and PLC MER only as a fallback.
+                    "mer": mer,
+                    "mse": None,
+                    "corrErrors": None,
+                    "nonCorrErrors": None,
+                })
+            except (KeyError, TypeError, ValueError) as exc:
+                log.warning("Failed to parse Sercom DM1000 DS OFDM row: %s", exc)
+        return channels
+
+    def _parse_us_scqam(self, rows: list[dict[str, Any]]) -> list[RawChannel]:
+        channels: list[RawChannel] = []
+        for row in rows:
+            try:
+                modulation = normalize_modulation(row.get("modulation", ""))
+                upstream = str(row.get("upstream", "")).strip()
+                rate_text = str(row.get("rate", "")).strip()
+                power = float(row["rep_power"])
+                if (
+                    not modulation
+                    or modulation in {"QAM_NONE", "NONE"}
+                    or upstream in {"", "---"}
+                    or not math.isfinite(power)
+                    or rate_text.lower() == "invalid"
+                ):
+                    continue
+                channel: RawChannel = {
+                    "channelID": int(upstream),
+                    "frequency": hz_to_mhz(row.get("Freq", "")),
+                    "powerLevel": power,
+                    "modulation": modulation,
+                    "multiplex": "ATDMA",
+                }
+                symbol_rate = self._symbol_rate_ksym(rate_text)
+                if symbol_rate is not None:
+                    channel["symbolRate"] = symbol_rate
+                channels.append(channel)
+            except (KeyError, TypeError, ValueError) as exc:
+                log.warning("Failed to parse Sercom DM1000 US row: %s", exc)
+        return channels
+
+    def _parse_us_ofdma(self, rows: list[dict[str, Any]]) -> list[RawChannel]:
+        channels: list[RawChannel] = []
+        for column in self._pivot_indexed_rows(rows):
+            try:
+                state = str(column.get("STATE", "")).strip().upper()
+                power_state = str(column.get("Power", "")).strip().upper()
+                # Captured active state was RNG3. Treat any explicit non-disabled
+                # state as usable because Sercom firmware may report other
+                # ranging/operational labels while the OFDMA channel is up.
+                if power_state != "ON" or state in {"", "DISABLED", "OFF"}:
+                    continue
+                frequency_value = column.get("Center Freq SC0")
+                frequency_mhz = self._optional_float(frequency_value)
+                if frequency_mhz is None or frequency_mhz <= 0:
+                    continue
+                channel: RawChannel = {
+                    "channelID": int(str(column.get("CH", "")).strip()),
+                    "type": "OFDMA",
+                    # The captured label is SC0 rather than a guaranteed center;
+                    # preserve the modem-exposed frequency instead of inventing one.
+                    "frequency": hz_to_mhz(frequency_value),
+                    "powerLevel": self._ofdma_power(column),
+                    "modulation": "OFDMA",
+                    "multiplex": "OFDMA",
+                }
+                profile_modulation = self._profile_modulation_from_bits(column.get("bit Loading"))
+                if profile_modulation:
+                    channel["profile_modulation"] = profile_modulation
+                channels.append(channel)
+            except (KeyError, TypeError, ValueError) as exc:
+                log.warning("Failed to parse Sercom DM1000 US OFDMA row: %s", exc)
+        return channels
+
+    @staticmethod
+    def _pivot_indexed_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        indexes: list[str] = []
+        pivot: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            name = str(row.get("name") or "").strip()
+            if not name:
+                continue
+            for key, value in row.items():
+                if not key.startswith("index"):
+                    continue
+                if key not in pivot:
+                    pivot[key] = {}
+                    indexes.append(key)
+                pivot[key][name] = value
+        return [pivot[key] for key in sorted(indexes, key=SercomDM1000Driver._index_sort_key)]
+
+    @staticmethod
+    def _index_sort_key(index_name: str) -> int:
+        suffix = index_name.removeprefix("index")
+        try:
+            return int(suffix)
+        except ValueError:
+            return 0
+
+    @staticmethod
+    def _ofdma_power(column: dict[str, Any]) -> float | None:
+        if "rep power1_6" not in column:
+            log.warning("Sercom DM1000 OFDMA row missing rep power1_6; leaving power unsupported")
+            return None
+        return SercomDM1000Driver._optional_float(column.get("rep power1_6"))
+
+    @staticmethod
+    def _optional_float(value: Any) -> float | None:
+        try:
+            number = float(str(value).strip())
+        except (TypeError, ValueError):
+            return None
+        return number if math.isfinite(number) else None
+
+    @staticmethod
+    def _symbol_rate_ksym(value: Any) -> int | None:
+        try:
+            number = float(str(value).strip())
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(number):
+            return None
+        return int(round(number * 1000))
+
+    @staticmethod
+    def _profile_modulation_from_bits(value: Any) -> str | None:
+        try:
+            bits = int(float(str(value).strip()))
+        except (TypeError, ValueError):
+            return None
+        if bits == 2:
+            return "QPSK"
+        if bits <= 0 or bits > 12:
+            return None
+        return f"{2 ** bits}QAM"

--- a/tests/test_sercom_dm1000_driver.py
+++ b/tests/test_sercom_dm1000_driver.py
@@ -1,0 +1,349 @@
+"""Tests for the authenticated Sercom DM1000 modem driver."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from app.analyzer import analyze
+from app.drivers import driver_registry
+from app.drivers.sercom_dm1000 import SercomDM1000Driver
+
+
+DS_INFO = {
+    "nodes": [
+        {
+            "numD": "1",
+            "DCIDD": "7",
+            "FreqD": "591000000",
+            "SNRD": "38.983261",
+            "qamD": "256QAM",
+            "octetsD": "-1688606920",
+            "correctedsD": "41",
+            "uncorrectedsD": "2",
+            "PowerD": "8.800003",
+        },
+        {
+            "numD": "2",
+            "DCIDD": "8",
+            "FreqD": "597000000",
+            "SNRD": "38.605377",
+            "qamD": "256QAM",
+            "octetsD": "-1689299334",
+            "correctedsD": "64",
+            "uncorrectedsD": "12",
+            "PowerD": "8.800003",
+        },
+    ]
+}
+
+DS_OFDM = {
+    "nodes": [
+        {
+            "num": "0",
+            "fftType": "4K",
+            "OFDMFreq": "275600000",
+            "PLC": "YES",
+            "NCP": "YES",
+            "MDC1": "YES",
+            "PLC_power": "10.300003",
+            "AV_Pilot": "45",
+            "AV_PLC": "40",
+            "AV_Data": "39",
+        },
+        {
+            "num": "1",
+            "fftType": "4K",
+            "OFDMFreq": "827600000",
+            "PLC": "YES",
+            "NCP": "YES",
+            "MDC1": "NO",
+            "PLC_power": "4.599998",
+            "AV_Pilot": "44",
+            "AV_PLC": "39",
+            "AV_Data": "38",
+        },
+    ]
+}
+
+US_INFO = {
+    "nodes": [
+        {
+            "num": "0",
+            "Freq": "21.100000",
+            "rate": "    2.56",
+            "modulation": "64QAM",
+            "channelType": "DOCSIS 3.0",
+            "rep_power": "35.260300",
+            "upstream": "5",
+        },
+        {
+            "num": "4",
+            "Freq": "9.961089",
+            "rate": " Invalid",
+            "modulation": "QAM_NONE",
+            "channelType": "DOCSIS 3.0",
+            "rep_power": "-inf",
+            "upstream": "---",
+        },
+    ]
+}
+
+US_OFDMA = {
+    "nodes": [
+        {"name": "CH", "index1": "0", "index2": "1"},
+        {"name": "Power", "index1": "ON", "index2": "OFF"},
+        {"name": "STATE", "index1": "    RNG3", "index2": "DISABLED"},
+        {"name": "BW (sc s*fft)", "index1": "39.200001", "index2": "0.000000"},
+        {"name": "rep power", "index1": "51.141663", "index2": "0.000000"},
+        {"name": "rep power1_6", "index1": "37.250000", "index2": "0.000000"},
+        {"name": "FFT SIZE", "index1": "2K", "index2": "2K"},
+        {"name": "Center Freq SC0", "index1": "42.000000", "index2": "0.000000"},
+        {"name": "bit Loading", "index1": "8", "index2": "0"},
+    ]
+}
+
+
+def make_response(payload=None, *, status_code=200, content_type="applation/json"):
+    resp = MagicMock(status_code=status_code)
+    resp.headers = {"Content-Type": content_type}
+    resp.raise_for_status = MagicMock()
+    if payload is None:
+        resp.text = ""
+        resp.json.side_effect = ValueError("empty body")
+    else:
+        resp.text = json.dumps(payload) if not isinstance(payload, str) else payload
+        if isinstance(payload, str):
+            resp.json.side_effect = ValueError("not json")
+        else:
+            resp.json.return_value = payload
+    return resp
+
+
+def make_http_error_response(status_code=403):
+    resp = make_response({"error": "expired"}, status_code=status_code)
+    error = requests.HTTPError(f"{status_code} Client Error")
+    error.response = resp
+    resp.raise_for_status.side_effect = error
+    return resp
+
+
+@pytest.fixture
+def driver():
+    return SercomDM1000Driver("http://192.168.100.1", "technician", "secret")
+
+
+class TestLogin:
+    def test_login_posts_captured_sercom_form_and_verifies_protected_endpoint(self, driver):
+        with patch.object(driver._session, "post", return_value=make_response("<html>ok</html>", content_type="text/html")) as post:
+            with patch.object(driver, "_fetch_payload", return_value=DS_INFO) as fetch:
+                driver.login()
+
+        post.assert_called_once()
+        assert post.call_args.args[0] == "http://192.168.100.1/setup.cgi"
+        payload = post.call_args.kwargs["data"]
+        assert payload["login_user"] == "technician"
+        assert payload["pws"] == "secret"
+        assert payload["passwd"] == "secret"
+        assert payload["todo"] == "login"
+        assert payload["this_file"] == "login.html"
+        fetch.assert_called_once_with("RF_DS_param", raise_on_error=True, allow_reauth=False)
+
+    def test_login_fails_when_post_login_probe_fails(self, driver):
+        with patch.object(driver._session, "post", return_value=make_response("<html>login</html>", content_type="text/html")):
+            with patch.object(driver, "_fetch_payload", side_effect=RuntimeError("login page returned")):
+                with pytest.raises(RuntimeError, match="login page returned"):
+                    driver.login()
+
+
+class TestFetchPayload:
+    def test_fetch_payload_accepts_sercom_json_mime_typo(self, driver):
+        with patch.object(driver._session, "get", return_value=make_response(DS_INFO, content_type="applation/json")):
+            assert driver._fetch_payload("RF_DS_param") == DS_INFO
+
+    def test_fetch_payload_returns_empty_for_html_login_page_in_best_effort_mode(self, driver):
+        with patch.object(driver._session, "get", return_value=make_response("<html>login</html>", content_type="text/html")):
+            with patch.object(driver, "login", side_effect=RuntimeError("bad credentials")):
+                assert driver._fetch_payload("RF_DS_param") == {}
+
+    def test_fetch_payload_strict_mode_raises_for_html_login_page(self, driver):
+        with patch.object(driver._session, "get", return_value=make_response("<html>login</html>", content_type="text/html")):
+            with pytest.raises(RuntimeError, match="returned an HTML login page"):
+                driver._fetch_payload("RF_DS_param", raise_on_error=True, allow_reauth=False)
+
+    def test_fetch_payload_reauthenticates_once_after_session_expiry(self, driver):
+        with patch.object(driver._session, "get", side_effect=[make_http_error_response(403), make_response(DS_INFO)]) as get:
+            with patch.object(driver, "login") as login:
+                assert driver._fetch_payload("RF_DS_param") == DS_INFO
+
+        login.assert_called_once_with()
+        assert get.call_count == 2
+
+    def test_fetch_payload_returns_empty_for_non_object_json(self, driver):
+        with patch.object(driver._session, "get", return_value=make_response(["not", "object"])):
+            assert driver._fetch_payload("RF_DS_param") == {}
+
+    def test_fetch_payload_retries_html_login_page_only_once(self, driver):
+        with patch.object(
+            driver._session,
+            "get",
+            side_effect=[
+                make_response("<html>login</html>", content_type="text/html"),
+                make_response("<html>login</html>", content_type="text/html"),
+            ],
+        ) as get:
+            with patch.object(driver, "login") as login:
+                assert driver._fetch_payload("RF_DS_param") == {}
+
+        login.assert_called_once_with()
+        assert get.call_count == 2
+
+    def test_fetch_payload_returns_empty_for_sercom_error_code(self, driver, caplog):
+        with patch.object(
+            driver._session,
+            "get",
+            return_value=make_response({"errCode": "101", "errMsg": "not authenticated"}),
+        ):
+            assert driver._fetch_payload("RF_DS_param") == {}
+
+        assert "not authenticated" in caplog.text
+
+
+class TestDocsisData:
+    def test_parses_sercom_dm1000_channel_payloads(self, driver):
+        payloads = {
+            "RF_DS_param": DS_INFO,
+            "RF_DS_31_param": DS_OFDM,
+            "RF_US_param": US_INFO,
+            "RF_US_31_param": US_OFDMA,
+        }
+        with patch.object(driver, "_fetch_payload", side_effect=lambda todo: payloads[todo]):
+            data = driver.get_docsis_data()
+
+        assert len(data["channelDs"]["docsis30"]) == 2
+        assert len(data["channelDs"]["docsis31"]) == 1
+        assert len(data["channelUs"]["docsis30"]) == 1
+        assert len(data["channelUs"]["docsis31"]) == 1
+
+        ds = data["channelDs"]["docsis30"][0]
+        assert ds == {
+            "channelID": 7,
+            "frequency": "591 MHz",
+            "powerLevel": pytest.approx(8.800003),
+            "modulation": "256QAM",
+            "mer": pytest.approx(38.983261),
+            "mse": pytest.approx(-38.983261),
+            "corrErrors": 41,
+            "nonCorrErrors": 2,
+        }
+
+        ds_ofdm = data["channelDs"]["docsis31"][0]
+        assert ds_ofdm["channelID"] == 0
+        assert ds_ofdm["type"] == "OFDM"
+        assert ds_ofdm["frequency"] == "275.6 MHz"
+        assert ds_ofdm["powerLevel"] == pytest.approx(10.300003)
+        assert ds_ofdm["mer"] == pytest.approx(39.0)
+        assert ds_ofdm["corrErrors"] is None
+        assert ds_ofdm["nonCorrErrors"] is None
+
+        us = data["channelUs"]["docsis30"][0]
+        assert us["channelID"] == 5
+        assert us["frequency"] == "21.1 MHz"
+        assert us["powerLevel"] == pytest.approx(35.2603)
+        assert us["modulation"] == "64QAM"
+        assert us["multiplex"] == "ATDMA"
+        assert us["symbolRate"] == 2560
+
+        us_ofdma = data["channelUs"]["docsis31"][0]
+        assert us_ofdma["channelID"] == 0
+        assert us_ofdma["type"] == "OFDMA"
+        assert us_ofdma["frequency"] == "42 MHz"
+        assert us_ofdma["powerLevel"] == pytest.approx(37.25)
+        assert us_ofdma["powerLevel"] != pytest.approx(51.141663)
+        assert us_ofdma["profile_modulation"] == "256QAM"
+
+    def test_us_ofdma_without_rep_power_1_6_keeps_power_unsupported(self, driver, caplog):
+        rows = [dict(row) for row in US_OFDMA["nodes"] if row["name"] != "rep power1_6"]
+
+        channels = driver._parse_us_ofdma(rows)
+
+        assert len(channels) == 1
+        assert channels[0]["powerLevel"] is None
+        assert "rep power1_6" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("plc", "mdc1", "av_data", "av_plc", "expected_count"),
+        [
+            ("NO", "YES", "39", "40", 0),
+            ("YES", "NO", "39", "40", 0),
+            ("YES", "YES", "", "", 0),
+            ("YES", "YES", "", "40", 1),
+        ],
+    )
+    def test_ds_ofdm_requires_plc_mdc1_and_numeric_mer(self, driver, plc, mdc1, av_data, av_plc, expected_count):
+        row = dict(DS_OFDM["nodes"][0], PLC=plc, MDC1=mdc1, AV_Data=av_data, AV_PLC=av_plc)
+
+        channels = driver._parse_ds_ofdm([row])
+
+        assert len(channels) == expected_count
+        if channels:
+            assert channels[0]["mer"] == pytest.approx(40.0)
+
+    def test_us_scqam_rejects_inactive_rows(self, driver):
+        inactive = {
+            "Freq": "9.961089",
+            "rate": " Invalid",
+            "modulation": "QAM_NONE",
+            "rep_power": "-inf",
+            "upstream": "---",
+        }
+
+        assert driver._parse_us_scqam([inactive]) == []
+
+    def test_us_ofdma_skips_disabled_and_zero_frequency_columns(self, driver):
+        zero_frequency = [
+            dict(row, index1="0.000000") if row["name"] == "Center Freq SC0" else dict(row)
+            for row in US_OFDMA["nodes"]
+        ]
+
+        assert driver._parse_us_ofdma(zero_frequency) == []
+        assert len(driver._parse_us_ofdma(US_OFDMA["nodes"])) == 1
+
+    @pytest.mark.parametrize(
+        ("bits", "expected"),
+        [("0", None), ("2", "QPSK"), ("8", "256QAM"), ("13", None), (None, None)],
+    )
+    def test_profile_modulation_from_bit_loading(self, driver, bits, expected):
+        assert driver._profile_modulation_from_bits(bits) == expected
+
+    def test_analyzer_accepts_sercom_dm1000_payload(self, driver):
+        payloads = {
+            "RF_DS_param": DS_INFO,
+            "RF_DS_31_param": DS_OFDM,
+            "RF_US_param": US_INFO,
+            "RF_US_31_param": US_OFDMA,
+        }
+        with patch.object(driver, "_fetch_payload", side_effect=lambda todo: payloads[todo]):
+            analysis = analyze(driver.get_docsis_data())
+
+        assert len(analysis["ds_channels"]) == 3
+        assert len(analysis["us_channels"]) == 2
+        ofdma = next(ch for ch in analysis["us_channels"] if ch["channel_family"] == "ofdma")
+        assert ofdma["power"] == pytest.approx(37.25)
+        assert ofdma["profile_modulation"] == "256QAM"
+
+
+class TestDeviceInfo:
+    def test_get_device_info_uses_safe_static_fallback_when_pd_info_is_unavailable(self, driver):
+        with patch.object(driver, "_fetch_payload", return_value={}):
+            info = driver.get_device_info()
+
+        assert info == {"manufacturer": "Sercom", "model": "DM1000", "sw_version": ""}
+
+
+class TestRegistry:
+    def test_sercom_dm1000_driver_is_registered(self):
+        assert driver_registry.has_driver("sercom_dm1000")
+        drivers = dict(driver_registry.get_available_drivers())
+        assert drivers["sercom_dm1000"] == "Sercom DM1000"


### PR DESCRIPTION
## Summary
- add an authenticated Sercom DM1000 driver for `/setup.cgi` JSON endpoints
- parse downstream/upstream DOCSIS 3.0 and 3.1 channel data, including OFDM/OFDMA payload shapes
- register `sercom_dm1000` with Sercom defaults and cover auth/session edge cases with tests

Refs #561

## Notes
- OFDMA upstream power intentionally uses `rep power1_6` only. Missing `rep power1_6` leaves power unsupported instead of falling back to total `rep power`.
- The Sercom UI may return JSON with a typo MIME type (`applation/json`), so the driver parses the body directly.
- Vendor event logs are out of scope for this signal driver.

## Verification
- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest tests/test_sercom_dm1000_driver.py -q --tb=short`
- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest tests/test_sercom_dm1000_driver.py tests/test_hitron_coda_4680_driver.py tests/test_driver_registry.py -q --tb=short`
- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m py_compile app/drivers/sercom_dm1000.py tests/test_sercom_dm1000_driver.py`
- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest tests --ignore=tests/e2e -q --tb=short`
- `TZ=UTC uv run --with-requirements requirements.txt --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest -q tests/e2e/test_mobile_quality_gate.py tests/e2e/test_settings.py --tb=short`
