### PR TITLE
Fix Sercom DM1000 login navigation

### DIFF
--- a/app/drivers/sercom_dm1000.py
+++ b/app/drivers/sercom_dm1000.py
@@ -25,6 +25,7 @@ from .utils import hz_to_mhz, normalize_modulation
 log = logging.getLogger("docsis.driver.sercom_dm1000")
 
 _AUTH_STATUSES = {401, 403}
+_HTML_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
 
 
 class SercomDM1000Driver(ModemDriver):
@@ -58,15 +59,50 @@ class SercomDM1000Driver(ModemDriver):
             "cur_passwd": "",
         }
         try:
-            resp = self._session.post(f"{self._url}/setup.cgi", data=payload, timeout=15)
+            resp = self._session.post(
+                f"{self._url}/setup.cgi",
+                data=payload,
+                headers={
+                    "Accept": _HTML_ACCEPT,
+                    "Origin": self._url,
+                    "Referer": f"{self._url}/login.html",
+                    # Override the session-level XHR header for the form POST;
+                    # requests omits headers set to None when preparing the call.
+                    "X-Requested-With": None,
+                },
+                timeout=15,
+            )
             resp.raise_for_status()
         except requests.RequestException as exc:
             raise RuntimeError(f"Sercom DM1000 login failed: {exc}") from exc
+
+        # The captured browser flow performs a normal page navigation after the
+        # form post before the RF JSON XHRs run. Some firmware builds only make
+        # the authenticated RF endpoints return JSON after this status page load.
+        self._load_status_page()
 
         # A Sercom login can return 200 + HTML even when authentication failed.
         # Probe a protected JSON endpoint before reporting success.
         self._fetch_payload("RF_DS_param", raise_on_error=True, allow_reauth=False)
         log.info("Sercom DM1000 login OK")
+
+    def _load_status_page(self) -> None:
+        try:
+            resp = self._session.get(
+                f"{self._url}/status.html",
+                headers={
+                    "Accept": _HTML_ACCEPT,
+                    # The HAR records status.html as a normal navigation from
+                    # setup.cgi, not as an XHR. Preserve that shape before the
+                    # first protected RF JSON probe.
+                    "Referer": f"{self._url}/setup.cgi",
+                    "X-Requested-With": None,
+                },
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Sercom DM1000 status page load failed: {exc}") from exc
 
     def get_docsis_data(self) -> DocsisData:
         """Retrieve DOCSIS channel data from the captured Sercom endpoints."""

--- a/tests/test_sercom_dm1000_driver.py
+++ b/tests/test_sercom_dm1000_driver.py
@@ -137,11 +137,18 @@ def driver():
 class TestLogin:
     def test_login_posts_captured_sercom_form_and_verifies_protected_endpoint(self, driver):
         with patch.object(driver._session, "post", return_value=make_response("<html>ok</html>", content_type="text/html")) as post:
-            with patch.object(driver, "_fetch_payload", return_value=DS_INFO) as fetch:
-                driver.login()
+            with patch.object(driver._session, "get", return_value=make_response("<html>status</html>", content_type="text/html")):
+                with patch.object(driver, "_fetch_payload", return_value=DS_INFO) as fetch:
+                    driver.login()
 
         post.assert_called_once()
         assert post.call_args.args[0] == "http://192.168.100.1/setup.cgi"
+        assert post.call_args.kwargs["headers"] == {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Origin": "http://192.168.100.1",
+            "Referer": "http://192.168.100.1/login.html",
+            "X-Requested-With": None,
+        }
         payload = post.call_args.kwargs["data"]
         assert payload["login_user"] == "technician"
         assert payload["pws"] == "secret"
@@ -150,11 +157,37 @@ class TestLogin:
         assert payload["this_file"] == "login.html"
         fetch.assert_called_once_with("RF_DS_param", raise_on_error=True, allow_reauth=False)
 
+    def test_login_loads_status_page_before_probing_rf_json(self, driver):
+        with patch.object(driver._session, "post", return_value=make_response("<html>ok</html>", content_type="text/html")):
+            with patch.object(driver._session, "get", return_value=make_response("<html>status</html>", content_type="text/html")) as get:
+                with patch.object(driver, "_fetch_payload", return_value=DS_INFO):
+                    driver.login()
+
+        get.assert_called_once_with(
+            "http://192.168.100.1/status.html",
+            headers={
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Referer": "http://192.168.100.1/setup.cgi",
+                "X-Requested-With": None,
+            },
+            timeout=15,
+        )
+
+    def test_login_fails_when_status_page_navigation_fails(self, driver):
+        error = requests.HTTPError("500 Server Error")
+        status_response = make_response("boom", status_code=500, content_type="text/plain")
+        status_response.raise_for_status.side_effect = error
+        with patch.object(driver._session, "post", return_value=make_response("<html>ok</html>", content_type="text/html")):
+            with patch.object(driver._session, "get", return_value=status_response):
+                with pytest.raises(RuntimeError, match="status page load failed"):
+                    driver.login()
+
     def test_login_fails_when_post_login_probe_fails(self, driver):
         with patch.object(driver._session, "post", return_value=make_response("<html>login</html>", content_type="text/html")):
-            with patch.object(driver, "_fetch_payload", side_effect=RuntimeError("login page returned")):
-                with pytest.raises(RuntimeError, match="login page returned"):
-                    driver.login()
+            with patch.object(driver._session, "get", return_value=make_response("<html>status</html>", content_type="text/html")):
+                with patch.object(driver, "_fetch_payload", side_effect=RuntimeError("login page returned")):
+                    with pytest.raises(RuntimeError, match="login page returned"):
+                        driver.login()
 
 
 class TestFetchPayload:


### PR DESCRIPTION
## Summary
- make the Sercom DM1000 login flow match the captured browser sequence
- load `status.html` after the form POST before probing RF JSON endpoints
- keep normal navigation requests separate from XHR-style RF JSON requests

## Test plan
- `pytest tests/test_sercom_dm1000_driver.py -q --tb=short`
- `pytest tests/test_sercom_dm1000_driver.py tests/test_driver_registry.py tests/collectors/test_builtin_drivers.py -q --tb=short`
- `pytest tests --ignore=tests/e2e -q --tb=short`
- `pytest --collect-only -q tests/e2e` → 416 tests collected
- `pytest -q tests/e2e` in resource-safe batches → 416 passed

Refs #561
