### PR TITLE
Fix Sercom DM1000 browser login flow

### DIFF
--- a/app/drivers/sercom_dm1000.py
+++ b/app/drivers/sercom_dm1000.py
@@ -26,6 +26,11 @@ log = logging.getLogger("docsis.driver.sercom_dm1000")
 
 _AUTH_STATUSES = {401, 403}
 _HTML_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+_BROWSER_ACCEPT_LANGUAGE = "en-GB,en-US;q=0.9,en;q=0.8"
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
+)
 
 
 class SercomDM1000Driver(ModemDriver):
@@ -36,8 +41,10 @@ class SercomDM1000Driver(ModemDriver):
         self._session = requests.Session()
         self._session.headers.update({
             "Accept": "application/json, text/javascript, */*; q=0.01",
+            "Accept-Language": _BROWSER_ACCEPT_LANGUAGE,
             "X-Requested-With": "XMLHttpRequest",
             "Referer": f"{self._url}/status.html",
+            "User-Agent": _BROWSER_USER_AGENT,
         })
 
     def login(self) -> None:
@@ -64,21 +71,34 @@ class SercomDM1000Driver(ModemDriver):
                 data=payload,
                 headers={
                     "Accept": _HTML_ACCEPT,
+                    "Accept-Language": _BROWSER_ACCEPT_LANGUAGE,
                     "Origin": self._url,
                     "Referer": f"{self._url}/login.html",
+                    "Upgrade-Insecure-Requests": "1",
                     # Override the session-level XHR header for the form POST;
                     # requests omits headers set to None when preparing the call.
                     "X-Requested-With": None,
                 },
+                allow_redirects=False,
                 timeout=15,
             )
             resp.raise_for_status()
         except requests.RequestException as exc:
             raise RuntimeError(f"Sercom DM1000 login failed: {exc}") from exc
 
-        # The captured browser flow performs a normal page navigation after the
-        # form post before the RF JSON XHRs run. Some firmware builds only make
-        # the authenticated RF endpoints return JSON after this status page load.
+        if marker := self._login_redirect_marker(resp):
+            raise RuntimeError(f"Sercom DM1000 login was redirected to login ({marker})")
+
+        # The captured browser flow first primes the authenticated UI context
+        # from setup.cgi, then performs a normal status-page navigation before
+        # the RF JSON XHRs run. Some firmware builds redirect status.html back
+        # to login.html unless this post-login JSON probe has happened first.
+        self._fetch_payload(
+            "Pd_info",
+            raise_on_error=False,
+            allow_reauth=False,
+            referer=f"{self._url}/setup.cgi",
+        )
         self._load_status_page()
 
         # A Sercom login can return 200 + HTML even when authentication failed.
@@ -92,10 +112,12 @@ class SercomDM1000Driver(ModemDriver):
                 f"{self._url}/status.html",
                 headers={
                     "Accept": _HTML_ACCEPT,
+                    "Accept-Language": _BROWSER_ACCEPT_LANGUAGE,
                     # The HAR records status.html as a normal navigation from
                     # setup.cgi, not as an XHR. Preserve that shape before the
                     # first protected RF JSON probe.
                     "Referer": f"{self._url}/setup.cgi",
+                    "Upgrade-Insecure-Requests": "1",
                     "X-Requested-With": None,
                 },
                 timeout=15,
@@ -147,10 +169,18 @@ class SercomDM1000Driver(ModemDriver):
         *,
         raise_on_error: bool = False,
         allow_reauth: bool = True,
+        referer: str | None = None,
     ) -> dict[str, Any]:
         """Fetch a ``/setup.cgi?todo=...`` JSON object with one reauth retry."""
         try:
-            resp = self._session.get(f"{self._url}/setup.cgi", params={"todo": todo}, timeout=30)
+            headers = {"Referer": referer} if referer else None
+            resp = self._session.get(
+                f"{self._url}/setup.cgi",
+                params={"todo": todo},
+                headers=headers,
+                allow_redirects=False,
+                timeout=30,
+            )
             resp.raise_for_status()
         except requests.HTTPError as exc:
             if allow_reauth and self._is_auth_error(exc):
@@ -164,6 +194,16 @@ class SercomDM1000Driver(ModemDriver):
             if raise_on_error:
                 raise RuntimeError(f"Sercom DM1000 fetch {todo} failed: {exc}") from exc
             log.warning("Sercom DM1000 fetch %s failed: %s", todo, exc)
+            return {}
+
+        if marker := self._login_redirect_marker(resp):
+            message = f"Sercom DM1000 fetch {todo} redirected to login ({marker})"
+            if allow_reauth:
+                log.info("%s; retrying after login", message)
+                return self._retry_after_reauth(todo, raise_on_error=raise_on_error)
+            if raise_on_error:
+                raise RuntimeError(message)
+            log.warning(message)
             return {}
 
         if self._looks_like_html(resp):
@@ -214,6 +254,43 @@ class SercomDM1000Driver(ModemDriver):
         content_type = str(resp.headers.get("Content-Type", "")).lower()
         text = str(getattr(resp, "text", "") or "").lstrip().lower()
         return "text/html" in content_type or text.startswith(("<html", "<!doctype html"))
+
+    @staticmethod
+    def _login_redirect_marker(resp: requests.Response) -> str:
+        location = str(resp.headers.get("Location", "") or "")
+        if "login.html" in location.lower():
+            return f"Location: {location}"
+
+        text = str(getattr(resp, "text", "") or "")
+        if SercomDM1000Driver._contains_login_location_header_line(text):
+            return "body Location: login.html"
+
+        raw_text = SercomDM1000Driver._raw_unparsed_header_payload(resp)
+        if SercomDM1000Driver._contains_login_location_header_line(raw_text):
+            return "malformed header Location: login.html"
+
+        return ""
+
+    @staticmethod
+    def _contains_login_location_header_line(text: str) -> bool:
+        for line in text.splitlines():
+            key, separator, value = line.strip().partition(":")
+            if separator and key.lower() == "location" and "login.html" in value.lower():
+                return True
+        return False
+
+    @staticmethod
+    def _raw_unparsed_header_payload(resp: requests.Response) -> str:
+        # Best-effort fallback for Sercom's malformed header block. urllib3
+        # stores the unparsed remainder behind private attributes, which may be
+        # absent or change across versions, so failures here must stay harmless.
+        try:
+            original_response = getattr(resp.raw, "_original_response", None)
+            message = getattr(original_response, "msg", None)
+            payload = message.get_payload() if message is not None else ""
+        except Exception:
+            return ""
+        return str(payload or "")
 
     @staticmethod
     def _ensure_ok(payload: dict[str, Any], context: str, *, raise_on_error: bool = False) -> bool:

--- a/tests/test_sercom_dm1000_driver.py
+++ b/tests/test_sercom_dm1000_driver.py
@@ -105,10 +105,26 @@ US_OFDMA = {
 }
 
 
-def make_response(payload=None, *, status_code=200, content_type="applation/json"):
+def make_response(
+    payload=None,
+    *,
+    status_code=200,
+    content_type="applation/json",
+    headers=None,
+    unparsed_headers="",
+):
     resp = MagicMock(status_code=status_code)
     resp.headers = {"Content-Type": content_type}
+    if headers:
+        resp.headers.update(headers)
     resp.raise_for_status = MagicMock()
+    if unparsed_headers:
+        msg = MagicMock()
+        msg.get_payload.return_value = unparsed_headers
+        original_response = MagicMock()
+        original_response.msg = msg
+        resp.raw = MagicMock()
+        resp.raw._original_response = original_response
     if payload is None:
         resp.text = ""
         resp.json.side_effect = ValueError("empty body")
@@ -145,42 +161,87 @@ class TestLogin:
         assert post.call_args.args[0] == "http://192.168.100.1/setup.cgi"
         assert post.call_args.kwargs["headers"] == {
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
             "Origin": "http://192.168.100.1",
             "Referer": "http://192.168.100.1/login.html",
+            "Upgrade-Insecure-Requests": "1",
             "X-Requested-With": None,
         }
+        assert post.call_args.kwargs["allow_redirects"] is False
         payload = post.call_args.kwargs["data"]
         assert payload["login_user"] == "technician"
         assert payload["pws"] == "secret"
         assert payload["passwd"] == "secret"
         assert payload["todo"] == "login"
         assert payload["this_file"] == "login.html"
-        fetch.assert_called_once_with("RF_DS_param", raise_on_error=True, allow_reauth=False)
+        assert fetch.call_args_list[0].args == ("Pd_info",)
+        assert fetch.call_args_list[0].kwargs == {
+            "raise_on_error": False,
+            "allow_reauth": False,
+            "referer": "http://192.168.100.1/setup.cgi",
+        }
+        assert fetch.call_args_list[1].args == ("RF_DS_param",)
+        assert fetch.call_args_list[1].kwargs == {"raise_on_error": True, "allow_reauth": False}
 
-    def test_login_loads_status_page_before_probing_rf_json(self, driver):
+    def test_login_primes_pd_info_before_loading_status_page_and_probing_rf_json(self, driver):
+        calls = []
+
+        def fetch(todo, **kwargs):
+            calls.append(("fetch", todo, kwargs))
+            return DS_INFO
+
+        def load_status():
+            calls.append(("status",))
+
         with patch.object(driver._session, "post", return_value=make_response("<html>ok</html>", content_type="text/html")):
-            with patch.object(driver._session, "get", return_value=make_response("<html>status</html>", content_type="text/html")) as get:
-                with patch.object(driver, "_fetch_payload", return_value=DS_INFO):
+            with patch.object(driver, "_fetch_payload", side_effect=fetch):
+                with patch.object(driver, "_load_status_page", side_effect=load_status):
                     driver.login()
+
+        assert calls == [
+            (
+                "fetch",
+                "Pd_info",
+                {
+                    "raise_on_error": False,
+                    "allow_reauth": False,
+                    "referer": "http://192.168.100.1/setup.cgi",
+                },
+            ),
+            ("status",),
+            ("fetch", "RF_DS_param", {"raise_on_error": True, "allow_reauth": False}),
+        ]
+
+    def test_load_status_page_uses_captured_browser_navigation_headers(self, driver):
+        with patch.object(driver._session, "get", return_value=make_response("<html>status</html>", content_type="text/html")) as get:
+            driver._load_status_page()
 
         get.assert_called_once_with(
             "http://192.168.100.1/status.html",
             headers={
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
                 "Referer": "http://192.168.100.1/setup.cgi",
+                "Upgrade-Insecure-Requests": "1",
                 "X-Requested-With": None,
             },
             timeout=15,
         )
+
+    def test_session_uses_browser_like_headers_from_capture(self, driver):
+        headers = driver._session.headers
+        assert "Mozilla/5.0" in headers["User-Agent"]
+        assert headers["Accept-Language"] == "en-GB,en-US;q=0.9,en;q=0.8"
 
     def test_login_fails_when_status_page_navigation_fails(self, driver):
         error = requests.HTTPError("500 Server Error")
         status_response = make_response("boom", status_code=500, content_type="text/plain")
         status_response.raise_for_status.side_effect = error
         with patch.object(driver._session, "post", return_value=make_response("<html>ok</html>", content_type="text/html")):
-            with patch.object(driver._session, "get", return_value=status_response):
-                with pytest.raises(RuntimeError, match="status page load failed"):
-                    driver.login()
+            with patch.object(driver, "_fetch_payload", return_value=DS_INFO):
+                with patch.object(driver._session, "get", return_value=status_response):
+                    with pytest.raises(RuntimeError, match="status page load failed"):
+                        driver.login()
 
     def test_login_fails_when_post_login_probe_fails(self, driver):
         with patch.object(driver._session, "post", return_value=make_response("<html>login</html>", content_type="text/html")):
@@ -204,6 +265,39 @@ class TestFetchPayload:
         with patch.object(driver._session, "get", return_value=make_response("<html>login</html>", content_type="text/html")):
             with pytest.raises(RuntimeError, match="returned an HTML login page"):
                 driver._fetch_payload("RF_DS_param", raise_on_error=True, allow_reauth=False)
+
+    def test_fetch_payload_strict_mode_reports_sercom_login_redirect_from_headers(self, driver):
+        response = make_response(None, headers={"Location": "login.html"})
+        with patch.object(driver._session, "get", return_value=response):
+            with pytest.raises(RuntimeError, match="redirected to login"):
+                driver._fetch_payload("RF_DS_param", raise_on_error=True, allow_reauth=False)
+
+    def test_fetch_payload_strict_mode_reports_sercom_login_redirect_from_well_formed_redirect(self, driver):
+        response = make_response(None, status_code=302, headers={"Location": "/login.html"})
+        with patch.object(driver._session, "get", return_value=response):
+            with pytest.raises(RuntimeError, match="redirected to login"):
+                driver._fetch_payload("RF_DS_param", raise_on_error=True, allow_reauth=False)
+
+    def test_fetch_payload_strict_mode_reports_sercom_login_redirect_from_malformed_headers(self, driver):
+        response = make_response(
+            None,
+            unparsed_headers="pragma :no-cache\r\nX-Frame-Options: DENY\r\nLocation: login.html\r\n\r\n",
+        )
+        with patch.object(driver._session, "get", return_value=response):
+            with pytest.raises(RuntimeError, match="redirected to login"):
+                driver._fetch_payload("RF_DS_param", raise_on_error=True, allow_reauth=False)
+
+    def test_fetch_payload_accepts_referer_override_for_post_login_pd_info_prime(self, driver):
+        with patch.object(driver._session, "get", return_value=make_response(DS_INFO)) as get:
+            assert driver._fetch_payload("Pd_info", referer="http://192.168.100.1/setup.cgi") == DS_INFO
+
+        get.assert_called_once_with(
+            "http://192.168.100.1/setup.cgi",
+            params={"todo": "Pd_info"},
+            headers={"Referer": "http://192.168.100.1/setup.cgi"},
+            allow_redirects=False,
+            timeout=30,
+        )
 
     def test_fetch_payload_reauthenticates_once_after_session_expiry(self, driver):
         with patch.object(driver._session, "get", side_effect=[make_http_error_response(403), make_response(DS_INFO)]) as get:


### PR DESCRIPTION
## Summary
- align the Sercom DM1000 login sequence more closely with the captured browser flow
- add a post-login `Pd_info` prime before loading `status.html` and probing RF data
- detect well-formed and malformed `Location: login.html` responses as session rejection instead of reporting invalid JSON
- expand regression coverage for the login flow, redirect handling, and browser-like request headers

## Tests
- `git diff --check`
- `pytest -q tests --ignore=tests/e2e`
- `pytest -q tests/e2e` collected 416 tests; run in resource-safe batches: 154 + 93 + 54 + 54 + 61 passed

Refs #561
