### PR TITLE
Fix stable DOCSIS error trend ranges

### DIFF
--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v41';
+var CACHE_VERSION = 'v42';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+from datetime import timedelta
 from typing import cast
 
 from ..types import AnalysisResult
-from ..tz import local_date_to_utc_range, utc_cutoff, utc_now
+from ..tz import _parse_utc, local_date_to_utc_range, utc_cutoff, utc_now
 from .error_counters import unwrap_uint32_counter_series
 
 
 _SUMMARY_ERROR_KEYS = ("ds_correctable_errors", "ds_uncorrectable_errors")
+_LONGEST_TREND_RANGE_DAYS = 90
+_UNWRAP_PRE_RANGE_ANCHOR_DAYS = 2
+_UNWRAP_ANCHOR_DAYS = _LONGEST_TREND_RANGE_DAYS + _UNWRAP_PRE_RANGE_ANCHOR_DAYS
 
 log = logging.getLogger("docsis.storage")
 
@@ -24,6 +28,34 @@ def _normalize_summary_errors(summary):
         summary["ds_correctable_errors"] = None
         summary["ds_uncorrectable_errors"] = None
     return summary
+
+
+def _timestamp_in_range(
+    timestamp: str,
+    start_ts: str | None = None,
+    end_ts: str | None = None,
+) -> bool:
+    """Return True when a canonical ISO UTC timestamp is inside the optional bounds."""
+    if start_ts is not None and timestamp < start_ts:
+        return False
+    if end_ts is not None and timestamp > end_ts:
+        return False
+    return True
+
+
+def _unwrap_anchor_start(timestamp: str) -> str:
+    """Return the shared bounded anchor for range-stable uint32 unwrapping.
+
+    Error trend ranges are presentation-level derived values. Anchor unwrapping
+    from the query end, not the visible start, so every exposed rolling range up
+    to 90 days uses the same unwrap history for the same endpoint while still
+    avoiding full-history scans on long-lived installs. Stored timestamps are
+    canonical UTC strings, so the result remains lexicographically sortable for
+    SQLite filters.
+    """
+    return (_parse_utc(timestamp) - timedelta(days=_UNWRAP_ANCHOR_DAYS)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
 
 
 class SnapshotMixin:
@@ -87,27 +119,38 @@ class SnapshotMixin:
 
     def get_range_data(self, start_ts: str, end_ts: str) -> list[dict]:
         """Get all snapshots between two ISO timestamps (inclusive)."""
+        anchor_start = _unwrap_anchor_start(end_ts)
         with sqlite3.connect(self.db_path) as conn:
-            rows = conn.execute(
+            anchor_rows = conn.execute(
+                "SELECT timestamp, summary_json FROM snapshots "
+                "WHERE timestamp >= ? AND timestamp < ? ORDER BY timestamp",
+                (anchor_start, start_ts),
+            ).fetchall()
+            visible_rows = conn.execute(
                 "SELECT timestamp, summary_json, ds_channels_json, us_channels_json "
                 "FROM snapshots WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp",
                 (start_ts, end_ts),
             ).fetchall()
-        results = []
-        for row in rows:
-            entry = {
+        anchor_entries = []
+        for row in anchor_rows:
+            anchor_entries.append({
+                "timestamp": row[0],
+                "summary": _normalize_summary_errors(json.loads(row[1])),
+            })
+        visible_entries = []
+        for row in visible_rows:
+            visible_entries.append({
                 "timestamp": row[0],
                 "summary": _normalize_summary_errors(json.loads(row[1])),
                 "ds_channels": json.loads(row[2]),
                 "us_channels": json.loads(row[3]),
-            }
-            results.append(entry)
+            })
         unwrap_uint32_counter_series(
-            (entry["summary"] for entry in results),
+            (entry["summary"] for entry in [*anchor_entries, *visible_entries]),
             _SUMMARY_ERROR_KEYS,
             allow_aggregate_wrap=True,
         )
-        return results
+        return visible_entries
 
     def get_intraday_data(self, date):
         """Get all snapshots for a single day (for day-detail trends).
@@ -115,11 +158,12 @@ class SnapshotMixin:
         date is a local calendar date — converted to UTC range for querying.
         """
         start_utc, end_utc = local_date_to_utc_range(date, self.tz_name)
+        anchor_start = _unwrap_anchor_start(end_utc)
         with sqlite3.connect(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp",
-                (start_utc, end_utc),
+                (anchor_start, end_utc),
             ).fetchall()
         results = []
         for row in rows:
@@ -131,9 +175,17 @@ class SnapshotMixin:
             _SUMMARY_ERROR_KEYS,
             allow_aggregate_wrap=True,
         )
-        return results
+        return [
+            entry for entry in results
+            if _timestamp_in_range(entry["timestamp"], start_utc, end_utc)
+        ]
 
-    def _summary_rows_to_entries(self, rows):
+    def _summary_rows_to_entries(
+        self,
+        rows,
+        start_ts: str | None = None,
+        end_ts: str | None = None,
+    ):
         results = []
         for row in rows:
             entry = {"timestamp": row[0]}
@@ -144,18 +196,22 @@ class SnapshotMixin:
             _SUMMARY_ERROR_KEYS,
             allow_aggregate_wrap=True,
         )
-        return results
+        return [
+            entry for entry in results
+            if _timestamp_in_range(entry["timestamp"], start_ts, end_ts)
+        ]
 
     def get_summary_since(self, hours):
         """Get summary snapshots from the last N hours."""
         cutoff = utc_cutoff(hours=hours)
+        anchor_start = utc_cutoff(hours=_UNWRAP_ANCHOR_DAYS * 24)
         with sqlite3.connect(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? ORDER BY timestamp",
-                (cutoff,),
+                (anchor_start,),
             ).fetchall()
-        return self._summary_rows_to_entries(rows)
+        return self._summary_rows_to_entries(rows, start_ts=cutoff)
 
     def get_summary_range(self, start_date, end_date):
         """Get all snapshots (summary only) between two dates. Like get_intraday_data but multi-day.
@@ -164,14 +220,19 @@ class SnapshotMixin:
         """
         range_start, _ = local_date_to_utc_range(start_date, self.tz_name)
         _, range_end = local_date_to_utc_range(end_date, self.tz_name)
+        anchor_start = _unwrap_anchor_start(range_end)
         with sqlite3.connect(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? AND timestamp <= ? "
                 "ORDER BY timestamp",
-                (range_start, range_end),
+                (anchor_start, range_end),
             ).fetchall()
-        return self._summary_rows_to_entries(rows)
+        return self._summary_rows_to_entries(
+            rows,
+            start_ts=range_start,
+            end_ts=range_end,
+        )
 
     def get_closest_snapshot(self, timestamp: str) -> dict | None:
         """Find the snapshot closest to a given ISO timestamp (within 2 hours).

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1241,7 +1241,7 @@
                         <line x1="12" y1="8" x2="12" y2="12"/>
                         <line x1="12" y1="16" x2="12.01" y2="16"/>
                     </svg>
-                    <div class="chart-label">{{ t.errors }}</div>
+                    <div class="chart-label">{{ t.metric_error_count }}</div>
                 </div>
                 <button class="chart-expand-btn" data-chart="chart-errors" title="{{ t.expand }}">&#x26F6;</button>
             </div>

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -76,7 +76,7 @@ class TestHeroChart:
             var toggle = document.getElementById('theme-toggle-sidebar');
             if (toggle) { toggle.checked = !toggle.checked; toggle.dispatchEvent(new Event('change')); }
         """)
-        demo_page.wait_for_timeout(500)
+        wait_for_uplot(demo_page, "hero-trend-chart")
         # Chart should still be present after theme toggle
         canvases = count_uplot_canvases(demo_page, "hero-trend-chart")
         assert canvases >= 1

--- a/tests/e2e/test_comparison.py
+++ b/tests/e2e/test_comparison.py
@@ -71,6 +71,10 @@ class TestComparisonView:
         assert nav.count() == 1
 
     def test_run_comparison_shows_health_distribution(self, demo_page):
+        demo_page.route(
+            "**/api/comparison**",
+            lambda route: route.fulfill(json=_comparison_payload(True, 0)),
+        )
         navigate_to_comparison(demo_page)
         demo_page.locator("#comparison-run-btn").click()
 
@@ -133,6 +137,10 @@ class TestComparisonView:
         expect(demo_page.locator("#comparison-errors-card")).to_be_visible()
 
     def test_comparison_can_open_report_modal_with_attached_evidence(self, demo_page):
+        demo_page.route(
+            "**/api/comparison**",
+            lambda route: route.fulfill(json=_comparison_payload(True, 0)),
+        )
         navigate_to_comparison(demo_page)
         demo_page.locator("#comparison-run-btn").click()
         expect(demo_page.locator("#comparison-health")).to_be_visible()

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -198,7 +198,10 @@ class TestModulationControls:
     @pytest.fixture(autouse=True)
     def navigate_to_modulation(self, demo_page):
         demo_page.locator('.nav-item[data-view="modulation"]').click()
-        demo_page.wait_for_timeout(500)
+        demo_page.wait_for_function(
+            "() => (window._modCharts || []).length > 0",
+            timeout=150_000,
+        )
         self.page = demo_page
 
     def test_switch_to_ds(self):
@@ -224,7 +227,15 @@ class TestModulationControls:
     def test_30_day_charts_bound_x_axis_labels(self):
         d30 = self.page.locator('#modulation-range-tabs .trend-tab[data-days="30"]')
         d30.click()
-        self.page.wait_for_timeout(1000)
+        self.page.wait_for_function(
+            """
+            () => (window._modCharts || []).some((chart) => {
+                const samples = chart.data && chart.data[0] ? chart.data[0].length : 0;
+                return samples >= 30;
+            })
+            """,
+            timeout=150_000,
+        )
 
         chart_tick_counts = self.page.evaluate(
             """
@@ -363,7 +374,10 @@ class TestProtocolGroups:
     @pytest.fixture(autouse=True)
     def navigate_to_modulation(self, demo_page):
         demo_page.locator('.nav-item[data-view="modulation"]').click()
-        demo_page.wait_for_timeout(1500)
+        demo_page.locator(".mod-protocol-group").first.wait_for(
+            state="visible",
+            timeout=150_000,
+        )
         self.page = demo_page
 
     def test_protocol_groups_rendered(self):

--- a/tests/e2e/test_modulation_visual.py
+++ b/tests/e2e/test_modulation_visual.py
@@ -23,7 +23,10 @@ def ensure_screenshot_dir():
 def modulation_page(demo_page):
     """Navigate to modulation tab and wait for data to load."""
     demo_page.locator('.nav-item[data-view="modulation"]').click()
-    demo_page.wait_for_timeout(2000)  # Wait for API + Chart.js render
+    demo_page.locator(".mod-protocol-group").first.wait_for(
+        state="visible",
+        timeout=150_000,
+    )
     return demo_page
 
 

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -137,7 +137,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v41';" in sw_js
+    assert "var CACHE_VERSION = 'v42';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -402,6 +402,20 @@ def test_trend_title_uses_rolling_range_without_stale_date_suffix():
     assert "title.textContent = (T.signal_trends || 'Signal Trends') + ' (' + label + ')'" in trends_js
     assert "formatDateDE(date)" not in trends_js
     assert "&date=" not in trends_js
+
+
+def test_trend_errors_chart_labels_values_as_total_error_count():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    errors_card = template[template.index('id="trend-errors-card"') : template.index('id="chart-errors"')]
+
+    assert "{{ t.metric_error_count }}" in errors_card
+    assert "{{ t.errors }}" not in errors_card
+    offenders = []
+    for path in sorted(APP_I18N_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+        if "metric_error_count" not in data:
+            offenders.append(path.name)
+    assert offenders == []
 
 
 def test_hero_chart_fetches_normalized_one_day_range():

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -134,6 +134,51 @@ class TestSnapshotStorage:
         assert [row["summary"]["ds_correctable_errors"] for row in range_data] == expected
         assert [row["summary"]["ds_uncorrectable_errors"] for row in range_data] == [0, 0, 0]
 
+    def test_range_data_uses_summary_only_for_unwrap_anchor_rows(self, storage):
+        """Historical anchor rows initialize unwrap without loading channel payloads."""
+        with sqlite3.connect(storage.db_path) as conn:
+            conn.execute(
+                "INSERT INTO snapshots "
+                "(timestamp, summary_json, ds_channels_json, us_channels_json) "
+                "VALUES (?, ?, ?, ?)",
+                (
+                    "2026-05-31T23:59:00Z",
+                    json.dumps({
+                        "errors_supported": True,
+                        "ds_correctable_errors": 4_200_000_000,
+                        "ds_uncorrectable_errors": 0,
+                    }),
+                    "not-json-anchor-ds",
+                    "not-json-anchor-us",
+                ),
+            )
+            conn.execute(
+                "INSERT INTO snapshots "
+                "(timestamp, summary_json, ds_channels_json, us_channels_json) "
+                "VALUES (?, ?, ?, ?)",
+                (
+                    "2026-06-01T00:00:00Z",
+                    json.dumps({
+                        "errors_supported": True,
+                        "ds_correctable_errors": 500_000_000,
+                        "ds_uncorrectable_errors": 0,
+                    }),
+                    json.dumps([{"channel_id": 1}]),
+                    json.dumps([{"channel_id": 2}]),
+                ),
+            )
+
+        range_data = storage.get_range_data(
+            "2026-06-01T00:00:00Z",
+            "2026-06-01T00:00:00Z",
+        )
+
+        assert len(range_data) == 1
+        assert range_data[0]["timestamp"] == "2026-06-01T00:00:00Z"
+        assert range_data[0]["summary"]["ds_correctable_errors"] == 4_794_967_296
+        assert range_data[0]["ds_channels"] == [{"channel_id": 1}]
+        assert range_data[0]["us_channels"] == [{"channel_id": 2}]
+
     def test_empty_storage(self, storage):
         assert storage.get_snapshot_list() == []
 

--- a/tests/test_trends_api.py
+++ b/tests/test_trends_api.py
@@ -154,3 +154,82 @@ class TestTrendsRangeEndpoint:
             4_294_495_351,
             4_295_659_550,
         ]
+
+    def test_trend_error_counter_unwrap_is_stable_across_ranges(self, client):
+        flask_client, storage = client
+        _insert_snapshot(
+            storage,
+            _analysis(
+                1.0,
+                ds_correctable_errors=4_200_000_000,
+                ds_uncorrectable_errors=4_100_000_000,
+            ),
+            _utc_ts(timedelta(days=91)),
+        )
+        _insert_snapshot(
+            storage,
+            _analysis(
+                2.0,
+                ds_correctable_errors=500_000_000,
+                ds_uncorrectable_errors=200_000_000,
+            ),
+            _utc_ts(timedelta(hours=5)),
+        )
+        _insert_snapshot(
+            storage,
+            _analysis(
+                3.0,
+                ds_correctable_errors=700_000_000,
+                ds_uncorrectable_errors=300_000_000,
+            ),
+            _utc_ts(timedelta(minutes=20)),
+        )
+
+        values_by_range = {}
+        middle_values_by_range = {}
+        raw_summaries_before_api = []
+        with sqlite3.connect(storage.db_path) as conn:
+            raw_summaries_before_api = [
+                row[0]
+                for row in conn.execute(
+                    "SELECT summary_json FROM snapshots ORDER BY timestamp"
+                ).fetchall()
+            ]
+        for range_name in ("1h", "6h", "1d", "30d", "90d"):
+            resp = flask_client.get(f"/api/trends?range={range_name}")
+            assert resp.status_code == 200, range_name
+            data = json.loads(resp.data)
+            latest = data[-1]
+            assert latest["ds_power_avg"] == 3.0
+            values_by_range[range_name] = (
+                latest["ds_correctable_errors"],
+                latest["ds_uncorrectable_errors"],
+            )
+            for row in data:
+                if row["ds_power_avg"] == 2.0:
+                    middle_values_by_range[range_name] = (
+                        row["ds_correctable_errors"],
+                        row["ds_uncorrectable_errors"],
+                    )
+
+        assert values_by_range == {
+            "1h": (4_994_967_296, 4_594_967_296),
+            "6h": (4_994_967_296, 4_594_967_296),
+            "1d": (4_994_967_296, 4_594_967_296),
+            "30d": (4_994_967_296, 4_594_967_296),
+            "90d": (4_994_967_296, 4_594_967_296),
+        }
+        assert middle_values_by_range == {
+            "6h": (4_794_967_296, 4_494_967_296),
+            "1d": (4_794_967_296, 4_494_967_296),
+            "30d": (4_794_967_296, 4_494_967_296),
+            "90d": (4_794_967_296, 4_494_967_296),
+        }
+        with sqlite3.connect(storage.db_path) as conn:
+            raw_summaries_after_api = [
+                row[0]
+                for row in conn.execute(
+                    "SELECT summary_json FROM snapshots ORDER BY timestamp"
+                ).fetchall()
+            ]
+        assert raw_summaries_after_api == raw_summaries_before_api


### PR DESCRIPTION
## Summary
- keep DOCSIS error trend values stable across rolling ranges by unwrapping from a shared bounded history window
- preserve raw modem-provided snapshot values and unsupported counter null semantics
- update the error trend label/i18n key and harden browser waits around the affected chart surfaces

## Tests
- `git diff --check`
- `TZ=UTC .venv311/bin/python -m pytest tests/test_storage.py::TestSnapshotStorage::test_range_data_uses_summary_only_for_unwrap_anchor_rows tests/test_trends_api.py::TestTrendsRangeEndpoint::test_trend_error_counter_unwrap_is_stable_across_ranges tests/test_static_contracts.py::test_trend_errors_chart_labels_values_as_total_error_count -q`
- `TZ=UTC .venv311/bin/python -m pytest tests/test_storage.py tests/test_trends_api.py tests/test_error_counter_unwrap.py tests/test_static_contracts.py -q`
- `.venv311/bin/python scripts/i18n_check.py --validate`
- `TZ=UTC .venv311/bin/python -m pytest tests --ignore=tests/e2e -q`
- `TZ=UTC .venv311/bin/python -m pytest --collect-only -q tests/e2e` (416 collected)
- final E2E batches: 73 + 81 + 93 + 169 = 416 passed

Closes #565
