### PR TITLE
Add Sercom DM1000 diagnostics

### DIFF
--- a/app/drivers/sercom_dm1000.py
+++ b/app/drivers/sercom_dm1000.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 
@@ -31,6 +33,18 @@ _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
 )
+_DIAGNOSTIC_ENV = "DOCSIGHT_SERCOM_DM1000_DIAGNOSTICS"
+_SAFE_DIAGNOSTIC_HEADER_VALUES = {
+    "connection",
+    "content-length",
+    "content-type",
+    "location",
+    "pragma",
+    "server",
+    "transfer-encoding",
+}
+_DIAGNOSTIC_HEADER_CAP = 512
+_DIAGNOSTIC_BODY_PEEK = 64
 
 
 class SercomDM1000Driver(ModemDriver):
@@ -46,6 +60,8 @@ class SercomDM1000Driver(ModemDriver):
             "Referer": f"{self._url}/status.html",
             "User-Agent": _BROWSER_USER_AGENT,
         })
+        self._diagnostics_enabled = self._env_flag_enabled(os.environ.get(_DIAGNOSTIC_ENV, ""))
+        self._diagnostic_signatures: set[tuple[Any, ...]] = set()
 
     def login(self) -> None:
         """Authenticate with the Sercom form and verify a protected endpoint."""
@@ -65,6 +81,7 @@ class SercomDM1000Driver(ModemDriver):
             "passwd": self._password,
             "cur_passwd": "",
         }
+        self._log_diagnostic_snapshot("before_login_post")
         try:
             resp = self._session.post(
                 f"{self._url}/setup.cgi",
@@ -82,8 +99,10 @@ class SercomDM1000Driver(ModemDriver):
                 allow_redirects=False,
                 timeout=15,
             )
+            self._log_response_diagnostics("login_post", resp)
             resp.raise_for_status()
         except requests.RequestException as exc:
+            self._log_failure_diagnostics("login_post", exc)
             raise RuntimeError(f"Sercom DM1000 login failed: {exc}") from exc
 
         if marker := self._login_redirect_marker(resp):
@@ -122,8 +141,10 @@ class SercomDM1000Driver(ModemDriver):
                 },
                 timeout=15,
             )
+            self._log_response_diagnostics("status_page", resp)
             resp.raise_for_status()
         except requests.RequestException as exc:
+            self._log_failure_diagnostics("status_page", exc)
             raise RuntimeError(f"Sercom DM1000 status page load failed: {exc}") from exc
 
     def get_docsis_data(self) -> DocsisData:
@@ -181,6 +202,7 @@ class SercomDM1000Driver(ModemDriver):
                 allow_redirects=False,
                 timeout=30,
             )
+            self._log_response_diagnostics(f"fetch_{todo}", resp)
             resp.raise_for_status()
         except requests.HTTPError as exc:
             if allow_reauth and self._is_auth_error(exc):
@@ -191,6 +213,7 @@ class SercomDM1000Driver(ModemDriver):
             log.warning("Sercom DM1000 fetch %s failed: %s", todo, exc)
             return {}
         except requests.RequestException as exc:
+            self._log_failure_diagnostics(f"fetch_{todo}", exc)
             if raise_on_error:
                 raise RuntimeError(f"Sercom DM1000 fetch {todo} failed: {exc}") from exc
             log.warning("Sercom DM1000 fetch %s failed: %s", todo, exc)
@@ -248,6 +271,145 @@ class SercomDM1000Driver(ModemDriver):
     def _is_auth_error(exc: requests.HTTPError) -> bool:
         response = getattr(exc, "response", None)
         return getattr(response, "status_code", None) in _AUTH_STATUSES
+
+    @staticmethod
+    def _env_flag_enabled(value: str) -> bool:
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+
+    def _log_diagnostic_snapshot(self, label: str) -> None:
+        if not self._diagnostics_enabled:
+            return
+        self._emit_diagnostic(
+            label,
+            {
+                "session_cookie_names": self._session_cookie_names(),
+            },
+        )
+
+    def _log_response_diagnostics(self, label: str, resp: requests.Response) -> None:
+        if not self._diagnostics_enabled:
+            return
+        headers = getattr(resp, "headers", {}) or {}
+        request = getattr(resp, "request", None)
+        request_headers = getattr(request, "headers", {}) or {}
+        raw_unparsed = self._raw_unparsed_header_payload(resp)
+        self._emit_diagnostic(
+            label,
+            {
+                "status_code": getattr(resp, "status_code", None),
+                "parsed_header_names": sorted(str(name) for name in headers.keys()),
+                "set_cookie_names": self._set_cookie_names(headers),
+                "session_cookie_names": self._session_cookie_names(),
+                "request_cookie_names": self._cookie_header_names(str(request_headers.get("Cookie", "") or "")),
+                "content_type": str(headers.get("Content-Type", "") or ""),
+                "text_len": len(str(getattr(resp, "text", "") or "")),
+                "body_shape": self._body_shape(resp),
+                "malformed_headers": self._redacted_header_block(raw_unparsed) if raw_unparsed else "",
+            },
+        )
+
+    def _log_failure_diagnostics(self, label: str, exc: requests.RequestException) -> None:
+        if not self._diagnostics_enabled:
+            return
+        self._emit_diagnostic(
+            label,
+            {
+                "exception_type": exc.__class__.__name__,
+                "session_cookie_names": self._session_cookie_names(),
+            },
+        )
+
+    def _emit_diagnostic(self, label: str, fields: dict[str, Any]) -> None:
+        if not self._diagnostics_enabled:
+            return
+        signature = (
+            label,
+            fields.get("status_code"),
+            tuple(fields.get("session_cookie_names") or []),
+            tuple(fields.get("request_cookie_names") or []),
+            fields.get("body_shape"),
+            fields.get("malformed_headers"),
+            fields.get("exception_type"),
+        )
+        if signature in self._diagnostic_signatures:
+            return
+        self._diagnostic_signatures.add(signature)
+        rendered = " ".join(f"{key}={value!r}" for key, value in fields.items() if value not in (None, "", []))
+        log.warning("Sercom DM1000 diagnostic %s: %s", label, rendered)
+
+    def _session_cookie_names(self) -> list[str]:
+        try:
+            return sorted(str(cookie.name) for cookie in self._session.cookies)
+        except Exception:
+            return []
+
+    @staticmethod
+    def _set_cookie_names(headers: Any) -> list[str]:
+        value = str(headers.get("Set-Cookie", "") or "")
+        names: list[str] = []
+        for segment in value.split(","):
+            first = segment.strip().split(";", 1)[0]
+            name, separator, _ = first.partition("=")
+            if separator and name.strip():
+                names.append(name.strip())
+        return names
+
+    @staticmethod
+    def _cookie_header_names(header_value: str) -> list[str]:
+        names: list[str] = []
+        for segment in header_value.split(";"):
+            name, separator, _ = segment.strip().partition("=")
+            if separator and name:
+                names.append(name)
+        return names
+
+    @staticmethod
+    def _body_shape(resp: requests.Response) -> str:
+        text = str(getattr(resp, "text", "") or "").lstrip()[:_DIAGNOSTIC_BODY_PEEK].lower()
+        if not text:
+            return "empty"
+        if text.startswith(("<html", "<!doctype html")):
+            return "html"
+        if text.startswith(("{", "[")):
+            return "jsonish"
+        return "other"
+
+    @staticmethod
+    def _redacted_header_block(block: str) -> str:
+        lines: list[str] = []
+        for raw_line in str(block or "").splitlines():
+            name, separator, value = raw_line.partition(":")
+            header_name = name.strip()
+            if not separator or not header_name:
+                lines.append("[redacted]")
+                continue
+            normalized = header_name.lower()
+            if normalized in _SAFE_DIAGNOSTIC_HEADER_VALUES:
+                rendered_value = value.strip()
+                if normalized == "location":
+                    rendered_value = SercomDM1000Driver._sanitize_location_header(rendered_value)
+                lines.append(f"{header_name}: {rendered_value}")
+            else:
+                lines.append(f"{header_name}: [redacted]")
+        redacted = " | ".join(lines)
+        if len(redacted) > _DIAGNOSTIC_HEADER_CAP:
+            return f"{redacted[:_DIAGNOSTIC_HEADER_CAP]}..."
+        return redacted
+
+    @staticmethod
+    def _sanitize_location_header(value: str) -> str:
+        try:
+            parts = urlsplit(value.strip())
+            netloc = parts.hostname or ""
+            if parts.port is not None:
+                netloc = f"{netloc}:{parts.port}"
+        except ValueError:
+            return "[redacted]"
+        if parts.scheme or parts.netloc:
+            return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+        if parts.query or parts.fragment:
+            return urlunsplit(("", "", parts.path, "", ""))
+        return value.strip()
 
     @staticmethod
     def _looks_like_html(resp: requests.Response) -> bool:

--- a/tests/test_sercom_dm1000_driver.py
+++ b/tests/test_sercom_dm1000_driver.py
@@ -112,6 +112,7 @@ def make_response(
     content_type="applation/json",
     headers=None,
     unparsed_headers="",
+    request_headers=None,
 ):
     resp = MagicMock(status_code=status_code)
     resp.headers = {"Content-Type": content_type}
@@ -134,6 +135,7 @@ def make_response(
             resp.json.side_effect = ValueError("not json")
         else:
             resp.json.return_value = payload
+    resp.request = MagicMock(headers=request_headers or {})
     return resp
 
 
@@ -151,6 +153,54 @@ def driver():
 
 
 class TestLogin:
+    def test_diagnostics_are_disabled_by_default(self, driver, caplog):
+        with patch.object(driver._session, "post", return_value=make_response("<html>ok</html>", content_type="text/html")):
+            with patch.object(driver._session, "get", return_value=make_response("<html>status</html>", content_type="text/html")):
+                with patch.object(driver, "_fetch_payload", return_value=DS_INFO):
+                    driver.login()
+
+        assert "Sercom DM1000 diagnostic" not in caplog.text
+
+    def test_login_diagnostics_redact_cookie_values_and_passwords(self, monkeypatch, caplog):
+        monkeypatch.setenv("DOCSIGHT_SERCOM_DM1000_DIAGNOSTICS", "1")
+        driver = SercomDM1000Driver("http://192.168.100.1", "technician", "secret-password")
+        driver._session.cookies.set("sid", "jar-secret")
+        login_response = make_response(
+            "<html>ok</html>",
+            content_type="text/html",
+            headers={"Set-Cookie": "session=parsed-secret; Path=/; HttpOnly"},
+            unparsed_headers=(
+                "Set-Cookie: rawsession=raw-secret; Path=/\r\n"
+                "X-CSRF-Token: token-secret\r\n"
+                "Location: http://user:pass@modem.local/status.html?sid=url-secret#frag\r\n"
+            ),
+            request_headers={"Cookie": "pre=pre-secret; other=other-secret"},
+        )
+
+        with patch.object(driver._session, "post", return_value=login_response):
+            with patch.object(driver._session, "get", return_value=make_response("<html>status</html>", content_type="text/html")):
+                with patch.object(driver, "_fetch_payload", return_value=DS_INFO):
+                    driver.login()
+
+        logs = caplog.text
+        assert "Sercom DM1000 diagnostic before_login_post" in logs
+        assert "Sercom DM1000 diagnostic login_post" in logs
+        assert "set_cookie_names=['session']" in logs
+        assert "session_cookie_names=['sid']" in logs
+        assert "request_cookie_names=['pre', 'other']" in logs
+        assert "Set-Cookie: [redacted]" in logs
+        assert "X-CSRF-Token: [redacted]" in logs
+        assert "Location: http://modem.local/status.html" in logs
+        assert "parsed-secret" not in logs
+        assert "raw-secret" not in logs
+        assert "token-secret" not in logs
+        assert "url-secret" not in logs
+        assert "user:pass" not in logs
+        assert "pre-secret" not in logs
+        assert "other-secret" not in logs
+        assert "jar-secret" not in logs
+        assert "secret-password" not in logs
+
     def test_login_posts_captured_sercom_form_and_verifies_protected_endpoint(self, driver):
         with patch.object(driver._session, "post", return_value=make_response("<html>ok</html>", content_type="text/html")) as post:
             with patch.object(driver._session, "get", return_value=make_response("<html>status</html>", content_type="text/html")):
@@ -252,6 +302,56 @@ class TestLogin:
 
 
 class TestFetchPayload:
+    def test_fetch_payload_diagnostics_log_malformed_redirect_without_cookie_values(self, monkeypatch, caplog):
+        monkeypatch.setenv("DOCSIGHT_SERCOM_DM1000_DIAGNOSTICS", "yes")
+        driver = SercomDM1000Driver("http://192.168.100.1", "technician", "secret")
+        response = make_response(
+            None,
+            unparsed_headers=(
+                "pragma :no-cache\r\n"
+                "Set-Cookie: modem_session=do-not-log\r\n"
+                "Location: login.html\r\n\r\n"
+            ),
+            request_headers={"Cookie": "modem_session=also-secret"},
+        )
+
+        with patch.object(driver._session, "get", return_value=response):
+            with pytest.raises(RuntimeError, match="redirected to login"):
+                driver._fetch_payload("RF_DS_param", raise_on_error=True, allow_reauth=False)
+
+        logs = caplog.text
+        assert "Sercom DM1000 diagnostic fetch_RF_DS_param" in logs
+        assert "request_cookie_names=['modem_session']" in logs
+        assert "Set-Cookie: [redacted]" in logs
+        assert "Location: login.html" in logs
+        assert "do-not-log" not in logs
+        assert "also-secret" not in logs
+
+    def test_sanitize_location_header_handles_malformed_ports(self):
+        assert SercomDM1000Driver._sanitize_location_header("http://modem.local:abc/status.html") == "[redacted]"
+
+    def test_raw_unparsed_header_payload_preserves_legacy_non_string_stringification(self):
+        resp = MagicMock()
+        msg = MagicMock()
+        msg.get_payload.return_value = ["Location: login.html"]
+        original_response = MagicMock(msg=msg)
+        resp.raw = MagicMock(_original_response=original_response)
+
+        assert SercomDM1000Driver._raw_unparsed_header_payload(resp) == "['Location: login.html']"
+
+    def test_diagnostics_deduplicate_structural_duplicate_date_headers(self, monkeypatch, caplog):
+        monkeypatch.setenv("DOCSIGHT_SERCOM_DM1000_DIAGNOSTICS", "yes")
+        driver = SercomDM1000Driver("http://192.168.100.1", "technician", "secret")
+
+        first = make_response(None, unparsed_headers="Date: Tue, 02 Jun 2026 20:00:00 GMT\r\nLocation: login.html\r\n")
+        second = make_response(None, unparsed_headers="Date: Tue, 02 Jun 2026 20:00:01 GMT\r\nLocation: login.html\r\n")
+
+        driver._log_response_diagnostics("fetch_RF_DS_param", first)
+        driver._log_response_diagnostics("fetch_RF_DS_param", second)
+
+        assert caplog.text.count("Sercom DM1000 diagnostic fetch_RF_DS_param") == 1
+        assert "Tue, 02 Jun" not in caplog.text
+
     def test_fetch_payload_accepts_sercom_json_mime_typo(self, driver):
         with patch.object(driver._session, "get", return_value=make_response(DS_INFO, content_type="applation/json")):
             assert driver._fetch_payload("RF_DS_param") == DS_INFO


### PR DESCRIPTION
## Summary
- Adds Sercom DM1000 diagnostic logging behind `DOCSIGHT_SERCOM_DM1000_DIAGNOSTICS`.
- Captures structural login/session/header information without logging password, cookie values, token values, query strings, fragments, or URL userinfo.
- Keeps the normal driver path quiet unless the diagnostic flag is enabled.

## Test Plan
- `git diff --check`
- `python -m py_compile app/drivers/sercom_dm1000.py tests/test_sercom_dm1000_driver.py`
- `pytest -q tests/test_sercom_dm1000_driver.py --tb=short`
- `pytest -q tests --ignore=tests/e2e --tb=short`
- `pytest --collect-only -q tests/e2e` (416 collected)
- Batched `pytest -q tests/e2e --tb=short` by file (416/416 passed)

Refs #561
