### PR TITLE
fix: cap Smart Capture Speedtest Tracker actions

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -78,6 +78,9 @@ DEFAULTS = {
     "sc_global_cooldown": 300,
     "sc_trigger_cooldown": 900,
     "sc_max_actions_per_hour": 4,
+    "sc_speedtest_min_interval": 14400,
+    "sc_speedtest_max_actions_per_day": 4,
+    "sc_speedtest_match_window": 900,
     "sc_flapping_window": 3600,
     "sc_flapping_threshold": 3,
     "sc_trigger_modulation": True,
@@ -145,6 +148,9 @@ ENV_MAP = {
     "sc_global_cooldown": "SC_GLOBAL_COOLDOWN",
     "sc_trigger_cooldown": "SC_TRIGGER_COOLDOWN",
     "sc_max_actions_per_hour": "SC_MAX_ACTIONS_PER_HOUR",
+    "sc_speedtest_min_interval": "SC_SPEEDTEST_MIN_INTERVAL",
+    "sc_speedtest_max_actions_per_day": "SC_SPEEDTEST_MAX_ACTIONS_PER_DAY",
+    "sc_speedtest_match_window": "SC_SPEEDTEST_MATCH_WINDOW",
     "sc_flapping_window": "SC_FLAPPING_WINDOW",
     "sc_flapping_threshold": "SC_FLAPPING_THRESHOLD",
     "sc_trigger_modulation": "SC_TRIGGER_MODULATION",
@@ -175,6 +181,7 @@ _LEGACY_KEY_MAP = {
 
 INT_KEYS = {"poll_interval", "web_port", "history_days", "notify_cooldown", "health_hysteresis",
             "sc_global_cooldown", "sc_trigger_cooldown", "sc_max_actions_per_hour",
+            "sc_speedtest_min_interval", "sc_speedtest_max_actions_per_day", "sc_speedtest_match_window",
             "sc_flapping_window", "sc_flapping_threshold",
             "sc_trigger_error_spike_min_delta"}
 BOOL_KEYS = {"demo_mode", "gaming_quality_enabled", "segment_utilization_enabled", "notify_apprise_enabled",

--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Все още няма екзекуции. Smart Capture ще регистрира активност тук, след като бъде активирана.",
   "sc_history_error": "Неуспешно зареждане на хронологията на изпълнението",
   "sc_history_loading": "Зарежда се хронологията на изпълнението...",
-  "sc_guardrails_summary": "Най-много %max%/час, минимум %cooldown% разстояние",
+  "sc_guardrails_summary": "Най-много %max%/час, минимум %cooldown% пауза; Speedtest чрез Smart Capture: %speedtestMax%/ден, през %speedtestInterval%",
   "sc_status_pending": "Предстои",
   "sc_status_fired": "Уволнен",
   "sc_status_completed": "Завършено",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "активен канал",
   "metric_active_channel_plural": "активни канала",
   "signal_family_average_section_title": "Средни стойности по сигнални семейства",
-  "signal_family_average_section_hint": "Стойностите са осреднени за активните канали във всяко DOCSIS сигнално семейство."
+  "signal_family_average_section_hint": "Стойностите са осреднени за активните канали във всяко DOCSIS сигнално семейство.",
+  "sc_speedtest_min_interval": "Минимален интервал за Speedtest (секунди)",
+  "sc_speedtest_min_interval_hint": "Блокира Smart Capture, ако Speedtest Tracker вече е изпълнил скорошен тест, включително по собствения си график.",
+  "sc_speedtest_max_actions_per_day": "Speedtest тестове чрез Smart Capture на ден",
+  "sc_speedtest_max_actions_per_day_hint": "Плъзгащ се 24-часов лимит за допълнителни Speedtest Tracker тестове, задействани от DOCSight. 0 изключва този лимит.",
+  "sc_speedtest_match_window": "Прозорец за свързване на резултат от Speedtest (секунди)",
+  "sc_speedtest_match_window_hint": "Колко дълго DOCSight изчаква, за да свърже задействан резултат от Speedtest Tracker, преди да го отбележи като изтекъл."
 }

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Dosud žádné popravy. Jakmile bude funkce Smart Capture povolena, bude zde protokolovat aktivitu.",
   "sc_history_error": "Nepodařilo se načíst historii provádění",
   "sc_history_loading": "Načítání historie provádění...",
-  "sc_guardrails_summary": "Maximálně %max%/hod, minimálně %cooldown% od sebe",
+  "sc_guardrails_summary": "Nejvýše %max%/hod, minimálně %cooldown% od sebe; Speedtesty ze Smart Capture: %speedtestMax%/den, po %speedtestInterval%",
   "sc_status_pending": "Čeká na vyřízení",
   "sc_status_fired": "Vyhozeno",
   "sc_status_completed": "Dokončeno",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktivní kanál",
   "metric_active_channel_plural": "aktivní kanály",
   "signal_family_average_section_title": "Průměry rodin signálu",
-  "signal_family_average_section_hint": "Hodnoty jsou průměrovány přes aktivní kanály v každé DOCSIS rodině signálu."
+  "signal_family_average_section_hint": "Hodnoty jsou průměrovány přes aktivní kanály v každé DOCSIS rodině signálu.",
+  "sc_speedtest_min_interval": "Minimální interval Speedtestu (sekundy)",
+  "sc_speedtest_min_interval_hint": "Zablokuje Smart Capture, pokud Speedtest Tracker nedávno spustil test, včetně vlastního plánu.",
+  "sc_speedtest_max_actions_per_day": "Speedtesty ze Smart Capture za den",
+  "sc_speedtest_max_actions_per_day_hint": "Klouzavý 24hodinový limit pro další běhy Speedtest Tracker spuštěné DOCSight. Hodnota 0 tento limit vypne.",
+  "sc_speedtest_match_window": "Okno pro přiřazení výsledku Speedtestu (sekundy)",
+  "sc_speedtest_match_window_hint": "Jak dlouho DOCSight čeká na přiřazení výsledku Speedtest Tracker, než běh označí jako vypršený."
 }

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Ingen henrettelser endnu. Smart Capture vil logge aktivitet her, når den er aktiveret.",
   "sc_history_error": "Kunne ikke indlæse eksekveringshistorikken",
   "sc_history_loading": "Indlæser eksekveringshistorik...",
-  "sc_guardrails_summary": "Højst %max%/time, minimum %cooldown% fra hinanden",
+  "sc_guardrails_summary": "Højst %max%/time, mindst %cooldown% imellem; Speedtest via Smart Capture: %speedtestMax%/dag, med %speedtestInterval% imellem",
   "sc_status_pending": "Afventer",
   "sc_status_fired": "Fyret",
   "sc_status_completed": "Fuldført",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktiv kanal",
   "metric_active_channel_plural": "aktive kanaler",
   "signal_family_average_section_title": "Signalfamiliegennemsnit",
-  "signal_family_average_section_hint": "Værdierne beregnes som gennemsnit over aktive kanaler i hver DOCSIS-signalfamilie."
+  "signal_family_average_section_hint": "Værdierne beregnes som gennemsnit over aktive kanaler i hver DOCSIS-signalfamilie.",
+  "sc_speedtest_min_interval": "Mindste interval for Speedtest (sekunder)",
+  "sc_speedtest_min_interval_hint": "Blokerer Smart Capture, hvis Speedtest Tracker allerede har kørt for nylig, også via sin egen tidsplan.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture-speedtests pr. dag",
+  "sc_speedtest_max_actions_per_day_hint": "Rullende 24-timers grænse for ekstra Speedtest Tracker-kørsler udløst af DOCSight. 0 deaktiverer grænsen.",
+  "sc_speedtest_match_window": "Matchvindue for Speedtest-resultat (sekunder)",
+  "sc_speedtest_match_window_hint": "Hvor længe DOCSight venter på at knytte et udløst Speedtest Tracker-resultat, før det udløber."
 }

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Noch keine Ausführungen. Smart Capture protokolliert Aktivitäten hier sobald es aktiviert ist.",
   "sc_history_error": "Ausführungsverlauf konnte nicht geladen werden",
   "sc_history_loading": "Ausführungsverlauf wird geladen...",
-  "sc_guardrails_summary": "Maximal %max%/Stunde, mindestens %cooldown% Abstand",
+  "sc_guardrails_summary": "Höchstens %max%/Stunde, mindestens %cooldown% Abstand; Speedtests per Smart Capture: %speedtestMax%/Tag, %speedtestInterval% Abstand",
   "sc_status_pending": "Ausstehend",
   "sc_status_fired": "Ausgelöst",
   "sc_status_completed": "Abgeschlossen",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktiver Kanal",
   "metric_active_channel_plural": "aktive Kanäle",
   "signal_family_average_section_title": "Signalgruppen-Durchschnitte",
-  "signal_family_average_section_hint": "Werte werden über aktive Kanäle in jeder DOCSIS-Signalgruppe gemittelt."
+  "signal_family_average_section_hint": "Werte werden über aktive Kanäle in jeder DOCSIS-Signalgruppe gemittelt.",
+  "sc_speedtest_min_interval": "Speedtest-Mindestabstand (Sekunden)",
+  "sc_speedtest_min_interval_hint": "Blockiert Smart Capture, wenn Speedtest Tracker kürzlich bereits gelaufen ist, einschließlich seines eigenen Zeitplans.",
+  "sc_speedtest_max_actions_per_day": "Smart-Capture-Speedtests pro Tag",
+  "sc_speedtest_max_actions_per_day_hint": "Rollierendes 24-Stunden-Limit für zusätzliche Speedtest-Tracker-Läufe, die DOCSight auslöst. 0 deaktiviert dieses Limit.",
+  "sc_speedtest_match_window": "Zuordnungsfenster für Speedtest-Ergebnisse (Sekunden)",
+  "sc_speedtest_match_window_hint": "Wie lange DOCSight wartet, um ein ausgelöstes Speedtest-Tracker-Ergebnis zuzuordnen, bevor es abläuft."
 }

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Δεν υπάρχουν ακόμη εκτελέσεις. Το Smart Capture θα καταγράφει τη δραστηριότητα εδώ μόλις ενεργοποιηθεί.",
   "sc_history_error": "Αποτυχία φόρτωσης του ιστορικού εκτέλεσης",
   "sc_history_loading": "Φόρτωση ιστορικού εκτέλεσης...",
-  "sc_guardrails_summary": "Το πολύ %max%/ώρα, ελάχιστο %cooldown% διαφορά",
+  "sc_guardrails_summary": "Έως %max%/ώρα, με ελάχιστη απόσταση %cooldown%; Speedtest από Smart Capture: %speedtestMax%/ημέρα, ανά %speedtestInterval%",
   "sc_status_pending": "Σε εκκρεμότητα",
   "sc_status_fired": "Απολύθηκε",
   "sc_status_completed": "Ολοκληρώθηκε",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "ενεργό κανάλι",
   "metric_active_channel_plural": "ενεργά κανάλια",
   "signal_family_average_section_title": "Μέσοι όροι οικογενειών σήματος",
-  "signal_family_average_section_hint": "Οι τιμές υπολογίζονται ως μέσος όρος των ενεργών καναλιών σε κάθε οικογένεια σήματος DOCSIS."
+  "signal_family_average_section_hint": "Οι τιμές υπολογίζονται ως μέσος όρος των ενεργών καναλιών σε κάθε οικογένεια σήματος DOCSIS.",
+  "sc_speedtest_min_interval": "Ελάχιστο διάστημα Speedtest (δευτερόλεπτα)",
+  "sc_speedtest_min_interval_hint": "Μπλοκάρει το Smart Capture αν το Speedtest Tracker εκτέλεσε πρόσφατα μέτρηση, συμπεριλαμβανομένου του δικού του προγράμματος.",
+  "sc_speedtest_max_actions_per_day": "Speedtest από Smart Capture ανά ημέρα",
+  "sc_speedtest_max_actions_per_day_hint": "Κυλιόμενο όριο 24 ωρών για πρόσθετες εκτελέσεις Speedtest Tracker που ενεργοποιεί το DOCSight. Το 0 απενεργοποιεί το όριο.",
+  "sc_speedtest_match_window": "Παράθυρο αντιστοίχισης αποτελέσματος Speedtest (δευτερόλεπτα)",
+  "sc_speedtest_match_window_hint": "Πόσο περιμένει το DOCSight για να συνδέσει ένα αποτέλεσμα Speedtest Tracker πριν το χαρακτηρίσει ληγμένο."
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "No executions yet. Smart Capture will log activity here once enabled.",
   "sc_history_error": "Failed to load execution history",
   "sc_history_loading": "Loading execution history...",
-  "sc_guardrails_summary": "At most %max%/hour, minimum %cooldown% apart",
+  "sc_guardrails_summary": "At most %max%/hour, minimum %cooldown% apart; Smart Capture speedtests: %speedtestMax%/day, %speedtestInterval% apart",
   "sc_status_pending": "Pending",
   "sc_status_fired": "Fired",
   "sc_status_completed": "Completed",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "active channel",
   "metric_active_channel_plural": "active channels",
   "signal_family_average_section_title": "Signal family averages",
-  "signal_family_average_section_hint": "Values are averaged across active channels in each DOCSIS signal family."
+  "signal_family_average_section_hint": "Values are averaged across active channels in each DOCSIS signal family.",
+  "sc_speedtest_min_interval": "Speedtest min interval (seconds)",
+  "sc_speedtest_min_interval_hint": "Blocks Smart Capture if Speedtest Tracker already ran recently, including its own schedule.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture speedtests per day",
+  "sc_speedtest_max_actions_per_day_hint": "Rolling 24h cap for extra Speedtest Tracker runs triggered by DOCSight. 0 disables this cap.",
+  "sc_speedtest_match_window": "Speedtest result match window (seconds)",
+  "sc_speedtest_match_window_hint": "How long DOCSight waits to link a triggered Speedtest Tracker result before expiring it."
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -903,7 +903,7 @@
   "sc_history_empty": "Sin ejecuciones aun. Smart Capture registrara la actividad aqui una vez activado.",
   "sc_history_error": "Error al cargar el historial de ejecuciones",
   "sc_history_loading": "Cargando historial de ejecuciones...",
-  "sc_guardrails_summary": "Maximo %max%/hora, minimo %cooldown% entre capturas",
+  "sc_guardrails_summary": "Como máximo %max%/hora, mínimo %cooldown% de separación; Speedtests de Smart Capture: %speedtestMax%/día, cada %speedtestInterval%",
   "sc_status_pending": "Pendiente",
   "sc_status_fired": "Activado",
   "sc_status_completed": "Completado",
@@ -1055,5 +1055,11 @@
   "metric_active_channel_singular": "canal activo",
   "metric_active_channel_plural": "canales activos",
   "signal_family_average_section_title": "Promedios por familia de señal",
-  "signal_family_average_section_hint": "Los valores se promedian entre los canales activos de cada familia de señal DOCSIS."
+  "signal_family_average_section_hint": "Los valores se promedian entre los canales activos de cada familia de señal DOCSIS.",
+  "sc_speedtest_min_interval": "Intervalo mínimo de Speedtest (segundos)",
+  "sc_speedtest_min_interval_hint": "Bloquea Smart Capture si Speedtest Tracker ya se ejecutó recientemente, incluido su propio horario.",
+  "sc_speedtest_max_actions_per_day": "Speedtests de Smart Capture por día",
+  "sc_speedtest_max_actions_per_day_hint": "Límite móvil de 24 h para ejecuciones adicionales de Speedtest Tracker iniciadas por DOCSight. 0 desactiva este límite.",
+  "sc_speedtest_match_window": "Ventana para vincular resultados de Speedtest (segundos)",
+  "sc_speedtest_match_window_hint": "Cuánto tiempo espera DOCSight para vincular un resultado de Speedtest Tracker antes de marcarlo como expirado."
 }

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Hukkamisi veel pole. Smart Capture logib siin tegevused, kui see on lubatud.",
   "sc_history_error": "Täitmisajaloo laadimine ebaõnnestus",
   "sc_history_loading": "Täitmisajaloo laadimine...",
-  "sc_guardrails_summary": "Maksimaalselt %max%/tunnis, minimaalselt % jahutus% vahega",
+  "sc_guardrails_summary": "Kuni %max%/tunnis, vähemalt %cooldown% vahega; Smart Capture Speedtestid: %speedtestMax%/päev, %speedtestInterval% vahega",
   "sc_status_pending": "Ootel",
   "sc_status_fired": "Vallandatud",
   "sc_status_completed": "Lõpetatud",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktiivne kanal",
   "metric_active_channel_plural": "aktiivsed kanalid",
   "signal_family_average_section_title": "Signaaliperekondade keskmised",
-  "signal_family_average_section_hint": "Väärtused on keskmistatud iga DOCSIS-signaaliperekonna aktiivsete kanalite lõikes."
+  "signal_family_average_section_hint": "Väärtused on keskmistatud iga DOCSIS-signaaliperekonna aktiivsete kanalite lõikes.",
+  "sc_speedtest_min_interval": "Speedtesti minimaalne intervall (sekundites)",
+  "sc_speedtest_min_interval_hint": "Blokeerib Smart Capture’i, kui Speedtest Tracker on hiljuti juba käivitunud, sh oma ajakava järgi.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture’i Speedtestid päevas",
+  "sc_speedtest_max_actions_per_day_hint": "Libisev 24 h piir DOCSighti käivitatud täiendavatele Speedtest Tracker mõõtmistele. 0 keelab selle piiri.",
+  "sc_speedtest_match_window": "Speedtesti tulemuse sidumise aken (sekundites)",
+  "sc_speedtest_match_window_hint": "Kui kaua DOCSight ootab käivitatud Speedtest Tracker tulemuse sidumist enne selle aegunuks märkimist."
 }

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Ei vielä teloituksia. Smart Capture kirjaa toiminnan tänne, kun se on otettu käyttöön.",
   "sc_history_error": "Suoritushistorian lataaminen epäonnistui",
   "sc_history_loading": "Ladataan suoritushistoriaa...",
-  "sc_guardrails_summary": "Enintään %max%/tunti, vähintään %jäähdytys% toisistaan",
+  "sc_guardrails_summary": "Enintään %max%/tunti, vähintään %cooldown% välein; Smart Capture -speedtestit: %speedtestMax%/päivä, %speedtestInterval% välein",
   "sc_status_pending": "Odottaa",
   "sc_status_fired": "Ammutettu",
   "sc_status_completed": "Valmis",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktiivinen kanava",
   "metric_active_channel_plural": "aktiivista kanavaa",
   "signal_family_average_section_title": "Signaaliperheiden keskiarvot",
-  "signal_family_average_section_hint": "Arvot ovat aktiivisten kanavien keskiarvoja kussakin DOCSIS-signaaliperheessä."
+  "signal_family_average_section_hint": "Arvot ovat aktiivisten kanavien keskiarvoja kussakin DOCSIS-signaaliperheessä.",
+  "sc_speedtest_min_interval": "Speedtestin vähimmäisväli (sekuntia)",
+  "sc_speedtest_min_interval_hint": "Estää Smart Capturen, jos Speedtest Tracker on ajanut testin hiljattain, myös oman aikataulunsa kautta.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture -speedtestit päivässä",
+  "sc_speedtest_max_actions_per_day_hint": "Liukuva 24 tunnin raja DOCSightin käynnistämille lisäajoille Speedtest Trackerissa. 0 poistaa rajan käytöstä.",
+  "sc_speedtest_match_window": "Speedtest-tuloksen täsmäytysikkuna (sekuntia)",
+  "sc_speedtest_match_window_hint": "Kuinka kauan DOCSight odottaa käynnistetyn Speedtest Tracker -tuloksen linkittämistä ennen sen vanhentamista."
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -900,7 +900,7 @@
   "sc_history_empty": "Aucune execution pour le moment. Smart Capture enregistrera les activites ici une fois active.",
   "sc_history_error": "Echec du chargement de l'historique des executions",
   "sc_history_loading": "Chargement de l'historique des executions...",
-  "sc_guardrails_summary": "Maximum %max%/heure, minimum %cooldown% entre chaque",
+  "sc_guardrails_summary": "Au plus %max%/heure, au minimum %cooldown% d’écart ; Speedtests Smart Capture : %speedtestMax%/jour, toutes les %speedtestInterval%",
   "sc_status_pending": "En attente",
   "sc_status_fired": "Declenche",
   "sc_status_completed": "Termine",
@@ -1052,5 +1052,11 @@
   "metric_active_channel_singular": "canal actif",
   "metric_active_channel_plural": "canaux actifs",
   "signal_family_average_section_title": "Moyennes par famille de signal",
-  "signal_family_average_section_hint": "Les valeurs sont moyennées sur les canaux actifs de chaque famille de signal DOCSIS."
+  "signal_family_average_section_hint": "Les valeurs sont moyennées sur les canaux actifs de chaque famille de signal DOCSIS.",
+  "sc_speedtest_min_interval": "Intervalle minimal de Speedtest (secondes)",
+  "sc_speedtest_min_interval_hint": "Bloque Smart Capture si Speedtest Tracker a déjà lancé un test récemment, y compris via sa propre planification.",
+  "sc_speedtest_max_actions_per_day": "Speedtests Smart Capture par jour",
+  "sc_speedtest_max_actions_per_day_hint": "Plafond glissant de 24 h pour les exécutions Speedtest Tracker supplémentaires déclenchées par DOCSight. 0 désactive ce plafond.",
+  "sc_speedtest_match_window": "Fenêtre de correspondance des résultats Speedtest (secondes)",
+  "sc_speedtest_match_window_hint": "Durée pendant laquelle DOCSight attend pour lier un résultat Speedtest Tracker déclenché avant de l’expirer."
 }

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Níl aon básuithe fós. Logálfaidh Smart Capture gníomhaíocht anseo nuair a bheidh sé cumasaithe.",
   "sc_history_error": "Theip ar an stair fhorghníomhaithe a lódáil",
   "sc_history_loading": "Stair forghníomhaithe á lódáil...",
-  "sc_guardrails_summary": "% max%/uair ar a mhéad, % fuarú% ar a laghad óna chéile",
+  "sc_guardrails_summary": "Uasmhéid %max%/uair, ar a laghad %cooldown% eatarthu; Speedtests Smart Capture: %speedtestMax%/lá, gach %speedtestInterval%",
   "sc_status_pending": "ar feitheamh",
   "sc_status_fired": "fired",
   "sc_status_completed": "Críochnaithe",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "cainéal gníomhach",
   "metric_active_channel_plural": "cainéil ghníomhacha",
   "signal_family_average_section_title": "Meáin de réir teaghlaigh comhartha",
-  "signal_family_average_section_hint": "Ríomhtar na luachanna mar mheán thar chainéil ghníomhacha i ngach teaghlach comhartha DOCSIS."
+  "signal_family_average_section_hint": "Ríomhtar na luachanna mar mheán thar chainéil ghníomhacha i ngach teaghlach comhartha DOCSIS.",
+  "sc_speedtest_min_interval": "Eatramh íosta Speedtest (soicindí)",
+  "sc_speedtest_min_interval_hint": "Cuireann sé bac ar Smart Capture má rith Speedtest Tracker le déanaí cheana féin, lena sceideal féin san áireamh.",
+  "sc_speedtest_max_actions_per_day": "Speedtests Smart Capture in aghaidh an lae",
+  "sc_speedtest_max_actions_per_day_hint": "Teorainn rollach 24 uair do ritheanna breise Speedtest Tracker a spreagann DOCSight. Díchumasaíonn 0 an teorainn seo.",
+  "sc_speedtest_match_window": "Fuinneog mheaitseála torthaí Speedtest (soicindí)",
+  "sc_speedtest_match_window_hint": "Cá fhad a fhanann DOCSight chun toradh Speedtest Tracker spreagtha a nascadh sula rachaidh sé in éag."
 }

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Još nema izvršenja. Smart Capture će ovdje zabilježiti aktivnost nakon što se omogući.",
   "sc_history_error": "Nije uspjelo učitavanje povijesti izvršenja",
   "sc_history_loading": "Učitavanje povijesti izvršenja...",
-  "sc_guardrails_summary": "Najviše %max%/sat, minimalno %cooldown% razmak",
+  "sc_guardrails_summary": "Najviše %max%/sat, najmanje %cooldown% razmaka; Speedtestovi iz Smart Capturea: %speedtestMax%/dan, svakih %speedtestInterval%",
   "sc_status_pending": "Na čekanju",
   "sc_status_fired": "Otpušten",
   "sc_status_completed": "Završeno",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktivan kanal",
   "metric_active_channel_plural": "aktivna kanala",
   "signal_family_average_section_title": "Prosjeci po signalnim obiteljima",
-  "signal_family_average_section_hint": "Vrijednosti su prosjeci aktivnih kanala u svakoj DOCSIS signalnoj obitelji."
+  "signal_family_average_section_hint": "Vrijednosti su prosjeci aktivnih kanala u svakoj DOCSIS signalnoj obitelji.",
+  "sc_speedtest_min_interval": "Minimalni interval Speedtesta (sekunde)",
+  "sc_speedtest_min_interval_hint": "Blokira Smart Capture ako je Speedtest Tracker nedavno već pokrenut, uključujući njegov vlastiti raspored.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture Speedtestovi po danu",
+  "sc_speedtest_max_actions_per_day_hint": "Klizno 24-satno ograničenje za dodatna pokretanja Speedtest Trackera koja pokrene DOCSight. 0 isključuje ovo ograničenje.",
+  "sc_speedtest_match_window": "Prozor za povezivanje rezultata Speedtesta (sekunde)",
+  "sc_speedtest_match_window_hint": "Koliko dugo DOCSight čeka da poveže pokrenuti rezultat Speedtest Trackera prije isteka."
 }

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Még nincsenek kivégzések. Az Intelligens rögzítés itt naplózza a tevékenységet, ha engedélyezve van.",
   "sc_history_error": "Nem sikerült betölteni a végrehajtási előzményeket",
   "sc_history_loading": "Végrehajtási előzmények betöltése...",
-  "sc_guardrails_summary": "Legfeljebb %max%/óra, minimum %lehűlés% távolságra",
+  "sc_guardrails_summary": "Legfeljebb %max%/óra, legalább %cooldown% különbséggel; Smart Capture Speedtestek: %speedtestMax%/nap, %speedtestInterval% különbséggel",
   "sc_status_pending": "Függőben",
   "sc_status_fired": "Kirúgva",
   "sc_status_completed": "Befejezve",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktív csatorna",
   "metric_active_channel_plural": "aktív csatorna",
   "signal_family_average_section_title": "Jelcsalád-átlagok",
-  "signal_family_average_section_hint": "Az értékek az egyes DOCSIS jelcsaládok aktív csatornáinak átlagai."
+  "signal_family_average_section_hint": "Az értékek az egyes DOCSIS jelcsaládok aktív csatornáinak átlagai.",
+  "sc_speedtest_min_interval": "Speedtest minimális időköze (másodperc)",
+  "sc_speedtest_min_interval_hint": "Letiltja a Smart Capture-t, ha a Speedtest Tracker nemrég már futott, beleértve a saját ütemezését is.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture Speedtestek naponta",
+  "sc_speedtest_max_actions_per_day_hint": "Gördülő 24 órás korlát a DOCSight által indított további Speedtest Tracker futásokra. A 0 kikapcsolja ezt a korlátot.",
+  "sc_speedtest_match_window": "Speedtest-eredmény illesztési ablaka (másodperc)",
+  "sc_speedtest_match_window_hint": "Meddig vár a DOCSight egy indított Speedtest Tracker eredmény összekapcsolására, mielőtt lejártnak jelöli."
 }

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Ancora nessuna esecuzione. Smart Capture registrerà l'attività qui una volta abilitata.",
   "sc_history_error": "Impossibile caricare la cronologia di esecuzione",
   "sc_history_loading": "Caricamento cronologia esecuzioni...",
-  "sc_guardrails_summary": "Al massimo %max%/ora, minimo %cooldown% a parte",
+  "sc_guardrails_summary": "Al massimo %max%/ora, almeno %cooldown% di distanza; Speedtest da Smart Capture: %speedtestMax%/giorno, ogni %speedtestInterval%",
   "sc_status_pending": "In attesa",
   "sc_status_fired": "Licenziato",
   "sc_status_completed": "Completato",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "canale attivo",
   "metric_active_channel_plural": "canali attivi",
   "signal_family_average_section_title": "Medie per famiglia di segnale",
-  "signal_family_average_section_hint": "I valori sono mediati sui canali attivi in ogni famiglia di segnale DOCSIS."
+  "signal_family_average_section_hint": "I valori sono mediati sui canali attivi in ogni famiglia di segnale DOCSIS.",
+  "sc_speedtest_min_interval": "Intervallo minimo Speedtest (secondi)",
+  "sc_speedtest_min_interval_hint": "Blocca Smart Capture se Speedtest Tracker ha già eseguito un test di recente, inclusa la propria pianificazione.",
+  "sc_speedtest_max_actions_per_day": "Speedtest Smart Capture al giorno",
+  "sc_speedtest_max_actions_per_day_hint": "Limite mobile di 24 ore per esecuzioni aggiuntive di Speedtest Tracker attivate da DOCSight. 0 disattiva questo limite.",
+  "sc_speedtest_match_window": "Finestra di associazione risultato Speedtest (secondi)",
+  "sc_speedtest_match_window_hint": "Per quanto tempo DOCSight attende di associare un risultato Speedtest Tracker attivato prima di farlo scadere."
 }

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Egzekucijos dar nėra. „Smart Capture“ čia registruos veiklą, kai bus įjungta.",
   "sc_history_error": "Nepavyko įkelti vykdymo istorijos",
   "sc_history_loading": "Įkeliama vykdymo istorija...",
-  "sc_guardrails_summary": "Daugiausia %max%/val., mažiausiai % vėsinimo%.",
+  "sc_guardrails_summary": "Daugiausia %max%/val., bent %cooldown% tarpas; Smart Capture Speedtestai: %speedtestMax%/dieną, kas %speedtestInterval%",
   "sc_status_pending": "Laukiama",
   "sc_status_fired": "Atleista",
   "sc_status_completed": "Užbaigta",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktyvus kanalas",
   "metric_active_channel_plural": "aktyvūs kanalai",
   "signal_family_average_section_title": "Signalų šeimų vidurkiai",
-  "signal_family_average_section_hint": "Reikšmės apskaičiuojamos kaip aktyvių kanalų vidurkis kiekvienoje DOCSIS signalų šeimoje."
+  "signal_family_average_section_hint": "Reikšmės apskaičiuojamos kaip aktyvių kanalų vidurkis kiekvienoje DOCSIS signalų šeimoje.",
+  "sc_speedtest_min_interval": "Minimalus Speedtest intervalas (sekundės)",
+  "sc_speedtest_min_interval_hint": "Blokuoja Smart Capture, jei Speedtest Tracker neseniai jau veikė, įskaitant jo paties tvarkaraštį.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture Speedtestai per dieną",
+  "sc_speedtest_max_actions_per_day_hint": "Slenkantis 24 val. limitas papildomiems Speedtest Tracker paleidimams, kuriuos inicijuoja DOCSight. 0 išjungia šį limitą.",
+  "sc_speedtest_match_window": "Speedtest rezultato susiejimo langas (sekundės)",
+  "sc_speedtest_match_window_hint": "Kiek laiko DOCSight laukia, kad susietų inicijuotą Speedtest Tracker rezultatą, prieš pažymėdamas jį pasibaigusiu."
 }

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Pagaidām nav izpildīts neviens nāvessods. Viedā tveršana šeit reģistrēs darbības, kad tā būs iespējota.",
   "sc_history_error": "Neizdevās ielādēt izpildes vēsturi",
   "sc_history_loading": "Notiek izpildes vēstures ielāde...",
-  "sc_guardrails_summary": "Ne vairāk kā %max%/stundā, vismaz % atdzišanas% intervāls",
+  "sc_guardrails_summary": "Ne vairāk kā %max%/stundā, vismaz ar %cooldown% starplaiku; Smart Capture Speedtesti: %speedtestMax%/dienā, ik pēc %speedtestInterval%",
   "sc_status_pending": "Gaida",
   "sc_status_fired": "Atlaists",
   "sc_status_completed": "Pabeigts",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktīvs kanāls",
   "metric_active_channel_plural": "aktīvi kanāli",
   "signal_family_average_section_title": "Signālu saimju vidējās vērtības",
-  "signal_family_average_section_hint": "Vērtības ir vidējotas pa aktīvajiem kanāliem katrā DOCSIS signālu saimē."
+  "signal_family_average_section_hint": "Vērtības ir vidējotas pa aktīvajiem kanāliem katrā DOCSIS signālu saimē.",
+  "sc_speedtest_min_interval": "Minimālais Speedtest intervāls (sekundes)",
+  "sc_speedtest_min_interval_hint": "Bloķē Smart Capture, ja Speedtest Tracker nesen jau ir palaists, tostarp pēc sava grafika.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture Speedtesti dienā",
+  "sc_speedtest_max_actions_per_day_hint": "Slīdošs 24 h limits papildu Speedtest Tracker palaišanām, ko ierosina DOCSight. 0 atspējo šo limitu.",
+  "sc_speedtest_match_window": "Speedtest rezultāta sasaistes logs (sekundes)",
+  "sc_speedtest_match_window_hint": "Cik ilgi DOCSight gaida, lai sasaistītu ierosinātu Speedtest Tracker rezultātu, pirms to atzīmē kā beigušos."
 }

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Ingen henrettelser ennå. Smart Capture vil logge aktivitet her når den er aktivert.",
   "sc_history_error": "Kunne ikke laste inn kjøringshistorikken",
   "sc_history_loading": "Laster utføringshistorikk...",
-  "sc_guardrails_summary": "Høyst %max%/time, minimum %cooldown% fra hverandre",
+  "sc_guardrails_summary": "Maks %max%/time, minst %cooldown% mellom; Speedtester fra Smart Capture: %speedtestMax%/dag, med %speedtestInterval% mellom",
   "sc_status_pending": "Venter",
   "sc_status_fired": "Avfyrt",
   "sc_status_completed": "Fullført",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktiv kanal",
   "metric_active_channel_plural": "aktive kanaler",
   "signal_family_average_section_title": "Gjennomsnitt per signalfamilie",
-  "signal_family_average_section_hint": "Verdiene er gjennomsnitt over aktive kanaler i hver DOCSIS-signalfamilie."
+  "signal_family_average_section_hint": "Verdiene er gjennomsnitt over aktive kanaler i hver DOCSIS-signalfamilie.",
+  "sc_speedtest_min_interval": "Minste intervall for Speedtest (sekunder)",
+  "sc_speedtest_min_interval_hint": "Blokkerer Smart Capture hvis Speedtest Tracker nylig allerede har kjørt, inkludert etter sin egen tidsplan.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture-speedtester per dag",
+  "sc_speedtest_max_actions_per_day_hint": "Rullerende 24-timers grense for ekstra Speedtest Tracker-kjøringer utløst av DOCSight. 0 deaktiverer grensen.",
+  "sc_speedtest_match_window": "Matchvindu for Speedtest-resultat (sekunder)",
+  "sc_speedtest_match_window_hint": "Hvor lenge DOCSight venter på å koble et utløst Speedtest Tracker-resultat før det utløper."
 }

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Nog geen executies. Smart Capture registreert hier de activiteit zodra deze is ingeschakeld.",
   "sc_history_error": "Kan de uitvoeringsgeschiedenis niet laden",
   "sc_history_loading": "Uitvoeringsgeschiedenis laden...",
-  "sc_guardrails_summary": "Maximaal %max%/uur, minimaal %cooldown% uit elkaar",
+  "sc_guardrails_summary": "Maximaal %max%/uur, minimaal %cooldown% ertussen; Smart Capture-speedtests: %speedtestMax%/dag, elke %speedtestInterval%",
   "sc_status_pending": "In behandeling",
   "sc_status_fired": "Ontslagen",
   "sc_status_completed": "Voltooid",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "actief kanaal",
   "metric_active_channel_plural": "actieve kanalen",
   "signal_family_average_section_title": "Gemiddelden per signaalfamilie",
-  "signal_family_average_section_hint": "Waarden zijn gemiddeld over actieve kanalen in elke DOCSIS-signaalfamilie."
+  "signal_family_average_section_hint": "Waarden zijn gemiddeld over actieve kanalen in elke DOCSIS-signaalfamilie.",
+  "sc_speedtest_min_interval": "Minimale Speedtest-interval (seconden)",
+  "sc_speedtest_min_interval_hint": "Blokkeert Smart Capture als Speedtest Tracker onlangs al heeft gedraaid, inclusief de eigen planning.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture-speedtests per dag",
+  "sc_speedtest_max_actions_per_day_hint": "Voortschrijdende 24-uurs limiet voor extra Speedtest Tracker-runs die DOCSight start. 0 schakelt deze limiet uit.",
+  "sc_speedtest_match_window": "Koppelvenster voor Speedtest-resultaat (seconden)",
+  "sc_speedtest_match_window_hint": "Hoe lang DOCSight wacht om een gestart Speedtest Tracker-resultaat te koppelen voordat het verloopt."
 }

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Nie ma jeszcze egzekucji. Po włączeniu funkcja Smart Capture będzie rejestrować tutaj aktywność.",
   "sc_history_error": "Nie udało się załadować historii wykonania",
   "sc_history_loading": "Ładowanie historii wykonania...",
-  "sc_guardrails_summary": "Maksymalnie %max%/godzinę, z minimalnym odstępem %ochłodzenia%.",
+  "sc_guardrails_summary": "Maksymalnie %max%/godz., co najmniej %cooldown% odstępu; Speedtesty ze Smart Capture: %speedtestMax%/dzień, co %speedtestInterval%",
   "sc_status_pending": "Oczekuje",
   "sc_status_fired": "Zwolniony",
   "sc_status_completed": "Ukończono",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktywny kanał",
   "metric_active_channel_plural": "aktywne kanały",
   "signal_family_average_section_title": "Średnie rodzin sygnału",
-  "signal_family_average_section_hint": "Wartości są uśredniane dla aktywnych kanałów w każdej rodzinie sygnału DOCSIS."
+  "signal_family_average_section_hint": "Wartości są uśredniane dla aktywnych kanałów w każdej rodzinie sygnału DOCSIS.",
+  "sc_speedtest_min_interval": "Minimalny odstęp Speedtestu (sekundy)",
+  "sc_speedtest_min_interval_hint": "Blokuje Smart Capture, jeśli Speedtest Tracker niedawno już wykonał test, także z własnego harmonogramu.",
+  "sc_speedtest_max_actions_per_day": "Speedtesty Smart Capture dziennie",
+  "sc_speedtest_max_actions_per_day_hint": "Ruchomy limit 24 h dla dodatkowych uruchomień Speedtest Tracker wyzwalanych przez DOCSight. 0 wyłącza ten limit.",
+  "sc_speedtest_match_window": "Okno dopasowania wyniku Speedtestu (sekundy)",
+  "sc_speedtest_match_window_hint": "Jak długo DOCSight czeka na powiązanie wyzwolonego wyniku Speedtest Tracker, zanim oznaczy go jako wygasły."
 }

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Nenhuma execução ainda. O Smart Capture registrará a atividade aqui, uma vez ativado.",
   "sc_history_error": "Falha ao carregar o histórico de execução",
   "sc_history_loading": "Carregando histórico de execução...",
-  "sc_guardrails_summary": "No máximo %max%/hora, intervalo mínimo de %cooldown%",
+  "sc_guardrails_summary": "No máximo %max%/hora, pelo menos %cooldown% de intervalo; Speedtests do Smart Capture: %speedtestMax%/dia, a cada %speedtestInterval%",
   "sc_status_pending": "Pendente",
   "sc_status_fired": "Demitido",
   "sc_status_completed": "Concluído",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "canal ativo",
   "metric_active_channel_plural": "canais ativos",
   "signal_family_average_section_title": "Médias por família de sinal",
-  "signal_family_average_section_hint": "Os valores são calculados como média dos canais ativos em cada família de sinal DOCSIS."
+  "signal_family_average_section_hint": "Os valores são calculados como média dos canais ativos em cada família de sinal DOCSIS.",
+  "sc_speedtest_min_interval": "Intervalo mínimo do Speedtest (segundos)",
+  "sc_speedtest_min_interval_hint": "Bloqueia o Smart Capture se o Speedtest Tracker já tiver executado recentemente, incluindo o próprio agendamento.",
+  "sc_speedtest_max_actions_per_day": "Speedtests do Smart Capture por dia",
+  "sc_speedtest_max_actions_per_day_hint": "Limite móvel de 24 h para execuções adicionais do Speedtest Tracker acionadas pelo DOCSight. 0 desativa este limite.",
+  "sc_speedtest_match_window": "Janela de correspondência do resultado Speedtest (segundos)",
+  "sc_speedtest_match_window_hint": "Por quanto tempo o DOCSight aguarda para vincular um resultado do Speedtest Tracker acionado antes de marcá-lo como expirado."
 }

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Nicio execuție încă. Smart Capture va înregistra activitatea aici odată ce este activată.",
   "sc_history_error": "Nu s-a încărcat istoricul execuțiilor",
   "sc_history_loading": "Se încarcă istoricul execuțiilor...",
-  "sc_guardrails_summary": "Cel mult %max%/oră, minim %cooldown% separat",
+  "sc_guardrails_summary": "Cel mult %max%/oră, la cel puțin %cooldown% distanță; Speedtesturi Smart Capture: %speedtestMax%/zi, la %speedtestInterval%",
   "sc_status_pending": "În așteptare",
   "sc_status_fired": "Demis",
   "sc_status_completed": "Finalizat",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "canal activ",
   "metric_active_channel_plural": "canale active",
   "signal_family_average_section_title": "Medii pe familii de semnal",
-  "signal_family_average_section_hint": "Valorile sunt mediate pe canalele active din fiecare familie de semnal DOCSIS."
+  "signal_family_average_section_hint": "Valorile sunt mediate pe canalele active din fiecare familie de semnal DOCSIS.",
+  "sc_speedtest_min_interval": "Interval minim Speedtest (secunde)",
+  "sc_speedtest_min_interval_hint": "Blochează Smart Capture dacă Speedtest Tracker a rulat deja recent, inclusiv după propriul program.",
+  "sc_speedtest_max_actions_per_day": "Speedtesturi Smart Capture pe zi",
+  "sc_speedtest_max_actions_per_day_hint": "Limită glisantă de 24 h pentru rulări suplimentare Speedtest Tracker declanșate de DOCSight. 0 dezactivează această limită.",
+  "sc_speedtest_match_window": "Fereastră de asociere rezultat Speedtest (secunde)",
+  "sc_speedtest_match_window_hint": "Cât timp așteaptă DOCSight pentru a asocia un rezultat Speedtest Tracker declanșat înainte de expirare."
 }

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Zatiaľ žiadne popravy. Po aktivácii Smart Capture tu zaznamená aktivitu.",
   "sc_history_error": "Nepodarilo sa načítať históriu vykonávania",
   "sc_history_loading": "Načítava sa história vykonávania...",
-  "sc_guardrails_summary": "Najviac %max%/hodinu, minimálne %ochladzovanie% od seba",
+  "sc_guardrails_summary": "Najviac %max%/hod., minimálne %cooldown% odstup; Speedtesty zo Smart Capture: %speedtestMax%/deň, každých %speedtestInterval%",
   "sc_status_pending": "Čaká sa",
   "sc_status_fired": "Prepustený",
   "sc_status_completed": "Dokončené",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktívny kanál",
   "metric_active_channel_plural": "aktívne kanály",
   "signal_family_average_section_title": "Priemery rodín signálu",
-  "signal_family_average_section_hint": "Hodnoty sú priemerované cez aktívne kanály v každej DOCSIS rodine signálu."
+  "signal_family_average_section_hint": "Hodnoty sú priemerované cez aktívne kanály v každej DOCSIS rodine signálu.",
+  "sc_speedtest_min_interval": "Minimálny interval Speedtestu (sekundy)",
+  "sc_speedtest_min_interval_hint": "Zablokuje Smart Capture, ak Speedtest Tracker nedávno už bežal, vrátane vlastného plánu.",
+  "sc_speedtest_max_actions_per_day": "Speedtesty Smart Capture za deň",
+  "sc_speedtest_max_actions_per_day_hint": "Kĺzavý 24-hodinový limit pre dodatočné behy Speedtest Tracker spustené DOCSight. 0 tento limit vypne.",
+  "sc_speedtest_match_window": "Okno priradenia výsledku Speedtestu (sekundy)",
+  "sc_speedtest_match_window_hint": "Ako dlho DOCSight čaká na priradenie spusteného výsledku Speedtest Tracker, kým ho označí ako expirovaný."
 }

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Usmrtitev še ni. Smart Capture bo tukaj beležil dejavnost, ko bo omogočena.",
   "sc_history_error": "Nalaganje zgodovine izvajanja ni uspelo",
   "sc_history_loading": "Nalaganje zgodovine izvajanja ...",
-  "sc_guardrails_summary": "Največ %max%/uro, najmanj %cooldown% narazen",
+  "sc_guardrails_summary": "Največ %max%/uro, vsaj %cooldown% narazen; Speedtesti iz Smart Capture: %speedtestMax%/dan, vsakih %speedtestInterval%",
   "sc_status_pending": "V teku",
   "sc_status_fired": "Odpuščen",
   "sc_status_completed": "Dokončano",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktiven kanal",
   "metric_active_channel_plural": "aktivni kanali",
   "signal_family_average_section_title": "Povprečja družin signalov",
-  "signal_family_average_section_hint": "Vrednosti so povprečene po aktivnih kanalih v vsaki družini signalov DOCSIS."
+  "signal_family_average_section_hint": "Vrednosti so povprečene po aktivnih kanalih v vsaki družini signalov DOCSIS.",
+  "sc_speedtest_min_interval": "Najmanjši interval Speedtesta (sekunde)",
+  "sc_speedtest_min_interval_hint": "Blokira Smart Capture, če je Speedtest Tracker nedavno že tekel, vključno z lastnim urnikom.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture Speedtesti na dan",
+  "sc_speedtest_max_actions_per_day_hint": "Drseča 24-urna omejitev za dodatne zagone Speedtest Tracker, ki jih sproži DOCSight. 0 onemogoči to omejitev.",
+  "sc_speedtest_match_window": "Okno ujemanja rezultata Speedtesta (sekunde)",
+  "sc_speedtest_match_window_hint": "Kako dolgo DOCSight čaka, da poveže sprožen rezultat Speedtest Tracker, preden ga označi kot poteklega."
 }

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -908,7 +908,7 @@
   "sc_history_empty": "Inga avrättningar än. Smart Capture loggar aktivitet här när den har aktiverats.",
   "sc_history_error": "Det gick inte att ladda exekveringshistoriken",
   "sc_history_loading": "Laddar exekveringshistorik...",
-  "sc_guardrails_summary": "Högst %max%/timme, minst %cooldown% från varandra",
+  "sc_guardrails_summary": "Högst %max%/timme, minst %cooldown% emellan; Speedtester från Smart Capture: %speedtestMax%/dag, med %speedtestInterval% emellan",
   "sc_status_pending": "Väntar",
   "sc_status_fired": "Avskedad",
   "sc_status_completed": "Slutförd",
@@ -1060,5 +1060,11 @@
   "metric_active_channel_singular": "aktiv kanal",
   "metric_active_channel_plural": "aktiva kanaler",
   "signal_family_average_section_title": "Medelvärden per signalfamilj",
-  "signal_family_average_section_hint": "Värdena är medelvärden över aktiva kanaler i varje DOCSIS-signalfamilj."
+  "signal_family_average_section_hint": "Värdena är medelvärden över aktiva kanaler i varje DOCSIS-signalfamilj.",
+  "sc_speedtest_min_interval": "Minsta Speedtest-intervall (sekunder)",
+  "sc_speedtest_min_interval_hint": "Blockerar Smart Capture om Speedtest Tracker nyligen redan har körts, inklusive enligt sitt eget schema.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture-speedtester per dag",
+  "sc_speedtest_max_actions_per_day_hint": "Rullande 24-timmarsgräns för extra Speedtest Tracker-körningar som DOCSight startar. 0 inaktiverar denna gräns.",
+  "sc_speedtest_match_window": "Matchningsfönster för Speedtest-resultat (sekunder)",
+  "sc_speedtest_match_window_hint": "Hur länge DOCSight väntar på att länka ett startat Speedtest Tracker-resultat innan det löper ut."
 }

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -905,5 +905,12 @@
   "metric_active_channel_singular": "",
   "metric_active_channel_plural": "",
   "signal_family_average_section_title": "",
-  "signal_family_average_section_hint": ""
+  "signal_family_average_section_hint": "",
+  "sc_guardrails_summary": "At most %max%/hour, minimum %cooldown% apart; Smart Capture speedtests: %speedtestMax%/day, %speedtestInterval% apart",
+  "sc_speedtest_min_interval": "Speedtest min interval (seconds)",
+  "sc_speedtest_min_interval_hint": "Blocks Smart Capture if Speedtest Tracker already ran recently, including its own schedule.",
+  "sc_speedtest_max_actions_per_day": "Smart Capture speedtests per day",
+  "sc_speedtest_max_actions_per_day_hint": "Rolling 24h cap for extra Speedtest Tracker runs triggered by DOCSight. 0 disables this cap.",
+  "sc_speedtest_match_window": "Speedtest result match window (seconds)",
+  "sc_speedtest_match_window_hint": "How long DOCSight waits to link a triggered Speedtest Tracker result before expiring it."
 }

--- a/app/main.py
+++ b/app/main.py
@@ -288,7 +288,12 @@ def polling_loop(config_mgr, storage, stop_event):
                 polling_loop._sc_expiry_counter += 1
                 if polling_loop._sc_expiry_counter >= 60:
                     polling_loop._sc_expiry_counter = 0
-                    cutoff = utc_cutoff(minutes=10)
+                    match_window = config_mgr.get("sc_speedtest_match_window", 900)
+                    try:
+                        expiry_minutes = max(10, int(match_window) // 60 + 5)
+                    except (TypeError, ValueError):
+                        expiry_minutes = 20
+                    cutoff = utc_cutoff(minutes=expiry_minutes)
                     for action_type in smart_capture.adapter_action_types:
                         expired = storage.expire_stale_fired(cutoff, action_type=action_type)
                         if expired:

--- a/app/smart_capture/adapters/speedtest.py
+++ b/app/smart_capture/adapters/speedtest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from datetime import datetime, timezone, timedelta
 from typing import Any
 
@@ -15,7 +16,8 @@ from .base import ActionAdapter
 
 log = logging.getLogger("docsis.smart_capture.adapters.speedtest")
 
-MATCH_WINDOW_SECONDS = 300  # 5 minutes
+DEFAULT_MATCH_WINDOW_SECONDS = 900  # 15 minutes
+_ACCEPTED_STATUS_CODES = {200, 201, 202, 204}
 
 
 def _as_bool(value: Any) -> bool:
@@ -38,7 +40,9 @@ class SpeedtestAdapter(ActionAdapter):
         token = config_mgr.get("speedtest_tracker_token", "")
         tls_insecure = _as_bool(config_mgr.get("speedtest_tls_insecure", False))
         self._run_url = f"{url}/api/v1/speedtests/run"
+        self._results_url = f"{url}/api/v1/results"
         self._verify_tls = not tls_insecure
+        self._execute_lock = threading.Lock()
         self._session = requests.Session()
         self._session.headers.update({
             "Authorization": f"Bearer {token}",
@@ -46,42 +50,54 @@ class SpeedtestAdapter(ActionAdapter):
         })
 
     def execute(self, execution_id: int, event: EventDict) -> tuple[bool, str | None]:
-        """POST to STT run endpoint. Updates execution to FIRED or EXPIRED."""
+        """POST to STT run endpoint after speedtest-specific safety preflight."""
+        # Keep preflight and fired_at recording atomic for this adapter instance.
+        # Without this, future concurrent execution paths could pass preflight twice
+        # before either accepted external side effect is persisted.
+        with self._execute_lock:
+            return self._execute_locked(execution_id, event)
+
+    def _execute_locked(self, execution_id: int, event: EventDict) -> tuple[bool, str | None]:
+        reference_ts = self._parse_timestamp(event.get("timestamp", ""))
+        if reference_ts is None:
+            reference_ts = datetime.now(timezone.utc)
+
+        suppression_reason = self._preflight_suppression_reason(reference_ts)
+        if suppression_reason:
+            self._storage.update_execution(
+                execution_id,
+                status=ExecutionStatus.SUPPRESSED,
+                suppression_reason=suppression_reason,
+            )
+            log.info("Smart Capture: suppressed STT run for #%d (%s)",
+                     execution_id, suppression_reason)
+            return False, suppression_reason
+
         try:
             resp = self._session.post(self._run_url, timeout=15, verify=self._verify_tls)
-            if resp.status_code == 201:
-                ts = utc_now()
-                self._storage.update_execution(
-                    execution_id,
-                    status=ExecutionStatus.FIRED,
-                    fired_at=ts,
-                )
-                # Emit event for Event Log visibility
-                self._storage.save_event(
-                    timestamp=ts,
-                    severity="info",
-                    event_type="smart_capture_triggered",
-                    message=f"Speedtest triggered by {event.get('event_type', 'unknown')}",
-                    details={
-                        "trigger_type": event.get("event_type"),
-                        "action_type": self.action_type,
-                        "execution_id": execution_id,
-                        "source_event": event.get("message", ""),
-                    },
-                )
+            if resp.status_code in _ACCEPTED_STATUS_CODES:
+                self._mark_fired(execution_id, event)
                 log.info("Smart Capture: triggered STT run (execution #%d)", execution_id)
                 return True, None
-            else:
-                error = f"STT returned {resp.status_code}: {resp.text[:200]}"
-                self._storage.update_execution(
-                    execution_id,
-                    status=ExecutionStatus.EXPIRED,
-                    last_error=error,
-                    attempt_count=1,
-                )
-                log.warning("Smart Capture: STT trigger failed for #%d: %s",
-                            execution_id, error)
-                return False, error
+
+            error = f"STT returned {resp.status_code}: {resp.text[:200]}"
+            self._storage.update_execution(
+                execution_id,
+                status=ExecutionStatus.EXPIRED,
+                last_error=error,
+                attempt_count=1,
+            )
+            log.warning("Smart Capture: STT trigger failed for #%d: %s",
+                        execution_id, error)
+            return False, error
+        except requests.exceptions.ReadTimeout:
+            # The POST reached the remote service but the response did not return in time.
+            # Treat it as accepted/unknown so rate limits persist and later imports can link.
+            error = "trigger response timeout; external run state unknown, awaiting result import"
+            self._mark_fired(execution_id, event, last_error=error)
+            log.warning("Smart Capture: STT trigger timeout for #%d; awaiting result import",
+                        execution_id)
+            return True, None
         except Exception as e:
             error = str(e)
             self._storage.update_execution(
@@ -94,12 +110,128 @@ class SpeedtestAdapter(ActionAdapter):
                         execution_id, error)
             return False, error
 
+    def _mark_fired(self, execution_id: int, event: EventDict,
+                    last_error: str | None = None) -> None:
+        ts = utc_now()
+        self._storage.update_execution(
+            execution_id,
+            status=ExecutionStatus.FIRED,
+            fired_at=ts,
+            attempt_count=1,
+            last_error=last_error,
+        )
+        self._storage.save_event(
+            timestamp=ts,
+            severity="info",
+            event_type="smart_capture_triggered",
+            message=f"Speedtest triggered by {event.get('event_type', 'unknown')}",
+            details={
+                "trigger_type": event.get("event_type"),
+                "action_type": self.action_type,
+                "execution_id": execution_id,
+                "source_event": event.get("message", ""),
+                "state": "unknown" if last_error else "accepted",
+            },
+        )
+
+    def _preflight_suppression_reason(self, reference_ts: datetime) -> str | None:
+        min_interval = self._get_int("sc_speedtest_min_interval", 14400)
+        if min_interval > 0:
+            latest_result_ts = self._latest_tracker_result_timestamp()
+            reason = self._interval_reason(
+                latest_result_ts,
+                reference_ts,
+                min_interval,
+                "recent_speedtest_result",
+            )
+            if reason:
+                return reason
+
+            latest_fire_ts = self._parse_timestamp(
+                self._storage.get_latest_smart_capture_fire(self.action_type) or ""
+            )
+            reason = self._interval_reason(
+                latest_fire_ts,
+                reference_ts,
+                min_interval,
+                "speedtest_min_interval",
+            )
+            if reason:
+                return reason
+
+        max_per_day = self._get_int("sc_speedtest_max_actions_per_day", 4)
+        if max_per_day > 0:
+            cutoff = reference_ts - timedelta(hours=24)
+            used = self._storage.count_smart_capture_fires_since(
+                self.action_type,
+                self._format_utc(cutoff),
+            )
+            if used >= max_per_day:
+                return f"speedtest_daily_cap: {used}/{max_per_day} used in rolling 24h"
+
+        return None
+
+    def _latest_tracker_result_timestamp(self) -> datetime | None:
+        timestamps = []
+        cached_ts = self._parse_timestamp(
+            self._storage.get_latest_speedtest_result_timestamp() or ""
+        )
+        if cached_ts is not None:
+            timestamps.append(cached_ts)
+
+        remote_ts = self._fetch_latest_remote_result_timestamp()
+        if remote_ts is not None:
+            timestamps.append(remote_ts)
+
+        return max(timestamps) if timestamps else None
+
+    def _fetch_latest_remote_result_timestamp(self) -> datetime | None:
+        try:
+            resp = self._session.get(
+                self._results_url,
+                params={"per_page": 1},
+                timeout=5,
+                verify=self._verify_tls,
+            )
+            if resp.status_code != 200:
+                return None
+            payload = resp.json()
+            data = payload.get("data", []) if isinstance(payload, dict) else []
+            if not data:
+                return None
+            first = data[0] if isinstance(data[0], dict) else {}
+            return self._parse_timestamp(str(first.get("timestamp", "")))
+        except Exception:
+            return None
+
+    @staticmethod
+    def _interval_reason(previous_ts: datetime | None, reference_ts: datetime,
+                         min_interval: int, code: str) -> str | None:
+        if previous_ts is None:
+            return None
+        elapsed = (reference_ts - previous_ts).total_seconds()
+        if elapsed < 0:
+            elapsed = 0
+        if elapsed < min_interval:
+            remaining = int(min_interval - elapsed)
+            return f"{code}: {remaining}s remaining"
+        return None
+
+    def _match_window_seconds(self) -> int:
+        return max(1, self._get_int("sc_speedtest_match_window", DEFAULT_MATCH_WINDOW_SECONDS))
+
+    def _get_int(self, key: str, default: int) -> int:
+        try:
+            return int(self._config.get(key, default))
+        except (TypeError, ValueError):
+            return default
+
     def on_results_imported(self, results: list[dict[str, Any]]) -> None:
         """Match newly imported speedtest results to FIRED executions.
 
         For each FIRED execution (FIFO, oldest first), find the closest
-        result within the match window. This ensures the nearest result
-        is selected when multiple results fall in the same window.
+        result within the configured match window. This ensures the nearest
+        result is selected when multiple results fall in the same window.
         """
         fired = self._storage.get_fired_unmatched(self.action_type)
         if not fired:
@@ -116,14 +248,15 @@ class SpeedtestAdapter(ActionAdapter):
             return
 
         matched_result_ids = set()
+        match_window = self._match_window_seconds()
 
         for execution in fired:
             fired_ts = self._parse_timestamp(execution.get("fired_at", ""))
             if fired_ts is None:
                 continue
 
-            # Find the closest result within [fired_at, fired_at + 5min]
-            window_end = fired_ts + timedelta(seconds=MATCH_WINDOW_SECONDS)
+            # Find the closest result within [fired_at, fired_at + window]
+            window_end = fired_ts + timedelta(seconds=match_window)
             best_result = None
             best_distance = None
 
@@ -148,6 +281,10 @@ class SpeedtestAdapter(ActionAdapter):
                     log.info("Smart Capture: linked execution #%d to speedtest #%d",
                              execution["id"], best_result["id"])
                     matched_result_ids.add(best_result["id"])
+
+    @staticmethod
+    def _format_utc(dt: datetime) -> str:
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     @staticmethod
     def _parse_timestamp(ts: str) -> datetime | None:

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -1878,22 +1878,34 @@ function updateGuardrailsSummary() {
     var el = document.getElementById('sc-guardrails-summary');
     var cooldownEl = document.getElementById('sc_global_cooldown');
     var maxEl = document.getElementById('sc_max_actions_per_hour');
+    var speedtestIntervalEl = document.getElementById('sc_speedtest_min_interval');
+    var speedtestDailyEl = document.getElementById('sc_speedtest_max_actions_per_day');
     if (!el || !cooldownEl || !maxEl) return;
     var cooldown = parseInt(cooldownEl.value) || 0;
     var maxPerHour = parseInt(maxEl.value) || 1;
+    var speedtestInterval = speedtestIntervalEl ? (parseInt(speedtestIntervalEl.value) || 0) : 0;
+    var speedtestDaily = speedtestDailyEl ? (parseInt(speedtestDailyEl.value) || 0) : 0;
     var cooldownStr;
     if (cooldown >= 3600) cooldownStr = Math.round(cooldown / 3600) + 'h';
     else if (cooldown >= 60) cooldownStr = Math.round(cooldown / 60) + ' min';
     else cooldownStr = cooldown + 's';
-    var tpl = T.sc_guardrails_summary || 'At most %max%/hour, minimum %cooldown% apart';
-    el.textContent = tpl.replace('%max%', maxPerHour).replace('%cooldown%', cooldownStr);
+    var speedtestIntervalStr;
+    if (speedtestInterval >= 3600) speedtestIntervalStr = Math.round(speedtestInterval / 3600) + 'h';
+    else if (speedtestInterval >= 60) speedtestIntervalStr = Math.round(speedtestInterval / 60) + ' min';
+    else speedtestIntervalStr = speedtestInterval + 's';
+    var tpl = T.sc_guardrails_summary || 'At most %max%/hour, minimum %cooldown% apart; Smart Capture speedtests: %speedtestMax%/day, %speedtestInterval% apart';
+    el.textContent = tpl
+        .replace('%max%', maxPerHour)
+        .replace('%cooldown%', cooldownStr)
+        .replace('%speedtestMax%', speedtestDaily)
+        .replace('%speedtestInterval%', speedtestIntervalStr);
 }
 
 // Initialize guardrails summary on load and input
 (function() {
     function init() {
         updateGuardrailsSummary();
-        ['sc_global_cooldown', 'sc_max_actions_per_hour'].forEach(function(id) {
+        ['sc_global_cooldown', 'sc_max_actions_per_hour', 'sc_speedtest_min_interval', 'sc_speedtest_max_actions_per_day'].forEach(function(id) {
             var el = document.getElementById(id);
             if (el) el.addEventListener('input', updateGuardrailsSummary);
         });

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v42';
+var CACHE_VERSION = 'v43';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/storage/smart_capture.py
+++ b/app/storage/smart_capture.py
@@ -7,6 +7,7 @@ from ..tz import utc_now
 
 
 class SmartCaptureMixin:
+    db_path: str
 
     def save_execution(self, trigger_type, action_type, status,
                        trigger_event_id=None, trigger_timestamp=None,
@@ -50,7 +51,8 @@ class SmartCaptureMixin:
 
     def update_execution(self, execution_id, status=None, fired_at=None,
                          completed_at=None, linked_result_id=None,
-                         last_error=None, attempt_count=None):
+                         last_error=None, attempt_count=None,
+                         suppression_reason=None):
         """Update fields on an existing execution record."""
         updates = []
         params = []
@@ -72,6 +74,9 @@ class SmartCaptureMixin:
         if attempt_count is not None:
             updates.append("attempt_count = ?")
             params.append(attempt_count)
+        if suppression_reason is not None:
+            updates.append("suppression_reason = ?")
+            params.append(suppression_reason)
         if not updates:
             return
         params.append(execution_id)
@@ -102,6 +107,40 @@ class SmartCaptureMixin:
                     pass
             results.append(record)
         return results
+
+    def get_latest_smart_capture_fire(self, action_type):
+        """Return the latest fired_at timestamp for accepted Smart Capture actions."""
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT fired_at FROM smart_capture_executions "
+                "WHERE action_type = ? AND fired_at IS NOT NULL "
+                "ORDER BY fired_at DESC LIMIT 1",
+                (action_type,),
+            ).fetchone()
+        return row[0] if row else None
+
+    def count_smart_capture_fires_since(self, action_type, since_timestamp):
+        """Count accepted Smart Capture actions since a UTC timestamp."""
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM smart_capture_executions "
+                "WHERE action_type = ? AND fired_at IS NOT NULL AND fired_at >= ?",
+                (action_type, since_timestamp),
+            ).fetchone()
+        return int(row[0]) if row else 0
+
+    def get_latest_speedtest_result_timestamp(self):
+        """Return latest cached Speedtest Tracker result timestamp, if present."""
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                row = conn.execute(
+                    "SELECT timestamp FROM speedtest_results "
+                    "WHERE COALESCE(is_demo, 0) = 0 "
+                    "ORDER BY timestamp DESC, id DESC LIMIT 1"
+                ).fetchone()
+            return row[0] if row else None
+        except sqlite3.Error:
+            return None
 
     def expire_stale_fired(self, cutoff_timestamp, action_type=None):
         """Bulk-expire FIRED executions with fired_at before cutoff and no linked result.

--- a/app/templates/settings/smart_capture.html
+++ b/app/templates/settings/smart_capture.html
@@ -194,6 +194,24 @@
                     <input type="number" id="sc_max_actions_per_hour" name="sc_max_actions_per_hour"
                            value="{{ config.get('sc_max_actions_per_hour', 4) }}" min="1" max="60">
                 </div>
+                <div class="form-group">
+                    <label for="sc_speedtest_min_interval">{{ t.get('sc_speedtest_min_interval', 'Speedtest min interval (seconds)') }}</label>
+                    <input type="number" id="sc_speedtest_min_interval" name="sc_speedtest_min_interval"
+                           value="{{ config.get('sc_speedtest_min_interval', 14400) }}" min="0" max="86400">
+                    <div class="form-hint">{{ t.get('sc_speedtest_min_interval_hint', 'Blocks Smart Capture if Speedtest Tracker already ran recently, including its own schedule.') }}</div>
+                </div>
+                <div class="form-group">
+                    <label for="sc_speedtest_max_actions_per_day">{{ t.get('sc_speedtest_max_actions_per_day', 'Smart Capture speedtests per day') }}</label>
+                    <input type="number" id="sc_speedtest_max_actions_per_day" name="sc_speedtest_max_actions_per_day"
+                           value="{{ config.get('sc_speedtest_max_actions_per_day', 4) }}" min="0" max="96">
+                    <div class="form-hint">{{ t.get('sc_speedtest_max_actions_per_day_hint', 'Rolling 24h cap for extra Speedtest Tracker runs triggered by DOCSight. 0 disables this cap.') }}</div>
+                </div>
+                <div class="form-group">
+                    <label for="sc_speedtest_match_window">{{ t.get('sc_speedtest_match_window', 'Speedtest result match window (seconds)') }}</label>
+                    <input type="number" id="sc_speedtest_match_window" name="sc_speedtest_match_window"
+                           value="{{ config.get('sc_speedtest_match_window', 900) }}" min="60" max="3600">
+                    <div class="form-hint">{{ t.get('sc_speedtest_match_window_hint', 'How long DOCSight waits to link a triggered Speedtest Tracker result before expiring it.') }}</div>
+                </div>
             </div>
             <div class="sc-guardrails-summary" id="sc-guardrails-summary"></div>
         </div>

--- a/tests/test_smart_capture_adapter_speedtest.py
+++ b/tests/test_smart_capture_adapter_speedtest.py
@@ -240,7 +240,7 @@ class TestSpeedtestAdapterMatching:
             trigger_type="modulation_change", action_type="capture",
             status=ExecutionStatus.FIRED, fired_at="2026-03-15T10:00:05Z",
         )
-        adapter.on_results_imported([{"id": 99, "timestamp": "2026-03-15T10:12:00Z"}])
+        adapter.on_results_imported([{"id": 99, "timestamp": "2026-03-15T10:20:00Z"}])
         assert storage.get_execution(eid)["status"] == "fired"
 
     def test_ignores_result_before_fired_at(self, storage):

--- a/tests/test_smart_capture_api.py
+++ b/tests/test_smart_capture_api.py
@@ -160,6 +160,10 @@ class TestSmartCaptureSettingsRender:
         assert 'name="sc_trigger_error_spike_min_delta"' in html
         assert 'name="sc_trigger_health_level"' in html
         assert 'name="sc_trigger_packet_loss_min_pct"' in html
+        assert 'name="sc_speedtest_min_interval"' in html
+        assert 'name="sc_speedtest_max_actions_per_day"' in html
+        assert 'name="sc_speedtest_match_window"' in html
+        assert 'Speedtest Tracker already ran recently' in html
 
     def test_settings_contains_qam_dropdown_options(self, client):
         resp = client.get("/settings")

--- a/tests/test_smart_capture_speedtest_adapter.py
+++ b/tests/test_smart_capture_speedtest_adapter.py
@@ -1,0 +1,182 @@
+"""Regression coverage for Smart Capture's Speedtest Tracker adapter."""
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from app.modules.speedtest.storage import SpeedtestStorage
+from app.smart_capture.adapters.speedtest import SpeedtestAdapter
+from app.smart_capture.types import ExecutionStatus
+from app.storage import SnapshotStorage
+from app.types import EventDict
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return SnapshotStorage(str(tmp_path / "test.db"), max_days=7)
+
+
+def _make_config(**overrides):
+    defaults = {
+        "speedtest_tracker_url": "http://speedtest.local",
+        "speedtest_tracker_token": "token",
+        "speedtest_tls_insecure": False,
+        "sc_speedtest_min_interval": 14400,
+        "sc_speedtest_max_actions_per_day": 4,
+        "sc_speedtest_match_window": 900,
+    }
+    defaults.update(overrides)
+    config = MagicMock()
+    config.get = lambda key, default=None: defaults.get(key, default)
+    return config
+
+
+def _pending_execution(storage, *, trigger_timestamp="2026-03-15T12:00:00Z"):
+    return storage.save_execution(
+        trigger_type="modulation_change",
+        action_type="capture",
+        status=ExecutionStatus.PENDING,
+        trigger_timestamp=trigger_timestamp,
+    )
+
+
+def _insert_speedtest_result(storage, *, result_id=10, timestamp="2026-03-15T11:30:00Z"):
+    SpeedtestStorage(storage.db_path)
+    with sqlite3.connect(storage.db_path) as conn:
+        conn.execute(
+            "INSERT INTO speedtest_results "
+            "(id, timestamp, download_mbps, upload_mbps, download_human, upload_human, "
+            " ping_ms, jitter_ms, packet_loss_pct, server_id, server_name) "
+            "VALUES (?, ?, 100, 20, '100 Mbps', '20 Mbps', 10, 1, 0, 1, 'test')",
+            (result_id, timestamp),
+        )
+
+
+def _event(timestamp="2026-03-15T12:00:00Z") -> EventDict:
+    return {
+        "event_type": "modulation_change",
+        "severity": "warning",
+        "timestamp": timestamp,
+        "message": "Modulation dropped on 1 channel(s)",
+    }
+
+
+class _Response:
+    def __init__(self, status_code=201, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def test_recent_tracker_result_suppresses_smart_capture_before_post(storage):
+    _insert_speedtest_result(storage, timestamp="2026-03-15T11:30:00Z")
+    execution_id = _pending_execution(storage, trigger_timestamp="2026-03-15T12:00:00Z")
+    adapter = SpeedtestAdapter(storage, _make_config())
+    adapter._session = MagicMock()
+    adapter._session.get.side_effect = requests.RequestException("offline")
+
+    ok, reason = adapter.execute(
+        execution_id,
+        _event(),
+    )
+
+    row = storage.get_execution(execution_id)
+    assert ok is False
+    assert reason is not None
+    assert "recent_speedtest_result" in reason
+    assert row["status"] == "suppressed"
+    assert "recent_speedtest_result" in row["suppression_reason"]
+    adapter._session.post.assert_not_called()
+
+
+def test_recent_smart_capture_fire_suppresses_after_adapter_restart(storage):
+    previous = storage.save_execution(
+        trigger_type="modulation_change",
+        action_type="capture",
+        status=ExecutionStatus.FIRED,
+        fired_at="2026-03-15T10:30:00Z",
+    )
+    assert previous == 1
+    execution_id = _pending_execution(storage, trigger_timestamp="2026-03-15T12:00:00Z")
+    adapter = SpeedtestAdapter(storage, _make_config())
+    adapter._session = MagicMock()
+    adapter._session.get.return_value = _Response(200, {"data": []})
+
+    ok, reason = adapter.execute(
+        execution_id,
+        _event(),
+    )
+
+    row = storage.get_execution(execution_id)
+    assert ok is False
+    assert reason is not None
+    assert "speedtest_min_interval" in reason
+    assert row["status"] == "suppressed"
+    adapter._session.post.assert_not_called()
+
+
+def test_daily_speedtest_smart_capture_budget_is_persistent(storage):
+    for fired_at in ("2026-03-15T01:00:00Z", "2026-03-15T06:00:00Z"):
+        storage.save_execution(
+            trigger_type="modulation_change",
+            action_type="capture",
+            status=ExecutionStatus.FIRED,
+            fired_at=fired_at,
+        )
+    execution_id = _pending_execution(storage, trigger_timestamp="2026-03-15T12:00:00Z")
+    adapter = SpeedtestAdapter(storage, _make_config(sc_speedtest_max_actions_per_day=2, sc_speedtest_min_interval=0))
+    adapter._session = MagicMock()
+    adapter._session.get.return_value = _Response(200, {"data": []})
+
+    ok, reason = adapter.execute(
+        execution_id,
+        _event(),
+    )
+
+    row = storage.get_execution(execution_id)
+    assert ok is False
+    assert reason is not None
+    assert "speedtest_daily_cap" in reason
+    assert row["status"] == "suppressed"
+    adapter._session.post.assert_not_called()
+
+
+def test_read_timeout_is_recorded_as_fired_pending_result_link(storage):
+    execution_id = _pending_execution(storage)
+    adapter = SpeedtestAdapter(storage, _make_config(sc_speedtest_min_interval=0))
+    adapter._session = MagicMock()
+    adapter._session.get.return_value = _Response(200, {"data": []})
+    adapter._session.post.side_effect = requests.exceptions.ReadTimeout("slow run")
+
+    ok, reason = adapter.execute(
+        execution_id,
+        _event(),
+    )
+
+    row = storage.get_execution(execution_id)
+    assert ok is True
+    assert reason is None
+    assert row["status"] == "fired"
+    assert row["fired_at"] is not None
+    assert "unknown" in row["last_error"]
+
+
+def test_configurable_match_window_links_long_running_speedtest(storage):
+    execution_id = storage.save_execution(
+        trigger_type="modulation_change",
+        action_type="capture",
+        status=ExecutionStatus.FIRED,
+        fired_at="2026-03-15T10:00:00Z",
+    )
+    adapter = SpeedtestAdapter(storage, _make_config(sc_speedtest_match_window=900))
+
+    adapter.on_results_imported([{"id": 42, "timestamp": "2026-03-15T10:12:00Z"}])
+
+    row = storage.get_execution(execution_id)
+    assert row["status"] == "completed"
+    assert row["linked_result_id"] == 42

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -137,7 +137,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v42';" in sw_js
+    assert "var CACHE_VERSION = 'v43';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js


### PR DESCRIPTION
## Summary
- add Speedtest Tracker-specific Smart Capture limits for minimum interval, daily budget, and result-linking window
- suppress event-storm-triggered runs before contacting Speedtest Tracker when recent or budgeted runs already exist
- persist accepted and timeout-after-trigger outcomes so later imports can link results without losing the action budget
- expose the Speedtest-specific limits in Settings with localized copy

## Validation
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- focused i18n fallback and placeholder scan for the new Smart Capture keys
- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC uv run --with-requirements requirements.txt --with-requirements requirements-test.txt --with pytest-playwright --with playwright python -m pytest --collect-only -q tests/e2e`
- E2E suite completed in resource-safe batches: 416 passed
- `git diff --check`

Closes #577
