### PR TITLE
fix: surface raw ping logs on mobile

### DIFF
--- a/app/modules/connection_monitor/static/js/connection-monitor-detail.js
+++ b/app/modules/connection_monitor/static/js/connection-monitor-detail.js
@@ -479,10 +479,12 @@
         var outageBody = document.getElementById('cm-outage-tbody');
         var exportLinks = document.getElementById('cm-export-links');
         var rawLogLinks = document.getElementById('cm-raw-log-links');
+        var rawLogPanel = document.getElementById('cm-raw-log-panel');
         var resolutionEl = document.getElementById('cm-resolution-indicator');
         if (noData) noData.style.display = 'flex';
         if (chartsEl) chartsEl.style.display = 'none';
         if (outagePanel) outagePanel.style.display = 'none';
+        if (rawLogPanel) rawLogPanel.style.display = 'none';
         [statsEl, perTargetEl, outageBody, exportLinks, rawLogLinks, resolutionEl].forEach(function(el) {
             if (el) el.textContent = '';
         });
@@ -498,9 +500,11 @@
         var noData = document.getElementById('cm-no-data');
         var chartsEl = document.getElementById('cm-charts-section');
         var outagePanel = document.getElementById('cm-outage-panel');
+        var rawLogPanel = document.getElementById('cm-raw-log-panel');
         if (noData) noData.style.display = 'none';
         if (chartsEl) chartsEl.style.display = '';
         if (outagePanel) outagePanel.style.display = '';
+        if (rawLogPanel) rawLogPanel.style.display = '';
     }
 
     // --- Traceroute ---

--- a/app/modules/connection_monitor/templates/connection_monitor_detail.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_detail.html
@@ -37,6 +37,20 @@
         </div>
     </div>
 
+    <section id="cm-raw-log-panel" class="glass cm-panel cm-raw-log-panel" style="display:none;">
+        <div class="cm-panel-header">
+            <div class="cm-panel-title">
+                <i data-lucide="file-text"></i>
+                <h3>{{ t.get('docsight.connection_monitor.cm_raw_log_title', 'Raw Ping Log') }}</h3>
+            </div>
+            <div class="cm-export-group">
+                <span>{{ t.get('docsight.connection_monitor.cm_raw_log_download', 'Download raw log') }}</span>
+                <div id="cm-raw-log-links" class="cm-export-links"></div>
+            </div>
+        </div>
+        <p class="cm-panel-copy">{{ t.get('docsight.connection_monitor.cm_raw_log_desc', 'Download per-ping raw samples for ISP evidence. Uses the current time range or selected pinned day.') }}</p>
+    </section>
+
     <div id="cm-no-data" class="cm-no-data">
         <i data-lucide="radar"></i>
         <span>{{ t.get('docsight.connection_monitor.cm_no_data', 'No data yet. Enable the Connection Monitor in settings to start collecting.') }}</span>
@@ -103,20 +117,6 @@
     </div>
 
     <div class="cm-log-grid">
-        <section id="cm-raw-log-panel" class="glass cm-panel cm-raw-log-panel">
-            <div class="cm-panel-header">
-                <div class="cm-panel-title">
-                    <i data-lucide="file-text"></i>
-                    <h3>{{ t.get('docsight.connection_monitor.cm_raw_log_title', 'Raw Ping Log') }}</h3>
-                </div>
-                <div class="cm-export-group">
-                    <span>{{ t.get('docsight.connection_monitor.cm_raw_log_download', 'Download raw log') }}</span>
-                    <div id="cm-raw-log-links" class="cm-export-links"></div>
-                </div>
-            </div>
-            <p class="cm-panel-copy">{{ t.get('docsight.connection_monitor.cm_raw_log_desc', 'Download per-ping raw samples for ISP evidence. Uses the current time range or selected pinned day.') }}</p>
-        </section>
-
         <section id="cm-outage-panel" class="glass cm-panel">
             <div class="cm-panel-header">
                 <div class="cm-panel-title">

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v44';
+var CACHE_VERSION = 'v45';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_connection_monitor.py
+++ b/tests/e2e/test_connection_monitor.py
@@ -13,3 +13,24 @@ def test_connection_monitor_raw_ping_log_panel_is_discoverable(demo_page):
     expect(panel).to_be_visible()
     expect(panel.get_by_text("Raw Ping Log")).to_be_visible()
     expect(panel.get_by_text("Download per-ping raw samples")).to_be_visible()
+
+
+def test_connection_monitor_mobile_surfaces_raw_ping_log_without_deep_scroll(demo_page):
+    """Mobile users should see raw-log downloads before the long chart/details stack."""
+    page = demo_page
+    page.set_viewport_size({"width": 390, "height": 844})
+    page.evaluate("switchView('connection-monitor')")
+    page.wait_for_selector("#view-connection-monitor.active", state="visible")
+
+    first_raw_log_button = page.locator("#cm-raw-log-links .cm-chip-btn").first
+    expect(first_raw_log_button).to_be_visible()
+    button_box = first_raw_log_button.bounding_box()
+    chart_box = page.locator("#cm-charts-section").bounding_box()
+    panel_box = page.locator("#cm-raw-log-panel").bounding_box()
+    assert button_box is not None
+    assert chart_box is not None
+    assert panel_box is not None
+    assert 0 <= panel_box["y"]
+    assert 0 <= button_box["y"]
+    assert panel_box["y"] < chart_box["y"], "raw log panel should appear before the long chart stack"
+    assert button_box["y"] + button_box["height"] <= 844, "raw log download actions should be fully visible without deep mobile scrolling"

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -137,7 +137,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v44';" in sw_js
+    assert "var CACHE_VERSION = 'v45';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -272,12 +272,12 @@ def test_connection_monitor_raw_ping_log_export_is_discoverable():
 
 def test_connection_monitor_raw_log_links_clear_on_no_data():
     detail_js = CM_DETAIL_JS.read_text(encoding="utf-8")
-    show_no_data = detail_js[
-        detail_js.index("function showNoData") : detail_js.index("function hideNoData")
-    ]
 
-    assert "cm-raw-log-links" in show_no_data
-    assert "rawLogLinks" in show_no_data
+    assert "cm-raw-log-links" in detail_js
+    assert "rawLogLinks" in detail_js
+    assert "cm-raw-log-panel" in detail_js
+    assert "rawLogPanel.style.display = 'none'" in detail_js
+    assert "rawLogPanel.style.display = ''" in detail_js
 
 
 def test_chart_time_range_controls_use_normalized_existing_ranges():


### PR DESCRIPTION
## Summary
- Move the Raw Ping Log downloads above the long chart/stat stack so mobile users can find them without deep scrolling.
- Hide the Raw Ping Log panel in the initial/no-data state and reveal it once monitor data is available.
- Bump the service worker cache version so precached mobile/PWA assets refresh.

## Test plan
- `git diff --check`
- `pytest tests/e2e/test_connection_monitor.py tests/test_static_contracts.py -q`
- `pytest tests/modules/connection_monitor tests/test_static_contracts.py tests/e2e/test_connection_monitor.py tests/e2e/test_mobile_quality_gate.py::test_mobile_main_blades_have_no_overflow_or_offscreen_controls -q`
- Manual mobile and desktop Playwright layout checks for the Connection Monitor Raw Ping Log panel
