### PR TITLE
Polish home KPI card anatomy

### DIFF
--- a/app/blueprints/data_bp.py
+++ b/app/blueprints/data_bp.py
@@ -1,7 +1,8 @@
 """Data retrieval routes: trends, export, snapshots."""
-
 import logging
-from datetime import datetime, timedelta
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, request, jsonify
 
@@ -53,6 +54,88 @@ def _format_error_count(value) -> str:
 data_bp = Blueprint("data_bp", __name__)
 
 
+def _append_connection_monitor_trends(data: list[dict], hours: int) -> None:
+    """Add Connection Monitor latency samples for home-card sparklines.
+
+    The dashboard sparkline renderer consumes /api/trends generically via
+    data-spark-key. DOCSIS snapshots and Speedtest rows already flow through
+    SnapshotStorage; Connection Monitor uses its own module database, so expose
+    a lightweight latency series here without coupling the card to a second
+    request path.
+    """
+    cfg = get_config_manager()
+    data_dir = getattr(cfg, "data_dir", None)
+    if not data_dir:
+        return
+
+    db_path = os.path.join(data_dir, "connection_monitor.db")
+    if not os.path.exists(db_path):
+        return
+
+    try:
+        from app.modules.connection_monitor.storage import ConnectionMonitorStorage
+
+        storage = ConnectionMonitorStorage(db_path)
+        enabled_targets = [t for t in storage.get_targets() if t.get("enabled")]
+        if not enabled_targets:
+            return
+
+        # Home-card sparklines only need the short rolling windows used by the
+        # dashboard. Longer trend views use the module's dedicated chart APIs.
+        if hours > 24:
+            return
+
+        start_ts = datetime.now(timezone.utc).timestamp() - hours * 3600
+        buckets: dict[int, list[float]] = defaultdict(list)
+        for target in enabled_targets:
+            samples = [
+                sample for sample in storage.get_samples(target["id"], start=start_ts, limit=0)
+                if not sample.get("timeout") and sample.get("latency_ms") is not None
+            ]
+            for sample in samples:
+                bucket = int(sample["timestamp"] // 60) * 60
+                buckets[bucket].append(float(sample["latency_ms"]))
+
+        aggregated = sorted(
+            (bucket, sum(values) / len(values))
+            for bucket, values in buckets.items()
+            if values
+        )
+        if len(aggregated) > 288:
+            step = max(1, (len(aggregated) + 287) // 288)
+            aggregated = aggregated[::step]
+        for bucket, latency_ms in aggregated:
+            data.append({
+                "timestamp": datetime.fromtimestamp(bucket, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "source": "connection_monitor",
+                "connection_monitor_latency_ms": latency_ms,
+            })
+    except Exception:
+        log.debug("Unable to append Connection Monitor trend data", exc_info=True)
+
+
+def _append_speedtest_trends(data: list[dict], db_path: str, hours: int) -> None:
+    """Add Speedtest download/upload rows for dashboard sparklines."""
+    try:
+        from app.modules.speedtest.storage import SpeedtestStorage
+
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(hours=hours)
+        storage = SpeedtestStorage(db_path)
+        for row in storage.get_speedtest_in_range(
+            start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        ):
+            data.append({
+                "timestamp": row["timestamp"],
+                "source": "speedtest",
+                "speedtest_download": row.get("download_mbps"),
+                "speedtest_upload": row.get("upload_mbps"),
+            })
+    except Exception:
+        log.debug("Unable to append Speedtest trend data", exc_info=True)
+
+
 @data_bp.route("/api/trends")
 @require_auth
 def api_trends():
@@ -90,6 +173,9 @@ def api_trends():
         data = _storage.get_summary_range(start, date_str)
     else:
         data = _storage.get_summary_since(hours)
+        _append_speedtest_trends(data, _storage.db_path, hours)
+        _append_connection_monitor_trends(data, hours)
+        data.sort(key=lambda row: row.get("timestamp") or "")
     _localize_timestamps(data)
     return jsonify(data)
 

--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -310,6 +310,8 @@
   "packet_loss": "Загуба на пакети",
   "via_speedtest_tracker": "чрез Speedtest Tracker",
   "speedtest_no_data": "Няма налични резултати от тест за скорост.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Скорост",
   "refresh": "Опресни",
   "refreshing": "Опресняване...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtest тестове чрез Smart Capture на ден",
   "sc_speedtest_max_actions_per_day_hint": "Плъзгащ се 24-часов лимит за допълнителни Speedtest Tracker тестове, задействани от DOCSight. 0 изключва този лимит.",
   "sc_speedtest_match_window": "Прозорец за свързване на резултат от Speedtest (секунди)",
-  "sc_speedtest_match_window_hint": "Колко дълго DOCSight изчаква, за да свърже задействан резултат от Speedtest Tracker, преди да го отбележи като изтекъл."
+  "sc_speedtest_match_window_hint": "Колко дълго DOCSight изчаква, за да свърже задействан резултат от Speedtest Tracker, преди да го отбележи като изтекъл.",
+  "cm_latency_range": "Диапазон на латентността",
+  "speed_contract_good_label": "≥ 80% от договора"
 }

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -310,6 +310,8 @@
   "packet_loss": "Ztráta paketů",
   "via_speedtest_tracker": "přes Speedtest Tracker",
   "speedtest_no_data": "Žádné výsledky testu rychlosti nejsou k dispozici.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Rychlost",
   "refresh": "Obnovit",
   "refreshing": "Obnovování...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtesty ze Smart Capture za den",
   "sc_speedtest_max_actions_per_day_hint": "Klouzavý 24hodinový limit pro další běhy Speedtest Tracker spuštěné DOCSight. Hodnota 0 tento limit vypne.",
   "sc_speedtest_match_window": "Okno pro přiřazení výsledku Speedtestu (sekundy)",
-  "sc_speedtest_match_window_hint": "Jak dlouho DOCSight čeká na přiřazení výsledku Speedtest Tracker, než běh označí jako vypršený."
+  "sc_speedtest_match_window_hint": "Jak dlouho DOCSight čeká na přiřazení výsledku Speedtest Tracker, než běh označí jako vypršený.",
+  "cm_latency_range": "Rozsah latence",
+  "speed_contract_good_label": "≥ 80 % smlouvy"
 }

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -310,6 +310,8 @@
   "packet_loss": "Pakketab",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "Ingen tilgængelige hastighedstestresultater.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Hastighed",
   "refresh": "Opdater",
   "refreshing": "Forfriskende...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture-speedtests pr. dag",
   "sc_speedtest_max_actions_per_day_hint": "Rullende 24-timers grænse for ekstra Speedtest Tracker-kørsler udløst af DOCSight. 0 deaktiverer grænsen.",
   "sc_speedtest_match_window": "Matchvindue for Speedtest-resultat (sekunder)",
-  "sc_speedtest_match_window_hint": "Hvor længe DOCSight venter på at knytte et udløst Speedtest Tracker-resultat, før det udløber."
+  "sc_speedtest_match_window_hint": "Hvor længe DOCSight venter på at knytte et udløst Speedtest Tracker-resultat, før det udløber.",
+  "cm_latency_range": "Forsinkelsesinterval",
+  "speed_contract_good_label": "≥ 80 % af kontrakten"
 }

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -310,6 +310,8 @@
   "packet_loss": "Paketverlust",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "Keine Speedtest-Ergebnisse verfügbar.",
+  "speedtest_latest_result": "Letztes Speedtest-Ergebnis",
+  "metric_download_contract": "Download vs. Vertrag",
   "speed": "Speed",
   "refresh": "Aktualisieren",
   "refreshing": "Aktualisiere...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart-Capture-Speedtests pro Tag",
   "sc_speedtest_max_actions_per_day_hint": "Rollierendes 24-Stunden-Limit für zusätzliche Speedtest-Tracker-Läufe, die DOCSight auslöst. 0 deaktiviert dieses Limit.",
   "sc_speedtest_match_window": "Zuordnungsfenster für Speedtest-Ergebnisse (Sekunden)",
-  "sc_speedtest_match_window_hint": "Wie lange DOCSight wartet, um ein ausgelöstes Speedtest-Tracker-Ergebnis zuzuordnen, bevor es abläuft."
+  "sc_speedtest_match_window_hint": "Wie lange DOCSight wartet, um ein ausgelöstes Speedtest-Tracker-Ergebnis zuzuordnen, bevor es abläuft.",
+  "cm_latency_range": "Latenzbereich",
+  "speed_contract_good_label": "≥ 80 % des Vertrags"
 }

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -310,6 +310,8 @@
   "packet_loss": "Απώλεια πακέτων",
   "via_speedtest_tracker": "μέσω Speedtest Tracker",
   "speedtest_no_data": "Δεν υπάρχουν διαθέσιμα αποτελέσματα δοκιμών ταχύτητας.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Ταχύτητα",
   "refresh": "Ανανέωση",
   "refreshing": "Αναζωογονητικό...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtest από Smart Capture ανά ημέρα",
   "sc_speedtest_max_actions_per_day_hint": "Κυλιόμενο όριο 24 ωρών για πρόσθετες εκτελέσεις Speedtest Tracker που ενεργοποιεί το DOCSight. Το 0 απενεργοποιεί το όριο.",
   "sc_speedtest_match_window": "Παράθυρο αντιστοίχισης αποτελέσματος Speedtest (δευτερόλεπτα)",
-  "sc_speedtest_match_window_hint": "Πόσο περιμένει το DOCSight για να συνδέσει ένα αποτέλεσμα Speedtest Tracker πριν το χαρακτηρίσει ληγμένο."
+  "sc_speedtest_match_window_hint": "Πόσο περιμένει το DOCSight για να συνδέσει ένα αποτέλεσμα Speedtest Tracker πριν το χαρακτηρίσει ληγμένο.",
+  "cm_latency_range": "Εύρος καθυστέρησης",
+  "speed_contract_good_label": "≥ 80% του συμβολαίου"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -310,6 +310,8 @@
   "packet_loss": "Packet Loss",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "No speed test results available.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Speed",
   "refresh": "Refresh",
   "refreshing": "Refreshing...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture speedtests per day",
   "sc_speedtest_max_actions_per_day_hint": "Rolling 24h cap for extra Speedtest Tracker runs triggered by DOCSight. 0 disables this cap.",
   "sc_speedtest_match_window": "Speedtest result match window (seconds)",
-  "sc_speedtest_match_window_hint": "How long DOCSight waits to link a triggered Speedtest Tracker result before expiring it."
+  "sc_speedtest_match_window_hint": "How long DOCSight waits to link a triggered Speedtest Tracker result before expiring it.",
+  "cm_latency_range": "Latency range",
+  "speed_contract_good_label": "≥ 80% of contract"
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -305,6 +305,8 @@
   "packet_loss": "Pérdida de paquetes",
   "via_speedtest_tracker": "vía Speedtest Tracker",
   "speedtest_no_data": "No hay resultados de speedtest disponibles.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Velocidad",
   "refresh": "Actualizar",
   "refreshing": "Actualizando...",
@@ -1061,5 +1063,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtests de Smart Capture por día",
   "sc_speedtest_max_actions_per_day_hint": "Límite móvil de 24 h para ejecuciones adicionales de Speedtest Tracker iniciadas por DOCSight. 0 desactiva este límite.",
   "sc_speedtest_match_window": "Ventana para vincular resultados de Speedtest (segundos)",
-  "sc_speedtest_match_window_hint": "Cuánto tiempo espera DOCSight para vincular un resultado de Speedtest Tracker antes de marcarlo como expirado."
+  "sc_speedtest_match_window_hint": "Cuánto tiempo espera DOCSight para vincular un resultado de Speedtest Tracker antes de marcarlo como expirado.",
+  "cm_latency_range": "Rango de latencia",
+  "speed_contract_good_label": "≥ 80 % del contrato"
 }

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -310,6 +310,8 @@
   "packet_loss": "Paketi kadu",
   "via_speedtest_tracker": "Speedtest Tracker kaudu",
   "speedtest_no_data": "Kiirustesti tulemused pole saadaval.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Kiirus",
   "refresh": "Värskenda",
   "refreshing": "Värskendab...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture’i Speedtestid päevas",
   "sc_speedtest_max_actions_per_day_hint": "Libisev 24 h piir DOCSighti käivitatud täiendavatele Speedtest Tracker mõõtmistele. 0 keelab selle piiri.",
   "sc_speedtest_match_window": "Speedtesti tulemuse sidumise aken (sekundites)",
-  "sc_speedtest_match_window_hint": "Kui kaua DOCSight ootab käivitatud Speedtest Tracker tulemuse sidumist enne selle aegunuks märkimist."
+  "sc_speedtest_match_window_hint": "Kui kaua DOCSight ootab käivitatud Speedtest Tracker tulemuse sidumist enne selle aegunuks märkimist.",
+  "cm_latency_range": "Latentsuse vahemik",
+  "speed_contract_good_label": "≥ 80% lepingust"
 }

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -310,6 +310,8 @@
   "packet_loss": "Pakettien katoaminen",
   "via_speedtest_tracker": "Speedtest Tracker:n kautta",
   "speedtest_no_data": "Nopeustestituloksia ei ole saatavilla.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Nopeus",
   "refresh": "Päivitä",
   "refreshing": "Virkistävää...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture -speedtestit päivässä",
   "sc_speedtest_max_actions_per_day_hint": "Liukuva 24 tunnin raja DOCSightin käynnistämille lisäajoille Speedtest Trackerissa. 0 poistaa rajan käytöstä.",
   "sc_speedtest_match_window": "Speedtest-tuloksen täsmäytysikkuna (sekuntia)",
-  "sc_speedtest_match_window_hint": "Kuinka kauan DOCSight odottaa käynnistetyn Speedtest Tracker -tuloksen linkittämistä ennen sen vanhentamista."
+  "sc_speedtest_match_window_hint": "Kuinka kauan DOCSight odottaa käynnistetyn Speedtest Tracker -tuloksen linkittämistä ennen sen vanhentamista.",
+  "cm_latency_range": "Viivealue",
+  "speed_contract_good_label": "≥ 80 % sopimuksesta"
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -302,6 +302,8 @@
   "packet_loss": "Perte de paquets",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "Aucun résultat de speedtest disponible.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Vitesse",
   "refresh": "Actualiser",
   "refreshing": "Actualisation...",
@@ -1058,5 +1060,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtests Smart Capture par jour",
   "sc_speedtest_max_actions_per_day_hint": "Plafond glissant de 24 h pour les exécutions Speedtest Tracker supplémentaires déclenchées par DOCSight. 0 désactive ce plafond.",
   "sc_speedtest_match_window": "Fenêtre de correspondance des résultats Speedtest (secondes)",
-  "sc_speedtest_match_window_hint": "Durée pendant laquelle DOCSight attend pour lier un résultat Speedtest Tracker déclenché avant de l’expirer."
+  "sc_speedtest_match_window_hint": "Durée pendant laquelle DOCSight attend pour lier un résultat Speedtest Tracker déclenché avant de l’expirer.",
+  "cm_latency_range": "Plage de latence",
+  "speed_contract_good_label": "≥ 80 % du contrat"
 }

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -310,6 +310,8 @@
   "packet_loss": "Caillteanas Paicéad",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "Níl torthaí tástála luais ar fáil.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Luas",
   "refresh": "Athnuaigh",
   "refreshing": "Ag athnuachan...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtests Smart Capture in aghaidh an lae",
   "sc_speedtest_max_actions_per_day_hint": "Teorainn rollach 24 uair do ritheanna breise Speedtest Tracker a spreagann DOCSight. Díchumasaíonn 0 an teorainn seo.",
   "sc_speedtest_match_window": "Fuinneog mheaitseála torthaí Speedtest (soicindí)",
-  "sc_speedtest_match_window_hint": "Cá fhad a fhanann DOCSight chun toradh Speedtest Tracker spreagtha a nascadh sula rachaidh sé in éag."
+  "sc_speedtest_match_window_hint": "Cá fhad a fhanann DOCSight chun toradh Speedtest Tracker spreagtha a nascadh sula rachaidh sé in éag.",
+  "cm_latency_range": "Raon moille",
+  "speed_contract_good_label": "≥ 80% den chonradh"
 }

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -310,6 +310,8 @@
   "packet_loss": "Gubitak paketa",
   "via_speedtest_tracker": "putem Speedtest Tracker",
   "speedtest_no_data": "Nema dostupnih rezultata testa brzine.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Brzina",
   "refresh": "Osvježi",
   "refreshing": "Osvježavam...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture Speedtestovi po danu",
   "sc_speedtest_max_actions_per_day_hint": "Klizno 24-satno ograničenje za dodatna pokretanja Speedtest Trackera koja pokrene DOCSight. 0 isključuje ovo ograničenje.",
   "sc_speedtest_match_window": "Prozor za povezivanje rezultata Speedtesta (sekunde)",
-  "sc_speedtest_match_window_hint": "Koliko dugo DOCSight čeka da poveže pokrenuti rezultat Speedtest Trackera prije isteka."
+  "sc_speedtest_match_window_hint": "Koliko dugo DOCSight čeka da poveže pokrenuti rezultat Speedtest Trackera prije isteka.",
+  "cm_latency_range": "Raspon latencije",
+  "speed_contract_good_label": "≥ 80 % ugovora"
 }

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -310,6 +310,8 @@
   "packet_loss": "Csomagvesztés",
   "via_speedtest_tracker": "a Speedtest Tracker-n keresztül",
   "speedtest_no_data": "Nem állnak rendelkezésre sebességteszt eredményei.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Sebesség",
   "refresh": "Frissítés",
   "refreshing": "Frissítés...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture Speedtestek naponta",
   "sc_speedtest_max_actions_per_day_hint": "Gördülő 24 órás korlát a DOCSight által indított további Speedtest Tracker futásokra. A 0 kikapcsolja ezt a korlátot.",
   "sc_speedtest_match_window": "Speedtest-eredmény illesztési ablaka (másodperc)",
-  "sc_speedtest_match_window_hint": "Meddig vár a DOCSight egy indított Speedtest Tracker eredmény összekapcsolására, mielőtt lejártnak jelöli."
+  "sc_speedtest_match_window_hint": "Meddig vár a DOCSight egy indított Speedtest Tracker eredmény összekapcsolására, mielőtt lejártnak jelöli.",
+  "cm_latency_range": "Késleltetési tartomány",
+  "speed_contract_good_label": "≥ 80% a szerződésből"
 }

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -310,6 +310,8 @@
   "packet_loss": "Perdita di pacchetti",
   "via_speedtest_tracker": "tramite Speedtest Tracker",
   "speedtest_no_data": "Nessun risultato del test di velocità disponibile.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Velocità",
   "refresh": "Aggiorna",
   "refreshing": "Rinfrescante...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtest Smart Capture al giorno",
   "sc_speedtest_max_actions_per_day_hint": "Limite mobile di 24 ore per esecuzioni aggiuntive di Speedtest Tracker attivate da DOCSight. 0 disattiva questo limite.",
   "sc_speedtest_match_window": "Finestra di associazione risultato Speedtest (secondi)",
-  "sc_speedtest_match_window_hint": "Per quanto tempo DOCSight attende di associare un risultato Speedtest Tracker attivato prima di farlo scadere."
+  "sc_speedtest_match_window_hint": "Per quanto tempo DOCSight attende di associare un risultato Speedtest Tracker attivato prima di farlo scadere.",
+  "cm_latency_range": "Intervallo di latenza",
+  "speed_contract_good_label": "≥ 80% del contratto"
 }

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -310,6 +310,8 @@
   "packet_loss": "Paketų praradimas",
   "via_speedtest_tracker": "per Speedtest Tracker",
   "speedtest_no_data": "Greičio testo rezultatų nėra.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Greitis",
   "refresh": "Atnaujinti",
   "refreshing": "Atnaujinama...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture Speedtestai per dieną",
   "sc_speedtest_max_actions_per_day_hint": "Slenkantis 24 val. limitas papildomiems Speedtest Tracker paleidimams, kuriuos inicijuoja DOCSight. 0 išjungia šį limitą.",
   "sc_speedtest_match_window": "Speedtest rezultato susiejimo langas (sekundės)",
-  "sc_speedtest_match_window_hint": "Kiek laiko DOCSight laukia, kad susietų inicijuotą Speedtest Tracker rezultatą, prieš pažymėdamas jį pasibaigusiu."
+  "sc_speedtest_match_window_hint": "Kiek laiko DOCSight laukia, kad susietų inicijuotą Speedtest Tracker rezultatą, prieš pažymėdamas jį pasibaigusiu.",
+  "cm_latency_range": "Delsos intervalas",
+  "speed_contract_good_label": "≥ 80 % sutarties"
 }

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -310,6 +310,8 @@
   "packet_loss": "Pakešu zudums",
   "via_speedtest_tracker": ", izmantojot Speedtest Tracker",
   "speedtest_no_data": "Ātruma testa rezultāti nav pieejami.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Ātrums",
   "refresh": "Atsvaidzināt",
   "refreshing": "Atsvaidzina...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture Speedtesti dienā",
   "sc_speedtest_max_actions_per_day_hint": "Slīdošs 24 h limits papildu Speedtest Tracker palaišanām, ko ierosina DOCSight. 0 atspējo šo limitu.",
   "sc_speedtest_match_window": "Speedtest rezultāta sasaistes logs (sekundes)",
-  "sc_speedtest_match_window_hint": "Cik ilgi DOCSight gaida, lai sasaistītu ierosinātu Speedtest Tracker rezultātu, pirms to atzīmē kā beigušos."
+  "sc_speedtest_match_window_hint": "Cik ilgi DOCSight gaida, lai sasaistītu ierosinātu Speedtest Tracker rezultātu, pirms to atzīmē kā beigušos.",
+  "cm_latency_range": "Latences diapazons",
+  "speed_contract_good_label": "≥ 80% no līguma"
 }

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -310,6 +310,8 @@
   "packet_loss": "Pakketap",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "Ingen hastighetstestresultater tilgjengelig.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Hastighet",
   "refresh": "Oppdater",
   "refreshing": "Forfriskende...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture-speedtester per dag",
   "sc_speedtest_max_actions_per_day_hint": "Rullerende 24-timers grense for ekstra Speedtest Tracker-kjøringer utløst av DOCSight. 0 deaktiverer grensen.",
   "sc_speedtest_match_window": "Matchvindu for Speedtest-resultat (sekunder)",
-  "sc_speedtest_match_window_hint": "Hvor lenge DOCSight venter på å koble et utløst Speedtest Tracker-resultat før det utløper."
+  "sc_speedtest_match_window_hint": "Hvor lenge DOCSight venter på å koble et utløst Speedtest Tracker-resultat før det utløper.",
+  "cm_latency_range": "Latensområde",
+  "speed_contract_good_label": "≥ 80 % av avtalen"
 }

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -310,6 +310,8 @@
   "packet_loss": "Pakketverlies",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "Geen snelheidstestresultaten beschikbaar.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Snelheid",
   "refresh": "Vernieuwen",
   "refreshing": "Verfrissend...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture-speedtests per dag",
   "sc_speedtest_max_actions_per_day_hint": "Voortschrijdende 24-uurs limiet voor extra Speedtest Tracker-runs die DOCSight start. 0 schakelt deze limiet uit.",
   "sc_speedtest_match_window": "Koppelvenster voor Speedtest-resultaat (seconden)",
-  "sc_speedtest_match_window_hint": "Hoe lang DOCSight wacht om een gestart Speedtest Tracker-resultaat te koppelen voordat het verloopt."
+  "sc_speedtest_match_window_hint": "Hoe lang DOCSight wacht om een gestart Speedtest Tracker-resultaat te koppelen voordat het verloopt.",
+  "cm_latency_range": "Latentiebereik",
+  "speed_contract_good_label": "≥ 80% van contract"
 }

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -310,6 +310,8 @@
   "packet_loss": "Utrata pakietów",
   "via_speedtest_tracker": "przez Speedtest Tracker",
   "speedtest_no_data": "Brak dostępnych wyników testu prędkości.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Prędkość",
   "refresh": "Odśwież",
   "refreshing": "Odświeżające...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtesty Smart Capture dziennie",
   "sc_speedtest_max_actions_per_day_hint": "Ruchomy limit 24 h dla dodatkowych uruchomień Speedtest Tracker wyzwalanych przez DOCSight. 0 wyłącza ten limit.",
   "sc_speedtest_match_window": "Okno dopasowania wyniku Speedtestu (sekundy)",
-  "sc_speedtest_match_window_hint": "Jak długo DOCSight czeka na powiązanie wyzwolonego wyniku Speedtest Tracker, zanim oznaczy go jako wygasły."
+  "sc_speedtest_match_window_hint": "Jak długo DOCSight czeka na powiązanie wyzwolonego wyniku Speedtest Tracker, zanim oznaczy go jako wygasły.",
+  "cm_latency_range": "Zakres opóźnienia",
+  "speed_contract_good_label": "≥ 80% umowy"
 }

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -310,6 +310,8 @@
   "packet_loss": "Perda de pacotes",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "Nenhum resultado de teste de velocidade disponível.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Velocidade",
   "refresh": "Atualizar",
   "refreshing": "Refrescante...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtests do Smart Capture por dia",
   "sc_speedtest_max_actions_per_day_hint": "Limite móvel de 24 h para execuções adicionais do Speedtest Tracker acionadas pelo DOCSight. 0 desativa este limite.",
   "sc_speedtest_match_window": "Janela de correspondência do resultado Speedtest (segundos)",
-  "sc_speedtest_match_window_hint": "Por quanto tempo o DOCSight aguarda para vincular um resultado do Speedtest Tracker acionado antes de marcá-lo como expirado."
+  "sc_speedtest_match_window_hint": "Por quanto tempo o DOCSight aguarda para vincular um resultado do Speedtest Tracker acionado antes de marcá-lo como expirado.",
+  "cm_latency_range": "Intervalo de latência",
+  "speed_contract_good_label": "≥ 80% do contrato"
 }

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -310,6 +310,8 @@
   "packet_loss": "Pierdere pachet",
   "via_speedtest_tracker": "prin Speedtest Tracker",
   "speedtest_no_data": "Nu sunt disponibile rezultate ale testelor de viteză.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Viteză",
   "refresh": "Reîmprospătare",
   "refreshing": "Reîmprospătare...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtesturi Smart Capture pe zi",
   "sc_speedtest_max_actions_per_day_hint": "Limită glisantă de 24 h pentru rulări suplimentare Speedtest Tracker declanșate de DOCSight. 0 dezactivează această limită.",
   "sc_speedtest_match_window": "Fereastră de asociere rezultat Speedtest (secunde)",
-  "sc_speedtest_match_window_hint": "Cât timp așteaptă DOCSight pentru a asocia un rezultat Speedtest Tracker declanșat înainte de expirare."
+  "sc_speedtest_match_window_hint": "Cât timp așteaptă DOCSight pentru a asocia un rezultat Speedtest Tracker declanșat înainte de expirare.",
+  "cm_latency_range": "Interval de latență",
+  "speed_contract_good_label": "≥ 80% din contract"
 }

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -310,6 +310,8 @@
   "packet_loss": "Strata paketov",
   "via_speedtest_tracker": "cez Speedtest Tracker",
   "speedtest_no_data": "Nie sú k dispozícii žiadne výsledky testu rýchlosti.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Rýchlosť",
   "refresh": "Obnoviť",
   "refreshing": "Obnovuje sa...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Speedtesty Smart Capture za deň",
   "sc_speedtest_max_actions_per_day_hint": "Kĺzavý 24-hodinový limit pre dodatočné behy Speedtest Tracker spustené DOCSight. 0 tento limit vypne.",
   "sc_speedtest_match_window": "Okno priradenia výsledku Speedtestu (sekundy)",
-  "sc_speedtest_match_window_hint": "Ako dlho DOCSight čaká na priradenie spusteného výsledku Speedtest Tracker, kým ho označí ako expirovaný."
+  "sc_speedtest_match_window_hint": "Ako dlho DOCSight čaká na priradenie spusteného výsledku Speedtest Tracker, kým ho označí ako expirovaný.",
+  "cm_latency_range": "Rozsah latencie",
+  "speed_contract_good_label": "≥ 80 % zmluvy"
 }

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -310,6 +310,8 @@
   "packet_loss": "Izguba paketa",
   "via_speedtest_tracker": "prek Speedtest Tracker",
   "speedtest_no_data": "Na voljo ni rezultatov preizkusa hitrosti.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Hitrost",
   "refresh": "Osveži",
   "refreshing": "Osvežitev ...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture Speedtesti na dan",
   "sc_speedtest_max_actions_per_day_hint": "Drseča 24-urna omejitev za dodatne zagone Speedtest Tracker, ki jih sproži DOCSight. 0 onemogoči to omejitev.",
   "sc_speedtest_match_window": "Okno ujemanja rezultata Speedtesta (sekunde)",
-  "sc_speedtest_match_window_hint": "Kako dolgo DOCSight čaka, da poveže sprožen rezultat Speedtest Tracker, preden ga označi kot poteklega."
+  "sc_speedtest_match_window_hint": "Kako dolgo DOCSight čaka, da poveže sprožen rezultat Speedtest Tracker, preden ga označi kot poteklega.",
+  "cm_latency_range": "Obseg zakasnitve",
+  "speed_contract_good_label": "≥ 80 % pogodbe"
 }

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -310,6 +310,8 @@
   "packet_loss": "Paketförlust",
   "via_speedtest_tracker": "via Speedtest Tracker",
   "speedtest_no_data": "Inga hastighetstestresultat tillgängliga.",
+  "speedtest_latest_result": "Latest speedtest result",
+  "metric_download_contract": "Download vs contract",
   "speed": "Hastighet",
   "refresh": "Uppdatera",
   "refreshing": "Uppfriskande...",
@@ -1066,5 +1068,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture-speedtester per dag",
   "sc_speedtest_max_actions_per_day_hint": "Rullande 24-timmarsgräns för extra Speedtest Tracker-körningar som DOCSight startar. 0 inaktiverar denna gräns.",
   "sc_speedtest_match_window": "Matchningsfönster för Speedtest-resultat (sekunder)",
-  "sc_speedtest_match_window_hint": "Hur länge DOCSight väntar på att länka ett startat Speedtest Tracker-resultat innan det löper ut."
+  "sc_speedtest_match_window_hint": "Hur länge DOCSight väntar på att länka ett startat Speedtest Tracker-resultat innan det löper ut.",
+  "cm_latency_range": "Latensintervall",
+  "speed_contract_good_label": "≥ 80 % av avtalet"
 }

--- a/app/i18n/template.json
+++ b/app/i18n/template.json
@@ -291,6 +291,8 @@
   "packet_loss": "",
   "via_speedtest_tracker": "",
   "speedtest_no_data": "",
+  "speedtest_latest_result": "",
+  "metric_download_contract": "",
   "speed": "",
   "refresh": "",
   "refreshing": "",
@@ -912,5 +914,7 @@
   "sc_speedtest_max_actions_per_day": "Smart Capture speedtests per day",
   "sc_speedtest_max_actions_per_day_hint": "Rolling 24h cap for extra Speedtest Tracker runs triggered by DOCSight. 0 disables this cap.",
   "sc_speedtest_match_window": "Speedtest result match window (seconds)",
-  "sc_speedtest_match_window_hint": "How long DOCSight waits to link a triggered Speedtest Tracker result before expiring it."
+  "sc_speedtest_match_window_hint": "How long DOCSight waits to link a triggered Speedtest Tracker result before expiring it.",
+  "cm_latency_range": "Latency range",
+  "speed_contract_good_label": "≥ 80% of contract"
 }

--- a/app/modules/connection_monitor/static/js/connection-monitor-card.js
+++ b/app/modules/connection_monitor/static/js/connection-monitor-card.js
@@ -2,34 +2,124 @@
     'use strict';
 
     var REFRESH_INTERVAL = 10000; // 10s
+    var LATENCY_RANGE_MAX_MS = 150;
 
-    function setStatusSpan(el, text, colorVar) {
+    function fmtNumber(value, digits) {
+        if (value == null || !isFinite(value)) return '–';
+        var fixed = Number(value).toFixed(digits == null ? 1 : digits);
+        return fixed.replace(/\.0$/, '');
+    }
+
+    function translate(key, fallback) {
+        var dict = (typeof window !== 'undefined' && window.T) || (typeof T !== 'undefined' && T) || {};
+        return dict[key] || fallback;
+    }
+
+    function pct(value, max) {
+        if (value == null || !isFinite(value) || max <= 0) return 0;
+        return Math.max(0, Math.min(100, value / max * 100));
+    }
+
+    function clear(el) {
+        if (!el) return;
         el.textContent = '';
+    }
+
+    function appendText(el, text, className) {
+        if (!el) return null;
         var span = document.createElement('span');
-        span.style.color = colorVar;
+        if (className) span.className = className;
         span.textContent = text;
         el.appendChild(span);
+        return span;
+    }
+
+    function setText(el, text) {
+        if (!el) return;
+        el.textContent = text;
+    }
+
+    function setEmpty(elements) {
+        setText(elements.latency, '–');
+        setText(elements.avg, '');
+        setText(elements.badge, '–');
+        if (elements.badge) elements.badge.className = 'badge badge-info';
+        setText(elements.modRow, '');
+        setText(elements.rangeContext, '–');
+        if (elements.range) {
+            elements.range.style.setProperty('--metric-marker', '0%');
+            elements.range.style.setProperty('--metric-span-start', '0%');
+            elements.range.style.setProperty('--metric-span-width', '0%');
+            elements.range.style.setProperty('--metric-range-accent', 'var(--muted)');
+        }
+    }
+
+    function collectStats(enabled) {
+        var latencies = enabled
+            .filter(function(t) { return t.avg_latency_ms != null; })
+            .map(function(t) { return Number(t.avg_latency_ms); })
+            .filter(function(v) { return isFinite(v); });
+        var ranges = enabled.map(function(t) {
+            var avg = t.avg_latency_ms != null ? Number(t.avg_latency_ms) : null;
+            var min = t.min_latency_ms != null ? Number(t.min_latency_ms) : avg;
+            var max = t.max_latency_ms != null ? Number(t.max_latency_ms) : avg;
+            if (avg == null || !isFinite(avg)) return null;
+            return {
+                min: isFinite(min) ? min : avg,
+                max: isFinite(max) ? max : avg
+            };
+        }).filter(Boolean);
+        var losses = enabled.map(function(t) { return Number(t.packet_loss_pct || 0); }).filter(function(v) { return isFinite(v); });
+
+        var avgLatency = null;
+        if (latencies.length > 0) {
+            avgLatency = latencies.reduce(function(a, b) { return a + b; }, 0) / latencies.length;
+        }
+        var minLatency = ranges.length ? Math.min.apply(null, ranges.map(function(r) { return r.min; })) : avgLatency;
+        var maxLatency = ranges.length ? Math.max.apply(null, ranges.map(function(r) { return r.max; })) : avgLatency;
+        var jitter = null;
+        if (ranges.length) {
+            jitter = ranges.reduce(function(sum, r) { return sum + Math.max(0, r.max - r.min); }, 0) / ranges.length;
+        }
+        var packetLoss = losses.length ? losses.reduce(function(a, b) { return a + b; }, 0) / losses.length : 0;
+
+        return {
+            avgLatency: avgLatency,
+            minLatency: minLatency,
+            maxLatency: maxLatency,
+            jitter: jitter,
+            packetLoss: packetLoss
+        };
+    }
+
+    function healthFor(enabled, down, degraded) {
+        if (down.length > 0) {
+            return { key: 'crit', badge: translate('health_critical', 'Critical') };
+        }
+        if (degraded.length > 0) {
+            return { key: 'warn', badge: translate('health_marginal', 'Marginal') };
+        }
+        return { key: 'good', badge: translate('health_good', 'Good') };
     }
 
     function updateCard() {
         fetch('/api/connection-monitor/summary')
             .then(function(r) { return r.json(); })
             .then(function(data) {
-                var statusEl = document.getElementById('cm-card-status');
-                var detailsEl = document.getElementById('cm-card-details');
-                if (!statusEl) return;
+                var elements = {
+                    latency: document.getElementById('cm-card-latency') || document.getElementById('cm-card-status'),
+                    avg: document.getElementById('cm-card-avg'),
+                    badge: document.getElementById('cm-card-badge'),
+                    modRow: document.getElementById('cm-card-mod-row') || document.getElementById('cm-card-details'),
+                    range: document.getElementById('cm-card-range'),
+                    rangeContext: document.getElementById('cm-card-range-context')
+                };
+                if (!elements.latency) return;
 
-                var targets = Object.values(data);
-                if (targets.length === 0) {
-                    statusEl.textContent = '—';
-                    detailsEl.textContent = '';
-                    return;
-                }
-
-                var enabled = targets.filter(function(t) { return t.enabled; });
+                var targets = Object.values(data || {});
+                var enabled = targets.filter(function(t) { return t && t.enabled; });
                 if (enabled.length === 0) {
-                    statusEl.textContent = '—';
-                    detailsEl.textContent = '';
+                    setEmpty(elements);
                     return;
                 }
 
@@ -39,26 +129,42 @@
                     return loss > 0 && loss < 100;
                 });
                 var down = enabled.filter(function(t) { return (t.packet_loss_pct || 0) >= 100; });
+                var health = healthFor(enabled, down, degraded);
+                var stats = collectStats(enabled);
 
-                // Status text
-                if (down.length > 0) {
-                    setStatusSpan(statusEl, down.length + ' Down', 'var(--crit)');
-                } else if (degraded.length > 0) {
-                    setStatusSpan(statusEl, degraded.length + ' Degraded', 'var(--warn)');
+                if (stats.avgLatency != null) {
+                    setText(elements.latency, fmtNumber(stats.avgLatency, 1) + ' ms ' + translate('metric_average_label', 'avg').toLowerCase());
                 } else {
-                    setStatusSpan(statusEl, ok.length + '/' + enabled.length + ' OK', 'var(--good)');
+                    setText(elements.latency, '–');
                 }
+                if (elements.latency) elements.latency.style.color = 'var(--' + health.key + ')';
 
-                // Details: avg latency across all targets
-                var latencies = enabled
-                    .filter(function(t) { return t.avg_latency_ms != null; })
-                    .map(function(t) { return t.avg_latency_ms; });
-                if (latencies.length > 0) {
-                    var sum = latencies.reduce(function(a, b) { return a + b; }, 0);
-                    var avgLatency = (sum / latencies.length).toFixed(1);
-                    detailsEl.textContent = avgLatency + ' ms avg';
-                } else {
-                    detailsEl.textContent = '';
+                setText(elements.avg, ok.length + '/' + enabled.length + ' OK');
+                setText(elements.badge, health.badge);
+                if (elements.badge) elements.badge.className = 'badge badge-' + health.key;
+
+                clear(elements.modRow);
+                appendText(elements.modRow, translate('packet_loss', 'Packet Loss') + ' ', 'metric-sub-label');
+                appendText(elements.modRow, fmtNumber(stats.packetLoss, 1) + '%', 'range');
+                appendText(elements.modRow, ' · ', 'metric-separator');
+                appendText(elements.modRow, translate('jitter', 'Jitter') + ' ', 'metric-sub-label');
+                appendText(elements.modRow, (stats.jitter == null ? '–' : fmtNumber(stats.jitter, 1) + ' ms'), 'range');
+
+                if (elements.range) {
+                    var marker = pct(stats.avgLatency, LATENCY_RANGE_MAX_MS);
+                    var start = pct(stats.minLatency, LATENCY_RANGE_MAX_MS);
+                    var end = pct(stats.maxLatency, LATENCY_RANGE_MAX_MS);
+                    elements.range.style.setProperty('--metric-marker', marker.toFixed(1) + '%');
+                    elements.range.style.setProperty('--metric-span-start', Math.min(start, end).toFixed(1) + '%');
+                    elements.range.style.setProperty('--metric-span-width', Math.max(0, Math.abs(end - start)).toFixed(1) + '%');
+                    elements.range.style.setProperty('--metric-range-accent', 'var(--' + health.key + ')');
+                }
+                if (elements.rangeContext) {
+                    if (stats.minLatency != null && stats.maxLatency != null) {
+                        setText(elements.rangeContext, fmtNumber(stats.minLatency, 1) + ' – ' + fmtNumber(stats.maxLatency, 1) + ' ms');
+                    } else {
+                        setText(elements.rangeContext, '–');
+                    }
                 }
             })
             .catch(function() {}); // silent on error

--- a/app/modules/connection_monitor/templates/connection_monitor_card.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_card.html
@@ -1,12 +1,42 @@
 {# ═══ Module Card: Connection Monitor ═══ #}
 <div class="metrics-grid">
-    <div class="metric-card glass" id="connection-monitor-card" style="cursor:pointer;" onclick="switchView('connection-monitor')">
+    <div class="metric-card glass" id="connection-monitor-card" role="button" tabindex="0" style="cursor:pointer;" onclick="switchView('connection-monitor')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();switchView('connection-monitor')}">
         <div class="metric-header">
             <span class="metric-label">{{ t.get('docsight.connection_monitor.connection_monitor', 'Connection Monitor') }}</span>
             <div class="metric-icon blue"><i data-lucide="satellite-dish"></i></div>
         </div>
-        <div class="metric-value" id="cm-card-status">—</div>
-        <div class="metric-sub" id="cm-card-details"></div>
+        <div class="metric-value-row">
+            <div class="metric-value" id="cm-card-latency">&ndash;</div>
+            <canvas class="metric-spark" id="spark-connection-monitor" data-spark-key="connection_monitor_latency_ms" data-spark-color="#38bdf8" width="144" height="56" aria-hidden="true"></canvas>
+        </div>
+        <div class="metric-sub metric-average-row">
+            <span class="range metric-average-copy" id="cm-card-avg">&ndash;</span>
+        </div>
+        <div class="metric-sub metric-status-row">
+            <span class="metric-context">
+                <span class="metric-sub-label">{{ t.get('metric_status_label', 'Status') }}</span>
+                <span class="badge badge-info" id="cm-card-badge">&ndash;</span>
+            </span>
+        </div>
+        <div class="metric-sub metric-modulation-row" id="cm-card-mod-row"></div>
+        <div class="metric-range-viz" id="cm-card-range" style="--metric-marker: 0%; --metric-span-start: 0%; --metric-span-width: 0%; --metric-range-accent: var(--muted);">
+            <div class="metric-range-caption">
+                <span>{{ t.get('cm_latency_range', 'Latency range') }}</span>
+                <strong id="cm-card-range-context">&ndash;</strong>
+            </div>
+            <div class="metric-range-track" aria-hidden="true">
+                <span class="metric-range-band good" style="left:0%;width:33.33%;"></span>
+                <span class="metric-range-band warn" style="left:33.33%;width:33.33%;"></span>
+                <span class="metric-range-band crit" style="left:66.67%;width:33.33%;"></span>
+                <span class="metric-range-window"></span>
+                <span class="metric-range-marker"></span>
+            </div>
+            <div class="metric-range-labels">
+                <span>0 ms</span>
+                <span class="metric-range-good">{{ t.health_good }} &lt; 50 ms</span>
+                <span>150 ms</span>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/app/static/js/hero-chart.js
+++ b/app/static/js/hero-chart.js
@@ -62,7 +62,9 @@
                 }
                 var now = new Date();
                 var cutoff = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-                var filtered = data.filter(function(d) { return new Date(d.timestamp) >= cutoff; });
+                var filtered = data.filter(function(d) {
+                    return isDocsisTrendRow(d) && new Date(d.timestamp) >= cutoff;
+                });
                 if (filtered.length === 0) {
                     renderEmptyChart(container);
                     return;
@@ -73,6 +75,14 @@
                 console.error('[HeroChart] Failed to load data:', err);
                 renderEmptyChart(container);
             });
+    }
+
+    function isDocsisTrendRow(row) {
+        return !!(row && (
+            row.ds_power_avg != null ||
+            row.us_power_avg != null ||
+            row.ds_snr_avg != null
+        ));
     }
 
     function heroTooltipPlugin(timestamps) {

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -86,6 +86,16 @@ function _hasTrendDocsisErrorSeries(data) {
     return !!(data && data.some(_supportsTrendDocsisErrors));
 }
 
+function _isDocsisTrendRow(row) {
+    return !!(row && (
+        row.ds_power_avg != null ||
+        row.us_power_avg != null ||
+        row.ds_snr_avg != null ||
+        row.ds_correctable_errors != null ||
+        row.ds_uncorrectable_errors != null
+    ));
+}
+
 function _setTrendErrorsVisible(visible) {
     var card = document.getElementById('trend-errors-card');
     if (card) card.style.display = visible ? '' : 'none';
@@ -137,7 +147,7 @@ function loadTrends(range) {
         fetch(trendsUrl).then(function(r) { return r.json(); }),
         fetch(weatherUrl).then(function(r) { return r.json(); }).catch(function() { return []; })
     ]).then(function(results) {
-            var data = results[0];
+            var data = (results[0] || []).filter(_isDocsisTrendRow);
             var weatherData = results[1];
             if (!data || data.length === 0) {
                 noData.textContent = T.no_data;

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v45';
+var CACHE_VERSION = 'v46';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -55,11 +55,13 @@ class AnalysisMixin:
             except (ImportError, Exception):
                 pass
             for st in speedtest_rows:
+                download_mbps = st.get("download_mbps")
                 timeline.append({
                     "timestamp": st["timestamp"],
                     "source": "speedtest",
                     "id": st["id"],
-                    "download_mbps": st.get("download_mbps"),
+                    "download_mbps": download_mbps,
+                    "speedtest_download": download_mbps,
                     "upload_mbps": st.get("upload_mbps"),
                     "ping_ms": st.get("ping_ms"),
                     "jitter_ms": st.get("jitter_ms"),

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -332,7 +332,59 @@
         {% else %}
             {% set ul_val_class = 'val-good' %}
         {% endif %}
+        {% set speed_health_map = {'val-good': 'good', 'val-warn': 'warn', 'val-bad': 'crit', 'val-tolerated': 'tolerated'} %}
+        {% set speed_health_key = speed_health_map.get(dl_val_class, 'crit') %}
+        {% set speed_badge_label = {'good': t.health_good, 'tolerated': t.health_tolerated, 'warn': t.health_marginal, 'crit': t.health_critical}.get(speed_health_key, t.health_critical) %}
+        {% set upload_health_key = 'crit' if ul_val_class == 'val-bad' else (ul_val_class|replace('val-', '')) %}
+        {% set speed_download_pct = none %}
+        {% set speed_pct_caption = '' %}
+        {% set speed_range_data = none %}
+        {% if eff_booked_dl > 0 %}
+            {% set speed_download_pct = speedtest_latest.download_mbps / eff_booked_dl * 100 %}
+            {% set speed_pct_caption = (speed_download_pct|round(0)|int) ~ '%' %}
+            {% set speed_marker_raw = speed_download_pct / 120 * 100 %}
+            {% set speed_marker = 0 if speed_marker_raw < 0 else (100 if speed_marker_raw > 100 else speed_marker_raw) %}
+            {% set speed_range_data = {
+                'marker': speed_marker|round(1),
+                'span_start': speed_marker|round(1),
+                'span_width': 0,
+                'low_label': '0%',
+                'good_label': t.get('speed_contract_good_label', '≥ 80% of contract'),
+                'high_label': '120%',
+                'bands': [
+                    {'kind': 'crit', 'left': 0, 'width': 41.67},
+                    {'kind': 'warn', 'left': 41.67, 'width': 25},
+                    {'kind': 'good', 'left': 66.67, 'width': 33.33}
+                ]
+            } %}
+        {% endif %}
     {% endif %}
+
+    {% macro metric_range_viz(range_data, health, good_label, context_label='', context_value='') -%}
+    {% if range_data %}
+    <div class="metric-range-viz"
+         style="--metric-marker: {{ range_data.marker }}%; --metric-span-start: {{ range_data.span_start }}%; --metric-span-width: {{ range_data.span_width }}%; --metric-range-accent: var(--{{ health }});">
+        {% if context_label or context_value %}
+        <div class="metric-range-caption">
+            <span>{{ context_label }}</span>
+            <strong>{{ context_value }}</strong>
+        </div>
+        {% endif %}
+        <div class="metric-range-track" aria-hidden="true">
+            {% for band in range_data.bands %}
+            <span class="metric-range-band {{ band.kind }}" style="left:{{ band.left }}%;width:{{ band.width }}%;"></span>
+            {% endfor %}
+            <span class="metric-range-window"></span>
+            <span class="metric-range-marker"></span>
+        </div>
+        <div class="metric-range-labels">
+            <span>{{ range_data.low_label }}</span>
+            <span class="metric-range-good">{{ good_label }} {{ range_data.good_label }}</span>
+            <span>{{ range_data.high_label }}</span>
+        </div>
+    </div>
+    {% endif %}
+    {%- endmacro %}
 
     {% if has_docsis %}
     {% set health_map = {"good": t.health_good, "tolerated": t.health_tolerated, "marginal": t.health_marginal, "critical": t.health_critical} %}
@@ -913,17 +965,33 @@
 
         {# Card 4: Speed (conditional) #}
         {% if speedtest_configured and speedtest_latest %}
-        <div class="metric-card glass">
+        <div class="metric-card glass" id="metric-speed-card">
             <div class="metric-header">
                 <span class="metric-label">{{ t.speed }}</span>
                 <div class="metric-icon green"><i data-lucide="zap"></i></div>
             </div>
-            <div class="metric-value" style="color:var(--{{ dl_val_class|replace('val-','') }});">{{ speedtest_latest.download_mbps|fmt_speed_value }}<span class="unit">{{ speedtest_latest.download_mbps|fmt_speed_unit }} {{ t.download }}</span></div>
-            <div class="metric-sub">
-                <span class="range">{{ speedtest_latest.upload_mbps|fmt_speed_value }} {{ speedtest_latest.upload_mbps|fmt_speed_unit }} {{ t.upload }}</span>
-                <span class="range">{{ speedtest_latest.ping_ms|round(0)|int }} ms Ping</span>
-                <span class="range">{{ speedtest_latest.jitter_ms|round(1) }} ms Jitter</span>
+            <div class="metric-value-row">
+                <div class="metric-value" style="color:var(--{{ speed_health_key }});">{{ speedtest_latest.download_mbps|fmt_speed_value }}<span class="unit">{{ speedtest_latest.download_mbps|fmt_speed_unit }} {{ t.download }}</span></div>
+                <canvas class="metric-spark" id="spark-speed" data-spark-key="speedtest_download" data-spark-color="#10b981" width="144" height="56" aria-hidden="true"></canvas>
             </div>
+            <div class="metric-sub metric-average-row">
+                <span class="range metric-average-copy">{{ t.get('speedtest_latest_result', 'Latest speedtest result') }}</span>
+            </div>
+            <div class="metric-sub metric-status-row">
+                <span class="metric-context">
+                    <span class="metric-sub-label">{{ t.get('metric_status_label', 'Status') }}</span>
+                    <span class="badge badge-{{ speed_health_key }}">{{ speed_badge_label }}</span>
+                </span>
+            </div>
+            <div class="metric-sub metric-modulation-row">
+                <span class="metric-sub-label">{{ t.upload }}:</span>
+                <span class="range" style="color:var(--{{ upload_health_key }});">{{ speedtest_latest.upload_mbps|fmt_speed_value }} {{ speedtest_latest.upload_mbps|fmt_speed_unit }}</span>
+                <span class="metric-sub-label">{{ t.ping }}:</span>
+                <span class="range">{{ speedtest_latest.ping_ms|round(0)|int }} ms</span>
+                <span class="metric-sub-label">{{ t.jitter }}:</span>
+                <span class="range">{{ speedtest_latest.jitter_ms|round(1) }} ms</span>
+            </div>
+            {{ metric_range_viz(speed_range_data, speed_health_key, t.health_good, t.get('metric_download_contract', 'Download vs contract'), speed_pct_caption) }}
         </div>
         {% endif %}
 
@@ -955,8 +1023,38 @@
                 <span class="metric-label">{{ t.get('docsight.connection_monitor.connection_monitor', 'Connection Monitor') }}</span>
                 <div class="metric-icon blue"><i data-lucide="satellite-dish"></i></div>
             </div>
-            <div class="metric-value" id="cm-card-status">&mdash;</div>
-            <div class="metric-sub" id="cm-card-details"></div>
+            <div class="metric-value-row">
+                <div class="metric-value" id="cm-card-latency">&ndash;</div>
+                <canvas class="metric-spark" id="spark-connection-monitor" data-spark-key="connection_monitor_latency_ms" data-spark-color="#38bdf8" width="144" height="56" aria-hidden="true"></canvas>
+            </div>
+            <div class="metric-sub metric-average-row">
+                <span class="range metric-average-copy" id="cm-card-avg">&ndash;</span>
+            </div>
+            <div class="metric-sub metric-status-row">
+                <span class="metric-context">
+                    <span class="metric-sub-label">{{ t.get('metric_status_label', 'Status') }}</span>
+                    <span class="badge badge-info" id="cm-card-badge">&ndash;</span>
+                </span>
+            </div>
+            <div class="metric-sub metric-modulation-row" id="cm-card-mod-row"></div>
+            <div class="metric-range-viz" id="cm-card-range" style="--metric-marker: 0%; --metric-span-start: 0%; --metric-span-width: 0%; --metric-range-accent: var(--muted);">
+                <div class="metric-range-caption">
+                    <span>{{ t.get('cm_latency_range', 'Latency range') }}</span>
+                    <strong id="cm-card-range-context">&ndash;</strong>
+                </div>
+                <div class="metric-range-track" aria-hidden="true">
+                    <span class="metric-range-band good" style="left:0%;width:33.33%;"></span>
+                    <span class="metric-range-band warn" style="left:33.33%;width:33.33%;"></span>
+                    <span class="metric-range-band crit" style="left:66.67%;width:33.33%;"></span>
+                    <span class="metric-range-window"></span>
+                    <span class="metric-range-marker"></span>
+                </div>
+                <div class="metric-range-labels">
+                    <span>0 ms</span>
+                    <span class="metric-range-good">{{ t.health_good }} &lt; 50 ms</span>
+                    <span>150 ms</span>
+                </div>
+            </div>
         </div>
         {% endif %}
     </div>
@@ -1115,17 +1213,33 @@
     {# ── Non-DOCSIS cards: speed, BNetzA, modules ── #}
     {% if speedtest_configured and speedtest_latest %}
     <div class="metrics-grid">
-        <div class="metric-card glass">
+        <div class="metric-card glass" id="metric-speed-card">
             <div class="metric-header">
                 <span class="metric-label">{{ t.speed }}</span>
                 <div class="metric-icon green"><i data-lucide="zap"></i></div>
             </div>
-            <div class="metric-value" style="color:var(--{{ dl_val_class|replace('val-','') }});">{{ speedtest_latest.download_mbps|fmt_speed_value }}<span class="unit">{{ speedtest_latest.download_mbps|fmt_speed_unit }} {{ t.download }}</span></div>
-            <div class="metric-sub">
-                <span class="range">{{ speedtest_latest.upload_mbps|fmt_speed_value }} {{ speedtest_latest.upload_mbps|fmt_speed_unit }} {{ t.upload }}</span>
-                <span class="range">{{ speedtest_latest.ping_ms|round(0)|int }} ms Ping</span>
-                <span class="range">{{ speedtest_latest.jitter_ms|round(1) }} ms Jitter</span>
+            <div class="metric-value-row">
+                <div class="metric-value" style="color:var(--{{ speed_health_key }});">{{ speedtest_latest.download_mbps|fmt_speed_value }}<span class="unit">{{ speedtest_latest.download_mbps|fmt_speed_unit }} {{ t.download }}</span></div>
+                <canvas class="metric-spark" id="spark-speed" data-spark-key="speedtest_download" data-spark-color="#10b981" width="144" height="56" aria-hidden="true"></canvas>
             </div>
+            <div class="metric-sub metric-average-row">
+                <span class="range metric-average-copy">{{ t.get('speedtest_latest_result', 'Latest speedtest result') }}</span>
+            </div>
+            <div class="metric-sub metric-status-row">
+                <span class="metric-context">
+                    <span class="metric-sub-label">{{ t.get('metric_status_label', 'Status') }}</span>
+                    <span class="badge badge-{{ speed_health_key }}">{{ speed_badge_label }}</span>
+                </span>
+            </div>
+            <div class="metric-sub metric-modulation-row">
+                <span class="metric-sub-label">{{ t.upload }}:</span>
+                <span class="range" style="color:var(--{{ upload_health_key }});">{{ speedtest_latest.upload_mbps|fmt_speed_value }} {{ speedtest_latest.upload_mbps|fmt_speed_unit }}</span>
+                <span class="metric-sub-label">{{ t.ping }}:</span>
+                <span class="range">{{ speedtest_latest.ping_ms|round(0)|int }} ms</span>
+                <span class="metric-sub-label">{{ t.jitter }}:</span>
+                <span class="range">{{ speedtest_latest.jitter_ms|round(1) }} ms</span>
+            </div>
+            {{ metric_range_viz(speed_range_data, speed_health_key, t.health_good, t.get('metric_download_contract', 'Download vs contract'), speed_pct_caption) }}
         </div>
     </div>
     {% endif %}

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -53,7 +53,7 @@ class TestDashboardSections:
     """Dashboard content sections in demo mode."""
 
     def test_demo_badge_visible(self, demo_page):
-        badge = demo_page.locator(".badge-muted")
+        badge = demo_page.get_by_text("DEMO", exact=True)
         assert badge.is_visible()
 
     def test_health_status_shown(self, demo_page):
@@ -250,10 +250,10 @@ class TestDashboardSections:
         assert card.get_attribute("tabindex") == "0"
 
     def test_disabled_connection_monitor_card_shows_no_data_state(self, demo_page):
-        status = demo_page.locator("#cm-card-status")
-        details = demo_page.locator("#cm-card-details")
+        status = demo_page.locator("#cm-card-latency")
+        details = demo_page.locator("#cm-card-mod-row")
         status.wait_for(state="visible")
-        demo_page.wait_for_function("document.querySelector('#cm-card-status').textContent.trim() === '—'")
+        demo_page.wait_for_function("document.querySelector('#cm-card-latency').textContent.trim() === '–'")
         assert details.text_content().strip() == ""
 
     def test_docsis_groups_expose_expanded_state(self, demo_page):

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -7,9 +7,15 @@ from datetime import datetime, timedelta, timezone
 
 from app.storage import SnapshotStorage
 from app.modules.speedtest.storage import SpeedtestStorage
-from app.tz import utc_now, utc_cutoff
-from app.web import app, update_state, init_config, init_storage
+from app.tz import to_local, utc_now, utc_cutoff
+from app.web import app, update_state, init_config, init_storage, _get_tz_name
 from app.config import ConfigManager
+
+
+def _api_response_date(utc_ts: str) -> str:
+    """Return the date part expected from APIs that localize UTC timestamps."""
+    tz_name = _get_tz_name()
+    return (to_local(utc_ts, tz_name) if tz_name else utc_ts.rstrip("Z"))[:10]
 
 
 @pytest.fixture
@@ -350,7 +356,7 @@ class TestCorrelationAPI:
 
         assert resp.status_code == 200
         data = json.loads(resp.data)
-        old_date = old_ts[:10]
+        old_date = _api_response_date(old_ts)
         assert any(entry["source"] == "modem" and entry["timestamp"].startswith(old_date) for entry in data)
 
     def test_correlation_clamps_above_ninety_days(self, client_with_storage, storage, sample_analysis):
@@ -373,8 +379,8 @@ class TestCorrelationAPI:
         assert resp.status_code == 200
         timestamps = {entry["timestamp"] for entry in json.loads(resp.data)}
         timestamp_dates = {ts[:10] for ts in timestamps}
-        assert inside_ts[:10] in timestamp_dates
-        assert outside_ts[:10] not in timestamp_dates
+        assert _api_response_date(inside_ts) in timestamp_dates
+        assert _api_response_date(outside_ts) not in timestamp_dates
 
     def test_correlation_segment_source_filter(self, client_with_storage, storage):
         """Segment source can be explicitly selected via API sources param."""

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -137,7 +137,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v45';" in sw_js
+    assert "var CACHE_VERSION = 'v46';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -278,6 +278,81 @@ def test_connection_monitor_raw_log_links_clear_on_no_data():
     assert "cm-raw-log-panel" in detail_js
     assert "rawLogPanel.style.display = 'none'" in detail_js
     assert "rawLogPanel.style.display = ''" in detail_js
+
+
+def test_connection_monitor_home_card_uses_kpi_card_anatomy():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    start = template.index('id="connection-monitor-card"')
+    card = template[start : template.index('{% endif %}', start)]
+
+    assert '<div class="metric-value-row">' in card
+    assert 'id="cm-card-latency"' in card
+    assert 'id="spark-connection-monitor"' in card
+    assert 'data-spark-key="connection_monitor_latency_ms"' in card
+    assert 'id="cm-card-avg"' in card
+    assert 'metric-sub metric-average-row' in card
+    assert 'id="cm-card-badge"' in card
+    assert 'metric-sub metric-status-row' in card
+    assert 'id="cm-card-mod-row"' in card
+    assert 'metric-sub metric-modulation-row' in card
+    assert 'id="cm-card-range"' in card
+    assert 'metric-range-viz' in card
+
+
+def test_connection_monitor_card_js_promotes_latency_to_primary_value():
+    script = f"""
+const fs = require('fs');
+const vm = require('vm');
+const code = fs.readFileSync({str(CM_CARD_JS)!r}, 'utf8');
+function makeEl(id) {{
+  return {{
+    id: id,
+    textContent: '',
+    className: '',
+    style: {{ props: {{}}, setProperty: function(k, v) {{ this.props[k] = v; }} }},
+    children: [],
+    appendChild: function(child) {{ this.children.push(child); this.textContent += child.textContent || ''; }},
+    setAttribute: function(k, v) {{ this[k] = v; }}
+  }};
+}}
+const elements = {{
+  'cm-card-latency': makeEl('cm-card-latency'),
+  'cm-card-avg': makeEl('cm-card-avg'),
+  'cm-card-badge': makeEl('cm-card-badge'),
+  'cm-card-mod-row': makeEl('cm-card-mod-row'),
+  'cm-card-range': makeEl('cm-card-range'),
+  'cm-card-range-context': makeEl('cm-card-range-context')
+}};
+const payload = {{
+  primary: {{ enabled: true, avg_latency_ms: 18.4, min_latency_ms: 15, max_latency_ms: 24, packet_loss_pct: 0 }},
+  backup: {{ enabled: true, avg_latency_ms: 21.6, min_latency_ms: 18, max_latency_ms: 26, packet_loss_pct: 0 }}
+}};
+const context = {{
+  console: console,
+  T: {{ health_good: 'Gut', health_marginal: 'Grenzwertig', health_critical: 'Kritisch', metric_average_label: 'Ø' }},
+  setInterval: function() {{}},
+  fetch: function() {{ return Promise.resolve({{ json: function() {{ return Promise.resolve(payload); }} }}); }},
+  document: {{
+    readyState: 'complete',
+    getElementById: function(id) {{ return elements[id] || null; }},
+    createElement: function() {{ return makeEl(null); }}
+  }}
+}};
+vm.createContext(context);
+vm.runInContext(code, context);
+setTimeout(function() {{
+  function assert(condition, message) {{ if (!condition) throw new Error(message); }}
+  assert(elements['cm-card-latency'].textContent === '20 ms ø', 'localized average label should be part of the primary value');
+  assert(elements['cm-card-avg'].textContent === '2/2 OK', 'target OK count should move to avg row');
+  assert(elements['cm-card-badge'].textContent === 'Gut', 'localized good status badge expected');
+  assert(elements['cm-card-badge'].className.indexOf('badge-good') !== -1, 'good badge class expected');
+  assert(elements['cm-card-mod-row'].textContent.indexOf('Packet Loss 0% · Jitter 8.5 ms') !== -1, 'packet loss and jitter metrics expected');
+  assert(elements['cm-card-range'].style.props['--metric-marker'] === '13.3%', 'latency marker should use 0-150 ms range');
+}}, 0);
+"""
+    result = subprocess.run(["node", "-e", script], cwd=ROOT, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr + result.stdout
 
 
 def test_chart_time_range_controls_use_normalized_existing_ranges():
@@ -448,6 +523,16 @@ def test_hero_chart_fetches_normalized_one_day_range():
     assert "fetch('/api/trends?range=week')" not in hero_chart_js
 
 
+def test_signal_trend_consumers_ignore_ancillary_sparkline_rows():
+    hero_chart_js = (ROOT / "app" / "static" / "js" / "hero-chart.js").read_text(encoding="utf-8")
+    trends_js = TRENDS_JS.read_text(encoding="utf-8")
+
+    assert "function isDocsisTrendRow(row)" in hero_chart_js
+    assert "isDocsisTrendRow(d) && new Date(d.timestamp) >= cutoff" in hero_chart_js
+    assert "function _isDocsisTrendRow(row)" in trends_js
+    assert "(results[0] || []).filter(_isDocsisTrendRow)" in trends_js
+
+
 def test_temperature_controls_are_consistently_after_time_range_controls_without_new_selectors():
     template = INDEX_HTML.read_text(encoding="utf-8")
     trend_header = template[template.index('id="view-trends"') : template.index('id="trend-no-data"')]
@@ -509,8 +594,8 @@ def test_connection_monitor_card_treats_no_enabled_targets_as_no_data():
     js = CM_CARD_JS.read_text(encoding="utf-8")
     no_enabled_block = js[js.index("if (enabled.length === 0)") : js.index("var ok = enabled.filter")]
 
-    assert "statusEl.textContent = '—';" in no_enabled_block
-    assert "detailsEl.textContent = '';" in no_enabled_block
+    assert "setEmpty(elements);" in no_enabled_block
+    assert "return;" in no_enabled_block
 
 
 def test_modulation_overview_charts_bound_daily_x_axis_ticks():

--- a/tests/test_trends_api.py
+++ b/tests/test_trends_api.py
@@ -3,12 +3,15 @@
 import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
 from app.config import ConfigManager
+from app.modules.connection_monitor.storage import ConnectionMonitorStorage
+from app.modules.speedtest.storage import SpeedtestStorage
 from app.storage import SnapshotStorage
-from app.web import app, init_config, init_storage
+from app.web import app, get_config_manager, init_config, init_storage
 
 
 def _utc_ts(delta: timedelta) -> str:
@@ -108,6 +111,92 @@ class TestTrendsRangeEndpoint:
         resp = flask_client.get("/api/trends?range=1d&date=not-a-date")
 
         assert resp.status_code == 200
+
+    def test_normalized_trends_include_speedtest_download_for_sparklines(self, client):
+        flask_client, storage = client
+        _insert_snapshot(storage, _analysis(2.0), _utc_ts(timedelta(minutes=20)))
+        speedtest_storage = SpeedtestStorage(storage.db_path)
+        speedtest_storage.save_speedtest_results([
+            {
+                "id": 101,
+                "timestamp": _utc_ts(timedelta(minutes=15)),
+                "download_mbps": 742.4,
+                "upload_mbps": 51.2,
+                "download_human": "742.4 Mbps",
+                "upload_human": "51.2 Mbps",
+                "ping_ms": 12.0,
+                "jitter_ms": 1.5,
+                "packet_loss_pct": 0.0,
+            },
+            {
+                "id": 102,
+                "timestamp": _utc_ts(timedelta(minutes=5)),
+                "download_mbps": 801.6,
+                "upload_mbps": 54.3,
+                "download_human": "801.6 Mbps",
+                "upload_human": "54.3 Mbps",
+                "ping_ms": 10.0,
+                "jitter_ms": 1.1,
+                "packet_loss_pct": 0.0,
+            },
+        ])
+
+        resp = flask_client.get("/api/trends?range=1h")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        speed_rows = [row for row in data if row.get("source") == "speedtest"]
+        assert [row["speedtest_download"] for row in speed_rows] == [742.4, 801.6]
+        assert [row["speedtest_upload"] for row in speed_rows] == [51.2, 54.3]
+
+    def test_normalized_trends_include_connection_monitor_latency_for_sparklines(self, client):
+        flask_client, storage = client
+        _insert_snapshot(storage, _analysis(2.0), _utc_ts(timedelta(minutes=20)))
+
+        manager = get_config_manager()
+        assert manager is not None
+        cm_storage = ConnectionMonitorStorage(str(Path(manager.data_dir) / "connection_monitor.db"))
+        target_id = cm_storage.create_target("Gateway", "192.0.2.1", enabled=True)
+        backup_target_id = cm_storage.create_target("Backup", "192.0.2.2", enabled=True)
+        first_ts = int((datetime.now(timezone.utc) - timedelta(minutes=10)).timestamp() // 60) * 60
+        second_ts = int((datetime.now(timezone.utc) - timedelta(minutes=5)).timestamp() // 60) * 60
+        cm_storage.save_samples([
+            {
+                "target_id": target_id,
+                "timestamp": first_ts,
+                "latency_ms": 18.5,
+                "timeout": False,
+                "probe_method": "icmp",
+            },
+            {
+                "target_id": target_id,
+                "timestamp": second_ts,
+                "latency_ms": 21.0,
+                "timeout": False,
+                "probe_method": "icmp",
+            },
+            {
+                "target_id": backup_target_id,
+                "timestamp": first_ts,
+                "latency_ms": 22.5,
+                "timeout": False,
+                "probe_method": "icmp",
+            },
+            {
+                "target_id": backup_target_id,
+                "timestamp": second_ts,
+                "latency_ms": 23.0,
+                "timeout": False,
+                "probe_method": "icmp",
+            },
+        ])
+
+        resp = flask_client.get("/api/trends?range=1h")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        cm_rows = [row for row in data if row.get("source") == "connection_monitor"]
+        assert [row["connection_monitor_latency_ms"] for row in cm_rows] == [20.5, 22.0]
 
     def test_legacy_ranges_still_validate_date_parameter(self, client):
         flask_client, storage = client

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -820,6 +820,8 @@ class TestIndexRoute:
             "modem_type": "generic",
             "speedtest_tracker_url": "http://speedtest.local",
             "speedtest_tracker_token": "testtoken123",
+            "booked_download": 250,
+            "booked_upload": 50,
         })
         init_config(mgr)
         init_storage(None)
@@ -858,7 +860,62 @@ class TestIndexRoute:
         # Speed card should appear in the non-DOCSIS section
         assert b"230" in html  # download speed value
         assert b"41" in html   # upload speed value
-        assert b"12 ms Ping" in html
+        assert b"Ping:" in html
+        assert b"12 ms" in html
+
+    def test_speedtest_card_uses_signal_family_card_anatomy(self, tmp_path):
+        """Speed card follows the same rows, badge, sparkline, and range anatomy as signal-family cards."""
+        mgr = ConfigManager(str(tmp_path / "data_speed_anatomy"))
+        mgr.save({
+            "modem_type": "generic",
+            "speedtest_tracker_url": "http://speedtest.local",
+            "speedtest_tracker_token": "testtoken123",
+            "booked_download": 250,
+            "booked_upload": 50,
+        })
+        init_config(mgr)
+        init_storage(None)
+        app.config["TESTING"] = True
+
+        analysis = {
+            "summary": {
+                "ds_total": 0, "us_total": 0,
+                "ds_power_min": 0, "ds_power_max": 0, "ds_power_avg": 0,
+                "us_power_min": 0, "us_power_max": 0, "us_power_avg": 0,
+                "ds_snr_min": 0, "ds_snr_avg": 0, "ds_snr_max": 0,
+                "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0,
+                "ds_uncorr_pct": 0,
+                "health": "good", "health_issues": [],
+                "us_capacity_mbps": 0,
+            },
+            "ds_channels": [],
+            "us_channels": [],
+        }
+        update_state(
+            analysis=analysis,
+            speedtest_latest={
+                "download_mbps": 230.5,
+                "upload_mbps": 41.2,
+                "ping_ms": 12.0,
+                "jitter_ms": 1.5,
+                "packet_loss_pct": 0,
+            },
+        )
+
+        with app.test_client() as c:
+            resp = c.get("/")
+
+        assert resp.status_code == 200
+        card = _element_by_id(resp.get_data(as_text=True), "metric-speed-card")
+        assert '<div class="metric-value-row">' in card
+        assert 'id="spark-speed"' in card
+        assert 'data-spark-key="speedtest_download"' in card
+        assert 'data-spark-color="#10b981"' in card
+        assert '<div class="metric-sub metric-status-row">' in card
+        assert 'badge badge-good' in card
+        assert '<div class="metric-sub metric-modulation-row">' in card
+        assert "41" in card and "Ping:" in card and "12 ms" in card and "Jitter:" in card and "1.5 ms" in card
+        assert '<div class="metric-range-viz"' in card
 
 class TestIndexSegmentUtilizationVisibility:
     def test_index_hides_segment_tab_when_disabled(self, client, config_mgr, sample_analysis):


### PR DESCRIPTION
## Summary
- Align Speed and Connection Monitor home KPI cards with the signal-family card anatomy.
- Add Speed and Connection Monitor sparkline trend data for the home dashboard.
- Localize new visible card labels and stabilize related frontend/API tests.

## Verification
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/ --ignore=tests/e2e -q`
  - `2588 passed, 11 skipped, 1 warning`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest tests/e2e --collect-only -q`
  - `418 tests collected`
- `bash /tmp/docsight_e2e_batches.sh`
  - `ALL_E2E_BATCHES_PASSED total=418`
