### PR TITLE
Fix home Speed KPI card action

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -965,10 +965,10 @@
 
         {# Card 4: Speed (conditional) #}
         {% if speedtest_configured and speedtest_latest %}
-        <div class="metric-card glass" id="metric-speed-card">
+        <div class="metric-card glass" id="metric-speed-card" role="button" tabindex="0" style="cursor:pointer;" onclick="switchView('speedtest')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();switchView('speedtest')}">
             <div class="metric-header">
                 <span class="metric-label">{{ t.speed }}</span>
-                <div class="metric-icon green"><i data-lucide="zap"></i></div>
+                <div class="metric-icon green"><i data-lucide="rabbit"></i></div>
             </div>
             <div class="metric-value-row">
                 <div class="metric-value" style="color:var(--{{ speed_health_key }});">{{ speedtest_latest.download_mbps|fmt_speed_value }}<span class="unit">{{ speedtest_latest.download_mbps|fmt_speed_unit }} {{ t.download }}</span></div>
@@ -1213,10 +1213,10 @@
     {# ── Non-DOCSIS cards: speed, BNetzA, modules ── #}
     {% if speedtest_configured and speedtest_latest %}
     <div class="metrics-grid">
-        <div class="metric-card glass" id="metric-speed-card">
+        <div class="metric-card glass" id="metric-speed-card" role="button" tabindex="0" style="cursor:pointer;" onclick="switchView('speedtest')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();switchView('speedtest')}">
             <div class="metric-header">
                 <span class="metric-label">{{ t.speed }}</span>
-                <div class="metric-icon green"><i data-lucide="zap"></i></div>
+                <div class="metric-icon green"><i data-lucide="rabbit"></i></div>
             </div>
             <div class="metric-value-row">
                 <div class="metric-value" style="color:var(--{{ speed_health_key }});">{{ speedtest_latest.download_mbps|fmt_speed_value }}<span class="unit">{{ speedtest_latest.download_mbps|fmt_speed_unit }} {{ t.download }}</span></div>

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -48,6 +48,18 @@ class TestNavigation:
         live_section = demo_page.locator("#view-dashboard")
         assert live_section.is_visible()
 
+    def test_speed_kpi_card_opens_speedtest_view_and_uses_rabbit_icon(self, demo_page):
+        speed_card = demo_page.locator("#metric-speed-card")
+        assert speed_card.is_visible()
+        assert speed_card.get_attribute("role") == "button"
+        assert speed_card.get_attribute("tabindex") == "0"
+        assert speed_card.locator('svg.lucide-rabbit').is_visible()
+
+        speed_card.click()
+
+        assert demo_page.locator("#view-speedtest").is_visible()
+        assert "active" in demo_page.locator('.nav-item[data-view="speedtest"]').get_attribute("class")
+
 
 class TestDashboardSections:
     """Dashboard content sections in demo mode."""

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -26,6 +26,21 @@ def _element_by_id(html, element_id):
     return html[start:end if end != -1 else len(html)]
 
 
+def _speed_card_opening_tag(html):
+    marker = 'id="metric-speed-card"'
+    marker_idx = html.index(marker)
+    start = html.rfind("<div", 0, marker_idx)
+    end = html.index(">", marker_idx) + 1
+    return html[start:end]
+
+
+def _speed_card_header(html):
+    marker = 'id="metric-speed-card"'
+    start = html.rfind("<div", 0, html.index(marker))
+    end = html.index('<div class="metric-value-row">', start)
+    return html[start:end]
+
+
 def _family_metric(health, avg, minimum=None, maximum=None, available=True):
     return {
         "available": available,
@@ -100,6 +115,22 @@ def _add_mixed_signal_families(analysis):
     return analysis
 
 
+def _latest_speedtest():
+    return {
+        "download_mbps": 812.4,
+        "upload_mbps": 54.2,
+        "ping_ms": 12.0,
+        "jitter_ms": 1.4,
+    }
+
+
+def _configure_speedtest(config_mgr):
+    config_mgr.save({
+        "speedtest_tracker_url": "http://speedtest.local:8999",
+        "speedtest_tracker_token": "test-token",
+    })
+
+
 class TestIndexRoute:
     @pytest.mark.parametrize(
         ("channel", "family"),
@@ -132,6 +163,40 @@ class TestIndexRoute:
         update_state(analysis=sample_analysis)
         resp = client.get("/?lang=de")
         assert resp.status_code == 200
+
+    def test_speed_kpi_card_links_to_speedtest_view_and_uses_rabbit_icon(self, client, config_mgr, sample_analysis):
+        _configure_speedtest(config_mgr)
+        update_state(analysis=sample_analysis, speedtest_latest=_latest_speedtest())
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        opening_tag = _speed_card_opening_tag(html)
+        header = _speed_card_header(html)
+        assert 'role="button"' in opening_tag
+        assert 'tabindex="0"' in opening_tag
+        assert 'onclick="switchView(\'speedtest\')"' in opening_tag
+        assert "onkeydown=\"if(event.key==='Enter'||event.key===' ')" in opening_tag
+        assert 'data-lucide="rabbit"' in header
+        assert 'data-lucide="zap"' not in header
+
+    def test_no_docsis_speed_kpi_card_links_to_speedtest_view_and_uses_rabbit_icon(self, client, config_mgr, no_docsis_analysis):
+        _configure_speedtest(config_mgr)
+        update_state(analysis=no_docsis_analysis, speedtest_latest=_latest_speedtest())
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        opening_tag = _speed_card_opening_tag(html)
+        header = _speed_card_header(html)
+        assert 'role="button"' in opening_tag
+        assert 'tabindex="0"' in opening_tag
+        assert 'onclick="switchView(\'speedtest\')"' in opening_tag
+        assert "onkeydown=\"if(event.key==='Enter'||event.key===' ')" in opening_tag
+        assert 'data-lucide="rabbit"' in header
+        assert 'data-lucide="zap"' not in header
 
     def test_index_hides_error_card_when_unsupported(self, client, sample_analysis):
         sample_analysis["summary"]["errors_supported"] = False


### PR DESCRIPTION
## Summary
- Make the Home Speed KPI card open the Speedtest view from both dashboard template branches.
- Replace the Speed card icon with the rabbit icon.
- Add web rendering and dashboard browser coverage for the card action and icon.

## Test plan
- `git diff --check`
- `.venv311/bin/python -m pytest tests/web/test_index.py::TestIndexRoute::test_speed_kpi_card_links_to_speedtest_view_and_uses_rabbit_icon tests/web/test_index.py::TestIndexRoute::test_no_docsis_speed_kpi_card_links_to_speedtest_view_and_uses_rabbit_icon tests/e2e/test_dashboard.py::TestNavigation::test_speed_kpi_card_opens_speedtest_view_and_uses_rabbit_icon -q`
- `.venv311/bin/python -m pytest tests/web/test_index.py tests/test_static_contracts.py -q`
- `.venv311/bin/python -m pytest tests -q --ignore=tests/e2e`
- `.venv311/bin/python scripts/i18n_check.py --validate`
- `.venv311/bin/python -m pytest --collect-only -q tests/e2e`
- `TZ=UTC .venv311/bin/python -m pytest -q tests/e2e --tb=short` (resource-safe by-file run: 419/419 passed)
