### PR TITLE
fix: parse CGA OFDMA modulation

### DIFF
--- a/app/drivers/vodafone_station.py
+++ b/app/drivers/vodafone_station.py
@@ -368,6 +368,7 @@ class VodafoneStationDriver(ModemDriver):
                 channel_id = int(self._parse_number(ch.get("channelidup", "0")))
                 freq = self._parse_number(ch.get("CentralFrequency", "0"))
                 power = self._parse_number(ch.get("power", "0"))
+                modulation = self._normalize_modulation(ch.get("FFT", "")) or "OFDMA"
 
                 if freq > 1_000_000:
                     freq = freq / 1_000_000
@@ -377,6 +378,7 @@ class VodafoneStationDriver(ModemDriver):
                     "type": "OFDMA",
                     "frequency": f"{int(freq)} MHz" if freq else "",
                     "powerLevel": power,
+                    "modulation": modulation,
                     "multiplex": "",
                 })
             except (ValueError, TypeError) as e:

--- a/tests/test_vodafone_station_cga.py
+++ b/tests/test_vodafone_station_cga.py
@@ -1,0 +1,66 @@
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+from app.analyzer import analyze
+from app.drivers.vodafone_station import VodafoneStationDriver
+
+
+def _driver_with_cga_payload(payload):
+    driver = VodafoneStationDriver(url="http://dummy", user="admin", password="admin")
+    response = MagicMock()
+    response.json.return_value = {"error": "ok", "data": payload}
+    return driver, response
+
+
+def test_cga_ofdma_upstream_uses_fft_modulation_while_preserving_ofdma_family():
+    driver, response = _driver_with_cga_payload({
+        "ofdma_upstream": [
+            {
+                "channelidup": "6",
+                "CentralFrequency": "51.0 MHz",
+                "power": "43.2 dBmV",
+                "ChannelType": "OFDMA",
+                "FFT": "64-qam",
+                "RangingStatus": "Completed",
+            }
+        ]
+    })
+
+    with patch.object(driver, "_cga_request", return_value=response):
+        docsis_data = driver._get_docsis_cga()
+
+    docsis_payload = cast(dict[str, Any], docsis_data)
+    raw_channel = docsis_payload["channelUs"]["docsis31"][0]
+    assert raw_channel["type"] == "OFDMA"
+    assert raw_channel["modulation"] == "64QAM"
+
+    analysis = cast(dict[str, Any], analyze(docsis_data))
+    analyzed_channel = analysis["us_channels"][0]
+    assert analyzed_channel["channel_family"] == "ofdma"
+    assert analyzed_channel["modulation"] == "64QAM"
+
+
+def test_cga_ofdma_upstream_falls_back_to_ofdma_when_fft_is_missing():
+    driver, response = _driver_with_cga_payload({
+        "ofdma_upstream": [
+            {
+                "channelidup": "6",
+                "CentralFrequency": "51.0 MHz",
+                "power": "43.2 dBmV",
+                "ChannelType": "OFDMA",
+            }
+        ]
+    })
+
+    with patch.object(driver, "_cga_request", return_value=response):
+        docsis_data = driver._get_docsis_cga()
+
+    docsis_payload = cast(dict[str, Any], docsis_data)
+    raw_channel = docsis_payload["channelUs"]["docsis31"][0]
+    assert raw_channel["type"] == "OFDMA"
+    assert raw_channel["modulation"] == "OFDMA"
+
+    analysis = cast(dict[str, Any], analyze(docsis_data))
+    analyzed_channel = analysis["us_channels"][0]
+    assert analyzed_channel["channel_family"] == "ofdma"
+    assert analyzed_channel["modulation"] == "OFDMA"


### PR DESCRIPTION
## Summary
- Preserves the Vodafone Station CGA OFDMA channel family while parsing the firmware FFT value as the displayed upstream modulation when available.
- Keeps the existing OFDMA fallback when the firmware omits the FFT value.
- Adds regression coverage for both FFT-derived modulation and fallback behavior through driver output and analyzer output.

Refs #584

## Test plan
- `git diff --check`
- `.venv311/bin/python -m pytest -q tests/test_vodafone_station_cga.py tests/test_vodafone_station_tg.py tests/analyzer/test_thresholds.py tests/test_modulation_static_contract.py`
- `ulimit -n 8192; .venv311/bin/python -m pytest -q tests --ignore=tests/e2e`
- `TZ=UTC` E2E suite collected 419 tests; completed by file/batch with 419/419 passing after the monolithic run timed out partway through.
