### PR TITLE
Normalize view page headers

### DIFF
--- a/app/modules/bqm/static/style.css
+++ b/app/modules/bqm/static/style.css
@@ -5,7 +5,7 @@
     display: flex;
     align-items: center;
     gap: var(--space-sm);
-    justify-content: center;
+    justify-content: flex-end;
     flex-wrap: wrap;
     margin-bottom: var(--space-sm);
 }

--- a/app/modules/comparison/templates/comparison_tab.html
+++ b/app/modules/comparison/templates/comparison_tab.html
@@ -1,7 +1,9 @@
 <div class="view-content">
     <!-- Controls -->
-    <div style="display:flex; align-items:center; gap:16px; margin-bottom:20px; flex-wrap:wrap;">
-        <h2 style="margin:0; flex:1;">{{ t.get('docsight.comparison.title', 'Before/After Comparison') }}</h2>
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.get('docsight.comparison.title', 'Before/After Comparison') }}</h2>
+        </div>
     </div>
 
     <!-- Preset + Date Picker Bar -->

--- a/app/modules/connection_monitor/static/style.css
+++ b/app/modules/connection_monitor/static/style.css
@@ -81,6 +81,11 @@
     font-size: 0.84rem;
 }
 
+
+.cm-page-header .cm-capability {
+    justify-content: flex-end;
+}
+
 .cm-capability {
     display: flex;
     align-items: center;

--- a/app/modules/connection_monitor/templates/connection_monitor_detail.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_detail.html
@@ -1,15 +1,12 @@
 <div class="view-content cm-monitor" id="cm-detail-view"
      data-l-remove="{{ t.get('docsight.connection_monitor.cm_remove', 'Remove') }}"
      data-l-raw-log-download="{{ t.get('docsight.connection_monitor.cm_raw_log_download', 'Download raw log') }}">
-    <div class="cm-console-head">
-        <div class="cm-title-block">
-            <div class="cm-title-row">
-                <span class="cm-title-icon"><i data-lucide="activity"></i></span>
-                <h2>{{ t.get('docsight.connection_monitor.cm_detail_title', 'Connection Monitor') }}</h2>
-            </div>
-            <p>{{ t.get('docsight.connection_monitor.connection_monitor_desc', 'Always-on latency monitoring for cable troubleshooting') }}</p>
+    <div class="view-page-header cm-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.get('docsight.connection_monitor.cm_detail_title', 'Connection Monitor') }}</h2>
+            <span class="view-page-subtitle">{{ t.get('docsight.connection_monitor.connection_monitor_desc', 'Always-on latency monitoring for cable troubleshooting') }}</span>
         </div>
-        <div id="cm-capability-info" class="cm-capability"
+        <div id="cm-capability-info" class="view-page-actions cm-capability"
              data-method-icmp="{{ t.get('docsight.connection_monitor.cm_method_icmp', 'ICMP') }}"
              data-method-tcp="{{ t.get('docsight.connection_monitor.cm_method_tcp', 'TCP') }}"
              data-hint-tcp="{{ t.get('docsight.connection_monitor.cm_method_hint_tcp', 'Using TCP probing. For more accurate ICMP probing, add cap_add: [NET_RAW] to your Docker Compose.') }}"

--- a/app/modules/journal/static/style.css
+++ b/app/modules/journal/static/style.css
@@ -2,17 +2,13 @@
 
 /* Header & Actions */
 .journal-header {
-    display: flex;
-    flex-direction: column;
     align-items: center;
-    margin-bottom: var(--space-lg);
-    gap: var(--space-sm);
 }
 .journal-header-actions {
     display: flex;
     gap: var(--space-sm);
     flex-wrap: wrap;
-    justify-content: center;
+    justify-content: flex-end;
 }
 .btn-delete-all {
     font-size: 0.85em;
@@ -53,12 +49,6 @@
 .journal-export-dropdown button:active {
     filter: brightness(0.85);
 }
-.journal-header .trend-title {
-    font-size: 1.5em;
-    color: var(--accent-purple, var(--accent));
-    font-weight: bold;
-}
-
 /* Purple pill button (matching Acknowledge All style) */
 .btn-new-entry {
     display: inline-flex;
@@ -1187,9 +1177,6 @@ mark.search-highlight {
     }
     .journal-header {
         align-items: stretch;
-    }
-    .journal-header .trend-title {
-        text-align: center;
     }
     .journal-header-actions {
         width: 100%;

--- a/app/modules/modulation/templates/modulation_tab.html
+++ b/app/modules/modulation/templates/modulation_tab.html
@@ -1,8 +1,10 @@
 <div class="view-content">
     <!-- Controls -->
-    <div class="mod-controls">
-        <h2 class="mod-view-title">{{ t.get('docsight.modulation.title', 'Modulation Performance') }}</h2>
-        <div class="mod-controls-tabs">
+    <div class="view-page-header mod-controls">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.get('docsight.modulation.title', 'Modulation Performance') }}</h2>
+        </div>
+        <div class="view-page-actions mod-controls-tabs">
             <div class="trend-tabs" id="modulation-direction-tabs">
                 <button class="trend-tab active" data-dir="us">{{ t.get('docsight.modulation.upstream', 'Upstream') }}</button>
                 <button class="trend-tab" data-dir="ds">{{ t.get('docsight.modulation.downstream', 'Downstream') }}</button>

--- a/app/static/css/segment-utilization.css
+++ b/app/static/css/segment-utilization.css
@@ -5,25 +5,12 @@
     margin: 0 auto;
 }
 
-.fritz-cable-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 16px;
-    margin-bottom: 20px;
-    flex-wrap: wrap;
-}
-
 .fritz-cable-title {
-    margin: 0 0 4px 0;
-    font-size: 1.4em;
-    font-weight: 600;
+    margin: 0;
 }
 
 .fritz-cable-subtitle {
     margin: 0;
-    color: var(--text-secondary, #888);
-    font-size: 0.9em;
 }
 
 .fritz-cable-range-tabs {

--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -237,16 +237,7 @@
    EVENT LOG - Phase 4.3: Modern Card Design with Pill Filters
    ══════════════════════════════════════════════════════════════════════════ */
 .events-header {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
     margin-bottom: var(--space-lg, 20px);
-    gap: var(--space-sm, 10px);
-}
-.events-header .trend-title {
-    font-size: clamp(1.2rem, 1rem + 0.5vw, 1.5rem);
-    color: var(--accent-purple, var(--accent));
-    font-weight: bold;
 }
 
 /* Phase 4.3: Pill filter section */
@@ -603,7 +594,50 @@
    Phase 4.4: Correlation Analysis View
    ═══════════════════════════════════════════════════════════════ */
 
-/* Correlation Header — left-aligned inline with tabs */
+/* Shared page header — Correlation-style Option A */
+.view-page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md, 16px);
+    margin-bottom: var(--space-lg, 20px);
+    flex-wrap: wrap;
+}
+.view-page-header-left {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+.view-page-title {
+    margin: 0;
+    font-size: 1.15em;
+    font-weight: 700;
+    color: var(--text, var(--text-primary));
+    line-height: 1.2;
+}
+.view-page-subtitle {
+    font-size: 0.8em;
+    color: var(--text-muted, var(--muted));
+    line-height: 1.4;
+}
+.view-page-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-sm, 8px);
+    flex-wrap: wrap;
+    min-width: 0;
+}
+.view-page-actions .trend-tabs {
+    flex-wrap: wrap;
+}
+.view-page-actions.ch-controls,
+.view-page-actions.bqm-toolbar {
+    margin-bottom: 0;
+}
+
+/* Correlation Header aliases retained for compatibility during the shared header migration */
 .correlation-header {
     display: flex;
     align-items: center;
@@ -918,9 +952,13 @@
     .correlation-chart-card {
         padding: var(--space-md, 16px);
     }
-    .correlation-header {
+    .view-page-header {
         flex-direction: column;
         align-items: flex-start;
+    }
+    .view-page-actions {
+        justify-content: flex-start;
+        width: 100%;
     }
     .correlation-chart-legend {
         flex-wrap: wrap;

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -135,8 +135,7 @@ function loadTrends(range) {
     var title = document.getElementById('trend-title');
     var noData = document.getElementById('trend-no-data');
     var grid = document.getElementById('charts-grid');
-    var label = String(range || '1d');
-    title.textContent = (T.signal_trends || 'Signal Trends') + ' (' + label + ')';
+    if (title) title.textContent = T.signal_trends || 'Signal Trends';
     _lastTrendRange = range;
 
     var wr = _getWeatherRange(range);

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v46';
+var CACHE_VERSION = 'v47';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1282,9 +1282,11 @@
 
 <!-- ═══ View: Trends ═══ -->
 <div id="view-trends" class="view">
-    <div class="trend-header">
-        <span class="trend-title" id="trend-title"></span>
-        <div style="display:flex; align-items:center; gap:8px;">
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title" id="trend-title">{{ t.signal_trends }}</h2>
+        </div>
+        <div class="view-page-actions">
             <div class="trend-tabs" id="trend-tabs">
                 <button class="trend-tab" data-range="1h">1h</button>
                 <button class="trend-tab" data-range="6h">6h</button>
@@ -1367,11 +1369,12 @@
 <!-- ═══ View: BQM Graphs ═══ -->
 {% if bqm_configured %}
 <div id="view-bqm" class="view">
-    <div class="trend-header">
-        <span class="trend-title">{{ t.bqm_title }}</span>
-    </div>
-    <!-- BQM Toolbar: quick-jump + month nav -->
-    <div id="bqm-toolbar" class="bqm-toolbar">
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.bqm_title }}</h2>
+        </div>
+        <!-- BQM Toolbar: quick-jump + month nav -->
+        <div id="bqm-toolbar" class="view-page-actions bqm-toolbar">
         <button class="trend-tab bqm-quick" id="bqm-today-btn">{{ t.bqm_today }}</button>
         <button class="trend-tab bqm-quick" id="bqm-yesterday-btn">{{ t.bqm_yesterday }}</button>
         <button class="trend-tab bqm-quick" id="bqm-7d-btn">{{ t.bqm_range_7d or '7d' }}</button>
@@ -1396,6 +1399,7 @@
                 <polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
             </svg>
         </button>
+        </div>
     </div>
     <!-- Calendar grid -->
     <div id="bqm-calendar" class="bqm-calendar">
@@ -1505,9 +1509,11 @@
 <!-- ═══ View: Smokeping Graphs ═══ -->
 {% if modules|selectattr('id', 'equalto', 'docsight.smokeping')|list and smokeping_configured %}
 <div id="view-smokeping" class="view">
-    <div style="text-align:center; margin-bottom:24px;">
-        <span class="trend-title">{{ t.smokeping_title }}</span>
-        <div class="trend-tabs" id="smokeping-tabs" style="display:inline-flex; margin-top:12px;">
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.smokeping_title }}</h2>
+        </div>
+        <div class="view-page-actions trend-tabs" id="smokeping-tabs">
             <button class="trend-tab active" data-span="3h">3h</button>
             <button class="trend-tab" data-span="30h">30h</button>
             <button class="trend-tab" data-span="10d">10d</button>
@@ -1523,12 +1529,12 @@
 <!-- ═══ View: Correlation Analysis ═══ -->
 {% if speedtest_configured or bqm_configured %}
 <div id="view-correlation" class="view">
-    <div class="correlation-header">
-        <div class="correlation-header-left">
-            <span class="correlation-view-title">{{ t.correlation_title }}</span>
-            <span class="correlation-view-subtitle">{{ t.get('correlation_subtitle', 'Build evidence for ISP complaints') }}</span>
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.correlation_title }}</h2>
+            <span class="view-page-subtitle">{{ t.get('correlation_subtitle', 'Build evidence for ISP complaints') }}</span>
         </div>
-        <div class="trend-tabs" id="correlation-tabs">
+        <div class="view-page-actions trend-tabs" id="correlation-tabs">
             <button class="trend-tab" data-value="1h" onclick="selectPill(this, loadCorrelationData)">1h</button>
             <button class="trend-tab" data-value="6h" onclick="selectPill(this, loadCorrelationData)">6h</button>
             <button class="trend-tab active" data-value="1d" onclick="selectPill(this, loadCorrelationData)">1d</button>
@@ -1607,9 +1613,11 @@
 
 <!-- ═══ View: Incident Journal ═══ -->
 <div id="view-journal" class="view">
-    <div class="journal-header">
-        <span class="trend-title">{{ t.incident_journal }}</span>
-        <div class="journal-header-actions">
+    <div class="view-page-header journal-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.incident_journal }}</h2>
+        </div>
+        <div class="view-page-actions journal-header-actions">
             <button class="btn-new-entry" onclick="openEntryModal()">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
                     <path d="M12 5v14m-7-7h14"/>
@@ -1735,8 +1743,10 @@
 
 <!-- ═══ View: Event Log ═══ -->
 <div id="view-events" class="view">
-    <div class="events-header">
-        <span class="trend-title">{{ t.event_log }}</span>
+    <div class="view-page-header events-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.event_log }}</h2>
+        </div>
     </div>
 
     <!-- Phase 4.3: Pill filter toggles for severity -->
@@ -1785,7 +1795,11 @@
 
 <!-- ═══ View: Channel Timeline ═══ -->
 <div id="view-channels" class="view">
-    <div class="ch-controls">
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.channels }}</h2>
+        </div>
+        <div class="view-page-actions ch-controls">
         <div class="trend-tabs" id="channel-mode-tabs">
             <button class="trend-tab active" data-value="timeline" onclick="selectPill(this, switchChannelMode)">{{ t.channel_timeline }}</button>
             <button class="trend-tab" data-value="compare" onclick="selectPill(this, switchChannelMode)">{{ t.channel_compare }}</button>
@@ -1835,6 +1849,7 @@
                 </svg>
             </button>
         </span>
+        </div>
     </div>
 
     <!-- Channel info bar (populated by JS after channel selection) -->
@@ -2152,9 +2167,11 @@
 <!-- ═══ View: Speedtest ═══ -->
 {% if speedtest_configured %}
 <div id="view-speedtest" class="view">
-    <div class="trend-header">
-        <span class="trend-title">{{ t.speedtest_tracker }}</span>
-        <div class="speedtest-controls">
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.speedtest_tracker }}</h2>
+        </div>
+        <div class="view-page-actions speedtest-controls">
             <div class="trend-tabs" id="speedtest-tabs">
                 <button class="trend-tab" data-value="1" onclick="selectPill(this, filterSpeedtestData)">1d</button>
                 <button class="trend-tab active" data-value="7" onclick="selectPill(this, filterSpeedtestData)">7d</button>
@@ -2225,10 +2242,15 @@
 
 {% if gaming_quality_enabled %}
 <div id="view-gaming" class="view">
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.gaming_quality_label }}</h2>
+        </div>
+    </div>
     {% if gaming_index %}
     {% set s = gaming_index.score %}
     {% set g = gaming_index.grade|lower %}
-    <!-- Gauge hero (no title - sidebar already names this view) -->
+    <!-- Gauge hero -->
     <div class="gaming-overview">
         <div class="gaming-gauge">
             <div class="gaming-gauge-band">
@@ -2327,9 +2349,11 @@
 <!-- ═══ View: Breitbandmessung (BNetzA) ═══ -->
 {% if bnetz_enabled %}
 <div id="view-bnetz" class="view">
-    <div class="trend-header">
-        <span class="trend-title">{{ t.bnetz_title }}</span>
-        <div style="display:flex;gap:8px;align-items:center;">
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.bnetz_title }}</h2>
+        </div>
+        <div class="view-page-actions">
             <label class="btn btn-muted" style="cursor:pointer;">
                 <i data-lucide="upload" style="width:14px;height:14px;vertical-align:-2px;"></i> {{ t.bnetz_upload }}
                 <input type="file" accept=".pdf,.csv" id="bnetz-file-input" style="display:none;" onchange="uploadBnetzFromView(this)">

--- a/app/templates/segment_utilization_tab.html
+++ b/app/templates/segment_utilization_tab.html
@@ -1,10 +1,10 @@
 <div class="view-content fritz-cable-view">
-    <div class="fritz-cable-header">
-        <div>
-            <h2 class="fritz-cable-title">{{ t.get('seg_title', 'Segment Utilization') }}</h2>
-            <p class="fritz-cable-subtitle">{{ t.get('seg_subtitle', 'Cable segment utilization from FRITZ!Box monitoring.') }}</p>
+    <div class="view-page-header fritz-cable-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title fritz-cable-title">{{ t.get('seg_title', 'Segment Utilization') }}</h2>
+            <span class="view-page-subtitle fritz-cable-subtitle">{{ t.get('seg_subtitle', 'Cable segment utilization from FRITZ!Box monitoring.') }}</span>
         </div>
-        <div class="fritz-cable-range-tabs" id="fritz-cable-range-tabs">
+        <div class="view-page-actions fritz-cable-range-tabs" id="fritz-cable-range-tabs">
             <button class="trend-tab" data-range="24h">{{ t.get('seg_range_24h', '24h') }}</button>
             <button class="trend-tab" data-range="7d">{{ t.get('seg_range_7d', '7d') }}</button>
             <button class="trend-tab" data-range="30d">{{ t.get('seg_range_30d', '30d') }}</button>

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -15,6 +15,9 @@ TRENDS_JS = ROOT / "app" / "static" / "js" / "trends.js"
 CHANNELS_JS = ROOT / "app" / "static" / "js" / "channels.js"
 MODULATION_MAIN_JS = ROOT / "app" / "modules" / "modulation" / "static" / "main.js"
 MODULATION_TEMPLATE = ROOT / "app" / "modules" / "modulation" / "templates" / "modulation_tab.html"
+COMPARISON_TEMPLATE = ROOT / "app" / "modules" / "comparison" / "templates" / "comparison_tab.html"
+CONNECTION_MONITOR_TEMPLATE = ROOT / "app" / "modules" / "connection_monitor" / "templates" / "connection_monitor_detail.html"
+SEGMENT_UTILIZATION_TEMPLATE = ROOT / "app" / "templates" / "segment_utilization_tab.html"
 SW_JS = ROOT / "app" / "static" / "sw.js"
 MAIN_CSS = ROOT / "app" / "static" / "css" / "main.css"
 INDEX_HTML = ROOT / "app" / "templates" / "index.html"
@@ -137,7 +140,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v46';" in sw_js
+    assert "var CACHE_VERSION = 'v47';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -494,10 +497,11 @@ def test_channels_legacy_days_hashes_normalize_to_range_tabs():
     assert "_normalizeChannelRangeValue(params.range || params.days || '1d')" in channels_js
 
 
-def test_trend_title_uses_rolling_range_without_stale_date_suffix():
+def test_trend_title_uses_stable_page_title_without_range_or_stale_date_suffix():
     trends_js = TRENDS_JS.read_text(encoding="utf-8")
 
-    assert "title.textContent = (T.signal_trends || 'Signal Trends') + ' (' + label + ')'" in trends_js
+    assert "title.textContent = T.signal_trends || 'Signal Trends'" in trends_js
+    assert "Signal Trends') + ' ('" not in trends_js
     assert "formatDateDE(date)" not in trends_js
     assert "&date=" not in trends_js
 
@@ -544,6 +548,102 @@ def test_temperature_controls_are_consistently_after_time_range_controls_without
     assert channel_controls.index('id="channel-time-tabs"') < channel_controls.index('id="channel-temp-toggle-btn"')
     assert compare_controls.index('id="compare-time-tabs"') < compare_controls.index('id="compare-temp-toggle-btn"')
     assert 'correlation-temp-toggle' not in correlation_header
+
+
+def _view_block(template: str, view_id: str) -> str:
+    start = template.index(f'id="{view_id}"')
+    next_view = template.find('id="view-', start + 1)
+    return template[start: next_view if next_view != -1 else len(template)]
+
+
+def test_main_blades_use_shared_correlation_style_page_header():
+    """Primary app views should use one Correlation-style top section contract."""
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    expected_titles = {
+        "view-trends": "t.signal_trends",
+        "view-bqm": "t.bqm_title",
+        "view-smokeping": "t.smokeping_title",
+        "view-correlation": "t.correlation_title",
+        "view-journal": "t.incident_journal",
+        "view-events": "t.event_log",
+        "view-channels": "t.channels",
+        "view-speedtest": "t.speedtest_tracker",
+        "view-gaming": "t.gaming_quality_label",
+        "view-bnetz": "t.bnetz_title",
+    }
+
+    offenders = []
+    for view_id, title_expression in expected_titles.items():
+        block = _view_block(template, view_id)
+        if "view-page-header" not in block:
+            offenders.append(f"{view_id}: missing shared header")
+        if "view-page-title" not in block:
+            offenders.append(f"{view_id}: missing shared title class")
+        if title_expression not in block:
+            offenders.append(f"{view_id}: missing stable title expression {title_expression}")
+
+    assert offenders == []
+
+
+def test_module_blades_use_shared_correlation_style_page_header():
+    module_templates = {
+        "connection-monitor": CONNECTION_MONITOR_TEMPLATE.read_text(encoding="utf-8"),
+        "modulation": MODULATION_TEMPLATE.read_text(encoding="utf-8"),
+        "comparison": COMPARISON_TEMPLATE.read_text(encoding="utf-8"),
+        "segment-utilization": SEGMENT_UTILIZATION_TEMPLATE.read_text(encoding="utf-8"),
+    }
+
+    offenders = []
+    for name, template in module_templates.items():
+        if "view-page-header" not in template:
+            offenders.append(f"{name}: missing shared header")
+        if "view-page-title" not in template:
+            offenders.append(f"{name}: missing shared title class")
+
+    assert offenders == []
+
+
+def test_touched_header_templates_do_not_mix_span_and_h2_closing_tags():
+    templates = {
+        "index.html": INDEX_HTML.read_text(encoding="utf-8"),
+        "connection-monitor": CONNECTION_MONITOR_TEMPLATE.read_text(encoding="utf-8"),
+        "modulation": MODULATION_TEMPLATE.read_text(encoding="utf-8"),
+        "comparison": COMPARISON_TEMPLATE.read_text(encoding="utf-8"),
+        "segment-utilization": SEGMENT_UTILIZATION_TEMPLATE.read_text(encoding="utf-8"),
+    }
+    mismatched_tag = re.compile(r"<(span|h2)\b[^>]*>[^\n]*</(?!\1>)(span|h2)>")
+
+    offenders = []
+    for name, template in templates.items():
+        offenders.extend(f"{name}: {match.group(0)}" for match in mismatched_tag.finditer(template))
+
+    assert offenders == []
+
+
+def test_signal_trends_title_is_stable_and_does_not_embed_selected_range():
+    template = INDEX_HTML.read_text(encoding="utf-8")
+    trends_block = _view_block(template, "view-trends")
+    trends_js = TRENDS_JS.read_text(encoding="utf-8")
+
+    assert "{{ t.signal_trends }}" in trends_block
+    assert "Signal Trends') + ' ('" not in trends_js
+    assert "signal_trends || 'Signal Trends') + ' ('" not in trends_js
+
+
+def test_shared_view_page_header_css_matches_correlation_option_a_contract():
+    css = VIEWS_CSS.read_text(encoding="utf-8")
+    header_block = css[css.index(".view-page-header") : css.index(".view-page-actions")]
+    title_block = css[css.index(".view-page-title") : css.index(".view-page-subtitle")]
+    subtitle_block = css[css.index(".view-page-subtitle") : css.index("/* Correlation Chart Card")]
+
+    assert "display: flex" in header_block
+    assert "justify-content: space-between" in header_block
+    assert "flex-wrap: wrap" in header_block
+    assert "font-size: 1.15em" in title_block
+    assert "font-weight: 700" in title_block
+    assert "color: var(--text" in title_block
+    assert "font-size: 0.8em" in subtitle_block
+    assert "color: var(--text-muted" in subtitle_block
 
 
 def test_chart_engine_has_configurable_axis_padding_for_long_qam_labels():


### PR DESCRIPTION
## Summary
- Adds a shared clean page-header pattern for DOCSight views based on the Correlation-style layout
- Normalizes headers across main views and module tab views, including Channels and Gaming Quality
- Keeps Signal Trends title stable while leaving the selected range in the range controls
- Bumps the service worker cache for the updated shell assets

## Validation
- `git diff --check`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e` via deterministic file batches: 419 passed

Closes #556
