### PR TITLE
Align Connection Monitor header actions

### DIFF
--- a/app/modules/connection_monitor/static/style.css
+++ b/app/modules/connection_monitor/static/style.css
@@ -82,10 +82,6 @@
 }
 
 
-.cm-page-header .cm-capability {
-    justify-content: flex-end;
-}
-
 .cm-capability {
     display: flex;
     align-items: center;
@@ -118,25 +114,6 @@
     border: 1px solid color-mix(in srgb, var(--warn) 28%, transparent);
 }
 
-.cm-control-strip {
-    display: flex;
-    align-items: stretch;
-    justify-content: space-between;
-    gap: var(--space-sm);
-    padding: var(--space-sm);
-    border: 1px solid var(--cm-panel-border);
-    border-radius: 8px;
-    background: color-mix(in srgb, var(--surface) 70%, transparent);
-}
-
-.cm-range-group {
-    display: flex;
-    align-items: center;
-    gap: var(--space-sm);
-    min-width: 0;
-}
-
-.cm-control-label,
 .cm-pinned-label,
 .cm-export-group > span {
     color: var(--text-muted);
@@ -155,12 +132,6 @@
     align-items: center;
     gap: 6px;
     flex-wrap: wrap;
-}
-
-.cm-range-picker .trend-tab {
-    min-height: 34px;
-    padding: 6px 13px;
-    border-radius: 8px;
 }
 
 .cm-pin-action,
@@ -236,8 +207,10 @@
     align-items: center;
     gap: var(--space-sm);
     min-width: 0;
-    padding-left: var(--space-sm);
-    border-left: 1px solid var(--cm-panel-border);
+    padding: var(--space-sm);
+    border: 1px solid var(--cm-panel-border);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--surface) 70%, transparent);
 }
 
 .cm-no-data {
@@ -787,8 +760,6 @@
 
 @media (max-width: 760px) {
     .cm-console-head,
-    .cm-control-strip,
-    .cm-range-group,
     .cm-side-stack {
         display: flex;
         flex-direction: column;
@@ -808,10 +779,8 @@
     }
 
     .cm-pinned-bar {
-        padding-left: 0;
-        padding-top: var(--space-sm);
-        border-left: 0;
-        border-top: 1px solid var(--cm-panel-border);
+        align-items: stretch;
+        flex-direction: column;
     }
 
     .cm-stats-grid {

--- a/app/modules/connection_monitor/templates/connection_monitor_detail.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_detail.html
@@ -6,16 +6,7 @@
             <h2 class="view-page-title">{{ t.get('docsight.connection_monitor.cm_detail_title', 'Connection Monitor') }}</h2>
             <span class="view-page-subtitle">{{ t.get('docsight.connection_monitor.connection_monitor_desc', 'Always-on latency monitoring for cable troubleshooting') }}</span>
         </div>
-        <div id="cm-capability-info" class="view-page-actions cm-capability"
-             data-method-icmp="{{ t.get('docsight.connection_monitor.cm_method_icmp', 'ICMP') }}"
-             data-method-tcp="{{ t.get('docsight.connection_monitor.cm_method_tcp', 'TCP') }}"
-             data-hint-tcp="{{ t.get('docsight.connection_monitor.cm_method_hint_tcp', 'Using TCP probing. For more accurate ICMP probing, add cap_add: [NET_RAW] to your Docker Compose.') }}"
-        ></div>
-    </div>
-
-    <div class="cm-control-strip">
-        <div class="cm-range-group">
-            <span class="cm-control-label">{{ t.get('docsight.connection_monitor.cm_timerange', 'Time range') }}</span>
+        <div class="view-page-actions cm-header-actions">
             <div class="cm-range-picker trend-tabs" role="group" aria-label="{{ t.get('docsight.connection_monitor.cm_timerange', 'Time range') }}">
                 <button class="trend-tab active" data-cm-range="3600" onclick="cmSetRange(this, 3600)">1h</button>
                 <button class="trend-tab" data-cm-range="21600" onclick="cmSetRange(this, 21600)">6h</button>
@@ -26,12 +17,17 @@
                 <button class="trend-tab" data-cm-range="2592000" onclick="cmSetRange(this, 2592000)">30d</button>
                 <button class="trend-tab" data-cm-range="7776000" onclick="cmSetRange(this, 7776000)">90d</button>
             </div>
+            <div id="cm-capability-info" class="cm-capability"
+                 data-method-icmp="{{ t.get('docsight.connection_monitor.cm_method_icmp', 'ICMP') }}"
+                 data-method-tcp="{{ t.get('docsight.connection_monitor.cm_method_tcp', 'TCP') }}"
+                 data-hint-tcp="{{ t.get('docsight.connection_monitor.cm_method_hint_tcp', 'Using TCP probing. For more accurate ICMP probing, add cap_add: [NET_RAW] to your Docker Compose.') }}"
+            ></div>
         </div>
+    </div>
 
-        <div id="cm-pinned-days-bar" class="cm-pinned-bar">
-            <span class="cm-pinned-label">Pinned</span>
-            <div id="cm-pinned-days" class="cm-pinned-days"></div>
-        </div>
+    <div id="cm-pinned-days-bar" class="cm-pinned-bar">
+        <span class="cm-pinned-label">Pinned</span>
+        <div id="cm-pinned-days" class="cm-pinned-days"></div>
     </div>
 
     <section id="cm-raw-log-panel" class="glass cm-panel cm-raw-log-panel" style="display:none;">

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v47';
+var CACHE_VERSION = 'v48';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_connection_monitor.py
+++ b/tests/e2e/test_connection_monitor.py
@@ -3,6 +3,21 @@
 from playwright.sync_api import expect
 
 
+def test_connection_monitor_uses_shared_page_header_action_layout(demo_page):
+    """Connection Monitor range controls should live in the same top header pattern as other views."""
+    page = demo_page
+    page.evaluate("switchView('connection-monitor')")
+    page.wait_for_selector("#view-connection-monitor.active", state="visible")
+
+    header = page.locator("#view-connection-monitor .view-page-header")
+    expect(header).to_be_visible()
+    expect(header.locator(".view-page-title")).to_have_text("Connection Monitor")
+    expect(header.locator(".view-page-actions .cm-range-picker")).to_be_visible()
+    expect(header.locator(".view-page-actions [data-cm-range='3600']")).to_be_visible()
+    expect(header.locator(".view-page-actions #cm-capability-info")).to_be_visible()
+    expect(page.locator("#view-connection-monitor .cm-control-strip")).to_have_count(0)
+
+
 def test_connection_monitor_raw_ping_log_panel_is_discoverable(demo_page):
     """The Connection Monitor view should expose the ISP-ready raw ping log export panel."""
     page = demo_page

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -140,7 +140,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v47';" in sw_js
+    assert "var CACHE_VERSION = 'v48';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -601,6 +601,21 @@ def test_module_blades_use_shared_correlation_style_page_header():
             offenders.append(f"{name}: missing shared title class")
 
     assert offenders == []
+
+
+def test_connection_monitor_range_controls_live_in_shared_page_header_actions():
+    """Connection Monitor should not keep a separate boxed top control strip."""
+    template = CONNECTION_MONITOR_TEMPLATE.read_text(encoding="utf-8")
+    header_block = template[
+        template.index('<div class="view-page-header cm-page-header">') :
+        template.index('<div id="cm-pinned-days-bar"')
+    ]
+
+    assert 'class="view-page-actions' in header_block
+    assert 'class="cm-range-picker trend-tabs"' in header_block
+    assert 'id="cm-capability-info" class="cm-capability"' in header_block
+    assert 'data-cm-range="3600"' in header_block
+    assert 'class="cm-control-strip"' not in template
 
 
 def test_touched_header_templates_do_not_mix_span_and_h2_closing_tags():


### PR DESCRIPTION
## Summary
- Moves Connection Monitor time-range controls into the shared page-header action row
- Removes the separate boxed top control strip so the view matches the other normalized headers
- Keeps the TCP/ICMP capability badge in the same header action area
- Bumps the service worker cache for the updated module shell assets

## Validation
- `git diff --check`
- `pytest -q tests --ignore=tests/e2e`
- `TZ=UTC pytest -q tests/e2e` via deterministic file batches: 420 passed

Refs #556
