### PR TITLE
Align event and channel header actions

### DIFF
--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -248,10 +248,9 @@
     margin-bottom: var(--space-lg, 20px);
     flex-wrap: wrap;
 }
-.events-filter-label {
-    font-size: 0.9em;
-    font-weight: 600;
-    color: var(--text-secondary, var(--muted));
+.events-header .events-filter-section {
+    margin-bottom: 0;
+    margin-left: auto;
 }
 .events-severity-pills {
     display: flex;
@@ -632,7 +631,6 @@
 .view-page-actions .trend-tabs {
     flex-wrap: wrap;
 }
-.view-page-actions.ch-controls,
 .view-page-actions.bqm-toolbar {
     margin-bottom: 0;
 }
@@ -1450,15 +1448,6 @@
 }
 .btn-ghost:hover { color: var(--text); }
 
-
-/* ── Channel View Controls ── */
-.ch-controls {
-    display: flex;
-    gap: 12px;
-    margin-bottom: var(--space-lg, 20px);
-    flex-wrap: wrap;
-    align-items: center;
-}
 
 /* Channel info bar */
 .ch-info-bar {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v48';
+var CACHE_VERSION = 'v49';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1747,19 +1747,17 @@
         <div class="view-page-header-left">
             <h2 class="view-page-title">{{ t.event_log }}</h2>
         </div>
-    </div>
-
-    <!-- Phase 4.3: Pill filter toggles for severity -->
-    <div class="events-filter-section">
-        <div class="events-filter-label">{{ t.event_severity }}:</div>
-        <div class="events-severity-pills">
-            <button class="severity-pill active" data-severity="" onclick="filterEventsBySeverity('')" aria-pressed="true">{{ t.event_all_severities }}</button>
-            <button class="severity-pill" data-severity="info" onclick="filterEventsBySeverity('info')" aria-pressed="false">{{ t.event_severity_info }}</button>
-            <button class="severity-pill" data-severity="warning" onclick="filterEventsBySeverity('warning')" aria-pressed="false">{{ t.event_severity_warning }}</button>
-            <button class="severity-pill" data-severity="critical" onclick="filterEventsBySeverity('critical')" aria-pressed="false">{{ t.event_severity_critical }}</button>
-            <button class="severity-pill" id="device-filter-pill" onclick="filterEventsByDevice()" aria-pressed="false">{{ t.event_filter_device }}</button>
-            <span style="border-left:1px solid var(--card-border, rgba(255,255,255,0.08)); height:20px; margin:0 8px;"></span>
-            <button class="severity-pill active" id="hide-operational-btn" onclick="toggleHideOperational()" aria-pressed="true">{{ t.event_hide_operational }}</button>
+        <!-- Phase 4.3: Pill filter toggles for severity -->
+        <div class="view-page-actions events-filter-section">
+            <div class="events-severity-pills" role="group" aria-label="{{ t.event_severity }}">
+                <button class="severity-pill active" data-severity="" onclick="filterEventsBySeverity('')" aria-pressed="true">{{ t.event_all_severities }}</button>
+                <button class="severity-pill" data-severity="info" onclick="filterEventsBySeverity('info')" aria-pressed="false">{{ t.event_severity_info }}</button>
+                <button class="severity-pill" data-severity="warning" onclick="filterEventsBySeverity('warning')" aria-pressed="false">{{ t.event_severity_warning }}</button>
+                <button class="severity-pill" data-severity="critical" onclick="filterEventsBySeverity('critical')" aria-pressed="false">{{ t.event_severity_critical }}</button>
+                <button class="severity-pill" id="device-filter-pill" onclick="filterEventsByDevice()" aria-pressed="false">{{ t.event_filter_device }}</button>
+                <span style="border-left:1px solid var(--card-border, rgba(255,255,255,0.08)); height:20px; margin:0 8px;"></span>
+                <button class="severity-pill active" id="hide-operational-btn" onclick="toggleHideOperational()" aria-pressed="true">{{ t.event_hide_operational }}</button>
+            </div>
         </div>
     </div>
 
@@ -1799,7 +1797,7 @@
         <div class="view-page-header-left">
             <h2 class="view-page-title">{{ t.channels }}</h2>
         </div>
-        <div class="view-page-actions ch-controls">
+        <div class="view-page-actions">
         <div class="trend-tabs" id="channel-mode-tabs">
             <button class="trend-tab active" data-value="timeline" onclick="selectPill(this, switchChannelMode)">{{ t.channel_timeline }}</button>
             <button class="trend-tab" data-value="compare" onclick="selectPill(this, switchChannelMode)">{{ t.channel_compare }}</button>

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -140,7 +140,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v48';" in sw_js
+    assert "var CACHE_VERSION = 'v49';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -616,6 +616,28 @@ def test_connection_monitor_range_controls_live_in_shared_page_header_actions():
     assert 'id="cm-capability-info" class="cm-capability"' in header_block
     assert 'data-cm-range="3600"' in header_block
     assert 'class="cm-control-strip"' not in template
+
+
+def test_events_and_channels_controls_are_part_of_shared_header_actions():
+    """Events and Channels should not keep visually separate legacy header/control rows."""
+    template = INDEX_HTML.read_text(encoding="utf-8")
+
+    events_header = template[
+        template.index('<div class="view-page-header events-header">') :
+        template.index('<div id="events-loading"')
+    ]
+    channels_header = template[
+        template.index('<div id="view-channels"') :
+        template.index('<div id="channel-info-bar"')
+    ]
+
+    assert '<div class="view-page-actions events-filter-section">' in events_header
+    assert '<div class="events-severity-pills" role="group" aria-label="{{ t.event_severity }}">' in events_header
+    assert 'events-filter-label' not in events_header
+    assert '<div class="events-filter-section">' not in events_header
+    assert '<div class="view-page-actions ch-controls">' not in channels_header
+    assert '<div class="view-page-actions">' in channels_header
+    assert 'id="channel-mode-tabs"' in channels_header
 
 
 def test_touched_header_templates_do_not_mix_span_and_h2_closing_tags():


### PR DESCRIPTION
## Summary
- move the Event Log severity controls into the shared page-header action area
- remove the legacy Channels header action class so it uses the shared header spacing
- bump the service worker cache for the updated shell assets

## Verification
- `.venv/bin/python -m pytest tests/test_static_contracts.py -q`
- `TZ=UTC .venv/bin/python -m pytest tests/e2e/test_events.py tests/e2e/test_channels.py tests/e2e/test_event_log_redesign.py tests/e2e/test_mobile_quality_gate.py::test_mobile_main_blades_have_no_overflow_or_offscreen_controls -q`
- `git diff --check`
- local browser smoke for `?lang=de#events` and `?lang=de#channels`
