### PR TITLE
Align Connection Monitor header controls

### DIFF
--- a/app/modules/connection_monitor/static/js/connection-monitor-detail.js
+++ b/app/modules/connection_monitor/static/js/connection-monitor-detail.js
@@ -81,7 +81,8 @@
 
         var btn = document.createElement('button');
         btn.id = 'cm-pin-day-btn';
-        btn.className = 'cm-pin-action';
+        btn.type = 'button';
+        btn.className = 'trend-tab cm-pin-day-btn';
         var pinIcon = document.createElement('i');
         pinIcon.setAttribute('data-lucide', 'pin');
         btn.appendChild(pinIcon);

--- a/app/modules/connection_monitor/static/style.css
+++ b/app/modules/connection_monitor/static/style.css
@@ -134,7 +134,6 @@
     flex-wrap: wrap;
 }
 
-.cm-pin-action,
 .cm-chip-btn {
     min-height: 32px;
     display: inline-flex;
@@ -152,11 +151,16 @@
     transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 }
 
-.cm-chip-btn:hover,
-.cm-pin-action:hover {
+.cm-chip-btn:hover {
     color: var(--text-primary);
     border-color: color-mix(in srgb, var(--info) 30%, var(--cm-panel-border));
     background: color-mix(in srgb, var(--info) 11%, var(--surface));
+}
+
+.cm-pin-day-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }
 
 .cm-chip-btn.active {
@@ -197,7 +201,7 @@
     opacity: 1;
 }
 
-.cm-pin-action svg {
+.cm-pin-day-btn svg {
     width: 13px;
     height: 13px;
 }
@@ -737,7 +741,7 @@
 @media (prefers-reduced-motion: reduce) {
     .cm-kpi-card,
     .cm-chip-btn,
-    .cm-pin-action {
+    .cm-pin-day-btn {
         animation: none !important;
         transition: none !important;
     }

--- a/app/modules/connection_monitor/templates/connection_monitor_detail.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_detail.html
@@ -7,6 +7,11 @@
             <span class="view-page-subtitle">{{ t.get('docsight.connection_monitor.connection_monitor_desc', 'Always-on latency monitoring for cable troubleshooting') }}</span>
         </div>
         <div class="view-page-actions cm-header-actions">
+            <div id="cm-capability-info" class="cm-capability"
+                 data-method-icmp="{{ t.get('docsight.connection_monitor.cm_method_icmp', 'ICMP') }}"
+                 data-method-tcp="{{ t.get('docsight.connection_monitor.cm_method_tcp', 'TCP') }}"
+                 data-hint-tcp="{{ t.get('docsight.connection_monitor.cm_method_hint_tcp', 'Using TCP probing. For more accurate ICMP probing, add cap_add: [NET_RAW] to your Docker Compose.') }}"
+            ></div>
             <div class="cm-range-picker trend-tabs" role="group" aria-label="{{ t.get('docsight.connection_monitor.cm_timerange', 'Time range') }}">
                 <button class="trend-tab active" data-cm-range="3600" onclick="cmSetRange(this, 3600)">1h</button>
                 <button class="trend-tab" data-cm-range="21600" onclick="cmSetRange(this, 21600)">6h</button>
@@ -17,11 +22,6 @@
                 <button class="trend-tab" data-cm-range="2592000" onclick="cmSetRange(this, 2592000)">30d</button>
                 <button class="trend-tab" data-cm-range="7776000" onclick="cmSetRange(this, 7776000)">90d</button>
             </div>
-            <div id="cm-capability-info" class="cm-capability"
-                 data-method-icmp="{{ t.get('docsight.connection_monitor.cm_method_icmp', 'ICMP') }}"
-                 data-method-tcp="{{ t.get('docsight.connection_monitor.cm_method_tcp', 'TCP') }}"
-                 data-hint-tcp="{{ t.get('docsight.connection_monitor.cm_method_hint_tcp', 'Using TCP probing. For more accurate ICMP probing, add cap_add: [NET_RAW] to your Docker Compose.') }}"
-            ></div>
         </div>
     </div>
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v49';
+var CACHE_VERSION = 'v50';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -140,7 +140,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v49';" in sw_js
+    assert "var CACHE_VERSION = 'v50';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -606,16 +606,26 @@ def test_module_blades_use_shared_correlation_style_page_header():
 def test_connection_monitor_range_controls_live_in_shared_page_header_actions():
     """Connection Monitor should not keep a separate boxed top control strip."""
     template = CONNECTION_MONITOR_TEMPLATE.read_text(encoding="utf-8")
+    detail_js = CM_DETAIL_JS.read_text(encoding="utf-8")
+    cm_css = CM_CSS.read_text(encoding="utf-8")
     header_block = template[
         template.index('<div class="view-page-header cm-page-header">') :
         template.index('<div id="cm-pinned-days-bar"')
+    ]
+    pin_block = detail_js[
+        detail_js.index("function updatePinButton") :
+        detail_js.index("// --- Pinned Days Bar ---")
     ]
 
     assert 'class="view-page-actions' in header_block
     assert 'class="cm-range-picker trend-tabs"' in header_block
     assert 'id="cm-capability-info" class="cm-capability"' in header_block
+    assert header_block.index('id="cm-capability-info"') < header_block.index('class="cm-range-picker trend-tabs"')
     assert 'data-cm-range="3600"' in header_block
     assert 'class="cm-control-strip"' not in template
+    assert "btn.className = 'trend-tab cm-pin-day-btn';" in pin_block
+    assert "btn.className = 'cm-pin-action';" not in pin_block
+    assert ".cm-pin-action" not in cm_css
 
 
 def test_events_and_channels_controls_are_part_of_shared_header_actions():


### PR DESCRIPTION
## Summary
- move the Connection Monitor mode badge before the time-range controls in the shared header
- make the dynamic `Pin this day` action use the same pill/tab styling as the range controls
- remove the old pin-button styling and bump the service worker cache

## Verification
- `.venv/bin/python -m pytest tests/test_static_contracts.py -q`
- `TZ=UTC .venv/bin/python -m pytest tests/e2e/test_connection_monitor.py tests/e2e/test_mobile_quality_gate.py::test_mobile_main_blades_have_no_overflow_or_offscreen_controls -q`
- `TZ=UTC .venv/bin/python -m pytest tests/modules/connection_monitor tests/test_static_contracts.py tests/e2e/test_connection_monitor.py tests/e2e/test_mobile_quality_gate.py::test_mobile_main_blades_have_no_overflow_or_offscreen_controls -q`
- `git diff --check`
- local browser smoke for `?lang=de#connection-monitor`, including the `1d` pinned-day header state
