### PR TITLE
Keep Connection Monitor pin action outside range controls

### DIFF
--- a/app/modules/connection_monitor/static/js/connection-monitor-detail.js
+++ b/app/modules/connection_monitor/static/js/connection-monitor-detail.js
@@ -69,36 +69,30 @@
 
     // --- Pin Button ---
 
+    function pinCurrentDay() {
+        var ts = Math.floor(Date.now() / 1000);
+        fetch('/api/connection-monitor/pinned-days', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ timestamp: ts })
+        }).then(function() {
+            loadPinnedDays();
+        });
+    }
+
     function updatePinButton() {
-        var existing = document.getElementById('cm-pin-day-btn');
-        if (existing) existing.remove();
+        var btn = document.getElementById('cm-pin-day-btn');
+        var bar = document.getElementById('cm-pinned-days-bar');
+        var daysContainer = document.getElementById('cm-pinned-days');
+        var label = document.getElementById('cm-pinned-label');
+        if (!btn || !bar || !daysContainer) return;
 
-        if (currentRange !== 86400 || pinnedDayView) return;
+        var showPinAction = currentRange === 86400 && !pinnedDayView;
+        var hasPinnedDays = daysContainer.children.length > 0;
 
-        var container = document.querySelector('#cm-detail-view [data-cm-range]');
-        if (!container) return;
-        var parent = container.parentElement;
-
-        var btn = document.createElement('button');
-        btn.id = 'cm-pin-day-btn';
-        btn.type = 'button';
-        btn.className = 'trend-tab cm-pin-day-btn';
-        var pinIcon = document.createElement('i');
-        pinIcon.setAttribute('data-lucide', 'pin');
-        btn.appendChild(pinIcon);
-        btn.appendChild(document.createTextNode('Pin this day'));
-        btn.onclick = function() {
-            var ts = Math.floor(Date.now() / 1000);
-            fetch('/api/connection-monitor/pinned-days', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ timestamp: ts })
-            }).then(function() {
-                loadPinnedDays();
-            });
-        };
-        parent.appendChild(btn);
-        if (window.lucide) window.lucide.createIcons({nameAttr: 'data-lucide', root: btn});
+        btn.hidden = !showPinAction;
+        if (label) label.hidden = !hasPinnedDays;
+        bar.hidden = !(showPinAction || hasPinnedDays);
     }
 
     // --- Pinned Days Bar ---
@@ -119,10 +113,9 @@
 
         container.textContent = '';
         if (days.length === 0) {
-            bar.style.display = 'none';
+            updatePinButton();
             return;
         }
-        bar.style.display = 'flex';
 
         days.forEach(function(day) {
             var chip = document.createElement('span');
@@ -173,6 +166,7 @@
             chip.appendChild(removeBtn);
             container.appendChild(chip);
         });
+        updatePinButton();
     }
 
     function viewPinnedDay(dateStr, utcStart, utcEnd) {
@@ -186,8 +180,7 @@
         document.querySelectorAll('[data-cm-range]').forEach(function(b) {
             b.classList.remove('active');
         });
-        var pinBtn = document.getElementById('cm-pin-day-btn');
-        if (pinBtn) pinBtn.remove();
+        updatePinButton();
 
         if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null; }
 
@@ -196,6 +189,11 @@
     }
 
     function init() {
+        var pinBtn = document.getElementById('cm-pin-day-btn');
+        if (pinBtn) {
+            pinBtn.onclick = pinCurrentDay;
+        }
+
         fetch('/api/connection-monitor/capability')
             .then(function(r) { return r.json(); })
             .then(function(data) {

--- a/app/modules/connection_monitor/static/style.css
+++ b/app/modules/connection_monitor/static/style.css
@@ -134,6 +134,7 @@
     flex-wrap: wrap;
 }
 
+.cm-pin-day-btn,
 .cm-chip-btn {
     min-height: 32px;
     display: inline-flex;
@@ -151,16 +152,20 @@
     transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 }
 
-.cm-chip-btn:hover {
+.cm-chip-btn:hover,
+.cm-pin-day-btn:hover {
     color: var(--text-primary);
     border-color: color-mix(in srgb, var(--info) 30%, var(--cm-panel-border));
     background: color-mix(in srgb, var(--info) 11%, var(--surface));
 }
 
 .cm-pin-day-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
+    flex-shrink: 0;
+}
+
+.cm-pin-day-btn[hidden],
+.cm-pinned-label[hidden] {
+    display: none;
 }
 
 .cm-chip-btn.active {
@@ -215,6 +220,10 @@
     border: 1px solid var(--cm-panel-border);
     border-radius: 8px;
     background: color-mix(in srgb, var(--surface) 70%, transparent);
+}
+
+.cm-pinned-bar:not([hidden]) {
+    display: flex;
 }
 
 .cm-no-data {

--- a/app/modules/connection_monitor/templates/connection_monitor_detail.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_detail.html
@@ -25,9 +25,14 @@
         </div>
     </div>
 
-    <div id="cm-pinned-days-bar" class="cm-pinned-bar">
-        <span class="cm-pinned-label">Pinned</span>
-        <div id="cm-pinned-days" class="cm-pinned-days"></div>
+    <div id="cm-pinned-days-bar" class="cm-pinned-bar" hidden>
+        <button id="cm-pin-day-btn" type="button" class="cm-pin-day-btn"
+                aria-label="{{ t.get('docsight.connection_monitor.cm_pin_this_day', 'Pin this day') }}" hidden>
+            <i data-lucide="pin" aria-hidden="true"></i>
+            <span>{{ t.get('docsight.connection_monitor.cm_pin_this_day', 'Pin this day') }}</span>
+        </button>
+        <span class="cm-pinned-label" id="cm-pinned-label" hidden>Pinned</span>
+        <div id="cm-pinned-days" class="cm-pinned-days" aria-live="polite"></div>
     </div>
 
     <section id="cm-raw-log-panel" class="glass cm-panel cm-raw-log-panel" style="display:none;">

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v50';
+var CACHE_VERSION = 'v51';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_connection_monitor.py
+++ b/tests/e2e/test_connection_monitor.py
@@ -18,6 +18,26 @@ def test_connection_monitor_uses_shared_page_header_action_layout(demo_page):
     expect(page.locator("#view-connection-monitor .cm-control-strip")).to_have_count(0)
 
 
+def test_connection_monitor_pin_day_action_does_not_shift_range_navigation(demo_page):
+    """Showing the 1d-only pin action must not move the time-range navigation."""
+    page = demo_page
+    page.evaluate("switchView('connection-monitor')")
+    page.wait_for_selector("#view-connection-monitor.active", state="visible")
+
+    range_picker = page.locator("#view-connection-monitor .view-page-actions .cm-range-picker")
+    expect(range_picker).to_be_visible()
+    before = range_picker.bounding_box()
+    assert before is not None
+
+    page.locator("#view-connection-monitor [data-cm-range='86400']").click()
+    expect(page.locator("#cm-pin-day-btn")).to_be_visible()
+
+    after = range_picker.bounding_box()
+    assert after is not None
+    assert abs(before["x"] - after["x"]) <= 1, "1d pin action should not shift the time-range controls horizontally"
+    expect(page.locator("#view-connection-monitor .cm-range-picker #cm-pin-day-btn")).to_have_count(0)
+
+
 def test_connection_monitor_raw_ping_log_panel_is_discoverable(demo_page):
     """The Connection Monitor view should expose the ISP-ready raw ping log export panel."""
     page = demo_page

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -140,7 +140,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v50';" in sw_js
+    assert "var CACHE_VERSION = 'v51';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js
@@ -616,6 +616,14 @@ def test_connection_monitor_range_controls_live_in_shared_page_header_actions():
         detail_js.index("function updatePinButton") :
         detail_js.index("// --- Pinned Days Bar ---")
     ]
+    pinned_bar = template[
+        template.index('<div id="cm-pinned-days-bar"') :
+        template.index('<section id="cm-raw-log-panel"')
+    ]
+    range_picker = header_block[
+        header_block.index('class="cm-range-picker trend-tabs"') :
+        header_block.index('</div>', header_block.index('class="cm-range-picker trend-tabs"'))
+    ]
 
     assert 'class="view-page-actions' in header_block
     assert 'class="cm-range-picker trend-tabs"' in header_block
@@ -623,7 +631,11 @@ def test_connection_monitor_range_controls_live_in_shared_page_header_actions():
     assert header_block.index('id="cm-capability-info"') < header_block.index('class="cm-range-picker trend-tabs"')
     assert 'data-cm-range="3600"' in header_block
     assert 'class="cm-control-strip"' not in template
-    assert "btn.className = 'trend-tab cm-pin-day-btn';" in pin_block
+    assert 'id="cm-pin-day-btn"' in pinned_bar
+    assert 'id="cm-pin-day-btn"' not in header_block
+    assert 'cm-pin-day-btn' not in range_picker
+    assert "document.createElement('button')" not in pin_block
+    assert "parent.appendChild(btn)" not in pin_block
     assert "btn.className = 'cm-pin-action';" not in pin_block
     assert ".cm-pin-action" not in cm_css
 


### PR DESCRIPTION
## Summary
- move `Pin this day` out of the Connection Monitor time-range pill group into the pinned-days area
- keep the range controls horizontally stable when switching to `1d`
- toggle the pinned-days bar from static markup instead of dynamically appending/removing the pin button
- bump the service worker cache for the updated static assets

## Verification
- `.venv/bin/python -m pytest tests/test_static_contracts.py::test_connection_monitor_range_controls_live_in_shared_page_header_actions tests/test_static_contracts.py::test_static_cache_version_was_bumped_for_ui_followup_assets -q`
- `TZ=UTC .venv/bin/python -m pytest tests/e2e/test_connection_monitor.py::test_connection_monitor_pin_day_action_does_not_shift_range_navigation -q`
- `.venv/bin/python -m pytest tests/test_static_contracts.py -q`
- `TZ=UTC .venv/bin/python -m pytest tests/e2e/test_connection_monitor.py tests/e2e/test_mobile_quality_gate.py::test_mobile_main_blades_have_no_overflow_or_offscreen_controls -q`
- `TZ=UTC .venv/bin/python -m pytest tests/modules/connection_monitor tests/test_static_contracts.py tests/e2e/test_connection_monitor.py tests/e2e/test_mobile_quality_gate.py::test_mobile_main_blades_have_no_overflow_or_offscreen_controls -q`
- `git diff --check`
- local browser smoke for `?lang=de#connection-monitor`, including the `1d` pin-action state
