### PR TITLE
docs: clarify local-first trust promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,10 @@ Generic Router mode still works for fiber, DSL, satellite, and other routers, bu
 | 📖 **Open source** | All code is public and verifiable |
 | 🔐 **Credentials encrypted** | Router login encrypted at rest (AES-128) |
 
-For the detailed ownership and sharing boundary, see the [Data contract](DATA_CONTRACT.md). It defines local data, system-owned files, generated artifacts, backups, exports, diagnostics, integration boundaries, and redaction expectations.
+For the detailed ownership and sharing boundary, see the [Data contract](DATA_CONTRACT.md). For supported versions, vulnerability reporting, and security boundaries, see the [Security policy](SECURITY.md).
+
+- **Optional integrations are user-configured:** Speedtest, BQM, Smokeping, Home Assistant, MQTT, Apprise, Web Push, webhooks, module registries, and similar integrations use the destinations or sources you configure. See the data contract for integration-specific boundaries.
+- **Exports and reports are generated locally and reviewed by you before sharing:** PDF reports, complaint text, AI/LLM exports, CSV/JSON downloads, screenshots, and backups are local artifacts first.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,6 +100,12 @@
     .btn:hover { transform: translateY(-1px); }
     .trust { display: flex; flex-wrap: wrap; gap: 8px; margin: 0; padding: 0; list-style: none; color: var(--muted); font-size: 0.92rem; }
     .trust li { padding: 7px 10px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255,255,255,0.04); }
+    .trust-promise { margin-top: 18px; padding: 16px 18px; border: 1px solid rgba(125,211,252,0.24); border-radius: 22px; background: rgba(125,211,252,0.07); color: var(--muted); }
+    .trust-promise strong { display: block; color: var(--text); margin-bottom: 5px; }
+    .trust-promise p { margin: 0 0 8px; }
+    .trust-promise p:last-child { margin-bottom: 0; }
+    .trust-promise a { color: var(--accent); font-weight: 750; text-decoration: none; }
+    .trust-promise a:hover { text-decoration: underline; }
     .hero-shot { position: relative; overflow: clip; border-radius: 34px; }
     .hero-shot::before {
       content: "";
@@ -213,6 +219,12 @@
             <li>16 modem families</li>
             <li>MIT licensed</li>
           </ul>
+          <div class="trust-promise" aria-label="Local-first trust promise">
+            <strong>No silent uploads.</strong>
+            <p>DOCSight runs locally: modem data, logs, reports, credentials, tokens, or installation identifiers are not uploaded automatically.</p>
+            <p>Optional integrations are configured by you. Exports and reports are generated locally and reviewed by you before sharing.</p>
+            <p><a href="https://github.com/itsDNNS/docsight/blob/main/SECURITY.md">Security policy</a> · <a href="https://github.com/itsDNNS/docsight/blob/main/DATA_CONTRACT.md">Data contract</a></p>
+          </div>
         </div>
         <div class="hero-shot">
           <div class="screenshot-card">

--- a/docs/proof-pack.md
+++ b/docs/proof-pack.md
@@ -1,6 +1,6 @@
 # DOCSight public proof pack
 
-This page collects demo-safe assets for README, launch posts, community replies, and support docs. Everything here uses synthetic data. Do not replace these files with screenshots from a real connection unless all personal and network data is removed.
+This page collects demo-safe assets for README, launch posts, community replies, and support docs. Everything here uses synthetic data. Do not replace these files with screenshots from a real connection unless all personal and network data is removed. Real exports and reports should be reviewed by the user before sharing, and should remove personal, network, account, and ticket details first.
 
 ## Ready-to-use assets
 

--- a/tests/test_public_launch_surface.py
+++ b/tests/test_public_launch_surface.py
@@ -194,6 +194,53 @@ def test_data_contract_covers_optional_integration_boundaries() -> None:
         assert phrase in text
 
 
+def test_readme_trust_promise_is_concise_and_boundaried() -> None:
+    text = README.read_text(encoding="utf-8")
+    trust_section = text.split("## Your Data Stays With You", 1)[1].split("## Features", 1)[0]
+
+    for phrase in [
+        "No silent uploads",
+        "reports, logs, credentials, tokens, and installation IDs are not uploaded automatically",
+        "Optional integrations are user-configured",
+        "Exports and reports are generated locally and reviewed by you before sharing",
+        "Security policy",
+        "Data contract",
+    ]:
+        assert phrase in trust_section
+    assert "DATA_CONTRACT.md" in trust_section
+    assert "SECURITY.md" in trust_section
+
+
+def test_landing_page_trust_promise_is_above_fold_and_links_boundaries() -> None:
+    text = INDEX.read_text(encoding="utf-8")
+    parser = parse_landing()
+    hero_text = text.split("</header>", 1)[0]
+    trust_block = hero_text.split('class="trust-promise"', 1)[1].split("</div>", 1)[0]
+
+    for phrase in [
+        "No silent uploads",
+        "modem data, logs, reports, credentials, tokens, or installation identifiers are not uploaded automatically",
+        "Optional integrations are configured by you",
+        "Exports and reports are generated locally and reviewed by you before sharing",
+    ]:
+        assert phrase in trust_block
+    assert "https://github.com/itsDNNS/docsight/blob/main/SECURITY.md" in trust_block
+    assert "https://github.com/itsDNNS/docsight/blob/main/DATA_CONTRACT.md" in trust_block
+    assert "https://github.com/itsDNNS/docsight/blob/main/SECURITY.md" in parser.links
+    assert "https://github.com/itsDNNS/docsight/blob/main/DATA_CONTRACT.md" in parser.links
+
+
+def test_proof_pack_warns_real_exports_need_user_review() -> None:
+    text = (DOCS / "proof-pack.md").read_text(encoding="utf-8")
+
+    for phrase in [
+        "synthetic data",
+        "Real exports and reports should be reviewed by the user before sharing",
+        "remove personal, network, account, and ticket details",
+    ]:
+        assert phrase in text
+
+
 def test_public_surface_docs_and_social_asset_exist() -> None:
     expected = [
         DATA_CONTRACT,


### PR DESCRIPTION
## Summary

- Add a concise local-first trust promise to the README and landing-page hero.
- Link the trust promise to the security policy and data contract.
- Clarify that optional integrations are user-configured and exports/reports are reviewed before sharing.
- Add a proof-pack note for synthetic public assets and real export review.
- Add static public-surface coverage for the trust promise and links.

## Validation

- `pytest tests/test_public_launch_surface.py::test_readme_trust_promise_is_concise_and_boundaried tests/test_public_launch_surface.py::test_landing_page_trust_promise_is_above_fold_and_links_boundaries tests/test_public_launch_surface.py::test_proof_pack_warns_real_exports_need_user_review -q --tb=short`
- `pytest tests/test_public_launch_surface.py tests/test_static_contracts.py -q --tb=short`
- `pytest -q tests --ignore=tests/e2e --tb=short`
- `TZ=UTC pytest -q tests/e2e --tb=short` attempted as a monolithic run and timed out after progressing through the suite; rerun by file batches covered all 421 collected E2E tests successfully.
- `git diff --check`

Closes #594
