### PR TITLE
fix: include connection monitor latency evidence

### DIFF
--- a/app/modules/evidence/checklist.py
+++ b/app/modules/evidence/checklist.py
@@ -60,8 +60,9 @@ def _item(
     action: dict[str, str] | None = None,
     hint_key: str | None = None,
     demo: bool = False,
+    sources: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "key": key,
         "status": status,
         "count": count,
@@ -71,11 +72,25 @@ def _item(
         "hint_key": hint_key or f"docsight.evidence.item.{key}.{status}",
         "demo": bool(demo),
     }
+    if sources is not None:
+        payload["sources"] = sources
+    return payload
 
 
 def _source_rows(timeline: Iterable[dict[str, Any]], *sources: str) -> list[dict[str, Any]]:
     wanted = set(sources)
     return [row for row in timeline if row.get("source") in wanted]
+
+
+def _row_count(rows: Iterable[dict[str, Any]]) -> int:
+    total = 0
+    for row in rows:
+        count = row.get("sample_count") or row.get("count") or 1
+        try:
+            total += int(count)
+        except (TypeError, ValueError):
+            total += 1
+    return total
 
 
 def _evidence_status(
@@ -99,20 +114,87 @@ def _evidence_status(
     return PRESENT, last_ts
 
 
+def _latency_item(
+    *,
+    bqm_rows: list[dict[str, Any]],
+    connection_latency_rows: list[dict[str, Any]],
+    bqm_configured: bool,
+    connection_monitor_configured: bool,
+    window_end: str | None,
+    demo: bool,
+) -> dict[str, Any]:
+    cm_status, cm_last = _evidence_status(
+        connection_latency_rows,
+        configured=connection_monitor_configured,
+        optional_when_unconfigured=True,
+        window_end=window_end,
+        stale_key="latency",
+    )
+    bqm_status, bqm_last = _evidence_status(
+        bqm_rows,
+        configured=bqm_configured,
+        optional_when_unconfigured=True,
+        window_end=window_end,
+        stale_key="latency",
+    )
+    source_statuses = [cm_status, bqm_status]
+    rows = [*connection_latency_rows, *bqm_rows]
+    if PRESENT in source_statuses:
+        status = PRESENT
+    elif STALE in source_statuses:
+        status = STALE
+    elif MISSING in source_statuses:
+        status = MISSING
+    else:
+        status = OPTIONAL
+
+    cm_count = _row_count(connection_latency_rows)
+    bqm_count = _row_count(bqm_rows)
+    if cm_count and bqm_count:
+        hint_key = "docsight.evidence.item.latency.present_both" if status == PRESENT else None
+        action = {"view": "connection-monitor"}
+    elif cm_count:
+        hint_key = "docsight.evidence.item.latency.present_cm_only" if status in {PRESENT, STALE} else None
+        action = {"view": "connection-monitor"}
+    elif bqm_count:
+        hint_key = "docsight.evidence.item.latency.present_bqm_only" if status in {PRESENT, STALE} else None
+        action = {"view": "bqm"}
+    else:
+        hint_key = None
+        action = {"view": "connection-monitor"} if connection_monitor_configured else {"view": "bqm"}
+
+    return _item(
+        "latency",
+        status,
+        cm_count + bqm_count,
+        _latest_ts(rows),
+        action,
+        hint_key=hint_key,
+        demo=demo,
+        sources=[
+            {"key": "connection_monitor", "status": cm_status, "count": cm_count, "last_ts": cm_last},
+            {"key": "bqm", "status": bqm_status, "count": bqm_count, "last_ts": bqm_last},
+        ],
+    )
+
+
 def build_checklist(
     window: dict[str, Any],
     *,
     timeline: list[dict[str, Any]],
     journal_entries: list[dict[str, Any]],
     bqm_rows: list[dict[str, Any]],
+    connection_latency_rows: list[dict[str, Any]] | None = None,
     capabilities: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Build the stateless evidence checklist for an incident or selected window."""
     capabilities = capabilities or {}
+    connection_latency_rows = connection_latency_rows or []
     demo = bool(capabilities.get("demo_mode"))
     docsis_supported = bool(capabilities.get("docsis_supported", True))
     speedtest_configured = bool(capabilities.get("speedtest_configured", True))
     bqm_configured = bool(capabilities.get("bqm_configured", True))
+    connection_monitor_configured = bool(capabilities.get("connection_monitor_configured", False))
     window_end = window.get("to")
 
     signal_rows = _source_rows(timeline, "modem")
@@ -133,13 +215,6 @@ def build_checklist(
         window_end=window_end,
         stale_key="speedtest",
     )
-    latency_status, latency_last = _evidence_status(
-        bqm_rows,
-        configured=bqm_configured,
-        optional_when_unconfigured=True,
-        window_end=window_end,
-        stale_key="latency",
-    )
     event_status, event_last = _evidence_status(
         event_rows,
         applicable=docsis_supported,
@@ -154,7 +229,14 @@ def build_checklist(
     items = [
         _item("signal", signal_status, len(signal_rows), signal_last, {"view": "correlation"}, demo=demo),
         _item("speedtest", speed_status, len(speedtest_rows), speed_last, {"view": "speedtest"}, demo=demo),
-        _item("latency", latency_status, len(bqm_rows), latency_last, {"view": "bqm"}, demo=demo),
+        _latency_item(
+            bqm_rows=bqm_rows,
+            connection_latency_rows=connection_latency_rows,
+            bqm_configured=bqm_configured,
+            connection_monitor_configured=connection_monitor_configured,
+            window_end=window_end,
+            demo=demo,
+        ),
         _item("events", event_status, len(event_rows), event_last, {"view": "events"}, demo=demo),
         _item("journal", journal_status, len(journal_entries), journal_last, {"view": "journal", "action": "add_note"}, demo=demo),
         _item("bnetz", bnetz_status, len(bnetz_rows), bnetz_last, {"view": "bnetz"}, demo=demo),

--- a/app/modules/evidence/i18n/bg.json
+++ b/app/modules/evidence/i18n/bg.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/cs.json
+++ b/app/modules/evidence/i18n/cs.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/da.json
+++ b/app/modules/evidence/i18n/da.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/de.json
+++ b/app/modules/evidence/i18n/de.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "In diesem Zeitraum wurde kein Speedtest-Ergebnis gefunden.",
   "item.speedtest.optional": "Speedtest Tracker ist nicht konfiguriert; Speed-Evidenz ist optional.",
   "item.latency.label": "Latenz-Evidenz",
-  "item.latency.present": "Latenz-/BQM-Messungen sind für diesen Zeitraum verfügbar.",
+  "item.latency.present": "Latenzmessungen sind für diesen Zeitraum verfügbar.",
   "item.latency.stale": "Latenz-Evidenz ist vorhanden, deckt aber das Ende dieses Zeitraums möglicherweise nicht ab.",
-  "item.latency.missing": "In diesem Zeitraum wurde keine Latenz-/BQM-Messung gefunden.",
-  "item.latency.optional": "ThinkBroadband BQM ist nicht konfiguriert; Latenz-Evidenz ist optional.",
+  "item.latency.missing": "In diesem Zeitraum wurde keine Connection-Monitor- oder BQM-Latenzmessung gefunden.",
+  "item.latency.optional": "Connection Monitor und ThinkBroadband BQM sind nicht konfiguriert; Latenz-Evidenz ist optional.",
   "item.events.label": "DOCSight-Events",
   "item.events.present": "DOCSight hat in diesem Zeitraum Events erkannt.",
   "item.events.missing": "In diesem Zeitraum wurden keine DOCSight-Events erkannt.",
@@ -61,5 +61,11 @@
   "action.comparison": "Vorher/Nachher-Vergleich öffnen",
   "action.report": "Report erzeugen",
   "item.comparison.label": "Vorher/Nachher-Vergleich",
-  "item.comparison.optional": "Vergleiche diesen Zeitraum mit einer anderen Periode, wenn ein Technikertermin, eine Anbieteränderung oder ein wiederkehrendes Muster Kontext braucht."
+  "item.comparison.optional": "Vergleiche diesen Zeitraum mit einer anderen Periode, wenn ein Technikertermin, eine Anbieteränderung oder ein wiederkehrendes Muster Kontext braucht.",
+  "action.connection-monitor": "Connection Monitor öffnen",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection-Monitor- und ThinkBroadband-BQM-Latenzmessungen sind für diesen Zeitraum verfügbar.",
+  "item.latency.present_cm_only": "Connection-Monitor-Latenzmessungen sind verfügbar. Ergänze BQM, wenn du externe Validierung brauchst.",
+  "item.latency.present_bqm_only": "ThinkBroadband-BQM-Latenzmessungen sind verfügbar. Ergänze den Connection Monitor für lokale kontinuierliche Messungen."
 }

--- a/app/modules/evidence/i18n/el.json
+++ b/app/modules/evidence/i18n/el.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/en.json
+++ b/app/modules/evidence/i18n/en.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/es.json
+++ b/app/modules/evidence/i18n/es.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/et.json
+++ b/app/modules/evidence/i18n/et.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/fi.json
+++ b/app/modules/evidence/i18n/fi.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/fr.json
+++ b/app/modules/evidence/i18n/fr.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/ga.json
+++ b/app/modules/evidence/i18n/ga.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/hr.json
+++ b/app/modules/evidence/i18n/hr.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/hu.json
+++ b/app/modules/evidence/i18n/hu.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/it.json
+++ b/app/modules/evidence/i18n/it.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/lt.json
+++ b/app/modules/evidence/i18n/lt.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/lv.json
+++ b/app/modules/evidence/i18n/lv.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/nb.json
+++ b/app/modules/evidence/i18n/nb.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/nl.json
+++ b/app/modules/evidence/i18n/nl.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/pl.json
+++ b/app/modules/evidence/i18n/pl.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/pt.json
+++ b/app/modules/evidence/i18n/pt.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/ro.json
+++ b/app/modules/evidence/i18n/ro.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/sk.json
+++ b/app/modules/evidence/i18n/sk.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/sl.json
+++ b/app/modules/evidence/i18n/sl.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/sv.json
+++ b/app/modules/evidence/i18n/sv.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "No speed test result was found in this window.",
   "item.speedtest.optional": "Speedtest Tracker is not configured; speed evidence is optional.",
   "item.latency.label": "Latency evidence",
-  "item.latency.present": "Latency/BQM samples are available for this window.",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "Latency evidence exists, but it may not cover the end of this window.",
-  "item.latency.missing": "No latency/BQM sample was found in this window.",
-  "item.latency.optional": "ThinkBroadband BQM is not configured; latency evidence is optional.",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "DOCSight events",
   "item.events.present": "DOCSight detected events in this window.",
   "item.events.missing": "No DOCSight events were detected in this window.",
@@ -61,5 +61,11 @@
   "action.comparison": "Open before/after comparison",
   "action.report": "Generate report",
   "item.comparison.label": "Before/after comparison",
-  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context."
+  "item.comparison.optional": "Compare this window with another period when a technician visit, ISP change, or recurring pattern needs context.",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/i18n/template.json
+++ b/app/modules/evidence/i18n/template.json
@@ -39,10 +39,10 @@
   "item.speedtest.missing": "",
   "item.speedtest.optional": "",
   "item.latency.label": "",
-  "item.latency.present": "",
+  "item.latency.present": "Latency samples are available for this window.",
   "item.latency.stale": "",
-  "item.latency.missing": "",
-  "item.latency.optional": "",
+  "item.latency.missing": "No Connection Monitor or BQM latency sample was found in this window.",
+  "item.latency.optional": "Connection Monitor and ThinkBroadband BQM are not configured; latency evidence is optional.",
   "item.events.label": "",
   "item.events.present": "",
   "item.events.missing": "",
@@ -61,5 +61,11 @@
   "action.comparison": "",
   "action.report": "",
   "item.comparison.label": "",
-  "item.comparison.optional": ""
+  "item.comparison.optional": "",
+  "action.connection-monitor": "Open Connection Monitor",
+  "source.connection_monitor": "Connection Monitor",
+  "source.bqm": "ThinkBroadband BQM",
+  "item.latency.present_both": "Connection Monitor and ThinkBroadband BQM latency samples are available for this window.",
+  "item.latency.present_cm_only": "Connection Monitor latency samples are available. Add BQM when you need external validation.",
+  "item.latency.present_bqm_only": "ThinkBroadband BQM latency samples are available. Add Connection Monitor for local continuous samples."
 }

--- a/app/modules/evidence/routes.py
+++ b/app/modules/evidence/routes.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-import sqlite3
 import logging
+import os
+import sqlite3
+from datetime import datetime, timezone
 from typing import Any
 
 from flask import Blueprint, jsonify, request
@@ -62,6 +64,84 @@ def _get_bqm_rows(db_path: str, start_ts: str, end_ts: str) -> list[dict[str, An
         return []
 
 
+def _epoch_to_iso(value: float | int | None) -> str | None:
+    if value is None:
+        return None
+    return datetime.fromtimestamp(float(value), tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _utc_ts_to_epoch(value: str) -> float:
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).timestamp()
+
+
+def _get_connection_monitor_db_path() -> str:
+    data_dir = os.environ.get("DATA_DIR", "/data")
+    return os.path.join(data_dir, "connection_monitor.db")
+
+
+def _get_connection_latency_rows(start_ts: str, end_ts: str) -> list[dict[str, Any]]:
+    """Return compact Connection Monitor latency evidence rows for a UTC window."""
+    db_path = _get_connection_monitor_db_path()
+    if not os.path.exists(db_path):
+        return []
+    start_epoch = _utc_ts_to_epoch(start_ts)
+    end_epoch = _utc_ts_to_epoch(end_ts)
+    rows: list[dict[str, Any]] = []
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            raw = conn.execute(
+                """
+                SELECT
+                    COUNT(*) AS sample_count,
+                    COUNT(CASE WHEN timeout = 0 AND latency_ms IS NOT NULL THEN 1 END) AS latency_count,
+                    AVG(CASE WHEN timeout = 0 THEN latency_ms END) AS avg_latency_ms,
+                    MAX(timestamp) AS latest_ts
+                FROM connection_samples
+                WHERE timestamp >= ? AND timestamp <= ?
+                """,
+                (start_epoch, end_epoch),
+            ).fetchone()
+            if raw and (raw["sample_count"] or 0) > 0:
+                rows.append({
+                    "timestamp": _epoch_to_iso(raw["latest_ts"]),
+                    "sample_count": raw["sample_count"],
+                    "latency_count": raw["latency_count"],
+                    "avg_latency_ms": raw["avg_latency_ms"],
+                    "source": "connection_monitor",
+                    "tier": "raw",
+                })
+            aggregated = conn.execute(
+                """
+                SELECT
+                    COALESCE(SUM(sample_count), 0) AS sample_count,
+                    COUNT(CASE WHEN avg_latency_ms IS NOT NULL THEN 1 END) AS latency_count,
+                    AVG(avg_latency_ms) AS avg_latency_ms,
+                    MAX(bucket_start) AS latest_ts
+                FROM connection_samples_aggregated
+                WHERE bucket_start >= ? AND bucket_start <= ?
+                """,
+                (start_epoch, end_epoch),
+            ).fetchone()
+            if aggregated and (aggregated["sample_count"] or 0) > 0:
+                rows.append({
+                    "timestamp": _epoch_to_iso(aggregated["latest_ts"]),
+                    "sample_count": aggregated["sample_count"],
+                    "latency_count": aggregated["latency_count"],
+                    "avg_latency_ms": aggregated["avg_latency_ms"],
+                    "source": "connection_monitor",
+                    "tier": "aggregated",
+                })
+    except sqlite3.Error:
+        log.warning("Evidence Connection Monitor rows unavailable")
+        return []
+    return rows
+
+
 def _capabilities(config_manager) -> dict[str, Any]:
     modem_type = ""
     if config_manager:
@@ -71,6 +151,7 @@ def _capabilities(config_manager) -> dict[str, Any]:
         "docsis_supported": docsis_supported,
         "speedtest_configured": bool(config_manager.is_speedtest_configured()) if config_manager else False,
         "bqm_configured": bool(config_manager.is_bqm_configured()) if config_manager else False,
+        "connection_monitor_configured": bool(config_manager.get("connection_monitor_enabled", False)) if config_manager else False,
         "demo_mode": bool(config_manager.is_demo_mode()) if config_manager else False,
     }
 
@@ -145,6 +226,7 @@ def api_evidence_checklist():
 
     timeline = core.get_correlation_timeline(window["from"], window["to"])
     bqm_rows = _get_bqm_rows(core.db_path, window["from"], window["to"])
+    connection_latency_rows = _get_connection_latency_rows(window["from"], window["to"])
     config_manager = get_config_manager()
     capabilities = _capabilities(config_manager)
     items = build_checklist(
@@ -152,6 +234,7 @@ def api_evidence_checklist():
         timeline=timeline,
         journal_entries=journal_entries,
         bqm_rows=bqm_rows,
+        connection_latency_rows=connection_latency_rows,
         capabilities=capabilities,
     )
     return jsonify({

--- a/app/modules/evidence/static/main.js
+++ b/app/modules/evidence/static/main.js
@@ -70,6 +70,25 @@ function _evidenceActionLabel(item) {
     return _evidenceT('docsight.evidence.action.' + (action || view || 'review'), 'Open related view');
 }
 
+function _evidenceSourceLabel(source) {
+    return _evidenceT('docsight.evidence.source.' + source.key, String(source.key || '').replace(/_/g, ' '));
+}
+
+function _evidenceRenderSourceBreakdown(item) {
+    if (!item.sources || !item.sources.length) return '';
+    return '<div class="evidence-source-list">' + item.sources.map(function(source) {
+        var status = _evidenceSafeStatus(source.status);
+        var count = typeof source.count === 'number' && source.count > 0
+            ? '<span class="evidence-source-count">' + _evidenceEscape(source.count) + '</span>'
+            : '';
+        return '<div class="evidence-source-row evidence-status-' + status + '">' +
+            '<span>' + _evidenceEscape(_evidenceSourceLabel(source)) + '</span>' +
+            '<span class="evidence-source-status">' + _evidenceEscape(_evidenceStatusLabel(status)) + '</span>' +
+            count +
+        '</div>';
+    }).join('') + '</div>';
+}
+
 function _evidenceRunAction(event) {
     var trigger = event.target.closest('[data-evidence-view], [data-evidence-action]');
     if (!trigger) return;
@@ -116,6 +135,7 @@ function _evidenceRenderItems(items) {
         var count = typeof item.count === 'number' && item.count > 0
             ? '<span class="evidence-count-pill">' + _evidenceEscape(item.count) + '</span>'
             : '';
+        var sources = _evidenceRenderSourceBreakdown(item);
         var last = item.last_ts ? '<span class="evidence-muted">' + _evidenceEscape(item.last_ts) + '</span>' : '';
         var action = '';
         if (item.action && item.action.view) {
@@ -130,7 +150,7 @@ function _evidenceRenderItems(items) {
                     '<h4>' + label + '</h4>' + count +
                     '<span class="evidence-badge">' + _evidenceEscape(_evidenceStatusLabel(status)) + '</span>' +
                 '</div>' +
-                '<p>' + hint + '</p>' +
+                '<p>' + hint + '</p>' + sources +
                 '<div class="evidence-item-meta">' + last + action + '</div>' +
             '</div>' +
         '</article>';

--- a/app/modules/evidence/static/style.css
+++ b/app/modules/evidence/static/style.css
@@ -164,28 +164,59 @@
     text-decoration: underline;
 }
 
+.evidence-source-list {
+    display: grid;
+    gap: 6px;
+    margin: 8px 0 10px;
+}
+
+.evidence-source-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    width: fit-content;
+    max-width: 100%;
+    border-radius: 999px;
+    border: 1px solid var(--border, rgba(255,255,255,0.12));
+    background: rgba(255,255,255,0.04);
+    padding: 4px 8px;
+    color: var(--text-muted, #9ca3af);
+    font-size: 0.78rem;
+}
+
+.evidence-source-status,
+.evidence-source-count {
+    font-weight: 700;
+}
+
 .evidence-status-present .evidence-badge,
-.evidence-status-present .evidence-item-icon {
+.evidence-status-present .evidence-item-icon,
+.evidence-source-row.evidence-status-present .evidence-source-status {
     color: #86efac;
 }
 
 .evidence-status-stale .evidence-badge,
-.evidence-status-stale .evidence-item-icon {
+.evidence-status-stale .evidence-item-icon,
+.evidence-source-row.evidence-status-stale .evidence-source-status {
     color: #fde68a;
 }
 
 .evidence-status-missing .evidence-badge,
-.evidence-status-missing .evidence-item-icon {
+.evidence-status-missing .evidence-item-icon,
+.evidence-source-row.evidence-status-missing .evidence-source-status {
     color: #fca5a5;
 }
 
 .evidence-status-optional .evidence-badge,
-.evidence-status-optional .evidence-item-icon {
+.evidence-status-optional .evidence-item-icon,
+.evidence-source-row.evidence-status-optional .evidence-source-status {
     color: #c4b5fd;
 }
 
 .evidence-status-not_applicable .evidence-badge,
-.evidence-status-not_applicable .evidence-item-icon {
+.evidence-status-not_applicable .evidence-item-icon,
+.evidence-source-row.evidence-status-not_applicable .evidence-source-status {
     color: var(--text-muted, #9ca3af);
 }
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v52';
+var CACHE_VERSION = 'v53';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/test_evidence_api.py
+++ b/tests/test_evidence_api.py
@@ -80,6 +80,7 @@ class TestEvidenceChecklistApi:
                  patch.object(routes, "get_config_manager", return_value=config), \
                  patch.object(routes, "_get_journal_storage", return_value=journal), \
                  patch.object(routes, "_get_bqm_rows", return_value=[]), \
+                 patch.object(routes, "_get_connection_latency_rows", return_value=[]), \
                  patch.object(routes, "_get_tz_name", return_value="UTC"):
                 response = getattr(routes.api_evidence_checklist, "__wrapped__")()
 
@@ -108,12 +109,67 @@ class TestEvidenceChecklistApi:
             with patch.object(routes, "get_storage", return_value=core), \
                  patch.object(routes, "get_config_manager", return_value=config), \
                  patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
-                 patch.object(routes, "_get_bqm_rows", return_value=[]):
+                 patch.object(routes, "_get_bqm_rows", return_value=[]), \
+                 patch.object(routes, "_get_connection_latency_rows", return_value=[]):
                 response = getattr(routes.api_evidence_checklist, "__wrapped__")()
 
         items = {item["key"]: item for item in response.get_json()["items"]}
         assert items["signal"]["status"] == "not_applicable"
         assert items["events"]["status"] == "not_applicable"
+
+    def test_manual_range_includes_connection_monitor_latency(self):
+        from app.modules.evidence import routes
+
+        core = FakeCoreStorage()
+        config = Mock()
+        config.get.side_effect = lambda key, default=None: {
+            "modem_type": "fritzbox",
+            "connection_monitor_enabled": True,
+        }.get(key, default)
+        config.is_speedtest_configured.return_value = False
+        config.is_bqm_configured.return_value = False
+        config.is_demo_mode.return_value = False
+
+        with app.test_request_context("/api/evidence/checklist?from=2026-06-10T18:00:00Z&to=2026-06-10T23:00:00Z"):
+            with patch.object(routes, "get_storage", return_value=core), \
+                 patch.object(routes, "get_config_manager", return_value=config), \
+                 patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
+                 patch.object(routes, "_get_bqm_rows", return_value=[]), \
+                 patch.object(routes, "_get_connection_latency_rows", return_value=[
+                     {"timestamp": "2026-06-10T22:40:00Z", "avg_latency_ms": 18.0}
+                 ]):
+                response = getattr(routes.api_evidence_checklist, "__wrapped__")()
+
+        items = {item["key"]: item for item in response.get_json()["items"]}
+        assert items["latency"]["status"] == "present"
+        assert items["latency"]["action"] == {"view": "connection-monitor"}
+        assert items["latency"]["sources"][0]["key"] == "connection_monitor"
+        assert items["latency"]["sources"][0]["status"] == "present"
+        assert items["latency"]["sources"][1]["key"] == "bqm"
+        assert items["latency"]["sources"][1]["status"] == "optional"
+
+    def test_connection_monitor_latency_rows_read_connection_monitor_database(self, tmp_path, monkeypatch):
+        from app.modules.connection_monitor.storage import ConnectionMonitorStorage
+        from app.modules.evidence import routes
+
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        storage = ConnectionMonitorStorage(str(tmp_path / "connection_monitor.db"))
+        target_id = storage.create_target("Router", "192.0.2.1")
+        storage.save_samples([
+            {"target_id": target_id, "timestamp": 1781114400.0, "latency_ms": 18.5, "timeout": False, "probe_method": "tcp"},
+            {"target_id": target_id, "timestamp": 1781118000.0, "latency_ms": 22.0, "timeout": False, "probe_method": "tcp"},
+        ])
+
+        rows = routes._get_connection_latency_rows("2026-06-10T18:00:00Z", "2026-06-10T20:00:00Z")
+
+        assert rows == [{
+            "timestamp": "2026-06-10T19:00:00Z",
+            "sample_count": 2,
+            "latency_count": 2,
+            "avg_latency_ms": 20.25,
+            "source": "connection_monitor",
+            "tier": "raw",
+        }]
 
     def test_manual_range_converts_datetime_local_with_configured_timezone(self):
         from app.modules.evidence import routes
@@ -130,6 +186,7 @@ class TestEvidenceChecklistApi:
                  patch.object(routes, "get_config_manager", return_value=config), \
                  patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
                  patch.object(routes, "_get_bqm_rows", return_value=[]), \
+                 patch.object(routes, "_get_connection_latency_rows", return_value=[]), \
                  patch.object(routes, "_get_tz_name", return_value="Europe/Berlin"):
                 response = getattr(routes.api_evidence_checklist, "__wrapped__")()
 

--- a/tests/test_evidence_checklist.py
+++ b/tests/test_evidence_checklist.py
@@ -35,6 +35,61 @@ def test_build_checklist_marks_available_sources_present():
     assert items["review"]["status"] == "optional"
 
 
+def test_build_checklist_treats_connection_monitor_latency_as_evidence():
+    items = _by_key(build_checklist(
+        WINDOW,
+        timeline=[],
+        journal_entries=[],
+        bqm_rows=[],
+        connection_latency_rows=[{"timestamp": "2026-06-10T22:45:00Z", "avg_latency_ms": 18.4, "source": "connection_monitor"}],
+        capabilities={
+            "docsis_supported": True,
+            "speedtest_configured": True,
+            "bqm_configured": True,
+            "connection_monitor_configured": True,
+            "demo_mode": False,
+        },
+    ))
+
+    latency = items["latency"]
+    assert latency["status"] == "present"
+    assert latency["count"] == 1
+    assert latency["last_ts"] == "2026-06-10T22:45:00Z"
+    assert latency["action"] == {"view": "connection-monitor"}
+    assert latency["hint_key"] == "docsight.evidence.item.latency.present_cm_only"
+    assert latency["sources"] == [
+        {"key": "connection_monitor", "status": "present", "count": 1, "last_ts": "2026-06-10T22:45:00Z"},
+        {"key": "bqm", "status": "missing", "count": 0, "last_ts": None},
+    ]
+
+
+def test_build_checklist_reports_bqm_and_connection_monitor_latency_sources_independently():
+    items = _by_key(build_checklist(
+        WINDOW,
+        timeline=[],
+        journal_entries=[],
+        bqm_rows=[{"timestamp": "2026-06-10T21:55:00Z", "latency_avg_ms": 33}],
+        connection_latency_rows=[{"timestamp": "2026-06-10T22:50:00Z", "avg_latency_ms": 17.8}],
+        capabilities={
+            "docsis_supported": True,
+            "speedtest_configured": True,
+            "bqm_configured": True,
+            "connection_monitor_configured": True,
+            "demo_mode": False,
+        },
+    ))
+
+    latency = items["latency"]
+    assert latency["status"] == "present"
+    assert latency["count"] == 2
+    assert latency["last_ts"] == "2026-06-10T22:50:00Z"
+    assert latency["action"] == {"view": "connection-monitor"}
+    assert latency["hint_key"] == "docsight.evidence.item.latency.present_both"
+    assert latency["sources"][0]["status"] == "present"
+    assert latency["sources"][1]["status"] == "present"
+
+
+
 def test_build_checklist_distinguishes_missing_optional_and_not_applicable():
     items = _by_key(build_checklist(
         WINDOW,

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -74,6 +74,11 @@ def test_evidence_module_registers_guided_journey_assets():
     assert "evidence-status-not_applicable" in css
     assert "docsight.evidence.placeholder" in template
     assert "item.label_key" in js
+    assert "function _evidenceRenderSourceBreakdown" in js
+    assert "docsight.evidence.source." in js
+    assert "evidence-source-row" in js
+    assert "evidence-source-list" in css
+    assert "evidence-source-row" in css
     assert "/modules/docsight.evidence/static/main.js" in sw_js
     assert "/modules/docsight.evidence/static/style.css" in sw_js
 
@@ -173,7 +178,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v52';" in sw_js
+    assert "var CACHE_VERSION = 'v53';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js


### PR DESCRIPTION
## Summary
- Counts Connection Monitor samples as latency evidence alongside ThinkBroadband BQM.
- Shows Connection Monitor and BQM source status separately inside the latency checklist item.
- Keeps the latency item ready when either source has samples, while marking the other source optional or missing based on configuration.
- Bumps the service-worker cache for the updated Evidence Journey assets.

## Validation
- `git diff --check`
- `../docsight/.venv311/bin/python -m pytest tests/test_evidence_api.py tests/test_evidence_checklist.py tests/test_static_contracts.py tests/web/test_index.py tests/test_public_launch_surface.py -q`
- `../docsight/.venv311/bin/python scripts/i18n_check.py --validate`
- `../docsight/.venv311/bin/python -m pytest -q tests --ignore=tests/e2e`
- `TZ=UTC PYTHON_BIN=../docsight/.venv311/bin/python python3 /tmp/docsight_e2e_by_file.py` (`421/421` collected E2E tests passed)
