### PR TITLE
Promote Evidence Journey in sidebar

### DIFF
--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v53';
+var CACHE_VERSION = 'v54';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -95,13 +95,21 @@
                 </button>
             </div>
         </div>
+        {% if modules|selectattr('id', 'equalto', 'docsight.evidence')|list %}
+        <div class="nav-section" data-nav-section="evidence" data-nav-label="{{ t.get('docsight.evidence.title', 'Evidence Journey') }}">
+            <div class="nav-section-items">
+                <button class="nav-item" data-view="evidence" data-nav-icon="clipboard-check" data-nav-title="{{ t.get('docsight.evidence.title', 'Evidence Journey') }}">
+                    <i data-lucide="clipboard-check"></i> {{ t.get('docsight.evidence.title', 'Evidence Journey') }}
+                </button>
+            </div>
+        </div>
+        {% endif %}
         <!-- Secondary analysis views (collapsible) -->
         {% set analysis_items = [] %}
         {% if speedtest_configured or bqm_configured %}{% if analysis_items.append('correlation') %}{% endif %}{% endif %}
         {% if modules|selectattr('id', 'equalto', 'docsight.connection_monitor')|list %}{% if analysis_items.append('connection_monitor') %}{% endif %}{% endif %}
         {% if is_fritzbox and segment_utilization_enabled %}{% if analysis_items.append('segment') %}{% endif %}{% endif %}
         {% if modules|selectattr('id', 'equalto', 'docsight.comparison')|list %}{% if analysis_items.append('comparison') %}{% endif %}{% endif %}
-        {% if modules|selectattr('id', 'equalto', 'docsight.evidence')|list %}{% if analysis_items.append('evidence') %}{% endif %}{% endif %}
         {% if gaming_quality_enabled %}{% if analysis_items.append('gaming') %}{% endif %}{% endif %}
         {% if modules|selectattr('id', 'equalto', 'docsight.modulation')|list %}{% if analysis_items.append('modulation') %}{% endif %}{% endif %}
         {% if analysis_items %}
@@ -129,11 +137,6 @@
                 {% if modules|selectattr('id', 'equalto', 'docsight.comparison')|list %}
                 <button class="nav-item" data-view="comparison" data-nav-icon="git-compare-arrows" data-nav-title="{{ t.get('docsight.comparison.title', 'Before/After Comparison') }}">
                     <i data-lucide="git-compare-arrows"></i> {{ t.get('docsight.comparison.title', 'Before/After Comparison') }}
-                </button>
-                {% endif %}
-                {% if modules|selectattr('id', 'equalto', 'docsight.evidence')|list %}
-                <button class="nav-item" data-view="evidence" data-nav-icon="clipboard-check" data-nav-title="{{ t.get('docsight.evidence.title', 'Evidence Journey') }}">
-                    <i data-lucide="clipboard-check"></i> {{ t.get('docsight.evidence.title', 'Evidence Journey') }}
                 </button>
                 {% endif %}
                 {% if gaming_quality_enabled %}

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -121,6 +121,34 @@ class TestMobileLayout:
         )
         assert nav_items.count() >= 4
 
+    def test_evidence_journey_is_standalone_between_monitoring_and_analysis(self, mobile_page):
+        mobile_page.locator("#hamburger").click()
+        mobile_page.wait_for_selector('#sidebar[aria-hidden="false"]')
+        order = mobile_page.locator("#sidebar").evaluate(
+            """
+            (sidebar) => Array.from(sidebar.querySelectorAll('.nav-section'))
+                .map((section) => ({
+                    key: section.dataset.navSection,
+                    hasEvidence: !!section.querySelector('[data-view="evidence"]'),
+                    collapsible: section.classList.contains('nav-section-collapsible')
+                }))
+            """
+        )
+        keys = [item["key"] for item in order]
+        assert keys.index("monitoring") < keys.index("evidence") < keys.index("analysis")
+        evidence_section = next(item for item in order if item["key"] == "evidence")
+        analysis_section = next(item for item in order if item["key"] == "analysis")
+        assert evidence_section["hasEvidence"] is True
+        assert evidence_section["collapsible"] is False
+        assert analysis_section["hasEvidence"] is False
+
+    def test_standalone_evidence_journey_nav_opens_the_evidence_view(self, mobile_page):
+        mobile_page.locator("#hamburger").click()
+        mobile_page.wait_for_selector('#sidebar[aria-hidden="false"]')
+        mobile_page.locator('.nav-section[data-nav-section="evidence"] [data-view="evidence"]').click()
+        mobile_page.wait_for_selector('#view-evidence.active')
+        assert mobile_page.locator('#evidence-placeholder').is_visible()
+
     def test_analysis_section_collapsible(self, mobile_page):
         mobile_page.locator("#hamburger").click()
         mobile_page.wait_for_timeout(300)

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -61,8 +61,20 @@ def test_evidence_module_registers_guided_journey_assets():
     assert manifest["type"] == "analysis"
     assert manifest["contributes"]["tab"] == "templates/evidence_tab.html"
     assert "if modules|selectattr('id', 'equalto', 'docsight.evidence')|list" in index
-    assert "data-view=\"evidence\"" in index
+    assert index.count('data-view="evidence"') == 1
+    assert "mod-docsight-evidence" not in index
     assert "view-evidence" in index
+    monitoring_idx = index.index('data-nav-section="monitoring"')
+    evidence_idx = index.index('data-nav-section="evidence"')
+    analysis_idx = index.index('data-nav-section="analysis"')
+    assert monitoring_idx < evidence_idx < analysis_idx
+    evidence_nav_block = index[evidence_idx:analysis_idx]
+    assert 'data-view="evidence"' in evidence_nav_block
+    assert 'data-nav-icon="clipboard-check"' in evidence_nav_block
+    analysis_setup = index[index.index("{% set analysis_items = [] %}"):analysis_idx]
+    assert "analysis_items.append('evidence')" not in analysis_setup
+    analysis_nav_block = index[analysis_idx:index.index('data-nav-section="external"')]
+    assert 'data-view="evidence"' not in analysis_nav_block
     assert "if (typeof initEvidence === 'function') initEvidence();" in index
     assert "function initEvidence()" in js
     assert "'/api/evidence/checklist?incident_id='" in js
@@ -178,7 +190,7 @@ def test_correlation_event_severity_filter_applies_to_table_and_chart():
 def test_static_cache_version_was_bumped_for_ui_followup_assets():
     sw_js = SW_JS.read_text(encoding="utf-8")
 
-    assert "var CACHE_VERSION = 'v53';" in sw_js
+    assert "var CACHE_VERSION = 'v54';" in sw_js
     assert "/static/css/main.css" in sw_js
     assert "/static/js/channels.js" in sw_js
     assert "/static/js/utils.js" in sw_js


### PR DESCRIPTION
## Summary
- Move Evidence Journey into its own always-visible sidebar section between Monitoring and Analysis
- Remove the duplicate Analysis placement while keeping module gating intact
- Add sidebar placement, exact-once, and mobile click-through regression coverage
- Bump the service-worker shell cache for the sidebar change

## Validation
- `git diff --check`
- `python -m pytest tests/test_static_contracts.py tests/web/test_index.py tests/test_public_launch_surface.py tests/e2e/test_responsive.py::TestMobileLayout::test_evidence_journey_is_standalone_between_monitoring_and_analysis tests/e2e/test_responsive.py::TestMobileLayout::test_standalone_evidence_journey_nav_opens_the_evidence_view -q --tb=short`
- `python scripts/i18n_check.py --validate`
- `python -m pytest -q tests --ignore=tests/e2e`
- Full browser E2E by file: 423 collected, 423 passed
