### PR TITLE
Fix community module storage path

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -37,7 +37,7 @@ Examples:
 - Built-in demo fixtures, built-in module manifests, bundled maintainer notices, and static product assets.
 - Container image layers outside the mounted data directory.
 
-Built-in system files differ from user-installed extension files. Community modules and themes installed into `MODULES_DIR`, usually `/modules`, are local installation files chosen by the user. Their code and assets are not overwritten by DOCSight core updates unless the user installs, updates, removes, or replaces them.
+Built-in system files differ from user-installed extension files. Community modules and themes installed into `MODULES_DIR`, usually `/data/modules` in the Docker image, are local installation files chosen by the user. Their code and assets are not overwritten by DOCSight core updates unless the user installs, updates, removes, or replaces them.
 
 System updates must not rely on overwriting user-owned local data. Data migrations should preserve existing local records, create backup or rollback paths where risk is meaningful, and keep raw evidence intact unless the user chooses a destructive action.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos "" --uid 1000 appuser && \
-    mkdir -p /data && chown appuser:appuser /data
+    mkdir -p /data/modules /modules && \
+    chown -R appuser:appuser /data /modules
 COPY app/ ./app/
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/app/blueprints/modules_bp.py
+++ b/app/blueprints/modules_bp.py
@@ -9,6 +9,7 @@ from flask import Blueprint, jsonify, request
 
 from app.module_download import download_github_directory, fetch_registry as fetch_module_registry
 from app.module_loader import ID_PATTERN, validate_manifest
+from app.module_paths import get_modules_dir
 from app.path_safety import safe_child_path
 from app.theme_registry import download_theme, fetch_registry as fetch_theme_registry
 from app.web import get_config_manager, get_module_loader, require_auth
@@ -249,7 +250,7 @@ def api_themes_install():
     if not isinstance(theme_id, str) or not ID_PATTERN.match(theme_id):
         return jsonify({"success": False, "error": "Invalid theme ID"}), 400
 
-    modules_dir = os.environ.get("MODULES_DIR", "/modules")
+    modules_dir = get_modules_dir()
 
     try:
         theme_dir = safe_child_path(modules_dir, theme_id.replace(".", "_"))
@@ -263,7 +264,7 @@ def api_themes_install():
 
 
 def _get_modules_dir():
-    return os.environ.get("MODULES_DIR", "/modules")
+    return get_modules_dir()
 
 
 def _scan_installed_community_ids():

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from . import analyzer, web
 from .config import ConfigManager
 from .event_detector import EventDetector
+from .module_paths import get_modules_dir
 from .storage import SnapshotStorage
 from .tz import guess_iana_timezone, utc_cutoff
 
@@ -382,7 +383,7 @@ def main():
     from .module_loader import ModuleLoader
 
     builtin_path = os.path.join(os.path.dirname(__file__), "modules")
-    community_path = os.environ.get("MODULES_DIR", "/modules")
+    community_path = get_modules_dir()
     disabled_raw = config_mgr.get("disabled_modules", "")
     disabled_ids = {s.strip() for s in disabled_raw.split(",") if s.strip()}
 

--- a/app/module_paths.py
+++ b/app/module_paths.py
@@ -1,0 +1,10 @@
+"""Shared runtime paths for community module storage."""
+
+import os
+
+DEFAULT_MODULES_DIR = "/data/modules"
+
+
+def get_modules_dir() -> str:
+    """Return the directory used for installed community modules and themes."""
+    return os.environ.get("MODULES_DIR", DEFAULT_MODULES_DIR)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 # Fix volume permissions (may be root-owned from previous versions)
+mkdir -p /data/modules 2>/dev/null || true
 chown -R appuser:appuser /data 2>/dev/null || true
+[ -d /modules ] && chown -R appuser:appuser /modules 2>/dev/null || true
 [ -d /backup ] && chown -R appuser:appuser /backup 2>/dev/null || true
 exec gosu appuser "$@"

--- a/tests/test_module_install_api.py
+++ b/tests/test_module_install_api.py
@@ -92,6 +92,39 @@ class TestModulesInstall:
             assert resp.status_code == 400
             mock_dl.assert_not_called()
 
+    def test_successful_install_uses_configured_modules_dir(self, client, tmp_path, monkeypatch):
+        """Community installs write below MODULES_DIR and persist disabled-by-default."""
+        modules_dir = tmp_path / "modules"
+        monkeypatch.setenv("MODULES_DIR", str(modules_dir))
+
+        def fake_download(_url, target_dir):
+            os.makedirs(target_dir, exist_ok=True)
+            manifest = {
+                "id": "community.test",
+                "name": "Community Test",
+                "description": "Test module",
+                "version": "1.0.0",
+                "author": "DOCSight",
+                "minAppVersion": "2026.1",
+                "type": "analysis",
+                "contributes": {},
+            }
+            with open(os.path.join(target_dir, "manifest.json"), "w", encoding="utf-8") as f:
+                json.dump(manifest, f)
+            return True
+
+        with patch("app.blueprints.modules_bp.download_github_directory", side_effect=fake_download):
+            resp = client.post("/api/modules/install",
+                               data=json.dumps({"id": "community.test", "download_url": "https://api.github.com/test"}),
+                               content_type="application/json")
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["success"] is True
+        assert (modules_dir / "community.test" / "manifest.json").is_file()
+        config = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
+        assert "community.test" in config["disabled_modules"].split(",")
+
 
 class TestThemesInstall:
     def test_rejects_invalid_theme_id(self, client):

--- a/tests/test_module_paths.py
+++ b/tests/test_module_paths.py
@@ -1,0 +1,40 @@
+"""Contracts for community module storage paths."""
+
+from pathlib import Path
+
+from app.module_paths import DEFAULT_MODULES_DIR, get_modules_dir
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_default_modules_dir_is_persisted_data_volume(monkeypatch):
+    monkeypatch.delenv("MODULES_DIR", raising=False)
+
+    assert DEFAULT_MODULES_DIR == "/data/modules"
+    assert get_modules_dir() == "/data/modules"
+
+
+def test_modules_dir_allows_explicit_override(monkeypatch):
+    monkeypatch.setenv("MODULES_DIR", "/custom/modules")
+
+    assert get_modules_dir() == "/custom/modules"
+
+
+def test_runtime_and_install_api_share_module_dir_helper():
+    main_py = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+    modules_bp_py = (ROOT / "app" / "blueprints" / "modules_bp.py").read_text(encoding="utf-8")
+
+    assert "from .module_paths import get_modules_dir" in main_py
+    assert "from app.module_paths import get_modules_dir" in modules_bp_py
+    assert "os.environ.get(\"MODULES_DIR\", \"/modules\")" not in main_py
+    assert "os.environ.get(\"MODULES_DIR\", \"/modules\")" not in modules_bp_py
+
+
+def test_container_prepares_community_module_storage():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    entrypoint = (ROOT / "entrypoint.sh").read_text(encoding="utf-8")
+
+    assert "mkdir -p /data/modules /modules" in dockerfile
+    assert "chown -R appuser:appuser /data /modules" in dockerfile
+    assert "mkdir -p /data/modules" in entrypoint
+    assert "chown -R appuser:appuser /data" in entrypoint


### PR DESCRIPTION
## Summary
- Store community modules under the persisted data volume by default.
- Prepare module storage directories during container startup and keep explicit MODULES_DIR overrides supported.
- Add regression coverage for module storage paths and successful installs.

## Checks
- python -m pytest -q tests/test_module_paths.py tests/test_module_install_api.py tests/test_module_download.py tests/test_modules_api.py tests/module_loader
- python -m pytest -q tests/e2e/test_settings.py
- git diff --check
- python -m compileall -q app

Note: full pytest was started locally but did not finish within the 600s tool timeout; targeted module and Settings browser coverage passed.