### PR TITLE
Handle wrapped CM3500 service flow rates

### DIFF
--- a/app/drivers/cm3500.py
+++ b/app/drivers/cm3500.py
@@ -154,6 +154,8 @@ class CM3500Driver(ModemDriver):
         The config_params_cgi page contains a <pre> block with service flows.
         Each flow has a direction (Downstream/Upstream) and SfMaxTrafficRate
         in bps.  The highest rate per direction is the provisioned speed.
+        Some CM3500B firmware renders uint32 rates above 2 Gbit/s as signed
+        32-bit integers, so negative values are unwrapped before comparison.
         """
         ds_rates = []
         us_rates = []
@@ -169,9 +171,11 @@ class CM3500Driver(ModemDriver):
                                      "UpstreamPacketClassification")):
                 current_dir = None
             elif current_dir and stripped.startswith("SfMaxTrafficRate"):
-                match = re.search(r"=\s*(\d+)", stripped)
+                match = re.search(r"=\s*(-?\d+)", stripped)
                 if match:
                     rate = int(match.group(1))
+                    if rate < 0:
+                        rate += 2**32
                     if current_dir == "ds":
                         ds_rates.append(rate)
                     else:

--- a/tests/test_cm3500.py
+++ b/tests/test_cm3500.py
@@ -321,6 +321,19 @@ UpstreamServiceFlow =
         assert result["max_downstream_kbps"] == 1126400
         assert result["max_upstream_kbps"] == 52480
 
+    def test_unwraps_signed_uint32_service_flow_rates(self):
+        html = """<pre>
+DownstreamServiceFlow =
+    SfMaxTrafficRate = -1794967296
+DownstreamServiceFlow =
+    SfMaxTrafficRate = 15000000
+UpstreamServiceFlow =
+    SfMaxTrafficRate = 100000000
+</pre>"""
+        result = CM3500Driver._parse_service_flows(html)
+        assert result["max_downstream_kbps"] == 2500000
+        assert result["max_upstream_kbps"] == 100000
+
     def test_ignores_packet_classification_section(self):
         html = """<pre>
 DownstreamServiceFlow =


### PR DESCRIPTION
## Summary
- Parse signed CM3500B `SfMaxTrafficRate` values in service-flow sections.
- Unwrap negative signed 32-bit values back to their uint32 provisioned rate before choosing the maximum downstream/upstream speed.
- Add regression coverage for a 2.5 Gbit/s downstream flow rendered as a negative value.

## Validation
- `pytest tests/test_cm3500.py -q`
- `pytest tests/test_cm3500.py tests/collectors/test_builtin_drivers.py tests/collectors/test_modem_collector.py tests/web/test_connection_and_gaming_api.py -q`
- `git diff --check`

## Notes
- Documentation unchanged: this is a modem parser correction with no setup, operator workflow, or user-facing documentation change.
