### PR TITLE
Use CODA-4680 per-channel OFDMA report power

### DIFF
--- a/app/drivers/hitron_coda_4680.py
+++ b/app/drivers/hitron_coda_4680.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from typing import Any
 
@@ -270,13 +271,24 @@ class HitronCoda4680Driver(ModemDriver):
                     # The captured CODA-4680 OFDMA API does not expose center
                     # frequency. Preserve unsupported as blank instead of 0 MHz.
                     "frequency": "",
-                    "powerLevel": float(row["repPower"]),
+                    "powerLevel": self._ofdma_power_1_6(row),
                     "modulation": "OFDMA",
                     "multiplex": "OFDMA",
                 })
             except (KeyError, TypeError, ValueError) as exc:
                 log.warning("Failed to parse Hitron CODA-4680 US OFDMA row: %s", exc)
         return channels
+
+    @staticmethod
+    def _ofdma_power_1_6(row: dict[str, Any]) -> float | None:
+        if "repPower1_6" not in row:
+            log.warning("Hitron CODA-4680 OFDMA row missing repPower1_6; leaving power unsupported")
+            return None
+        try:
+            power = float(str(row.get("repPower1_6")).strip())
+        except (TypeError, ValueError):
+            return None
+        return power if math.isfinite(power) else None
 
     @staticmethod
     def _parse_rate_kbps(value: Any) -> int:

--- a/tests/test_hitron_coda_4680_driver.py
+++ b/tests/test_hitron_coda_4680_driver.py
@@ -254,8 +254,41 @@ class TestDocsisData:
         assert us_ofdma["channelID"] == 0
         assert us_ofdma["type"] == "OFDMA"
         assert us_ofdma["frequency"] == ""
-        assert us_ofdma["powerLevel"] == pytest.approx(52.6417)
+        assert us_ofdma["powerLevel"] == pytest.approx(38.75)
         assert us_ofdma["multiplex"] == "OFDMA"
+
+    def test_us_ofdma_uses_1_6_mhz_report_power(self, driver):
+        rows = [
+            {
+                "uschindex": "2",
+                "state": "OPERATE",
+                "channelBw": "39.2000",
+                "repPower": "53.8917",
+                "repPower1_6": "40.0000",
+                "fftVal": "2K",
+            }
+        ]
+
+        channels = driver._parse_us_ofdma(rows)
+
+        assert len(channels) == 1
+        assert channels[0]["powerLevel"] == pytest.approx(40.0)
+
+    def test_us_ofdma_leaves_power_unsupported_without_1_6_mhz_report_power(self, driver):
+        rows = [
+            {
+                "uschindex": "2",
+                "state": "OPERATE",
+                "channelBw": "39.2000",
+                "repPower": "53.8917",
+                "fftVal": "2K",
+            }
+        ]
+
+        channels = driver._parse_us_ofdma(rows)
+
+        assert len(channels) == 1
+        assert channels[0]["powerLevel"] is None
 
     def test_ds_ofdm_unlocked_rows_are_ignored(self, driver):
         rows = [


### PR DESCRIPTION
## Summary
- Read CODA-4680 upstream OFDMA power from `repPower1_6` instead of aggregate `repPower`.
- Preserve OFDMA power as unsupported when the per-1.6 MHz value is missing or invalid, rather than reporting the aggregate value as channel power.
- Add regression coverage for both the reported CODA-4680 payload shape and the missing-value path.

## Validation
- `pytest tests/test_hitron_coda_4680_driver.py -q`
- `pytest tests/test_hitron_coda_4680_driver.py tests/collectors/test_builtin_drivers.py tests/collectors/test_modem_collector.py tests/web/test_index.py -q`
- `git diff --check`

## Notes
- Documentation unchanged: this corrects one modem parser field mapping without changing setup or operator workflow.
