### PR TITLE
Simplify offline static caching

### DIFF
--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v56';
+var CACHE_VERSION = 'v57';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {
@@ -10,59 +10,10 @@ var SHELL_URLS = [
   '/?source=pwa'
 ];
 
-var STATIC_URLS = [
-  '/static/css/fonts.css',
-  '/static/css/tokens.css',
-  '/static/css/components.css',
-  '/static/css/main.css',
-  '/static/css/views.css',
-  '/static/css/modals.css',
-  '/static/css/glossary.css',
-  '/static/css/segment-utilization.css',
-  '/static/js/chart-engine.js',
-  '/static/js/channels.js',
-  '/static/js/utils.js',
-  '/static/js/hero-chart.js',
-  '/static/js/sparklines.js',
-  '/static/js/events.js',
-  '/static/js/bqm.js',
-  '/static/js/speedtest.js',
-  '/static/js/journal.js',
-  '/static/js/correlation.js',
-  '/static/js/trends.js',
-  '/static/js/glossary.js',
-  '/static/js/icons.js',
-  '/static/js/settings.js',
-  '/static/js/integrations.js',
-  '/static/js/segment-utilization.js',
-  '/static/vendor/lucide.min.js',
-  '/static/vendor/uPlot.min.js',
-  '/static/vendor/uPlot.min.css',
-  '/static/fonts/outfit-latin.woff2',
-  '/static/fonts/outfit-latin-ext.woff2',
-  '/static/fonts/jetbrains-mono-latin.woff2',
-  '/static/fonts/jetbrains-mono-latin-ext.woff2',
-  '/static/logo.svg',
-  '/static/icon.png',
-  '/static/screenshots/dashboard-narrow.png',
-  '/static/screenshots/dashboard-wide.png',
+var CRITICAL_STATIC_URLS = [
   '/static/manifest.json',
-  '/modules/docsight.bnetz/static/style.css',
-  '/modules/docsight.bqm/static/js/bqm-chart.js',
-  '/modules/docsight.bqm/static/style.css',
-  '/modules/docsight.comparison/static/main.js',
-  '/modules/docsight.comparison/static/style.css',
-  '/modules/docsight.evidence/static/main.js',
-  '/modules/docsight.evidence/static/style.css',
-  '/modules/docsight.connection_monitor/static/js/connection-monitor-card.js',
-  '/modules/docsight.connection_monitor/static/js/connection-monitor-charts.js',
-  '/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js',
-  '/modules/docsight.connection_monitor/static/style.css',
-  '/modules/docsight.journal/static/style.css',
-  '/modules/docsight.modulation/static/main.js',
-  '/modules/docsight.modulation/static/style.css',
-  '/modules/docsight.smokeping/static/main.js',
-  '/modules/docsight.speedtest/static/style.css'
+  '/static/logo.svg',
+  '/static/icon.png'
 ];
 
 function sameOrigin(url) {
@@ -148,7 +99,7 @@ self.addEventListener('install', function(e) {
   e.waitUntil(
     Promise.all([
       caches.open(SHELL_CACHE).then(function(cache) { return cache.addAll(SHELL_URLS); }),
-      caches.open(STATIC_CACHE).then(function(cache) { return cache.addAll(STATIC_URLS); })
+      caches.open(STATIC_CACHE).then(function(cache) { return cache.addAll(CRITICAL_STATIC_URLS); })
     ])
   );
   self.skipWaiting();

--- a/tests/test_pwa_contract.py
+++ b/tests/test_pwa_contract.py
@@ -1,6 +1,7 @@
 """Regression checks for DOCSight PWA install and offline contracts."""
 
 import json
+import re
 from pathlib import Path
 
 
@@ -9,6 +10,12 @@ MANIFEST = ROOT / "app" / "static" / "manifest.json"
 SERVICE_WORKER = ROOT / "app" / "static" / "sw.js"
 INDEX_TEMPLATE = ROOT / "app" / "templates" / "index.html"
 MODULES = ROOT / "app" / "modules"
+
+
+def _array_entries(source: str, name: str) -> set[str]:
+    match = re.search(rf"var {name} = \[(.*?)\];", source, flags=re.S)
+    assert match is not None
+    return set(re.findall(r"'([^']+)'", match.group(1)))
 
 
 def test_manifest_exposes_modern_install_metadata():
@@ -65,11 +72,36 @@ def test_service_worker_handles_web_push_and_notification_clicks():
     assert "new URL(targetUrl, self.location.origin)" in source
 
 
-def test_service_worker_precaches_module_static_shell_assets():
-    """The first installed offline shell should include module CSS/JS referenced by the dashboard."""
+def test_service_worker_precaches_only_shell_and_critical_static_assets():
+    """Install should keep the offline shell small and cache other assets on demand."""
     source = SERVICE_WORKER.read_text(encoding="utf-8")
-    missing = []
+    shell_urls = _array_entries(source, "SHELL_URLS")
+    critical_urls = _array_entries(source, "CRITICAL_STATIC_URLS")
 
+    assert shell_urls == {"/", "/?source=pwa"}
+    assert critical_urls == {
+        "/static/manifest.json",
+        "/static/logo.svg",
+        "/static/icon.png",
+    }
+    assert "var STATIC_URLS =" not in source
+    assert "cache.addAll(CRITICAL_STATIC_URLS)" in source
+    assert "handleStaticRequest" in source
+    assert "cache.put(request.url, clone)" in source
+    assert all(not url.startswith("/modules/") for url in critical_urls)
+    assert "/modules/docsight." not in source
+    assert "/static/vendor/" not in source
+    assert "/static/screenshots/" not in source
+
+
+def test_service_worker_uses_runtime_cache_for_module_static_assets():
+    """Module CSS/JS should be runtime cached instead of hand-listed for install."""
+    source = SERVICE_WORKER.read_text(encoding="utf-8")
+    assert "url.pathname.indexOf('/modules/') === 0" in source
+    assert "if (isStaticRequest(url))" in source
+    assert "e.respondWith(handleStaticRequest(request));" in source
+
+    module_static_assets = []
     for module_manifest in MODULES.glob("*/manifest.json"):
         module = json.loads(module_manifest.read_text(encoding="utf-8"))
         module_id = module["id"]
@@ -77,14 +109,12 @@ def test_service_worker_precaches_module_static_shell_assets():
         if not static_dir.exists():
             continue
         for asset in sorted(static_dir.rglob("*")):
-            if asset.suffix not in {".css", ".js"}:
-                continue
-            relative = asset.relative_to(static_dir).as_posix()
-            url = f"/modules/{module_id}/static/{relative}"
-            if url not in source:
-                missing.append(url)
+            if asset.suffix in {".css", ".js"}:
+                relative = asset.relative_to(static_dir).as_posix()
+                module_static_assets.append(f"/modules/{module_id}/static/{relative}")
 
-    assert missing == []
+    assert module_static_assets
+    assert all(asset not in source for asset in module_static_assets)
 
 
 def test_index_template_exposes_honest_offline_state_and_pwa_test_mode():

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -167,8 +167,6 @@ def test_service_worker_precache_references_existing_public_assets() -> None:
         "/static/manifest.json",
         "/static/logo.svg",
         "/static/icon.png",
-        "/static/css/main.css",
-        "/static/js/chart-engine.js",
     ]:
         assert required in sw_js
 


### PR DESCRIPTION
## Summary

- Keep the offline shell and critical PWA identity assets precached at install.
- Cache other `/static` and `/modules` assets through the existing runtime static request strategy.
- Bump the service-worker cache version for the changed worker.
- Update PWA/static contract tests for the retained caching behavior.

## Checks

- `node --check app/static/sw.js`
- `python scripts/i18n_check.py --validate`
- `git diff --check`
- `python -m pytest tests/test_pwa_contract.py tests/test_static_contracts.py tests/test_public_launch_surface.py tests/test_pwa_web_push.py -q`
- `TZ=UTC python -m pytest tests/e2e/test_pwa_gate.py -q`
