### PR TITLE
Simplify storage module composition

### DIFF
--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,14 +1,18 @@
 """SQLite snapshot storage for DOCSIS timeline."""
 
+from __future__ import annotations
+
+from typing import Type
+
 from .base import StorageBase, ALLOWED_MIME_TYPES, MAX_ATTACHMENT_SIZE, MAX_ATTACHMENTS_PER_ENTRY
-from .snapshot import SnapshotMixin
-from .events import EventMixin
-from .analysis import AnalysisMixin
-from .tokens import TokenMixin
-from .smart_capture import SmartCaptureMixin
-from .cleanup import CleanupMixin
-from .device import DeviceStorageMixin
-from .pwa_push import PwaPushMixin
+from .snapshot import SnapshotMethods
+from .events import EventMethods
+from .analysis import AnalysisMethods
+from .tokens import TokenMethods
+from .smart_capture import SmartCaptureMethods
+from .cleanup import CleanupMethods
+from .device import DeviceStorageMethods
+from .pwa_push import PwaPushMethods
 
 __all__ = [
     "SnapshotStorage",
@@ -17,17 +21,28 @@ __all__ = [
     "MAX_ATTACHMENTS_PER_ENTRY",
 ]
 
+_STORAGE_METHOD_GROUPS: tuple[Type[object], ...] = (
+    TokenMethods,
+    SnapshotMethods,
+    EventMethods,
+    AnalysisMethods,
+    SmartCaptureMethods,
+    CleanupMethods,
+    DeviceStorageMethods,
+    PwaPushMethods,
+)
 
-class SnapshotStorage(
-    TokenMixin,
-    SnapshotMixin,
-    EventMixin,
-    AnalysisMixin,
-    SmartCaptureMixin,
-    CleanupMixin,
-    DeviceStorageMixin,
-    PwaPushMixin,
-    StorageBase,
-):
+
+class SnapshotStorage(StorageBase):
     """Persist DOCSIS analysis snapshots to SQLite."""
-    pass
+
+
+def _install_storage_methods() -> None:
+    for group in _STORAGE_METHOD_GROUPS:
+        for name, value in group.__dict__.items():
+            if name.startswith("__"):
+                continue
+            setattr(SnapshotStorage, name, value)
+
+
+_install_storage_methods()

--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -10,7 +10,7 @@ from .error_counters import unwrap_uint32_counter_series
 _CHANNEL_ERROR_KEYS = ("correctable_errors", "uncorrectable_errors")
 
 
-class AnalysisMixin:
+class AnalysisMethods:
 
     def get_correlation_timeline(self, start_ts, end_ts, sources=None):
         """Return unified timeline entries from all sources, sorted by timestamp.
@@ -69,7 +69,7 @@ class AnalysisMixin:
                 })
 
         if "events" in sources:
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
                 rows = conn.execute(
                     "SELECT id, timestamp, severity, event_type, message, details "
@@ -115,7 +115,7 @@ class AnalysisMixin:
         # Smart Capture executions
         if "capture" in sources:
             try:
-                with sqlite3.connect(self.db_path) as conn:
+                with self._connect() as conn:
                     conn.row_factory = sqlite3.Row
                     rows = conn.execute(
                         "SELECT * FROM smart_capture_executions "
@@ -175,7 +175,7 @@ class AnalysisMixin:
         channel_id = int(channel_id)
         _COL_MAP[direction]  # validated in web.py to be 'ds' or 'us'
         cutoff = utc_cutoff(hours=hours) if hours is not None else utc_cutoff(days=days)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             if direction == "ds":
                 rows = conn.execute(
                     "SELECT timestamp, ds_channels_json FROM snapshots WHERE timestamp >= ? ORDER BY timestamp",
@@ -215,7 +215,7 @@ class AnalysisMixin:
         channel_set = set(channel_ids)
         cutoff = utc_cutoff(hours=hours) if hours is not None else utc_cutoff(days=days)
         col = "ds_channels_json" if direction == "ds" else "us_channels_json"
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rows = conn.execute(
                 f"SELECT timestamp, {col} FROM snapshots WHERE timestamp >= ? ORDER BY timestamp",
                 (cutoff,),

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sqlite3
+from contextlib import contextmanager
 
 
 ALLOWED_MIME_TYPES = {
@@ -26,7 +27,7 @@ class StorageBase:
         self._init_db()
 
     def _init_db(self):
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.execute("PRAGMA journal_mode=WAL")
 
             # ── Migration: rename incidents → journal_entries ──
@@ -208,8 +209,16 @@ class StorageBase:
                 ON smart_capture_executions(created_at)
             """)
 
+    @contextmanager
     def _connect(self):
-        """Return a connection with foreign keys enabled."""
+        """Yield a connection with foreign keys enabled and close it afterwards."""
         conn = sqlite3.connect(self.db_path)
         conn.execute("PRAGMA foreign_keys = ON")
-        return conn
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()

--- a/app/storage/cleanup.py
+++ b/app/storage/cleanup.py
@@ -11,7 +11,7 @@ from ..tz import local_today, utc_now, utc_cutoff, local_to_utc
 log = logging.getLogger("docsis.storage")
 
 
-class CleanupMixin:
+class CleanupMethods:
 
     # ── Timezone ──
 
@@ -49,7 +49,7 @@ class CleanupMixin:
         - Runs in a single transaction (automatic rollback on error)
         - Skips NULL, empty, and already-UTC (Z-suffix) values
         """
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(
                 "SELECT value FROM _docsight_meta WHERE key = 'tz_migrated'"
             ).fetchone()
@@ -64,7 +64,7 @@ class CleanupMixin:
             log.info("UTC migration: backup created at %s", backup_path)
 
         migrated_count = 0
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             for table, column in self._TIMESTAMP_COLUMNS:
                 # Check table and column exist
                 try:
@@ -150,7 +150,7 @@ class CleanupMixin:
         if self.max_days <= 0:
             return
         cutoff = utc_cutoff(days=self.max_days)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             deleted = conn.execute(
                 "DELETE FROM snapshots WHERE timestamp < ?", (cutoff,)
             ).rowcount
@@ -160,7 +160,7 @@ class CleanupMixin:
         today = local_today(tz)
         cutoff_date = (datetime.strptime(today, "%Y-%m-%d") - timedelta(days=self.max_days)).strftime("%Y-%m-%d")
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connect() as conn:
                 bqm_deleted = conn.execute(
                     "DELETE FROM bqm_graphs WHERE date < ?", (cutoff_date,)
                 ).rowcount
@@ -169,7 +169,7 @@ class CleanupMixin:
         except sqlite3.OperationalError:
             pass  # Table may not exist if BQM module not loaded
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connect() as conn:
                 weather_deleted = conn.execute(
                     "DELETE FROM weather_data WHERE timestamp < ?", (cutoff,)
                 ).rowcount
@@ -181,7 +181,7 @@ class CleanupMixin:
         if events_deleted:
             log.info("Cleaned up %d old events (before %s)", events_deleted, cutoff)
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connect() as conn:
                 sc_deleted = conn.execute(
                     "DELETE FROM smart_capture_executions WHERE created_at < ?", (cutoff,)
                 ).rowcount

--- a/app/storage/device.py
+++ b/app/storage/device.py
@@ -3,10 +3,10 @@
 import sqlite3
 from typing import Dict, Any
 
-class DeviceStorageMixin:
+class DeviceStorageMethods:
     def get_device_state(self) -> Dict[str, Any]:
         """Fetch the current tracked device state."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute("SELECT * FROM device_state WHERE id = 1").fetchone()
             if row:
@@ -15,7 +15,7 @@ class DeviceStorageMixin:
 
     def update_device_state(self, uptime: int | None, sw_version: str | None, ipv4: str | None, ipv6: str | None, updated_at: str):
         """Update the tracked device state. Inserts if missing, otherwise overwrites."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.execute("""
                 INSERT INTO device_state (id, uptime_seconds, sw_version, wan_ipv4, wan_ipv6, updated_at)
                 VALUES (1, ?, ?, ?, ?, ?)

--- a/app/storage/events.py
+++ b/app/storage/events.py
@@ -9,11 +9,11 @@ from ..types import EventDict
 from ..tz import utc_cutoff
 
 
-class EventMixin:
+class EventMethods:
 
     def save_event(self, timestamp: str, severity: str, event_type: str, message: str, details: dict | None = None) -> int:
         """Save a single event. Returns the new event id."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             cur = conn.execute(
                 "INSERT INTO events (timestamp, severity, event_type, message, details) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -26,7 +26,7 @@ class EventMixin:
         """Bulk insert events. Returns count of inserted rows."""
         if not events_list:
             return 0
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.executemany(
                 "INSERT INTO events (timestamp, severity, event_type, message, details, is_demo) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
@@ -51,7 +51,7 @@ class EventMixin:
         if not events_list:
             return []
         ids = []
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             for e in events_list:
                 cur = conn.execute(
                     "INSERT INTO events (timestamp, severity, event_type, message, details, is_demo) "
@@ -88,7 +88,7 @@ class EventMixin:
             query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(query, params).fetchall()
         results = []
@@ -122,13 +122,13 @@ class EventMixin:
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(query, params).fetchone()
         return row[0] if row else 0
 
     def acknowledge_event(self, event_id):
         """Acknowledge a single event. Returns True if found."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rowcount = conn.execute(
                 "UPDATE events SET acknowledged = 1 WHERE id = ?", (event_id,)
             ).rowcount
@@ -136,7 +136,7 @@ class EventMixin:
 
     def acknowledge_all_events(self):
         """Acknowledge all unacknowledged events. Returns rows affected."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rowcount = conn.execute(
                 "UPDATE events SET acknowledged = 1 WHERE acknowledged = 0"
             ).rowcount
@@ -145,7 +145,7 @@ class EventMixin:
     def get_recent_events(self, hours: int = 48) -> list[dict]:
         """Return events from the last N hours, newest first."""
         cutoff = utc_cutoff(hours=hours)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT id, timestamp, severity, event_type, message, details, acknowledged "
@@ -168,7 +168,7 @@ class EventMixin:
         if days <= 0:
             return 0
         cutoff = utc_cutoff(days=days)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             deleted = conn.execute(
                 "DELETE FROM events WHERE timestamp < ?", (cutoff,)
             ).rowcount
@@ -176,7 +176,7 @@ class EventMixin:
 
     def get_latest_spike_timestamp(self):
         """Return timestamp of the most recent error_spike event, or None."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(
                 "SELECT timestamp FROM events WHERE event_type = 'error_spike' "
                 "ORDER BY timestamp DESC LIMIT 1"

--- a/app/storage/pwa_push.py
+++ b/app/storage/pwa_push.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 
-class PwaPushMixin:
+class PwaPushMethods:
     """Persist browser Push API subscriptions."""
 
     @staticmethod

--- a/app/storage/smart_capture.py
+++ b/app/storage/smart_capture.py
@@ -6,7 +6,7 @@ import sqlite3
 from ..tz import utc_now
 
 
-class SmartCaptureMixin:
+class SmartCaptureMethods:
     db_path: str
 
     def save_execution(self, trigger_type, action_type, status,
@@ -18,7 +18,7 @@ class SmartCaptureMixin:
         assigned a DB id at evaluation time. trigger_timestamp is stored
         as a secondary correlation key.
         """
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             cur = conn.execute(
                 "INSERT INTO smart_capture_executions "
                 "(trigger_event_id, trigger_timestamp, trigger_type, action_type, status, "
@@ -33,7 +33,7 @@ class SmartCaptureMixin:
 
     def get_execution(self, execution_id):
         """Return a single execution record by id, or None."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
                 "SELECT * FROM smart_capture_executions WHERE id = ?",
@@ -80,7 +80,7 @@ class SmartCaptureMixin:
         if not updates:
             return
         params.append(execution_id)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.execute(
                 f"UPDATE smart_capture_executions SET {', '.join(updates)} WHERE id = ?",
                 params,
@@ -89,7 +89,7 @@ class SmartCaptureMixin:
     def get_fired_unmatched(self, action_type):
         """Return FIRED executions without a linked result, filtered by action_type.
         Ordered by fired_at ASC (oldest first) for FIFO matching."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT * FROM smart_capture_executions "
@@ -110,7 +110,7 @@ class SmartCaptureMixin:
 
     def get_latest_smart_capture_fire(self, action_type):
         """Return the latest fired_at timestamp for accepted Smart Capture actions."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(
                 "SELECT fired_at FROM smart_capture_executions "
                 "WHERE action_type = ? AND fired_at IS NOT NULL "
@@ -121,7 +121,7 @@ class SmartCaptureMixin:
 
     def count_smart_capture_fires_since(self, action_type, since_timestamp):
         """Count accepted Smart Capture actions since a UTC timestamp."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(
                 "SELECT COUNT(*) FROM smart_capture_executions "
                 "WHERE action_type = ? AND fired_at IS NOT NULL AND fired_at >= ?",
@@ -132,7 +132,7 @@ class SmartCaptureMixin:
     def get_latest_speedtest_result_timestamp(self):
         """Return latest cached Speedtest Tracker result timestamp, if present."""
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connect() as conn:
                 row = conn.execute(
                     "SELECT timestamp FROM speedtest_results "
                     "WHERE COALESCE(is_demo, 0) = 0 "
@@ -155,7 +155,7 @@ class SmartCaptureMixin:
         if action_type:
             query += " AND action_type = ?"
             params.append(action_type)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rowcount = conn.execute(query, params).rowcount
         return rowcount
 
@@ -173,7 +173,7 @@ class SmartCaptureMixin:
             updates.append("linked_result_id = ?")
             params.append(linked_result_id)
         params.extend([execution_id, expected_status])
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rowcount = conn.execute(
                 f"UPDATE smart_capture_executions SET {', '.join(updates)} "
                 "WHERE id = ? AND status = ?",
@@ -190,7 +190,7 @@ class SmartCaptureMixin:
             params.append(status)
         query += " ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(query, params).fetchall()
         results = []
@@ -207,7 +207,7 @@ class SmartCaptureMixin:
     def expire_stale_pending(self, cutoff_timestamp):
         """Bulk-expire PENDING executions with created_at before cutoff.
         Handles orphaned executions when no adapter is registered."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rowcount = conn.execute(
                 "UPDATE smart_capture_executions "
                 "SET status = 'expired', "

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -58,13 +58,13 @@ def _unwrap_anchor_start(timestamp: str) -> str:
     )
 
 
-class SnapshotMixin:
+class SnapshotMethods:
 
     def save_snapshot(self, analysis: AnalysisResult) -> None:
         """Save current analysis as a snapshot. Runs cleanup afterwards."""
         ts = utc_now()
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with self._connect() as conn:
                 conn.execute(
                     "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?, ?, ?, ?)",
                     (
@@ -82,7 +82,7 @@ class SnapshotMixin:
 
     def get_snapshot_list(self) -> list[str]:
         """Return list of available snapshot timestamps (newest first)."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rows = conn.execute(
                 "SELECT timestamp FROM snapshots ORDER BY timestamp DESC"
             ).fetchall()
@@ -90,7 +90,7 @@ class SnapshotMixin:
 
     def get_latest_snapshot(self) -> AnalysisResult | None:
         """Load the latest stored snapshot, or None when no baseline exists."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(
                 "SELECT summary_json, ds_channels_json, us_channels_json FROM snapshots ORDER BY timestamp DESC, rowid DESC LIMIT 1"
             ).fetchone()
@@ -104,7 +104,7 @@ class SnapshotMixin:
 
     def get_snapshot(self, timestamp: str) -> AnalysisResult | None:
         """Load a single snapshot by timestamp. Returns analysis dict or None."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(
                 "SELECT summary_json, ds_channels_json, us_channels_json FROM snapshots WHERE timestamp = ?",
                 (timestamp,),
@@ -120,7 +120,7 @@ class SnapshotMixin:
     def get_range_data(self, start_ts: str, end_ts: str) -> list[dict]:
         """Get all snapshots between two ISO timestamps (inclusive)."""
         anchor_start = _unwrap_anchor_start(end_ts)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             anchor_rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? AND timestamp < ? ORDER BY timestamp",
@@ -159,7 +159,7 @@ class SnapshotMixin:
         """
         start_utc, end_utc = local_date_to_utc_range(date, self.tz_name)
         anchor_start = _unwrap_anchor_start(end_utc)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp",
@@ -205,7 +205,7 @@ class SnapshotMixin:
         """Get summary snapshots from the last N hours."""
         cutoff = utc_cutoff(hours=hours)
         anchor_start = utc_cutoff(hours=_UNWRAP_ANCHOR_DAYS * 24)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? ORDER BY timestamp",
@@ -221,7 +221,7 @@ class SnapshotMixin:
         range_start, _ = local_date_to_utc_range(start_date, self.tz_name)
         _, range_end = local_date_to_utc_range(end_date, self.tz_name)
         anchor_start = _unwrap_anchor_start(range_end)
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? AND timestamp <= ? "
@@ -241,7 +241,7 @@ class SnapshotMixin:
         All timestamps are now stored as UTC with Z suffix.
         """
         ts_param = timestamp
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(
                 """SELECT timestamp, summary_json, ds_channels_json, us_channels_json
                    FROM snapshots
@@ -261,7 +261,7 @@ class SnapshotMixin:
 
     def get_current_channels(self):
         """Return DS and US channels from the latest snapshot."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             row = conn.execute(
                 "SELECT ds_channels_json, us_channels_json FROM snapshots ORDER BY timestamp DESC LIMIT 1"
             ).fetchone()

--- a/app/storage/tokens.py
+++ b/app/storage/tokens.py
@@ -8,7 +8,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from ..tz import utc_now
 
 
-class TokenMixin:
+class TokenMethods:
 
     def create_api_token(self, name):
         """Create a new API token. Returns (token_id, plaintext_token)."""
@@ -17,7 +17,7 @@ class TokenMixin:
         prefix = plaintext[:8]
         token_hash = generate_password_hash(plaintext)
         created_at = utc_now()
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             cur = conn.execute(
                 "INSERT INTO api_tokens (name, token_hash, token_prefix, created_at) VALUES (?, ?, ?, ?)",
                 (name, token_hash, prefix, created_at),
@@ -26,7 +26,7 @@ class TokenMixin:
 
     def validate_api_token(self, token):
         """Validate a Bearer token. Returns token info dict or None."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT id, name, token_hash, token_prefix, created_at, last_used_at FROM api_tokens WHERE revoked = 0"
@@ -45,7 +45,7 @@ class TokenMixin:
 
     def get_api_tokens(self):
         """Return list of all tokens (without hashes) for UI display."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT id, name, token_prefix, created_at, last_used_at, revoked FROM api_tokens ORDER BY created_at DESC"
@@ -54,7 +54,7 @@ class TokenMixin:
 
     def revoke_api_token(self, token_id):
         """Soft-revoke a token. Returns True if a token was revoked."""
-        with sqlite3.connect(self.db_path) as conn:
+        with self._connect() as conn:
             cur = conn.execute(
                 "UPDATE api_tokens SET revoked = 1 WHERE id = ? AND revoked = 0",
                 (token_id,),

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -209,6 +209,14 @@ def test_static_templates_keep_basic_heading_markup_well_formed() -> None:
     assert offenders == []
 
 
+def test_snapshot_storage_uses_single_storage_base() -> None:
+    storage_init = (ROOT / "app" / "storage" / "__init__.py").read_text(encoding="utf-8")
+    assert "class SnapshotStorage(StorageBase):" in storage_init
+    assert "class SnapshotStorage(\n" not in storage_init
+    assert "_STORAGE_METHOD_GROUPS" in storage_init
+    assert "Mixin" not in storage_init
+
+
 def test_smart_capture_speedtest_adapter_tests_are_consolidated() -> None:
     files = sorted(path.name for path in ROOT.glob("tests/test_smart_capture*speedtest*.py"))
     assert files == ["test_smart_capture_adapter_speedtest.py"]


### PR DESCRIPTION
## Summary

- keep `SnapshotStorage` on a single storage base while installing cohesive storage method groups
- close SQLite connections from the shared storage helper after each operation
- add a static contract for the simplified storage shape

## Verification

- `python -m py_compile app/storage/*.py`
- `python -m pytest tests/test_storage.py tests/test_events.py tests/test_smart_capture_storage.py tests/test_auth.py tests/test_pwa_web_push.py tests/test_device_info_display.py tests/test_correlation.py tests/test_channel_timeline.py tests/test_static_contracts.py -q`
- `python scripts/i18n_check.py --validate`
- `git diff --check`
