### PR TITLE
Remove unused module driver registration path

### DIFF
--- a/app/builtin_modules.py
+++ b/app/builtin_modules.py
@@ -34,7 +34,6 @@ class BuiltinPythonContributions:
 
     collector: str | None = None
     publisher: str | None = None
-    driver: str | None = None
 
 
 BUILTIN_PYTHON_CONTRIBUTIONS: dict[str, BuiltinPythonContributions] = {

--- a/app/drivers/registry.py
+++ b/app/drivers/registry.py
@@ -1,26 +1,18 @@
-"""Unified driver registry for built-in and module-contributed modem drivers."""
+"""Built-in modem driver registry."""
 
 from __future__ import annotations
 
 import importlib
-import logging
 
 from .base import ModemDriver
 from ..types import DriverHints
 
-log = logging.getLogger("docsis.drivers")
-
 
 class DriverRegistry:
-    """Central registry for all modem drivers (built-in and module-contributed).
-
-    Built-in drivers are stored as qualified class paths (lazy-loaded).
-    Module drivers are stored as already-loaded classes.
-    """
+    """Central registry for DOCSight's built-in modem drivers."""
 
     def __init__(self):
         self._builtin: dict[str, str] = {}
-        self._module_drivers: dict[str, type[ModemDriver]] = {}
         self._display_names: dict[str, str] = {}
         self._hints: dict[str, DriverHints] = {}
 
@@ -30,18 +22,7 @@ class DriverRegistry:
         if hints:
             self._hints[type_key] = hints
 
-    def register_module_driver(self, type_key: str, cls: type[ModemDriver], display_name: str, hints: DriverHints | None = None) -> None:
-        self._module_drivers[type_key] = cls
-        self._display_names[type_key] = display_name
-        if hints:
-            self._hints[type_key] = hints
-
     def load_driver(self, modem_type: str, url: str, user: str, password: str) -> ModemDriver:
-        # Module drivers take priority (community can override/extend)
-        if modem_type in self._module_drivers:
-            cls = self._module_drivers[modem_type]
-            return cls(url, user, password)
-
         qualified = self._builtin.get(modem_type)
         if not qualified:
             supported = ", ".join(sorted(self.get_all_type_keys()))
@@ -61,19 +42,11 @@ class DriverRegistry:
         )
 
     def get_all_type_keys(self) -> set[str]:
-        return set(self._builtin) | set(self._module_drivers)
+        return set(self._builtin)
 
     def get_driver_hints(self) -> dict[str, DriverHints]:
         """Return UI hints for all registered drivers, keyed by type_key."""
         return dict(self._hints)
 
     def has_driver(self, modem_type: str) -> bool:
-        return modem_type in self._builtin or modem_type in self._module_drivers
-
-    def register_module_drivers(self, module_loader) -> None:
-        for mod in module_loader.get_enabled_modules():
-            if mod.driver_class and "driver" in mod.contributes:
-                type_key = mod.id
-                display_name = mod.name
-                self.register_module_driver(type_key, mod.driver_class, display_name, hints=mod.hints)
-                log.info("Registered module driver: %s (%s)", type_key, display_name)
+        return modem_type in self._builtin

--- a/app/main.py
+++ b/app/main.py
@@ -393,8 +393,6 @@ def main():
         disabled_ids=disabled_ids,
     )
     module_loader.load_all()
-    from .drivers import driver_registry
-    driver_registry.register_module_drivers(module_loader)
     web.init_modules(module_loader)
     web.setup_module_templates(module_loader)
 

--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -21,8 +21,8 @@ from app.theme_registry import BUILTIN_THEMES
 
 log = logging.getLogger("docsis.modules")
 
-VALID_TYPES = {"driver", "integration", "analysis", "theme"}
-VALID_CONTRIBUTES = {"collector", "routes", "settings", "tab", "card", "i18n", "static", "publisher", "thresholds", "theme", "driver"}
+VALID_TYPES = {"integration", "analysis", "theme"}
+VALID_CONTRIBUTES = {"collector", "routes", "settings", "tab", "card", "i18n", "static", "publisher", "thresholds", "theme"}
 REQUIRED_FIELDS = {"id", "name", "description", "version", "author", "minAppVersion", "type", "contributes"}
 ID_PATTERN = re.compile(r"^[a-z][a-z0-9_.]+$")
 
@@ -53,7 +53,6 @@ class ModuleInfo:
     template_paths: dict[str, str] = field(default_factory=dict)
     collector_class: type | None = None
     publisher_class: type | None = None
-    driver_class: type | None = None
     hints: dict[str, object] = field(default_factory=dict)
     thresholds_data: dict[str, object] | None = None
     theme_data: dict[str, object] | None = None
@@ -97,14 +96,6 @@ def validate_manifest(raw: dict[str, Any], module_path: str, *, builtin: bool | 
         if forbidden:
             raise ManifestError(
                 f"Theme modules must not contribute {', '.join(sorted(forbidden))} (security)"
-            )
-
-    # Security: driver modules should not execute arbitrary server code
-    if mod_type == "driver":
-        forbidden = {"collector", "publisher"} & set(contributes.keys())
-        if forbidden:
-            raise ManifestError(
-                f"Driver modules must not contribute {', '.join(sorted(forbidden))} (security)"
             )
 
     config = raw.get("config", {})
@@ -437,7 +428,6 @@ def attach_builtin_python_contributions(mod: ModuleInfo) -> None:
     for key, attr_name in (
         ("collector", "collector_class"),
         ("publisher", "publisher_class"),
-        ("driver", "driver_class"),
     ):
         if key not in mod.contributes or getattr(mod, attr_name) is not None:
             continue
@@ -615,51 +605,6 @@ def load_module_publisher(module_id: str, module_path: str, spec: str):
         return None
 
     log.info("Module '%s': loaded publisher class '%s'", module_id, class_name)
-    return cls
-
-
-def load_module_driver(module_id: str, module_path: str, spec: str):
-    """Load a ModemDriver subclass from a module file.
-
-    Args:
-        module_id: The module's unique identifier.
-        module_path: Filesystem path to the module directory.
-        spec: "filename.py:ClassName" format (e.g. "driver.py:MyModemDriver")
-
-    Returns:
-        The ModemDriver subclass, or None if loading failed.
-    """
-    if ":" not in spec:
-        log.warning("Module '%s': driver spec must be 'file.py:ClassName', got '%s'", module_id, spec)
-        return None
-
-    filename, class_name = spec.rsplit(":", 1)
-    file_path = safe_manifest_ref(module_path, filename)
-
-    if not os.path.isfile(file_path):
-        log.warning("Module '%s': driver file not found: %s", module_id, file_path)
-        return None
-
-    dir_name = os.path.basename(module_path)
-    mod_name = f"app.modules.{dir_name}.driver"
-    try:
-        im_spec = importlib.util.spec_from_file_location(mod_name, file_path)
-        if im_spec is None or im_spec.loader is None:
-            log.warning("Module '%s': could not create import spec for %s", module_id, file_path)
-            return None
-        mod = importlib.util.module_from_spec(im_spec)
-        sys.modules[mod_name] = mod
-        im_spec.loader.exec_module(mod)
-    except Exception as e:
-        log.error("Module '%s': failed to import driver: %s", module_id, e)
-        return None
-
-    cls = getattr(mod, class_name, None)
-    if cls is None:
-        log.warning("Module '%s': class '%s' not found in %s", module_id, class_name, file_path)
-        return None
-
-    log.info("Module '%s': loaded driver class '%s'", module_id, class_name)
     return cls
 
 
@@ -879,10 +824,6 @@ class ModuleLoader:
         if "publisher" in c and not mod.builtin:
             mod.publisher_class = load_module_publisher(mod.id, mod.path, c["publisher"])
 
-        # Driver (class loaded but not instantiated -- DriverRegistry handles that)
-        if "driver" in c and not mod.builtin:
-            mod.driver_class = load_module_driver(mod.id, mod.path, c["driver"])
-
         # Thresholds
         if "thresholds" in c:
             thresholds_path = safe_manifest_ref(mod.path, c["thresholds"])
@@ -931,7 +872,3 @@ class ModuleLoader:
     def get_theme_modules(self) -> list[ModuleInfo]:
         """Return all modules that contribute theme definitions."""
         return [m for m in self._modules if "theme" in m.contributes]
-
-    def get_driver_modules(self) -> list[ModuleInfo]:
-        """Return all modules that contribute a driver."""
-        return [m for m in self._modules if "driver" in m.contributes]

--- a/app/modules/thresholds_vfkd/manifest.json
+++ b/app/modules/thresholds_vfkd/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "itsDNNS",
   "minAppVersion": "2026.2",
-  "type": "driver",
+  "type": "analysis",
   "contributes": {
     "thresholds": "thresholds.json"
   }

--- a/app/templates/settings/_module_card.html
+++ b/app/templates/settings/_module_card.html
@@ -1,10 +1,8 @@
 <div class="module-card glass {{ 'active' if mod.enabled }}" data-module-id="{{ mod.id }}">
     <div class="module-card-header">
-        <div class="card-icon {% if mod.type == 'integration' %}purple{% elif mod.type == 'driver' %}blue{% elif mod.type == 'analysis' %}green{% else %}purple{% endif %}">
+        <div class="card-icon {% if mod.type == 'integration' %}purple{% elif mod.type == 'analysis' %}green{% else %}purple{% endif %}">
             {% if mod.type == 'integration' %}
             <i data-lucide="plug"></i>
-            {% elif mod.type == 'driver' %}
-            <i data-lucide="cpu"></i>
             {% elif mod.type == 'analysis' %}
             <i data-lucide="bar-chart-2"></i>
             {% elif mod.type == 'theme' %}

--- a/tests/module_loader/test_loading_core.py
+++ b/tests/module_loader/test_loading_core.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 from flask import Flask
-from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, load_module_driver, setup_module_static, setup_module_templates, ModuleLoader
+from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, setup_module_static, setup_module_templates, ModuleLoader
 
 class TestRegisterModuleConfig:
     """Test module config defaults registration."""

--- a/tests/module_loader/test_manifest_and_discovery.py
+++ b/tests/module_loader/test_manifest_and_discovery.py
@@ -9,7 +9,7 @@ import textwrap
 
 import pytest
 from flask import Flask
-from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, load_module_driver, setup_module_static, setup_module_templates, ModuleLoader
+from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, setup_module_static, setup_module_templates, ModuleLoader
 
 class TestValidateManifest:
     """Test manifest.json validation."""

--- a/tests/module_loader/test_security.py
+++ b/tests/module_loader/test_security.py
@@ -1,15 +1,12 @@
 """Tests for module loader path traversal and security constraints."""
 
 # tests/test_module_loader.py
-import importlib
 import json
 import os
-import tempfile
-import textwrap
 
 import pytest
 from flask import Flask
-from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, load_module_driver, setup_module_static, setup_module_templates, ModuleLoader
+from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, setup_module_static, setup_module_templates, ModuleLoader
 
 _VALID_THEME = {
     "dark": {
@@ -278,16 +275,6 @@ class TestContributesPathTraversal:
         with pytest.raises(ValueError, match="Unsafe manifest reference"):
             load_module_publisher("test.mod", str(mod_dir), "../evil.py:Evil")
 
-    def test_driver_traversal_blocked(self, tmp_path):
-        """Driver spec with traversal filename must be rejected."""
-        from app.module_loader import load_module_driver
-
-        mod_dir = tmp_path / "mymod"
-        mod_dir.mkdir()
-
-        with pytest.raises(ValueError, match="Unsafe manifest reference"):
-            load_module_driver("test.mod", str(mod_dir), "../evil.py:Evil")
-
     def test_static_traversal_blocked(self, tmp_path):
         """Static dir with traversal must be rejected."""
         mod_dir = tmp_path / "staticmod"
@@ -314,69 +301,13 @@ class TestContributesPathTraversal:
         assert "unsafe manifest subpath" in mod.error.lower()
 
 
-def test_driver_in_valid_contributes():
+def test_driver_is_not_valid_contributes():
     from app.module_loader import VALID_CONTRIBUTES
-    assert "driver" in VALID_CONTRIBUTES
-
-
-class TestLoadModuleDriver:
-    """Tests for load_module_driver()."""
-
-    def test_valid_driver_spec(self, tmp_path):
-        driver_code = textwrap.dedent('''
-            from app.drivers.base import ModemDriver
-
-            class TestDriver(ModemDriver):
-                def login(self): pass
-                def get_docsis_data(self): return {}
-                def get_device_info(self): return {}
-                def get_connection_info(self): return {}
-        ''')
-        driver_file = tmp_path / "driver.py"
-        driver_file.write_text(driver_code)
-        cls = load_module_driver("test.mod", str(tmp_path), "driver.py:TestDriver")
-        assert cls is not None
-        assert cls.__name__ == "TestDriver"
-
-    def test_missing_colon_returns_none(self, tmp_path):
-        cls = load_module_driver("test.mod", str(tmp_path), "driver.py")
-        assert cls is None
-
-    def test_missing_file_returns_none(self, tmp_path):
-        cls = load_module_driver("test.mod", str(tmp_path), "missing.py:Foo")
-        assert cls is None
-
-    def test_missing_class_returns_none(self, tmp_path):
-        driver_file = tmp_path / "driver.py"
-        driver_file.write_text("class Other: pass")
-        cls = load_module_driver("test.mod", str(tmp_path), "driver.py:Missing")
-        assert cls is None
+    assert "driver" not in VALID_CONTRIBUTES
 
 
 class TestDriverModuleSecurity:
-    def test_driver_module_forbidden_contributions_rejected(self):
-        base = {
-            "id": "community.mydriver",
-            "name": "My Driver",
-            "description": "A driver",
-            "version": "1.0.0",
-            "author": "Test",
-            "minAppVersion": "2026.2",
-            "type": "driver",
-        }
-
-        for contribution, spec in {
-            "collector": "collector.py:Foo",
-            "publisher": "pub.py:Foo",
-        }.items():
-            raw = {
-                **base,
-                "contributes": {"driver": "driver.py:MyDriver", contribution: spec},
-            }
-            with pytest.raises(ManifestError, match="must not contribute"):
-                validate_manifest(raw, "/path")
-
-    def test_driver_module_with_only_driver_is_valid(self):
+    def test_driver_module_type_is_not_supported(self):
         raw = {
             "id": "community.mydriver",
             "name": "My Driver",
@@ -385,7 +316,23 @@ class TestDriverModuleSecurity:
             "author": "Test",
             "minAppVersion": "2026.2",
             "type": "driver",
+            "contributes": {},
+        }
+
+        with pytest.raises(ManifestError, match="Invalid type"):
+            validate_manifest(raw, "/path")
+
+    def test_driver_contribution_is_not_supported(self):
+        raw = {
+            "id": "community.mydriver",
+            "name": "My Driver",
+            "description": "A driver",
+            "version": "1.0.0",
+            "author": "Test",
+            "minAppVersion": "2026.2",
+            "type": "integration",
             "contributes": {"driver": "driver.py:MyDriver"},
         }
-        info = validate_manifest(raw, "/path")
-        assert info.type == "driver"
+
+        with pytest.raises(ManifestError, match="Unknown contributes keys"):
+            validate_manifest(raw, "/path")

--- a/tests/module_loader/test_themes.py
+++ b/tests/module_loader/test_themes.py
@@ -9,7 +9,7 @@ import textwrap
 
 import pytest
 from flask import Flask
-from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, load_module_driver, setup_module_static, setup_module_templates, ModuleLoader
+from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, setup_module_static, setup_module_templates, ModuleLoader
 
 _VALID_THEME = {
     "dark": {

--- a/tests/module_loader/test_thresholds.py
+++ b/tests/module_loader/test_thresholds.py
@@ -9,7 +9,7 @@ import textwrap
 
 import pytest
 from flask import Flask
-from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, load_module_driver, setup_module_static, setup_module_templates, ModuleLoader
+from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, setup_module_static, setup_module_templates, ModuleLoader
 
 _VALID_THRESHOLDS = {
     "downstream_power": {"_default": "256QAM", "256QAM": {"good": [-4, 13], "warning": [-6, 18], "critical": [-8, 20]}},
@@ -32,7 +32,7 @@ class TestThresholdContributes:
             "version": "1.0.0",
             "author": "Test",
             "minAppVersion": "2026.2",
-            "type": "driver",
+            "type": "analysis",
             "contributes": {"thresholds": "thresholds.json"},
         }
         info = validate_manifest(raw, "/some/path")
@@ -52,7 +52,7 @@ class TestThresholdContributes:
                 "version": "1.0.0",
                 "author": "Test",
                 "minAppVersion": "2026.2",
-                "type": "driver",
+                "type": "analysis",
                 "contributes": {"thresholds": "thresholds.json"},
             }
             (mod_dir / "manifest.json").write_text(json.dumps(manifest))
@@ -82,7 +82,7 @@ class TestThresholdContributes:
                 "version": "1.0.0",
                 "author": "Test",
                 "minAppVersion": "2026.2",
-                "type": "driver",
+                "type": "analysis",
                 "contributes": {"thresholds": "thresholds.json"},
             }
             (mod_dir / "manifest.json").write_text(json.dumps(manifest))
@@ -111,7 +111,7 @@ class TestThresholdContributes:
                 "version": "1.0.0",
                 "author": "Test",
                 "minAppVersion": "2026.2",
-                "type": "driver",
+                "type": "analysis",
                 "contributes": {"thresholds": "thresholds.json"},
             }
             (mod_dir / "manifest.json").write_text(json.dumps(manifest))
@@ -143,7 +143,7 @@ class TestThresholdWiring:
                 "version": "1.0.0",
                 "author": "Test",
                 "minAppVersion": "2026.2",
-                "type": "driver",
+                "type": "analysis",
                 "contributes": {"thresholds": "thresholds.json"},
             }
             (mod_dir / "manifest.json").write_text(json.dumps(manifest))
@@ -177,7 +177,7 @@ class TestGetThresholdModules:
             (mod_t / "manifest.json").write_text(json.dumps({
                 "id": "test.thresh", "name": "T", "description": "d",
                 "version": "1.0.0", "author": "a", "minAppVersion": "2026.2",
-                "type": "driver", "contributes": {"thresholds": "thresholds.json"},
+                "type": "analysis", "contributes": {"thresholds": "thresholds.json"},
             }))
             (mod_t / "thresholds.json").write_text(json.dumps(_VALID_THRESHOLDS))
 

--- a/tests/test_builtin_module_registry.py
+++ b/tests/test_builtin_module_registry.py
@@ -60,7 +60,7 @@ def test_builtin_python_contribution_registry_covers_manifest_entry_points():
         manifest = json.loads((BUILTIN_MODULES_DIR / dirname / "manifest.json").read_text(encoding="utf-8"))
         contributes = manifest.get("contributes", {})
         specs = BUILTIN_PYTHON_CONTRIBUTIONS.get(manifest["id"])
-        for key in ("collector", "publisher", "driver"):
+        for key in ("collector", "publisher"):
             if key in contributes:
                 assert specs is not None, f"missing static Python contribution spec for {manifest['id']}"
                 assert getattr(specs, key), f"missing {key} spec for {manifest['id']}"

--- a/tests/test_driver_registry.py
+++ b/tests/test_driver_registry.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest.mock import MagicMock
 from app.drivers.registry import DriverRegistry
 from app.drivers.base import ModemDriver
 
@@ -35,37 +34,9 @@ class TestDriverRegistry:
         self.reg.register_builtin("fake", "tests.test_driver_registry.FakeDriver", "Fake")
         assert self.reg.has_driver("fake")
 
-    def test_module_driver_overrides_builtin(self):
-        self.reg.register_builtin("fake", "tests.test_driver_registry.FakeDriver", "Built-in Fake")
-        self.reg.register_module_driver("fake", FakeDriver, "Module Fake")
-        result = self.reg.get_available_drivers()
-        assert ("fake", "Module Fake") in result
-
-    def test_module_driver_loads(self):
-        self.reg.register_module_driver("custom", FakeDriver, "Custom Driver")
-        driver = self.reg.load_driver("custom", "http://x", "u", "p")
-        assert isinstance(driver, FakeDriver)
-
-    def test_register_module_drivers_from_loader(self):
-        mod = MagicMock()
-        mod.driver_class = FakeDriver
-        mod.contributes = {"driver": "driver.py:FakeDriver"}
-        mod.id = "community.fake"
-        mod.name = "Fake Community Driver"
-        loader = MagicMock()
-        loader.get_enabled_modules.return_value = [mod]
-        self.reg.register_module_drivers(loader)
-        assert self.reg.has_driver("community.fake")
-
-    def test_register_module_drivers_skips_non_driver_modules(self):
-        mod = MagicMock()
-        mod.driver_class = None
-        mod.contributes = {"collector": "collector.py:Foo"}
-        mod.id = "community.collector"
-        loader = MagicMock()
-        loader.get_enabled_modules.return_value = [mod]
-        self.reg.register_module_drivers(loader)
-        assert not self.reg.has_driver("community.collector")
+    def test_registered_builtin_keys_are_the_only_available_driver_keys(self):
+        self.reg.register_builtin("fake", "tests.test_driver_registry.FakeDriver", "Fake")
+        assert self.reg.get_all_type_keys() == {"fake"}
 
 
 class TestGenericDriver:

--- a/tests/test_modules_api.py
+++ b/tests/test_modules_api.py
@@ -180,7 +180,7 @@ class TestBatchModuleSettings:
                 "version": "1.0.0",
                 "author": "a",
                 "minAppVersion": "2026.2",
-                "type": "driver",
+                "type": "analysis" if contributes else "integration",
                 "contributes": contributes,
             }))
             if contributes:

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -187,9 +187,9 @@ def test_builtin_module_manifests_reference_existing_declared_files() -> None:
         module_dir = manifest_path.parent
         manifest = read_json(manifest_path)
         assert manifest["id"].startswith("docsight.")
-        assert manifest["type"] in {"analysis", "driver", "integration", "theme"}
+        assert manifest["type"] in {"analysis", "integration", "theme"}
         for key, value in manifest.get("contributes", {}).items():
-            if key in {"collector", "publisher", "driver"}:
+            if key in {"collector", "publisher"}:
                 value = value.split(":", 1)[0]
             elif key not in path_contributions:
                 continue
@@ -241,6 +241,30 @@ def test_smart_capture_uses_direct_speedtest_execution_wiring() -> None:
     assert "action_type: str" not in trigger_types
     assert "CAPTURE_ACTION_TYPE = \"capture\"" in trigger_types
     assert "register_speedtest_adapter(stt_adapter)" in main
+
+
+def test_module_driver_registration_path_is_not_supported() -> None:
+    """Module manifests should not expose modem-driver registration plumbing."""
+    module_loader = (ROOT / "app" / "module_loader.py").read_text(encoding="utf-8")
+    driver_registry = (ROOT / "app" / "drivers" / "registry.py").read_text(encoding="utf-8")
+    main = (ROOT / "app" / "main.py").read_text(encoding="utf-8")
+    module_card = (ROOT / "app" / "templates" / "settings" / "_module_card.html").read_text(encoding="utf-8")
+
+    for removed in [
+        "load_module_driver",
+        "driver_class",
+        "get_driver_modules",
+        "register_module_drivers",
+        "register_module_driver",
+        "_module_drivers",
+    ]:
+        assert removed not in module_loader
+        assert removed not in driver_registry
+        assert removed not in main
+
+    assert '"driver"' not in module_loader
+    assert "mod.type == 'driver'" not in module_card
+    assert json.loads((MODULES / "thresholds_vfkd" / "manifest.json").read_text(encoding="utf-8"))["type"] == "analysis"
 
 
 def test_core_i18n_template_is_generated_on_demand_not_tracked() -> None:


### PR DESCRIPTION
## Summary

- remove unused module-contributed modem driver registration and loading plumbing
- keep built-in modem drivers, driver hints, and the generic fallback on the built-in registry path
- reclassify the VF/KD threshold profile as analysis metadata while preserving threshold loading

## Checks

- `.venv/bin/python -m pytest tests/test_driver_registry.py tests/drivers tests/module_loader tests/test_builtin_module_registry.py tests/test_modules_api.py tests/test_static_contracts.py tests/test_public_launch_surface.py -q`
- `.venv/bin/python -m pytest tests/test_module_install_api.py tests/test_module_paths.py tests/test_module_integration.py tests/test_module_download.py -q`
- `.venv/bin/python -m pytest tests/ -q --ignore=tests/e2e`
- `.venv/bin/python -m py_compile app/module_loader.py app/drivers/registry.py app/builtin_modules.py app/main.py tests/module_loader/test_security.py tests/test_driver_registry.py tests/test_static_contracts.py`
- `.venv/bin/python scripts/i18n_check.py --validate`
- `git diff --check`

## Notes

Built-in modem driver behavior is unchanged. Threshold profiles continue to load through the module threshold contribution path.