### PR TITLE
Use stdlib PBKDF2 helpers in modem drivers

### DIFF
--- a/app/drivers/ultrahub7.py
+++ b/app/drivers/ultrahub7.py
@@ -14,11 +14,10 @@ import logging
 import os
 
 import requests
-from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESCCM
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from .base import ModemDriver
+from .utils import pbkdf2_sha256
 from ..types import DocsisData, DeviceInfo, ConnectionInfo, RawChannel
 
 log = logging.getLogger("docsis.driver.ultrahub7")
@@ -111,13 +110,10 @@ class UltraHub7Driver(ModemDriver):
                 salt = web_ui_secret[10:]
 
                 # Step 3: Derive encryption key with PBKDF2-HMAC-SHA256
-                kdf = PBKDF2HMAC(
-                    algorithm=hashes.SHA256(),
-                    length=16,  # AES-128
-                    salt=bytes(salt, "utf-8"),
-                    iterations=1000,
+                key = pbkdf2_sha256(
+                    bytes(salt_web_ui, "utf-8"),
+                    bytes(salt, "utf-8"),
                 )
-                key = kdf.derive(bytes(salt_web_ui, "utf-8"))
 
                 # Step 4: Encrypt password with AES-CCM
                 iv = os.urandom(16)

--- a/app/drivers/utils.py
+++ b/app/drivers/utils.py
@@ -5,6 +5,7 @@ ensures consistent parsing behaviour and makes future changes propagate
 automatically.
 """
 
+import hashlib
 import logging
 import re
 import ssl
@@ -12,6 +13,18 @@ import ssl
 from requests.adapters import HTTPAdapter
 
 log = logging.getLogger("docsis.drivers.utils")
+
+
+def pbkdf2_sha256(key_material: bytes, salt: bytes, *, length: int = 16, iterations: int = 1000) -> bytes:
+    """Derive PBKDF2-HMAC-SHA256 bytes.
+
+    Args:
+        key_material: Password or other secret bytes to derive from.
+        salt: Salt bytes used for the derivation.
+        length: Derived key length in bytes.
+        iterations: PBKDF2 iteration count.
+    """
+    return hashlib.pbkdf2_hmac("sha256", key_material, salt, iterations, dklen=length)
 
 
 # ---------------------------------------------------------------------------

--- a/app/drivers/vodafone_station.py
+++ b/app/drivers/vodafone_station.py
@@ -19,12 +19,10 @@ import re
 import time
 
 import requests
-from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESCCM
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from .base import ModemDriver
-from .utils import normalize_modulation
+from .utils import normalize_modulation, pbkdf2_sha256
 from ..types import DocsisData, DeviceInfo, ConnectionInfo
 
 log = logging.getLogger("docsis.driver.vodafone_station")
@@ -178,22 +176,16 @@ class VodafoneStationDriver(ModemDriver):
             )
 
         # Step 2: First PBKDF2 -- password + salt -> hash1
-        kdf1 = PBKDF2HMAC(
-            algorithm=hashes.SHA256(),
-            length=16,
-            salt=salt.encode("utf-8"),
-            iterations=1000,
-        )
-        hash1 = kdf1.derive(self._password.encode("utf-8")).hex()
+        hash1 = pbkdf2_sha256(
+            self._password.encode("utf-8"),
+            salt.encode("utf-8"),
+        ).hex()
 
         # Step 3: Second PBKDF2 -- hash1 (as hex string) + saltwebui -> hash2
-        kdf2 = PBKDF2HMAC(
-            algorithm=hashes.SHA256(),
-            length=16,
-            salt=salt_webui.encode("utf-8"),
-            iterations=1000,
-        )
-        hash2 = kdf2.derive(hash1.encode("utf-8")).hex()
+        hash2 = pbkdf2_sha256(
+            hash1.encode("utf-8"),
+            salt_webui.encode("utf-8"),
+        ).hex()
 
         # Step 4: Login with derived hash
         r2 = self._session.post(
@@ -547,7 +539,7 @@ class VodafoneStationDriver(ModemDriver):
         iv_hex = self._extract_js_var(html, "myIv")
         salt_hex = self._extract_js_var(html, "mySalt")
 
-        if not all([session_id, iv_hex, salt_hex]):
+        if not session_id or not iv_hex or not salt_hex:
             raise RuntimeError(
                 "TG: Could not extract session variables from login page "
                 f"(sessionId={bool(session_id)}, myIv={bool(iv_hex)}, "
@@ -561,13 +553,10 @@ class VodafoneStationDriver(ModemDriver):
                    session_id[:8], iv_hex, salt_hex)
 
         # Step 2: Derive AES key via PBKDF2
-        kdf = PBKDF2HMAC(
-            algorithm=hashes.SHA256(),
-            length=16,
-            salt=bytes.fromhex(salt_hex),
-            iterations=1000,
+        key = pbkdf2_sha256(
+            self._password.encode("utf-8"),
+            bytes.fromhex(salt_hex),
         )
-        key = kdf.derive(self._password.encode("utf-8"))
 
         # Step 3: Encrypt credentials with AES-CCM
         # Full IV as nonce (8 bytes from 16 hex chars), 16-byte tag, AAD

--- a/tests/test_ultrahub7_auth.py
+++ b/tests/test_ultrahub7_auth.py
@@ -1,0 +1,63 @@
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+from cryptography.hazmat.primitives.ciphers.aead import AESCCM
+
+from app.drivers.ultrahub7 import UltraHub7Driver
+from app.drivers.utils import pbkdf2_sha256
+
+
+def test_ultrahub_pbkdf2_helper_matches_sha256_contract():
+    # Reference vector generated with hashlib.pbkdf2_hmac("sha256", ...).
+    derived = pbkdf2_sha256(b"webuisalt1", b"router-salt")
+
+    assert derived.hex() == "62931075f8d4029ba615fa270e1e4d97"
+
+
+def test_ultrahub_login_uses_stdlib_pbkdf2_key_for_aesccm_payload():
+    driver = UltraHub7Driver(url="http://dummy", user="admin", password="admin")
+    fixed_iv = bytes.fromhex("0102030405060708090a0b0c0d0e0f10")
+
+    init_response = MagicMock()
+    init_response.raise_for_status = MagicMock()
+    init_response.json.return_value = {
+        "X_INTERNAL_ID": "7",
+        "csrf_token": "csrf-initial",
+    }
+
+    secret_response = MagicMock()
+    secret_response.raise_for_status = MagicMock()
+    secret_response.json.return_value = {
+        "X_VODAFONE_WebUISecret": "webuisalt1router-salt",
+    }
+
+    login_response = MagicMock()
+    login_response.raise_for_status = MagicMock()
+    login_response.json.return_value = {"csrf_token": "csrf-after-login"}
+
+    with patch.object(driver._session, "get", side_effect=[init_response, secret_response]), \
+         patch.object(driver._session, "post", return_value=login_response) as mock_post, \
+         patch("app.drivers.ultrahub7.os.urandom", return_value=fixed_iv):
+        driver.login()
+
+    login_payload = mock_post.call_args.kwargs["data"]
+    encrypted_password_json = login_payload["X_VODAFONE_Password"]
+    encrypted_password = json.loads(encrypted_password_json)
+
+    assert login_payload["__id"] == "7"
+    assert login_payload["csrf_token"] == "csrf-initial"
+    assert encrypted_password["iv"] == base64.b64encode(fixed_iv).decode("ascii")
+    assert encrypted_password["mode"] == "ccm"
+    assert encrypted_password["ts"] == 64
+
+    key = pbkdf2_sha256(b"webuisalt1", b"router-salt")
+    nonce = driver._truncate_iv(fixed_iv, len(driver._password) * 8, 8)
+    decrypted = AESCCM(key, tag_length=8).decrypt(
+        nonce,
+        base64.b64decode(encrypted_password["ct"]),
+        None,
+    )
+
+    assert decrypted == b"admin"
+    assert driver._csrf_token == "csrf-after-login"

--- a/tests/test_vodafone_station_cga.py
+++ b/tests/test_vodafone_station_cga.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from app.analyzer import analyze
 from app.drivers.vodafone_station import VodafoneStationDriver
+from app.drivers.utils import pbkdf2_sha256
 
 
 def _driver_with_cga_payload(payload):
@@ -10,6 +11,39 @@ def _driver_with_cga_payload(payload):
     response = MagicMock()
     response.json.return_value = {"error": "ok", "data": payload}
     return driver, response
+
+
+def test_cga_double_pbkdf2_hash_contract():
+    # Reference vectors generated with hashlib.pbkdf2_hmac("sha256", ...).
+    hash1 = pbkdf2_sha256(b"admin", b"salt-one").hex()
+    hash2 = pbkdf2_sha256(hash1.encode("utf-8"), b"salt-webui").hex()
+
+    assert hash1 == "6b081300747b39b79512fd1953f40054"
+    assert hash2 == "c2b69842ff6750b1e83368f092e4a405"
+
+
+def test_cga_login_posts_double_pbkdf2_hash():
+    driver = VodafoneStationDriver(url="http://dummy", user="admin", password="admin")
+
+    salt_response = MagicMock()
+    salt_response.raise_for_status = MagicMock()
+    salt_response.json.return_value = {"salt": "salt-one", "saltwebui": "salt-webui"}
+
+    login_response = MagicMock()
+    login_response.raise_for_status = MagicMock()
+    login_response.json.return_value = {"error": "ok", "token": "token-123"}
+
+    menu_response = MagicMock(status_code=200)
+
+    with patch.object(driver._session, "post", side_effect=[salt_response, login_response]) as mock_post, \
+         patch.object(driver._session, "get", return_value=menu_response):
+        driver._login_cga()
+
+    assert mock_post.call_args_list[0].kwargs["data"]["password"] == "seeksalthash"
+    assert mock_post.call_args_list[1].kwargs["data"]["password"] == (
+        "c2b69842ff6750b1e83368f092e4a405"
+    )
+    assert driver._cga_token == "token-123"
 
 
 def test_cga_ofdma_upstream_uses_fft_modulation_while_preserving_ofdma_family():

--- a/tests/test_vodafone_station_tg.py
+++ b/tests/test_vodafone_station_tg.py
@@ -2,14 +2,13 @@ import json
 from unittest.mock import patch, MagicMock
 
 import requests
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from app.drivers.vodafone_station import (
     VodafoneStationDriver,
     _aes_ccm_decrypt_hex,
     _aes_ccm_encrypt_hex,
 )
+from app.drivers.utils import pbkdf2_sha256
 
 # ===== Embedded fixture HTML =====
 # Two pages are fetched per call:
@@ -141,6 +140,13 @@ def test_tg_aes_ccm_helpers_match_retained_contract():
     assert _aes_ccm_decrypt_hex(key, nonce, encrypted_hex, b"loginPassword") == plaintext
 
 
+def test_vodafone_pbkdf2_helper_matches_sha256_contract():
+    # Reference vector generated with hashlib.pbkdf2_hmac("sha256", ...).
+    derived = pbkdf2_sha256(b"admin", bytes.fromhex("0011223344556677"))
+
+    assert derived.hex() == "924bdba9893e9331ea0545b8ac2a3099"
+
+
 def test_tg_login_posts_decryptable_aes_ccm_payload_from_cryptography():
     driver = VodafoneStationDriver(url="http://dummy", user="admin", password="admin")
     html = """
@@ -158,13 +164,7 @@ def test_tg_login_posts_decryptable_aes_ccm_payload_from_cryptography():
         text='createCookie("credential", "credential-cookie-value", 1);',
     )
 
-    kdf = PBKDF2HMAC(
-        algorithm=hashes.SHA256(),
-        length=16,
-        salt=bytes.fromhex("0011223344556677"),
-        iterations=1000,
-    )
-    key = kdf.derive(driver._password.encode("utf-8"))
+    key = pbkdf2_sha256(driver._password.encode("utf-8"), bytes.fromhex("0011223344556677"))
     encrypted_nonce = _aes_ccm_encrypt_hex(
         key,
         bytes.fromhex("0102030405060708"),


### PR DESCRIPTION
## Summary

- add a shared stdlib PBKDF2-SHA256 helper for modem-driver authentication
- switch Vodafone Station CGA/TG and UltraHub key derivations to that helper
- keep AES-CCM encryption paths unchanged and add regression coverage for the retained auth contracts

## Tests

- `python -m pytest tests/test_vodafone_station_tg.py tests/test_vodafone_station_cga.py tests/test_ultrahub7_auth.py tests/drivers/test_modulation_normalization.py -q`
- `python -m pytest tests/ -q --ignore=tests/e2e`
- `python -m py_compile app/drivers/vodafone_station.py app/drivers/ultrahub7.py app/drivers/utils.py tests/test_vodafone_station_tg.py tests/test_vodafone_station_cga.py tests/test_ultrahub7_auth.py`
- `git diff --check`

Docs unchanged: no user-facing behavior changes.
