### PR TITLE
Simplify modem driver base class

### DIFF
--- a/app/drivers/base.py
+++ b/app/drivers/base.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-
 from ..types import ConnectionInfo, DeviceInfo, DocsisData
 
 
-class ModemDriver(ABC):
-    """Abstract base class for modem data retrieval.
+class ModemDriver:
+    """Shared initialization and documented API convention for modem drivers.
 
     Each driver manages its own authentication state (SID, cookies, etc.)
-    and exposes a uniform interface for DOCSIS data access.
+    and exposes a uniform interface for DOCSIS data access. The registry loads
+    drivers by configured class path, so concrete driver behavior is validated
+    when the collector calls these methods rather than at class definition time.
     """
 
     def __init__(self, url: str, user: str, password: str):
@@ -19,22 +19,18 @@ class ModemDriver(ABC):
         self._user = user
         self._password = password
 
-    @abstractmethod
     def login(self) -> None:
         """Authenticate with the modem. Called before each poll cycle."""
-        ...
+        raise NotImplementedError("ModemDriver.login")
 
-    @abstractmethod
     def get_docsis_data(self) -> DocsisData:
         """Retrieve raw DOCSIS channel data."""
-        ...
+        raise NotImplementedError("ModemDriver.get_docsis_data")
 
-    @abstractmethod
     def get_device_info(self) -> DeviceInfo:
         """Retrieve device model and firmware info."""
-        ...
+        raise NotImplementedError("ModemDriver.get_device_info")
 
-    @abstractmethod
     def get_connection_info(self) -> ConnectionInfo:
         """Retrieve internet connection info (speeds, type)."""
-        ...
+        raise NotImplementedError("ModemDriver.get_connection_info")

--- a/tests/collectors/test_base.py
+++ b/tests/collectors/test_base.py
@@ -119,13 +119,28 @@ class TestCollectorABC:
         assert c.should_poll() is True
 
 
-# ── ModemDriver ABC Tests ──
+# ── ModemDriver Base-Class Tests ──
 
 
-class TestModemDriverABC:
-    def test_cannot_instantiate_abc(self):
-        with pytest.raises(TypeError):
-            ModemDriver("http://modem", "user", "pass")
+class TestModemDriverBase:
+    def test_base_driver_stores_credentials(self):
+        driver = ModemDriver("http://modem", "user", "pass")
+
+        assert driver._url == "http://modem"
+        assert driver._user == "user"
+        assert driver._password == "pass"
+
+    def test_base_methods_document_required_driver_api(self):
+        driver = ModemDriver("http://modem", "user", "pass")
+
+        for method_name in (
+            "login",
+            "get_docsis_data",
+            "get_device_info",
+            "get_connection_info",
+        ):
+            with pytest.raises(NotImplementedError, match=f"ModemDriver\\.{method_name}"):
+                getattr(driver, method_name)()
 
     def test_concrete_driver_stores_credentials(self):
         class DummyDriver(ModemDriver):


### PR DESCRIPTION
## Summary

- remove ABC/abstractmethod wiring from the modem driver base class
- keep shared credential initialization and explicit NotImplementedError method stubs for the documented driver API
- update base-class tests to cover the retained convention

## Tests

- `python -m pytest tests/collectors/test_base.py tests/test_driver_registry.py tests/collectors/test_builtin_drivers.py -q`
- `python -m pytest tests/ -q --ignore=tests/e2e`
- `python -m py_compile app/drivers/base.py tests/collectors/test_base.py tests/test_driver_registry.py`
- `git diff --check`

Docs unchanged: no user-facing behavior changes.
