### PR TITLE
Simplify collector base types

### DIFF
--- a/app/collectors/base.py
+++ b/app/collectors/base.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -24,19 +23,8 @@ class CollectorResult:
     error: str | None = None
     timestamp: float = field(default_factory=time.time)
 
-    @classmethod
-    def ok(cls, source: str, data: Any) -> "CollectorResult":
-        """Create a successful result."""
-        return cls(source=source, data=data, success=True)
-
-    @classmethod
-    def failure(cls, source: str, error: str) -> "CollectorResult":
-        """Create a failed result."""
-        return cls(source=source, success=False, error=error)
-
-
-class Collector(ABC):
-    """Abstract base class for all data collectors.
+class Collector:
+    """Base class for data collectors.
 
     Provides timestamp-based scheduling and fail-safe penalty tracking
     for consecutive failures with automatic recovery.
@@ -54,15 +42,13 @@ class Collector(ABC):
         self._collect_lock = threading.Lock()   # prevents concurrent collect()
 
     @property
-    @abstractmethod
     def name(self) -> str:
         """Unique identifier for this collector."""
-        ...
+        raise NotImplementedError("Collector.name")
 
-    @abstractmethod
     def collect(self) -> CollectorResult:
         """Run a single data collection cycle."""
-        ...
+        raise NotImplementedError("Collector.collect")
 
     def is_enabled(self) -> bool:
         """Override to conditionally disable this collector."""

--- a/app/collectors/segment_utilization.py
+++ b/app/collectors/segment_utilization.py
@@ -49,7 +49,7 @@ class SegmentUtilizationCollector(Collector):
                 self._config.get("modem_password"),
             )
         except Exception as e:
-            return CollectorResult.failure(self.name, str(e))
+            return CollectorResult(source=self.name, success=False, error=str(e))
 
         try:
             resp = requests.get(
@@ -59,7 +59,7 @@ class SegmentUtilizationCollector(Collector):
             )
             resp.raise_for_status()
         except Exception as e:
-            return CollectorResult.failure(self.name, f"API request failed: {e}")
+            return CollectorResult(source=self.name, success=False, error=f"API request failed: {e}")
 
         try:
             body = resp.json()
@@ -97,12 +97,12 @@ class SegmentUtilizationCollector(Collector):
 
             self._run_maintenance()
 
-            return CollectorResult.ok(
-                self.name,
-                {"ds_total": ds_total, "us_total": us_total, "ds_own": ds_own, "us_own": us_own},
+            return CollectorResult(
+                source=self.name,
+                data={"ds_total": ds_total, "us_total": us_total, "ds_own": ds_own, "us_own": us_own},
             )
         except Exception as e:
-            return CollectorResult.failure(self.name, f"Parse failed: {e}")
+            return CollectorResult(source=self.name, success=False, error=f"Parse failed: {e}")
 
     def _run_maintenance(self):
         """Run downsample + cleanup once per day."""

--- a/app/modules/backup/collector.py
+++ b/app/modules/backup/collector.py
@@ -72,7 +72,7 @@ class BackupCollector(Collector):
             filename = create_backup_to_file(data_dir, backup_path)
             cleanup_old_backups(backup_path, keep=retention)
             log.info("Scheduled backup created: %s", filename)
-            return CollectorResult.ok(self.name, {"filename": filename})
+            return CollectorResult(source=self.name, data={"filename": filename})
         except Exception as e:
             log.error("Scheduled backup failed: %s", e)
-            return CollectorResult.failure(self.name, str(e))
+            return CollectorResult(source=self.name, success=False, error=str(e))

--- a/app/modules/bnetz/collector.py
+++ b/app/modules/bnetz/collector.py
@@ -33,8 +33,10 @@ class BnetzWatcherCollector(Collector):
         watch_dir = self._config_mgr.get("bnetz_watch_dir", "/data/bnetz")
 
         if not os.path.isdir(watch_dir):
-            return CollectorResult.failure(
-                self.name, f"Watch directory does not exist: {watch_dir}"
+            return CollectorResult(
+                source=self.name,
+                success=False,
+                error=f"Watch directory does not exist: {watch_dir}",
             )
 
         # Read set of already-imported filenames
@@ -50,7 +52,7 @@ class BnetzWatcherCollector(Collector):
 
         if not new_files:
             self._last_import_count = 0
-            return CollectorResult.ok(self.name, data={"imported": 0, "errors": 0})
+            return CollectorResult(source=self.name, data={"imported": 0, "errors": 0})
 
         imported_count = 0
         error_count = 0
@@ -88,13 +90,14 @@ class BnetzWatcherCollector(Collector):
         )
 
         if error_count > 0 and imported_count == 0:
-            return CollectorResult.failure(
-                self.name,
-                f"All {error_count} file(s) failed to import",
+            return CollectorResult(
+                source=self.name,
+                success=False,
+                error=f"All {error_count} file(s) failed to import",
             )
 
-        return CollectorResult.ok(
-            self.name, data={"imported": imported_count, "errors": error_count}
+        return CollectorResult(
+            source=self.name, data={"imported": imported_count, "errors": error_count}
         )
 
     def _import_pdf(self, fpath):

--- a/app/modules/bqm/collector.py
+++ b/app/modules/bqm/collector.py
@@ -64,9 +64,9 @@ class BQMCollector(Collector):
         meta = self._storage.get_collection_metadata()
         if meta.get("last_success_target_date") == target_date:
             self._last_date = today
-            return CollectorResult.ok(
-                self.name,
-                {"skipped": True, "reason": "already_collected", "date": target_date},
+            return CollectorResult(
+                source=self.name,
+                data={"skipped": True, "reason": "already_collected", "date": target_date},
             )
 
         bqm_url = self._config_mgr.get("bqm_url") or ""
@@ -82,10 +82,18 @@ class BQMCollector(Collector):
         try:
             content = fetch_share_csv(share_id, variant="y")
             if not content:
-                return CollectorResult.failure(self.name, "Failed to download BQM CSV")
+                return CollectorResult(
+                    source=self.name,
+                    success=False,
+                    error="Failed to download BQM CSV",
+                )
             rows = parse_bqm_csv(content)
             if not rows:
-                return CollectorResult.failure(self.name, "BQM CSV contained no valid rows")
+                return CollectorResult(
+                    source=self.name,
+                    success=False,
+                    error="BQM CSV contained no valid rows",
+                )
             self._storage.store_csv_data(rows)
             dates = sorted({row["date"] for row in rows})
             graph_date = dates[-1]
@@ -96,11 +104,21 @@ class BQMCollector(Collector):
                 rows=len(rows),
             )
             self._last_date = today
-            return CollectorResult.ok(self.name, {"rows": len(rows), "date": graph_date})
+            return CollectorResult(
+                source=self.name, data={"rows": len(rows), "date": graph_date}
+            )
         except ThinkBroadbandBatchAbort as exc:
-            return CollectorResult.failure(self.name, f"ThinkBroadband batch aborted: {exc}")
+            return CollectorResult(
+                source=self.name,
+                success=False,
+                error=f"ThinkBroadband batch aborted: {exc}",
+            )
         except ValueError as exc:
-            return CollectorResult.failure(self.name, f"Invalid BQM CSV: {exc}")
+            return CollectorResult(
+                source=self.name,
+                success=False,
+                error=f"Invalid BQM CSV: {exc}",
+            )
 
     def _collect_png(self, url):
         """Legacy PNG collection: fetch graph image and store it for the daily target."""
@@ -116,5 +134,9 @@ class BQMCollector(Collector):
                 rows=1,
             )
             self._last_date = today
-            return CollectorResult.ok(self.name, {"date": graph_date, "mode": "png"})
-        return CollectorResult.failure(self.name, "Failed to fetch BQM graph")
+            return CollectorResult(
+                source=self.name, data={"date": graph_date, "mode": "png"}
+            )
+        return CollectorResult(
+            source=self.name, success=False, error="Failed to fetch BQM graph"
+        )

--- a/app/modules/connection_monitor/collector.py
+++ b/app/modules/connection_monitor/collector.py
@@ -68,7 +68,7 @@ class ConnectionMonitorCollector(Collector):
                 t for t in self._cm_storage.get_targets() if t["enabled"]
             ]
             if not targets:
-                return CollectorResult.ok(self.name, None)
+                return CollectorResult(source=self.name)
 
             # Determine which targets are due
             now = time.time()
@@ -80,7 +80,7 @@ class ConnectionMonitorCollector(Collector):
                     due.append(t)
 
             if not due:
-                return CollectorResult.ok(self.name, None)
+                return CollectorResult(source=self.name)
 
             # Probe all due targets in parallel
             samples = self._probe_targets(due, now)
@@ -102,10 +102,10 @@ class ConnectionMonitorCollector(Collector):
                 self._cm_storage.cleanup_traces(retention)
                 self._last_cleanup = now
 
-            return CollectorResult.ok(self.name, {"probed": len(due)})
+            return CollectorResult(source=self.name, data={"probed": len(due)})
         except Exception as exc:
             logger.exception("Connection Monitor collect error")
-            return CollectorResult.failure(self.name, str(exc))
+            return CollectorResult(source=self.name, success=False, error=str(exc))
 
     def _probe_targets(self, targets: list[dict], now: float) -> list[dict]:
         """Probe targets in parallel and return sample dicts."""

--- a/app/modules/speedtest/collector.py
+++ b/app/modules/speedtest/collector.py
@@ -47,7 +47,7 @@ class SpeedtestCollector(Collector):
         results, error = self._client.get_latest_with_error(1)
         if error:
             log.warning("Speedtest fetch failed: %s", error)
-            return CollectorResult.failure(self.name, f"Speedtest Tracker: {error}")
+            return CollectorResult(source=self.name, success=False, error=f"Speedtest Tracker: {error}")
         if results:
             self._web.update_state(speedtest_latest=results[0])
 

--- a/tests/collectors/test_base.py
+++ b/tests/collectors/test_base.py
@@ -33,7 +33,7 @@ class TestCollectorResult:
         assert r.error == "timeout"
 
 
-# ── Collector ABC Tests ──
+# ── Collector Base Tests ──
 
 
 class ConcreteCollector(Collector):
@@ -48,10 +48,18 @@ class ConcreteCollector(Collector):
         return CollectorResult(source=self.name)
 
 
-class TestCollectorABC:
-    def test_cannot_instantiate_abc(self):
-        with pytest.raises(TypeError):
-            Collector(60)
+class TestCollectorBase:
+    def test_base_collector_stores_schedule_state(self):
+        c = Collector(60)
+        assert c.poll_interval_seconds == 60
+        assert c.is_enabled() is True
+
+    def test_base_methods_document_required_collector_api(self):
+        c = Collector(60)
+        with pytest.raises(NotImplementedError, match=r"Collector\.name"):
+            _ = c.name
+        with pytest.raises(NotImplementedError, match=r"Collector\.collect"):
+            c.collect()
 
     def test_initial_state(self):
         c = ConcreteCollector(120)

--- a/tests/collectors/test_external_collectors.py
+++ b/tests/collectors/test_external_collectors.py
@@ -335,7 +335,7 @@ class TestBQMCollector:
 
     @patch("app.modules.bqm.collector.BQMCollector._collect_png")
     def test_collect_png_url_delegates(self, mock_png):
-        mock_png.return_value = CollectorResult.ok("bqm", {"mode": "png"})
+        mock_png.return_value = CollectorResult(source="bqm", data={"mode": "png"})
         c, _, storage = self._make_collector(bqm_url="https://www.thinkbroadband.com/share/abc.png")
         result = c.collect()
         assert result.data.get("mode") == "png"

--- a/tests/module_loader/test_loading_core.py
+++ b/tests/module_loader/test_loading_core.py
@@ -292,7 +292,7 @@ from app.collectors.base import Collector, CollectorResult
 class TestCollector(Collector):
     name = "test_collector"
     def collect(self):
-        return CollectorResult.ok("test", {})
+        return CollectorResult(source="test", data={})
 """)
             cls = load_module_collector("test.mod", mod_dir, "collector.py:TestCollector")
             assert cls is not None


### PR DESCRIPTION
## Summary
- simplify the collector base class by removing abstract-class ceremony while preserving shared scheduling/backoff behavior
- use direct `CollectorResult(...)` dataclass construction across collector implementations
- update collector tests for the retained base-class and result contracts

## Checks
- `168 passed` — focused collector/module-loader tests
- `2629 passed, 1 skipped, 2 warnings` — full non-E2E test suite
- `py_compile` on touched Python files
- `git diff --check`

Documentation was not changed because this preserves runtime/user-facing behavior.
