### PR TITLE
Remove unused collector registry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -757,30 +757,20 @@ class MyCollector(Collector):
             # Store results
             self._storage.save_my_data(data)
             
-            return CollectorResult.ok(self.name, data)
+            return CollectorResult(source=self.name, data=data)
         except Exception as e:
-            return CollectorResult.failure(self.name, str(e))
+            return CollectorResult(source=self.name, success=False, error=str(e))
     
     def is_enabled(self) -> bool:
         # Check if configured
         return bool(self._config.get("my_source_url"))
 ```
 
-2. **Register in discovery:**
+2. **Add it to discovery:**
 
 ```python
 # app/collectors/__init__.py
 from .my_collector import MyCollector
-
-COLLECTOR_REGISTRY = {
-    "modem": ModemCollector,
-    "demo": DemoCollector,
-    "speedtest": SpeedtestCollector,
-    "bqm": BQMCollector,
-    "bnetz_watcher": BnetzWatcherCollector,
-    "backup": BackupCollector,
-    "my_source": MyCollector,  # Add here
-}
 
 def discover_collectors(...):
     collectors = []

--- a/app/collectors/__init__.py
+++ b/app/collectors/__init__.py
@@ -1,7 +1,7 @@
-"""Collector registry and discovery.
+"""Collector discovery.
 
-Provides a registry-based pattern for discovering and instantiating
-data collectors based on runtime configuration.
+Instantiates core collectors from runtime configuration and adds collector
+contributions from enabled modules.
 """
 
 import logging
@@ -41,12 +41,6 @@ class _ModuleConfigProxy:
     @property
     def data_dir(self):
         return self._cfg.data_dir
-
-# Registry maps collector name -> class
-COLLECTOR_REGISTRY = {
-    "modem": ModemCollector,
-    "demo": DemoCollector,
-}
 
 
 def discover_collectors(config_mgr, storage, event_detector, mqtt_pub, web, analyzer, notifier=None, smart_capture=None):
@@ -144,7 +138,6 @@ def discover_collectors(config_mgr, storage, event_detector, mqtt_pub, web, anal
 __all__ = [
     "Collector",
     "CollectorResult",
-    "COLLECTOR_REGISTRY",
     "discover_collectors",
     "ModemCollector",
     "DemoCollector",

--- a/tests/collectors/test_discovery_orchestrator.py
+++ b/tests/collectors/test_discovery_orchestrator.py
@@ -19,6 +19,11 @@ from app.drivers.ch7465_play import CH7465PlayDriver
 
 
 class TestDiscoverCollectors:
+    def test_collector_registry_is_not_exported(self):
+        import app.collectors as collectors
+
+        assert not hasattr(collectors, "COLLECTOR_REGISTRY")
+
     def _make_storage(self, tmp_path=None):
         import tempfile, os
         s = MagicMock()


### PR DESCRIPTION
## Summary
- remove the unused collector registry export
- keep collector discovery behavior on the existing direct core/module discovery path
- update architecture guidance for collector discovery and result construction

## Checks
- `89 passed` — focused collector/module-loader/security tests
- `2630 passed, 1 skipped, 2 warnings` — full non-E2E test suite
- `py_compile` on touched Python files
- `git diff --check`
