### PR TITLE
Share modulation parsing helpers

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -7,9 +7,9 @@ community threshold profiles loaded through the module system.
 from __future__ import annotations
 
 import logging
-import re
 from typing import Literal
 
+from .docsis_utils import parse_qam_order as _parse_qam_order
 from .types import AnalysisResult, DocsisData, SignalFamilyHealthCause
 from .tz import utc_now, _parse_utc
 
@@ -391,19 +391,6 @@ def apply_spike_suppression(analysis: AnalysisResult, last_spike_ts: str | None)
     }
 
     _recalculate_summary_health(summary)
-
-
-def _parse_qam_order(modulation_str):
-    """Extract QAM order from modulation string. Returns None if unparseable."""
-    if not modulation_str:
-        return None
-    mod = modulation_str.upper().replace("-", "").strip()
-    if mod in ("QPSK",):
-        return 4
-    m = re.match(r"(\d+)\s*QAM", mod)
-    if m:
-        return int(m.group(1))
-    return None
 
 
 # EuroDOCSIS default symbol rate (kSym/s)

--- a/app/docsis_utils.py
+++ b/app/docsis_utils.py
@@ -1,4 +1,6 @@
-"""Shared DOCSIS utilities — QAM hierarchy and modulation ranking."""
+"""Shared DOCSIS utilities — QAM parsing, hierarchy, and modulation labels."""
+
+from __future__ import annotations
 
 import re
 
@@ -18,6 +20,45 @@ QAM_ORDER = {
 }
 
 
+_QAM_RE = re.compile(r"(?:(\d+)\s*QAM|QAM\s*(\d+))")
+
+
+def parse_qam_order(modulation: object) -> int | None:
+    """Extract numeric QAM order from a modulation value.
+
+    Returns ``None`` for non-QAM values such as OFDM/OFDMA or unknown strings.
+    ``QPSK`` is treated as 4-QAM because both carry two bits per symbol in the
+    analyzer and modulation statistics.
+    """
+    if not modulation:
+        return None
+
+    mod = str(modulation).upper().replace("-", "").replace("_", "").strip()
+    if mod == "QPSK":
+        return 4
+
+    match = _QAM_RE.fullmatch(mod)
+    if not match:
+        return None
+    return int(match.group(1) or match.group(2))
+
+
+def canonical_modulation_label(modulation: object) -> tuple[str, int | None]:
+    """Return a display label and numeric QAM order for a modulation value."""
+    if not modulation:
+        return ("Unknown", None)
+
+    raw = str(modulation).upper().replace("-", "").strip()
+    qam_order = parse_qam_order(modulation)
+    if qam_order is not None:
+        return (f"{qam_order}QAM", qam_order)
+
+    if raw in ("OFDM", "OFDMA"):
+        return (raw, None)
+
+    return ("Unknown", None)
+
+
 def qam_rank(modulation):
     """Get QAM rank for any modulation format.
 
@@ -26,15 +67,7 @@ def qam_rank(modulation):
 
     Returns 0 for unknown/empty modulation.
     """
-    if not modulation:
+    qam_order = parse_qam_order(modulation)
+    if qam_order is None:
         return 0
-    rank = QAM_ORDER.get(modulation)
-    if rank is not None:
-        return rank
-    mod = modulation.upper().replace("-", "").replace("_", "")
-    if mod == "QPSK":
-        return QAM_ORDER["QPSK"]
-    m = re.search(r"(\d+)", mod)
-    if m and "QAM" in mod:
-        return QAM_ORDER.get(f"{m.group(1)}QAM", 0)
-    return 0
+    return QAM_ORDER.get(f"{qam_order}QAM", 0)

--- a/app/drivers/cgm4981.py
+++ b/app/drivers/cgm4981.py
@@ -40,6 +40,7 @@ import re
 import requests
 
 from .base import ModemDriver
+from ..docsis_utils import parse_qam_order
 from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
 
 log = logging.getLogger("docsis.driver.cgm4981")
@@ -125,9 +126,9 @@ def _modulation(raw: str) -> str:
     if "OFDM" in up:
         return "OFDM"
     # '256 QAM' → '256QAM', '64 QAM' → '64QAM', etc.
-    m = re.search(r"(\d+)\s*QAM", up)
-    if m:
-        return f"{m.group(1)}QAM"
+    qam_order = parse_qam_order(up)
+    if qam_order is not None:
+        return f"{qam_order}QAM"
     if "QAM" in up:
         return "QAM"
     return raw.strip()

--- a/app/modules/modulation/engine.py
+++ b/app/modules/modulation/engine.py
@@ -5,10 +5,13 @@ multi-day overview distribution, and intraday per-channel timeline.
 """
 
 import math
-import re
 from datetime import datetime
 from collections import defaultdict
 
+from app.docsis_utils import (
+    canonical_modulation_label as _canonical_label,
+    parse_qam_order as _parse_qam_order,
+)
 from app.tz import to_local
 
 
@@ -31,46 +34,6 @@ DISCLAIMER = (
 
 
 # ── Parsing helpers ──────────────────────────────────────────────────
-
-
-def _parse_qam_order(modulation_str):
-    """Extract QAM order from modulation string. Returns None if unparseable.
-
-    Mirrors app.analyzer._parse_qam_order but kept local to avoid circular imports.
-    """
-    if not modulation_str:
-        return None
-    mod = modulation_str.upper().replace("-", "").strip()
-    if mod in ("QPSK",):
-        return 4
-    m = re.match(r"(\d+)\s{0,5}QAM", mod)
-    if m:
-        return int(m.group(1))
-    return None
-
-
-def _canonical_label(modulation_str):
-    """Return a canonical display label for a modulation string.
-
-    Returns (label, qam_order_or_none).
-    - Known QAM → ("64QAM", 64)
-    - QPSK/4QAM → ("4QAM", 4)
-    - OFDM/OFDMA → ("OFDM"/"OFDMA", None)
-    - Unknown → ("Unknown", None)
-    """
-    if not modulation_str:
-        return ("Unknown", None)
-    raw = modulation_str.upper().replace("-", "").strip()
-
-    qam = _parse_qam_order(modulation_str)
-    if qam is not None:
-        return (f"{qam}QAM", qam)
-
-    if raw in ("OFDM", "OFDMA"):
-        return (raw, None)
-
-    return ("Unknown", None)
-
 
 def _channel_modulation(ch):
     """Return the modulation value to use for modulation analytics."""

--- a/app/prometheus.py
+++ b/app/prometheus.py
@@ -5,7 +5,7 @@ Pure function -- no Flask dependency, no side effects.
 
 from __future__ import annotations
 
-from .analyzer import _parse_qam_order
+from .docsis_utils import parse_qam_order as _parse_qam_order
 from .types import AnalysisResult, ConnectionInfo, DeviceInfo
 
 # Health string to numeric mapping

--- a/tests/test_docsis_utils.py
+++ b/tests/test_docsis_utils.py
@@ -1,0 +1,59 @@
+"""Shared DOCSIS modulation utility contracts."""
+
+import pytest
+
+from app.docsis_utils import canonical_modulation_label, parse_qam_order, qam_rank
+
+
+@pytest.mark.parametrize(
+    ("value", "order"),
+    [
+        ("QPSK", 4),
+        ("qpsk", 4),
+        ("4QAM", 4),
+        ("8QAM", 8),
+        ("16 QAM", 16),
+        ("64-QAM", 64),
+        ("256QAM", 256),
+        ("qam_256", 256),
+        ("QAM1024", 1024),
+    ],
+)
+def test_parse_qam_order_supported_driver_formats(value, order):
+    assert parse_qam_order(value) == order
+
+
+@pytest.mark.parametrize("value", [None, "", "OFDM", "OFDMA", "SC-QAM", "unknown", "profile 256QAM"])
+def test_parse_qam_order_unparseable_values(value):
+    assert parse_qam_order(value) is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("QPSK", ("4QAM", 4)),
+        ("256-QAM", ("256QAM", 256)),
+        ("qam_256", ("256QAM", 256)),
+        ("OFDM", ("OFDM", None)),
+        ("OFDMA", ("OFDMA", None)),
+        ("", ("Unknown", None)),
+    ],
+)
+def test_canonical_modulation_label(value, expected):
+    assert canonical_modulation_label(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "rank"),
+    [
+        ("QPSK", 1),
+        ("4QAM", 1),
+        ("16QAM", 3),
+        ("64-QAM", 5),
+        ("qam_256", 7),
+        ("4096QAM", 11),
+        ("OFDMA", 0),
+    ],
+)
+def test_qam_rank_uses_shared_parser(value, rank):
+    assert qam_rank(value) == rank

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -678,8 +678,8 @@ class TestEdgeCases:
         has_flask_import = bool(re.search(r"^(import flask|from flask)", source, re.MULTILINE | re.IGNORECASE))
         assert not has_flask_import, "prometheus.py must not contain Flask imports"
 
-    def test_reuses_parse_qam_order_from_analyzer(self):
-        """prometheus.py must import _parse_qam_order from app.analyzer."""
+    def test_reuses_shared_parse_qam_order_helper(self):
+        """prometheus.py must import QAM parsing from shared DOCSIS utilities."""
         import importlib.util
         import pathlib
 
@@ -687,8 +687,8 @@ class TestEdgeCases:
         assert spec is not None, "app.prometheus module not found"
         source_path = pathlib.Path(spec.origin)
         source = source_path.read_text(encoding="utf-8")
-        assert "_parse_qam_order" in source
-        assert "analyzer" in source
+        assert "parse_qam_order" in source
+        assert "docsis_utils" in source
 
     def test_realistic_full_data_produces_valid_prometheus_text(self):
         """Integration test: full realistic data must produce parseable Prometheus format."""


### PR DESCRIPTION
## Summary
- add shared DOCSIS modulation helpers for QAM order parsing, canonical labels, and rank lookup
- route analyzer, modulation analytics, Prometheus, and CGM4981 normalization through the shared helper path
- keep existing private helper aliases where tests and internal call sites already use them

## Compatibility
- existing analyzer and modulation behavior is preserved for QPSK, QAM, OFDM, OFDMA, and common hyphen/space/case variants
- `qam_256` and `QAM1024` driver-style values are covered by the shared parser
- no user-facing workflow or documentation change is required

## Checks
- `528 passed` — focused analyzer/modulation/prometheus/events/web/smart-capture tests
- `542 passed` — focused suite plus CGM4981 driver coverage
- `2662 passed, 1 skipped, 2 warnings` — full non-E2E test suite
- `py_compile` on touched Python files
- `git diff --check`
- runtime parser duplication scan: no remaining local QAM parser definitions in `app/`
