### PR TITLE
Clarify signal-family KPI status drivers

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -529,6 +529,65 @@ def _distinct_modulation_healths(channels, *, prefer_profile=False):
     ]
 
 
+def _family_health_counts(channels):
+    """Count composite channel health states for one signal family."""
+    counts = {"good": 0, "tolerated": 0, "warning": 0, "critical": 0}
+    for channel in channels:
+        health = channel.get("health") or "good"
+        if health in counts:
+            counts[health] += 1
+    return counts
+
+
+def _driver_value(channel, cause: SignalFamilyHealthCause, *, prefer_profile=False):
+    if cause == "power":
+        return channel.get("power"), "dBmV"
+    if cause in {"snr", "mer"}:
+        return channel.get("snr"), "dB"
+    value = _channel_modulation_value(channel, prefer_profile=prefer_profile)
+    return (str(value) if value else None), None
+
+
+def _driver_health(channel, cause: SignalFamilyHealthCause):
+    if cause == "power":
+        return channel.get("power_health", "good") if channel.get("power") is not None else "missing"
+    if cause in {"snr", "mer"}:
+        return channel.get("snr_health", "good") if channel.get("snr") is not None else "missing"
+    return channel.get("modulation_health", "good")
+
+
+def _family_health_driver(family, channels, *, direction, cause, family_health, prefer_profile=False):
+    """Return the channel/dimension that explains a family's worst status."""
+    if not cause or family_health in {"good", "missing"}:
+        return None
+
+    candidates = []
+    for channel in channels:
+        value, unit = _driver_value(channel, cause, prefer_profile=prefer_profile)
+        if value is None:
+            continue
+        health = _driver_health(channel, cause)
+        if health == "missing":
+            continue
+        candidates.append({
+            "channel_id": channel.get("channel_id"),
+            "dimension": cause,
+            "family": family,
+            "direction": direction,
+            "health": health,
+            "unit": unit,
+            "value": value,
+        })
+
+    if not candidates:
+        return None
+
+    matching_family_health = [candidate for candidate in candidates if candidate["health"] == family_health]
+    if matching_family_health:
+        return matching_family_health[0]
+    return max(candidates, key=lambda candidate: _HEALTH_RANK.get(candidate["health"], 0))
+
+
 def _channel_text(channel, *keys):
     return " ".join(str(channel.get(key, "") or "") for key in keys).upper().replace("-", "")
 
@@ -636,6 +695,15 @@ def _family_summary(family, channels, *, direction):
         "count": len(channels),
         "health": family_health,
         "health_cause": health_cause,
+        "health_counts": _family_health_counts(channels),
+        "health_driver": _family_health_driver(
+            family,
+            channels,
+            direction=direction,
+            cause=health_cause,
+            family_health=family_health,
+            prefer_profile=prefer_profile,
+        ),
         "power": {**power, "health": power_health},
         "modulation": {
             "available": bool(modulation_values),

--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Причина",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Ср.",
   "metric_active_channel_singular": "активен канал",

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Příčina",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Prům.",
   "metric_active_channel_singular": "aktivní kanál",

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Årsag",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Gns.",
   "metric_active_channel_singular": "aktiv kanal",

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Auslöser",
   "signal_family_unavailable": "Nicht verfügbar",
   "metric_average_label": "Ø",
   "metric_active_channel_singular": "aktiver Kanal",

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Αιτία",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Μ.Ο.",
   "metric_active_channel_singular": "ενεργό κανάλι",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Driving",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Avg",
   "metric_active_channel_singular": "active channel",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1052,6 +1052,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Causa",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Prom.",
   "metric_active_channel_singular": "canal activo",

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Põhjus",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Kesk.",
   "metric_active_channel_singular": "aktiivne kanal",

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Syy",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Keskiarvo",
   "metric_active_channel_singular": "aktiivinen kanava",

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -1049,6 +1049,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Cause",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Moy.",
   "metric_active_channel_singular": "canal actif",

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Cúis",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Meán",
   "metric_active_channel_singular": "cainéal gníomhach",

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Uzrok",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Prosj.",
   "metric_active_channel_singular": "aktivan kanal",

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Ok",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Átl.",
   "metric_active_channel_singular": "aktív csatorna",

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Causa",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Media",
   "metric_active_channel_singular": "canale attivo",

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Priežastis",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Vid.",
   "metric_active_channel_singular": "aktyvus kanalas",

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Iemesls",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Vid.",
   "metric_active_channel_singular": "aktīvs kanāls",

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Årsak",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Snitt",
   "metric_active_channel_singular": "aktiv kanal",

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Oorzaak",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Gem.",
   "metric_active_channel_singular": "actief kanaal",

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Przyczyna",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Śr.",
   "metric_active_channel_singular": "aktywny kanał",

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Causa",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Méd.",
   "metric_active_channel_singular": "canal ativo",

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Cauză",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Med.",
   "metric_active_channel_singular": "canal activ",

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Príčina",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Priem.",
   "metric_active_channel_singular": "aktívny kanál",

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Vzrok",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Povp.",
   "metric_active_channel_singular": "aktiven kanal",

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -1057,6 +1057,7 @@
   "signal_family_metric_snr": "SNR",
   "signal_family_metric_mer": "MER",
   "signal_family_modulation_label": "Modulation",
+  "signal_family_driver_label": "Orsak",
   "signal_family_unavailable": "Unavailable",
   "metric_average_label": "Medel",
   "metric_active_channel_singular": "aktiv kanal",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -815,6 +815,31 @@
                     <span class="badge badge-{{ raw_health }} badge-{{ health_class }}">{{ health_labels.get(raw_health, health_labels.get(health_class, raw_health|title)) }}</span>
                 </span>
             </div>
+            {% set health_counts = family.get('health_counts', {}) %}
+            {% set health_count_total = health_counts.get('good', 0) + health_counts.get('tolerated', 0) + health_counts.get('warning', 0) + health_counts.get('critical', 0) %}
+            {% if health_count_total > 1 %}
+            <div class="metric-sub metric-health-distribution-row">
+                <span class="metric-sub-label">{{ t.get('signal_family_channels_label', t.get('channels', 'Channels')) }}:</span>
+                {% set distribution = namespace(first=true) %}
+                {% for health_key in ['good', 'tolerated', 'warning', 'critical'] %}
+                    {% set count = health_counts.get(health_key, 0) %}
+                    {% if count %}
+                        {% if not distribution.first %}<span class="metric-sub-label metric-health-distribution-separator">·</span>{% endif %}
+                        <span class="range metric-health-count metric-health-count-{{ health_key }}">{{ count }} {{ health_labels.get(health_key, health_key|title) }}</span>
+                        {% set distribution.first = false %}
+                    {% endif %}
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% set health_driver = family.get('health_driver') %}
+            {% if health_driver and health_driver.get('health') not in ['good', 'missing'] %}
+            {% set driver_dimension = health_driver.get('dimension') %}
+            {% set driver_label_key = 'signal_family_metric_' ~ driver_dimension %}
+            <div class="metric-sub metric-health-driver-row">
+                <span class="metric-sub-label">{{ t.get('signal_family_driver_label', 'Driving') }}:</span>
+                <span class="range metric-health-driver-value">{% if health_driver.get('channel_id') is not none %}{{ t.ch_abbr }} {{ health_driver.get('channel_id') }} {% endif %}{{ t.get(driver_label_key, driver_dimension|title) }}{% if health_driver.get('value') is not none %} {{ health_driver.get('value') }}{% if health_driver.get('unit') %} {{ health_driver.get('unit') }}{% endif %}{% endif %}</span>
+            </div>
+            {% endif %}
             {% if modulation.get('value') %}
             <div class="metric-sub metric-modulation-row">
                 <span class="metric-sub-label">{{ t.get('signal_family_modulation_label', 'Modulation') }}:</span>

--- a/app/types.py
+++ b/app/types.py
@@ -170,6 +170,18 @@ class SignalFamilyModulation(TypedDict):
 SignalFamilyHealthCause = Literal["power", "snr", "mer", "modulation"]
 
 
+class SignalFamilyHealthDriver(TypedDict):
+    """Channel/dimension that explains a signal family's worst status."""
+
+    channel_id: int | str | None
+    dimension: SignalFamilyHealthCause
+    family: str
+    direction: str
+    health: str
+    unit: str | None
+    value: float | str | None
+
+
 class SignalFamilySummary(TypedDict, total=False):
     """Summary for one DOCSIS signal family on the Home dashboard."""
 
@@ -177,6 +189,8 @@ class SignalFamilySummary(TypedDict, total=False):
     count: int
     health: str
     health_cause: SignalFamilyHealthCause | None
+    health_counts: dict[str, int]
+    health_driver: SignalFamilyHealthDriver | None
     power: SignalFamilyMetric
     snr: SignalFamilyMetric
     mer: SignalFamilyMetric

--- a/tests/analyzer/test_signal_metrics.py
+++ b/tests/analyzer/test_signal_metrics.py
@@ -575,6 +575,69 @@ class TestSignalFamilySummaries:
         sc_qam = result["summary"]["signal_families"]["downstream"]["families"]["sc_qam"]
         assert sc_qam["health"] == "good"
         assert sc_qam["health_cause"] is None
+        assert sc_qam["health_counts"] == {"good": 1, "tolerated": 0, "warning": 0, "critical": 0}
+        assert sc_qam["health_driver"] is None
+
+    def test_downstream_ofdm_family_counts_and_driver_explain_power_outlier(self):
+        data = _make_data(
+            ds31=[
+                _make_ds31(193, power=9.1, mer="42.0"),
+                {
+                    "channelID": 194,
+                    "frequency": "167 MHz",
+                    "powerLevel": "-7.5",
+                    "modulation": "1024QAM",
+                    "mer": "33.0",
+                },
+            ],
+            us30=[_make_us30(1, power=42.0)],
+        )
+
+        result = analyze(data)
+
+        ofdm = result["summary"]["signal_families"]["downstream"]["families"]["ofdm"]
+        assert ofdm["power"]["avg"] == 0.8
+        assert ofdm["health"] == "critical"
+        assert ofdm["health_cause"] == "power"
+        assert ofdm["health_counts"] == {"good": 1, "tolerated": 0, "warning": 0, "critical": 1}
+        assert ofdm["health_driver"] == {
+            "channel_id": 194,
+            "dimension": "power",
+            "family": "ofdm",
+            "direction": "downstream",
+            "health": "critical",
+            "unit": "dBmV",
+            "value": -7.5,
+        }
+
+    def test_upstream_sc_qam_family_counts_and_driver_explain_modulation_outlier(self):
+        data = _make_data(
+            ds30=[_make_ds30(1, power=2.0, mse="-35")],
+            us30=[
+                _make_us30(1, power=42.0, modulation="16QAM"),
+                _make_us30(2, power=42.0, modulation="16QAM"),
+                _make_us30(3, power=42.0, modulation="16QAM"),
+                _make_us30(4, power=42.0, modulation="QPSK"),
+            ],
+        )
+
+        result = analyze(data)
+
+        sc_qam = result["summary"]["signal_families"]["upstream"]["families"]["sc_qam"]
+        assert sc_qam["power"]["health"] == "good"
+        assert sc_qam["modulation"]["health"] == "critical"
+        assert sc_qam["health"] == "critical"
+        assert sc_qam["health_cause"] == "modulation"
+        assert sc_qam["health_counts"] == {"good": 0, "tolerated": 0, "warning": 3, "critical": 1}
+        assert sc_qam["health_driver"] == {
+            "channel_id": 4,
+            "dimension": "modulation",
+            "family": "sc_qam",
+            "direction": "upstream",
+            "health": "critical",
+            "unit": None,
+            "value": "QPSK",
+        }
 
     def test_downstream_sc_qam_family_health_surfaces_snr_cause(self):
         data = _make_data(
@@ -590,6 +653,15 @@ class TestSignalFamilySummaries:
         assert sc_qam["modulation"]["health"] == "good"
         assert sc_qam["health"] == "critical"
         assert sc_qam["health_cause"] == "snr"
+        assert sc_qam["health_driver"] == {
+            "channel_id": 1,
+            "dimension": "snr",
+            "family": "sc_qam",
+            "direction": "downstream",
+            "health": "critical",
+            "unit": "dB",
+            "value": 25.0,
+        }
 
     def test_downstream_ofdm_family_health_surfaces_mer_cause(self):
         data = _make_data(
@@ -605,6 +677,15 @@ class TestSignalFamilySummaries:
         assert ofdm["modulation"]["health"] == "good"
         assert ofdm["health"] == "critical"
         assert ofdm["health_cause"] == "mer"
+        assert ofdm["health_driver"] == {
+            "channel_id": 100,
+            "dimension": "mer",
+            "family": "ofdm",
+            "direction": "downstream",
+            "health": "critical",
+            "unit": "dB",
+            "value": 35.0,
+        }
 
 
 # -- Upstream bitrate calculation --

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -588,6 +588,57 @@ class TestIndexRoute:
         assert "Modulation" not in status_row
         assert "--metric-range-accent: var(--warn);" in card
 
+    def test_home_signal_family_card_renders_distribution_and_driver_outside_status(self, client, sample_analysis):
+        _add_mixed_signal_families(sample_analysis)
+        sc_qam = sample_analysis["summary"]["signal_families"]["upstream"]["families"]["sc_qam"]
+        sc_qam.update({
+            "count": 4,
+            "health": "critical",
+            "health_cause": "modulation",
+            "health_counts": {"good": 0, "tolerated": 0, "warning": 3, "critical": 1},
+            "health_driver": {
+                "channel_id": 4,
+                "dimension": "modulation",
+                "family": "sc_qam",
+                "direction": "upstream",
+                "health": "critical",
+                "unit": None,
+                "value": "QPSK",
+            },
+        })
+        sc_qam["power"].update({"available": True, "avg": 41.9, "min": 41.2, "max": 42.5, "health": "good"})
+        sc_qam["modulation"].update({
+            "value": "16QAM",
+            "secondary": "QPSK",
+            "distinct": ["16QAM", "QPSK"],
+            "values": [
+                {"value": "16QAM", "health": "warning"},
+                {"value": "QPSK", "health": "critical"},
+            ],
+            "health": "critical",
+        })
+        sample_analysis["summary"]["us_scqam_power_avg"] = 41.9
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        card = _element_by_id(resp.get_data(as_text=True), "metric-us-sc-qam-card")
+        status_row = card[card.index('<div class="metric-sub metric-status-row">'):]
+        status_row = status_row[:status_row.index("</div>")]
+        assert "badge badge-critical" in status_row
+        assert "Driving" not in status_row
+        assert "Channels" not in status_row
+        assert '<div class="metric-sub metric-health-distribution-row">' in card
+        assert "Channels:" in card
+        assert "3 Marginal" in card
+        assert "1 Critical" in card
+        assert '<div class="metric-sub metric-health-driver-row">' in card
+        assert "Driving:" in card
+        assert "Ch 4" in card
+        assert "Modulation" in card
+        assert "QPSK" in card
+
     def test_home_signal_family_modulation_row_shows_plain_label_and_colored_values_without_second_status_pill(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
         ofdma = sample_analysis["summary"]["signal_families"]["upstream"]["families"]["ofdma"]


### PR DESCRIPTION
## Summary
- keep signal-family KPI badges based on the worst detected family condition
- add compact family health distribution context to Home KPI cards
- add a visible driver row that identifies the channel, dimension, and value behind warning or critical states

Fixes #554

## Tests
- `uv run --with-requirements requirements-test.txt python -m pytest tests/analyzer/test_signal_metrics.py -q --tb=short`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/web/test_index.py -q --tb=short`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/test_static_contracts.py -q --tb=short`
- `git diff --check`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt python -m pytest tests --ignore=tests/e2e -q --tb=short`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest tests/e2e -q --tb=short` via file batches: 423/423 passed
