### PR TITLE
Show theoretical channel capacity from modulation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -461,6 +461,7 @@ Variant is auto-detected on first login: CGA is tried first, then TG on failure.
 │    • Load active thresholds from analyzer profile registry   │
 │    • Parse DS/US channels                                    │
 │    • Assess power, SNR, errors per channel                   │
+│    • Estimate SC-QAM gross channel capacity where supported   │
 │    • Aggregate to overall health (good/tolerated/marginal/critical) │
 │    • Return structured analysis dict                         │
 └────────────────────┬─────────────────────────────────────────┘

--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -393,8 +393,11 @@ def apply_spike_suppression(analysis: AnalysisResult, last_spike_ts: str | None)
     _recalculate_summary_health(summary)
 
 
-# EuroDOCSIS default symbol rate (kSym/s)
-_DEFAULT_SYMBOL_RATE = 5120
+# DOCSIS SC-QAM default symbol rates (kSym/s) used when modems omit the
+# symbol-rate field. Upstream commonly uses 5.12 MSym/s channels; downstream
+# EuroDOCSIS 8 MHz channels use ~6.952 MSym/s.
+_DEFAULT_US_SC_QAM_SYMBOL_RATE = 5120
+_DEFAULT_DS_SC_QAM_SYMBOL_RATE = 6952
 
 _BITS_PER_SYMBOL = {
     4: 2,      # QPSK / 4-QAM
@@ -411,16 +414,37 @@ _BITS_PER_SYMBOL = {
 }
 
 
-def _channel_bitrate_mbps(modulation_str, symbol_rate_ksym=None):
-    """Calculate theoretical bitrate for a channel in Mbit/s.
+def _channel_bitrate_mbps(
+    modulation_str,
+    symbol_rate_ksym=None,
+    default_symbol_rate=_DEFAULT_US_SC_QAM_SYMBOL_RATE,
+):
+    """Calculate theoretical gross bitrate for a SC-QAM channel in Mbit/s.
 
-    Returns None if modulation is unparseable (e.g. OFDMA).
+    Returns None if modulation is unparseable (for example OFDM/OFDMA) or no
+    symbol rate/default symbol rate is available.
     """
     qam_order = _parse_qam_order(modulation_str)
     if qam_order is None or qam_order not in _BITS_PER_SYMBOL:
         return None
-    rate = symbol_rate_ksym or _DEFAULT_SYMBOL_RATE
-    return round(rate * _BITS_PER_SYMBOL[qam_order] / 1000, 2)
+    rate = symbol_rate_ksym if symbol_rate_ksym is not None else default_symbol_rate
+    if rate is None:
+        return None
+    return round(float(rate) * _BITS_PER_SYMBOL[qam_order] / 1000, 2)
+
+
+def _capacity_coverage(channels):
+    """Return calculated/unsupported coverage for theoretical channel capacity."""
+    total = len(channels)
+    calculated = sum(
+        1 for ch in channels
+        if ch.get("theoretical_bitrate") is not None
+    )
+    return {
+        "calculated": calculated,
+        "total": total,
+        "unsupported": max(0, total - calculated),
+    }
 
 
 def get_thresholds():
@@ -870,13 +894,19 @@ def analyze(data: DocsisData) -> AnalysisResult:
         snr = abs(_parse_float(ch.get("mse"))) if ch.get("mse") else None
         health, health_detail = _assess_ds_channel(ch, "3.0")
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
-        metric_h["modulation_health"] = _assess_ds_modulation(ch.get("modulation") or ch.get("type", ""), "3.0")
+        ds_modulation = ch.get("modulation") or ch.get("type", "")
+        metric_h["modulation_health"] = _assess_ds_modulation(ds_modulation, "3.0")
         profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
+        bitrate = _channel_bitrate_mbps(
+            ds_modulation,
+            ch.get("symbolRate"),
+            _DEFAULT_DS_SC_QAM_SYMBOL_RATE,
+        )
         channel = {
             "channel_id": _parse_channel_id(ch.get("channelID", 0)),
             "frequency": ch.get("frequency", ""),
             "power": power,
-            "modulation": ch.get("modulation") or ch.get("type", ""),
+            "modulation": ds_modulation,
             "snr": snr,
             "correctable_errors": ch.get("corrErrors"),
             "uncorrectable_errors": ch.get("nonCorrErrors"),
@@ -884,6 +914,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
             "channel_family": "sc_qam",
             "health": health,
             "health_detail": health_detail,
+            "theoretical_bitrate": bitrate,
             **metric_h,
         }
         if profile_modulation:
@@ -909,6 +940,11 @@ def analyze(data: DocsisData) -> AnalysisResult:
         )
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
         metric_h["modulation_health"] = _assess_ds_modulation(ds_modulation, modulation_docsis_ver)
+        bitrate = _channel_bitrate_mbps(
+            ds_modulation,
+            ch.get("symbolRate"),
+            _DEFAULT_DS_SC_QAM_SYMBOL_RATE if channel_family == "sc_qam" else None,
+        )
         channel = {
             "channel_id": _parse_channel_id(ch.get("channelID", 0)),
             "frequency": ch.get("frequency", ""),
@@ -921,6 +957,7 @@ def analyze(data: DocsisData) -> AnalysisResult:
             "channel_family": channel_family,
             "health": health,
             "health_detail": health_detail,
+            "theoretical_bitrate": bitrate,
             **metric_h,
         }
         if profile_modulation:
@@ -936,7 +973,11 @@ def analyze(data: DocsisData) -> AnalysisResult:
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
         metric_h["modulation_health"] = _assess_us_modulation(ch, "3.0")
         mod = ch.get("modulation") or ch.get("type", "")
-        bitrate = _channel_bitrate_mbps(mod, ch.get("symbolRate"))
+        bitrate = _channel_bitrate_mbps(
+            mod,
+            ch.get("symbolRate"),
+            _DEFAULT_US_SC_QAM_SYMBOL_RATE,
+        )
         channel = {
             "channel_id": _parse_channel_id(ch.get("channelID", 0)),
             "frequency": ch.get("frequency", ""),
@@ -958,7 +999,11 @@ def analyze(data: DocsisData) -> AnalysisResult:
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
         metric_h["modulation_health"] = _assess_us_modulation(ch, "3.1")
         mod = ch.get("modulation") or ch.get("type", "")
-        bitrate = _channel_bitrate_mbps(mod, ch.get("symbolRate"))
+        bitrate = _channel_bitrate_mbps(
+            mod,
+            ch.get("symbolRate"),
+            _DEFAULT_US_SC_QAM_SYMBOL_RATE,
+        )
         raw_power = ch.get("powerLevel")
         profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
         channel = {
@@ -1005,8 +1050,14 @@ def analyze(data: DocsisData) -> AnalysisResult:
         else None
     )
 
+    ds_bitrates = [c["theoretical_bitrate"] for c in ds_channels if c.get("theoretical_bitrate") is not None]
+    ds_capacity = round(sum(ds_bitrates), 1) if ds_bitrates else None
     us_bitrates = [c["theoretical_bitrate"] for c in us_channels if c["theoretical_bitrate"] is not None]
     us_capacity = round(sum(us_bitrates), 1) if us_bitrates else None
+    capacity_coverage = {
+        "downstream": _capacity_coverage(ds_channels),
+        "upstream": _capacity_coverage(us_channels),
+    }
 
     signal_families = _build_signal_family_summary(ds_channels, us_channels)
     ds_family_summaries = signal_families["downstream"]["families"]
@@ -1027,7 +1078,9 @@ def analyze(data: DocsisData) -> AnalysisResult:
         "ds_correctable_errors": total_corr,
         "ds_uncorrectable_errors": total_uncorr,
         "errors_supported": has_error_data,
+        "ds_capacity_mbps": ds_capacity,
         "us_capacity_mbps": us_capacity,
+        "capacity_coverage": capacity_coverage,
         "signal_families": signal_families,
         "ds_scqam_power_avg": ds_family_summaries.get("sc_qam", {}).get("power", {}).get("avg"),
         "ds_scqam_snr_avg": ds_family_summaries.get("sc_qam", {}).get("snr", {}).get("avg"),

--- a/app/modules/modulation/i18n/en.json
+++ b/app/modules/modulation/i18n/en.json
@@ -37,5 +37,19 @@
     "glossary_sample_density": "Sample Density: number of polling samples collected for the selected period. More samples mean more accurate statistics.",
     "low_qam_denominator_hint": "Unknown samples stay in the total",
     "low_qam_legend_hint_d31_us": "US DOCSIS 3.1 upstream: 64QAM and below are Low-QAM (red). 128QAM is borderline (amber). 256QAM and above read as healthy.",
-    "low_qam_legend_hint_d30_us": "US DOCSIS 3.0 upstream: 64QAM is the healthy maximum (green). 32QAM is reduced (amber); 16QAM and below are low (red)."
+    "low_qam_legend_hint_d30_us": "US DOCSIS 3.0 upstream: 64QAM is the healthy maximum (green). 32QAM is reduced (amber); 16QAM and below are low (red).",
+    "capacity_short": "Capacity",
+    "capacity_tooltip": "Theoretical Layer-1 gross channel capacity; not usable throughput",
+    "capacity_kicker": "Layer-1 context",
+    "capacity_title": "Theoretical channel capacity (gross)",
+    "capacity_glossary": "Theoretical channel capacity is a Layer-1 gross estimate based on reported channel modulation and symbol rate. It is not guaranteed or currently usable internet throughput.",
+    "capacity_coverage": "Calculated channels",
+    "capacity_tariff": "Tariff",
+    "capacity_status_headroom": "Enough headroom versus tariff",
+    "capacity_status_close": "Close to tariff; watch modulation and bonding",
+    "capacity_status_below": "Below tariff; modulation or bonding may limit throughput",
+    "capacity_status_partial": "Partially calculated; unsupported channels are not included",
+    "capacity_status_calculated": "Calculated without tariff comparison",
+    "capacity_status_unavailable": "Not available from reported channel data",
+    "capacity_disclaimer": "Theoretical Layer-1 gross capacity based on reported channel modulation. Real IP throughput is lower and depends on tariff provisioning, DOCSIS overhead, segment utilization, and other shared-medium conditions."
 }

--- a/app/modules/modulation/static/style.css
+++ b/app/modules/modulation/static/style.css
@@ -55,6 +55,112 @@
     color: var(--text-secondary, var(--muted));
 }
 
+.mod-capacity-panel {
+    padding: var(--space-md, 16px) var(--space-lg, 20px);
+    margin-bottom: var(--space-lg, 20px);
+    background: var(--card-bg, var(--surface));
+    border: 1px solid var(--card-border, var(--glass-border));
+    border-radius: var(--radius-md, 12px);
+}
+
+.mod-capacity-panel-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-md, 16px);
+    margin-bottom: var(--space-md, 16px);
+}
+
+.mod-capacity-panel-head h3 {
+    margin: 2px 0 0;
+    font-size: 1.02em;
+}
+
+.mod-capacity-kicker {
+    color: var(--text-muted, var(--muted));
+    font-size: 0.72em;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.mod-capacity-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-md, 16px);
+}
+
+.mod-capacity-card {
+    display: grid;
+    gap: 8px;
+    padding: var(--space-md, 16px);
+    border-radius: var(--radius-sm, 8px);
+    background: var(--tint-subtle, rgba(255,255,255,0.02));
+    border-left: 3px solid var(--muted, #6b7280);
+}
+
+.mod-capacity-card.mod-capacity-headroom,
+.mod-capacity-card.mod-capacity-calculated {
+    border-left-color: var(--good, #10b981);
+}
+
+.mod-capacity-card.mod-capacity-close,
+.mod-capacity-card.mod-capacity-partial {
+    border-left-color: var(--warn, #f59e0b);
+}
+
+.mod-capacity-card.mod-capacity-below {
+    border-left-color: var(--crit, #ef4444);
+}
+
+.mod-capacity-card-top,
+.mod-capacity-subline {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.mod-capacity-card-top span,
+.mod-capacity-subline span {
+    color: var(--text-secondary, var(--muted));
+    font-size: 0.78em;
+}
+
+.mod-capacity-card-top strong {
+    font-size: 1.28em;
+    font-variant-numeric: tabular-nums;
+}
+
+.mod-capacity-card-top strong span {
+    font-size: 0.68em;
+    color: var(--text-muted, var(--muted));
+}
+
+.mod-capacity-subline strong {
+    font-size: 0.86em;
+    font-variant-numeric: tabular-nums;
+}
+
+.mod-capacity-status {
+    color: var(--text-secondary, var(--muted));
+    font-size: 0.82em;
+    font-weight: 600;
+}
+
+.mod-capacity-disclaimer {
+    margin: var(--space-md, 16px) 0 0;
+    color: var(--text-secondary, var(--muted));
+    font-size: 0.82em;
+    line-height: 1.45;
+}
+
+@media (max-width: 720px) {
+    .mod-capacity-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* KPI value health coloring — uses design system tokens */
 .mod-kpi-item-value.good { color: var(--good, #10b981); }
 .mod-kpi-item-value.warning { color: var(--warn, #f59e0b); }

--- a/app/modules/modulation/templates/modulation_tab.html
+++ b/app/modules/modulation/templates/modulation_tab.html
@@ -47,6 +47,46 @@
             </div>
         </div>
 
+        {% if capacity_context %}
+        <div class="mod-capacity-panel" id="modulation-capacity-panel">
+            <div class="mod-capacity-panel-head">
+                <div>
+                    <div class="mod-capacity-kicker">{{ t.get('docsight.modulation.capacity_kicker', 'Layer-1 context') }}</div>
+                    <h3>{{ t.get('docsight.modulation.capacity_title', 'Theoretical channel capacity (gross)') }}</h3>
+                </div>
+                {% if t.get('docsight.modulation.capacity_glossary') %}
+                <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.get('docsight.modulation.capacity_glossary') }}</div></span>
+                {% endif %}
+            </div>
+            <div class="mod-capacity-grid">
+                {% for cap in [capacity_context.downstream, capacity_context.upstream] %}
+                {% set cap_label = t.get('docsight.modulation.downstream', 'Downstream') if cap.direction == 'downstream' else t.get('docsight.modulation.upstream', 'Upstream') %}
+                {% set cap_status_label = t.get('docsight.modulation.capacity_status_' ~ cap.status, cap.status|replace('_', ' ')|title) %}
+                <div class="mod-capacity-card mod-capacity-{{ cap.status }}">
+                    <div class="mod-capacity-card-top">
+                        <span>{{ cap_label }}</span>
+                        <strong>{% if cap.capacity_mbps is not none %}{{ cap.capacity_mbps|round(1) }} <span>Mbit/s</span>{% else %}—{% endif %}</strong>
+                    </div>
+                    <div class="mod-capacity-subline">
+                        <span>{{ t.get('docsight.modulation.capacity_coverage', 'Calculated channels') }}</span>
+                        <strong>{{ cap.calculated }} / {{ cap.total }}</strong>
+                    </div>
+                    {% if cap.tariff_mbps %}
+                    <div class="mod-capacity-subline">
+                        <span>{{ t.get('docsight.modulation.capacity_tariff', 'Tariff') }}</span>
+                        <strong>{{ cap.tariff_mbps|round(0)|int }} Mbit/s{% if cap.ratio %} · {{ cap.ratio }}×{% endif %}</strong>
+                    </div>
+                    {% endif %}
+                    <div class="mod-capacity-status">{{ cap_status_label }}</div>
+                </div>
+                {% endfor %}
+            </div>
+            <p class="mod-capacity-disclaimer">
+                {{ t.get('docsight.modulation.capacity_disclaimer', 'Theoretical Layer-1 gross capacity based on reported channel modulation. Real IP throughput is lower and depends on tariff provisioning, DOCSIS overhead, segment utilization, and other shared-medium conditions.') }}
+            </p>
+        </div>
+        {% endif %}
+
         <!-- Protocol groups (dynamically populated by JS) -->
         <div id="modulation-protocol-groups"></div>
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v58';
+var CACHE_VERSION = 'v59';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1141,7 +1141,7 @@
                     <table class="channel-table">
                         <thead><tr>
                             <th>{{ t.ch_abbr }}</th><th>{{ t.frequency }}</th><th>{{ t.th_power }}</th>
-                            <th>{{ t.get('signal_family_metric_mer', 'MER') if group.grouper|string == '3.1' else t.snr_abbr }}</th><th>{{ t.mod_abbr }}</th><th>{{ t.signal_health }}</th>
+                            <th>{{ t.get('signal_family_metric_mer', 'MER') if group.grouper|string == '3.1' else t.snr_abbr }}</th><th>{{ t.mod_abbr }}</th><th title="{{ t.get('docsight.modulation.capacity_tooltip', 'Theoretical Layer-1 gross channel capacity; not usable throughput') }}">{{ t.get('docsight.modulation.capacity_short', 'Capacity') }}</th><th>{{ t.signal_health }}</th>
                         </tr></thead>
                         <tbody>
                         {% for ch in group.list %}
@@ -1154,6 +1154,7 @@
                             <td data-health="{{ ch.power_health or 'good' }}">{{ ch.power if ch.power is not none else "—" }}{% if ch.power is not none %} dBmV{% endif %}</td>
                             <td data-health="{{ ch.snr_health or 'good' }}">{{ ch.snr if ch.snr is not none else "—" }}{% if ch.snr is not none %} dB{% endif %}</td>
                             <td data-health="{{ ch.modulation_health or 'good' }}">{{ ch.modulation }}</td>
+                            <td title="{{ t.get('docsight.modulation.capacity_tooltip', 'Theoretical Layer-1 gross channel capacity; not usable throughput') }}">{% if ch.theoretical_bitrate is defined and ch.theoretical_bitrate is not none %}{{ ch.theoretical_bitrate|round(1) }} Mbit/s{% else %}—{% endif %}</td>
                             <td>
                                 {% if ch.health == "good" %}<span class="badge badge-good">{{ health_labels.good }}</span>
                                 {% elif ch.health == "critical" %}<span class="badge badge-crit" title="{{ ch_tip_parts|join(', ') }}">{{ health_labels.crit }}</span>
@@ -1199,7 +1200,7 @@
                     <table class="channel-table">
                         <thead><tr>
                             <th>{{ t.ch_abbr }}</th><th>{{ t.frequency }}</th><th>{{ t.th_power }}</th>
-                            <th>{{ t.mod_abbr }}</th><th>{{ t.signal_health }}</th>
+                            <th>{{ t.mod_abbr }}</th><th title="{{ t.get('docsight.modulation.capacity_tooltip', 'Theoretical Layer-1 gross channel capacity; not usable throughput') }}">{{ t.get('docsight.modulation.capacity_short', 'Capacity') }}</th><th>{{ t.signal_health }}</th>
                         </tr></thead>
                         <tbody>
                         {% for ch in group.list %}
@@ -1212,6 +1213,7 @@
                             <td>{{ ch.frequency }}{% if ch.frequency and 'MHz' not in ch.frequency|string %} MHz{% endif %}</td>
                             <td data-health="{{ ch.power_health or 'good' }}">{{ ch.power if ch.power is not none else "—" }}{% if ch.power is not none %} dBmV{% endif %}</td>
                             <td data-health="{{ ch.modulation_health or 'good' }}">{{ ch.modulation }}</td>
+                            <td title="{{ t.get('docsight.modulation.capacity_tooltip', 'Theoretical Layer-1 gross channel capacity; not usable throughput') }}">{% if ch.theoretical_bitrate is defined and ch.theoretical_bitrate is not none %}{{ ch.theoretical_bitrate|round(1) }} Mbit/s{% else %}—{% endif %}</td>
                             <td>
                                 {% if ch.health == "good" %}<span class="badge badge-good">{{ health_labels.good }}</span>
                                 {% elif ch.health == "critical" %}<span class="badge badge-crit" title="{{ ch_tip }}">{{ health_labels.crit }}</span>

--- a/app/types.py
+++ b/app/types.py
@@ -79,6 +79,7 @@ class DownstreamChannel(TypedDict):
     docsis_version: str
     health: str
     health_detail: str
+    theoretical_bitrate: float | None
     # Optional channel family for Home signal-family summaries
     channel_family: NotRequired[str]
     # Optional per-metric health keys (present when health_detail is non-empty)
@@ -228,7 +229,9 @@ class AnalysisSummary(TypedDict):
     ds_correctable_errors: int | None
     ds_uncorrectable_errors: int | None
     errors_supported: bool
+    ds_capacity_mbps: float | None
     us_capacity_mbps: float | None
+    capacity_coverage: dict[str, dict[str, int]]
     signal_families: NotRequired[SignalFamiliesSummary]
     ds_scqam_power_avg: NotRequired[float | None]
     ds_scqam_snr_avg: NotRequired[float | None]

--- a/app/web.py
+++ b/app/web.py
@@ -1198,6 +1198,54 @@ def _build_home_modulation_context(analysis):
     ]
 
 
+def _build_capacity_context(analysis, booked_download=0, booked_upload=0):
+    """Build current theoretical channel-capacity context for dashboard views."""
+    summary = analysis.get("summary", {}) if analysis else {}
+
+    def _direction(direction, channel_key, summary_key, tariff):
+        channels = analysis.get(channel_key, []) if analysis else []
+        coverage_all = summary.get("capacity_coverage") or {}
+        coverage = dict(coverage_all.get(direction) or {})
+        total = int(coverage.get("total", len(channels)) or 0)
+        calculated = int(coverage.get("calculated", 0) or 0)
+        if not coverage and channels:
+            calculated = sum(1 for ch in channels if ch.get("theoretical_bitrate") is not None)
+            total = len(channels)
+        unsupported = max(0, int(coverage.get("unsupported", total - calculated) or 0))
+        capacity = _to_float(summary.get(summary_key))
+        tariff_value = _to_float(tariff)
+        ratio = round(capacity / tariff_value, 2) if capacity is not None and tariff_value and tariff_value > 0 else None
+
+        if capacity is None or calculated == 0:
+            status = "unavailable"
+        elif unsupported > 0:
+            status = "partial"
+        elif ratio is None:
+            status = "calculated"
+        elif ratio < 1.0:
+            status = "below"
+        elif ratio < 1.3:
+            status = "close"
+        else:
+            status = "headroom"
+
+        return {
+            "direction": direction,
+            "capacity_mbps": capacity,
+            "tariff_mbps": tariff_value,
+            "ratio": ratio,
+            "calculated": calculated,
+            "total": total,
+            "unsupported": unsupported,
+            "status": status,
+        }
+
+    return {
+        "downstream": _direction("downstream", "ds_channels", "ds_capacity_mbps", booked_download),
+        "upstream": _direction("upstream", "us_channels", "us_capacity_mbps", booked_upload),
+    }
+
+
 @app.route("/sw.js")
 def service_worker():
     return send_from_directory(app.static_folder, "sw.js", mimetype="application/javascript")
@@ -1295,6 +1343,7 @@ def index():
         metric_ranges=_build_metric_ranges(analysis),
         home_snr_display=_build_home_snr_display_context(analysis),
         home_modulation_context=_build_home_modulation_context(analysis),
+        capacity_context=_build_capacity_context(analysis, booked_download, booked_upload),
         t=t, lang=lang, languages=LANGUAGES, lang_flags=LANG_FLAGS,
         temperature_unit=_config_manager.get("temperature_unit", "celsius") if _config_manager else "celsius",
         dashboard_notices=get_active_notices(

--- a/tests/test_analyzer_modulation.py
+++ b/tests/test_analyzer_modulation.py
@@ -27,3 +27,78 @@ def test_docsis_30_downstream_64qam_is_healthy_not_marginal():
     assert "modulation warning" not in channel["health_detail"]
     assert "ds_modulation_marginal" not in result["summary"]["health_issues"]
     assert result["summary"]["health"] == "good"
+
+
+def test_docsis_30_downstream_theoretical_capacity_uses_scqam_symbol_rate():
+    result = analyze({
+        "channelDs": {
+            "docsis30": [
+                {
+                    "channelID": "1",
+                    "frequency": "602 MHz",
+                    "powerLevel": "0.4",
+                    "mse": "-36.3",
+                    "modulation": "256QAM",
+                    "corrErrors": 0,
+                    "nonCorrErrors": 0,
+                },
+                {
+                    "channelID": "2",
+                    "frequency": "610 MHz",
+                    "powerLevel": "0.5",
+                    "mse": "-36.1",
+                    "modulation": "256QAM",
+                    "corrErrors": 0,
+                    "nonCorrErrors": 0,
+                },
+            ],
+            "docsis31": [{
+                "channelID": "33",
+                "frequency": "134.975 - 324.975",
+                "powerLevel": "3.1",
+                "mer": "38.5",
+                "modulation": "OFDM",
+            }],
+        },
+        "channelUs": {"docsis30": [], "docsis31": []},
+    })
+
+    assert result["ds_channels"][0]["theoretical_bitrate"] == 55.62
+    assert result["ds_channels"][1]["theoretical_bitrate"] == 55.62
+    assert result["ds_channels"][2]["theoretical_bitrate"] is None
+    assert result["summary"]["ds_capacity_mbps"] == 111.2
+    assert result["summary"]["capacity_coverage"]["downstream"] == {
+        "calculated": 2,
+        "total": 3,
+        "unsupported": 1,
+    }
+
+
+def test_upstream_capacity_compatibility_and_unknown_coverage():
+    result = analyze({
+        "channelDs": {"docsis30": [], "docsis31": []},
+        "channelUs": {
+            "docsis30": [{
+                "channelID": "1",
+                "frequency": "37 MHz",
+                "powerLevel": "42.0",
+                "modulation": "64QAM",
+            }],
+            "docsis31": [{
+                "channelID": "5",
+                "frequency": "18 - 44 MHz",
+                "powerLevel": "45.0",
+                "modulation": "OFDMA",
+                "profile_modulation": "1024QAM",
+            }],
+        },
+    })
+
+    assert result["us_channels"][0]["theoretical_bitrate"] == 30.72
+    assert result["us_channels"][1]["theoretical_bitrate"] is None
+    assert result["summary"]["us_capacity_mbps"] == 30.7
+    assert result["summary"]["capacity_coverage"]["upstream"] == {
+        "calculated": 1,
+        "total": 2,
+        "unsupported": 1,
+    }

--- a/tests/test_modulation_static_contract.py
+++ b/tests/test_modulation_static_contract.py
@@ -31,6 +31,17 @@ def test_clickable_distribution_chart_has_pointer_cursor():
     assert "cursor: pointer" in css
 
 
+def test_capacity_panel_contract_is_localized_and_styled():
+    css = MODULATION_CSS.read_text(encoding="utf-8")
+    i18n = (I18N_DIR / "en.json").read_text(encoding="utf-8")
+
+    assert ".mod-capacity-panel" in css
+    assert ".mod-capacity-card.mod-capacity-below" in css
+    assert "capacity_title" in i18n
+    assert "capacity_disclaimer" in i18n
+    assert "Layer-1 gross capacity" in i18n
+
+
 def test_low_qam_hint_does_not_use_stale_global_16qam_threshold():
     js = MODULATION_JS.read_text(encoding="utf-8")
 

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -1,6 +1,7 @@
 """Tests for index/dashboard rendering paths."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -202,6 +203,71 @@ class TestIndexRoute:
         docsis30_head = html[docsis30_start:html.index("</thead>", docsis30_start)]
         assert "<th>SNR</th>" in docsis30_head
         assert "<th>MER</th>" not in docsis30_head
+
+    def test_channel_tables_show_theoretical_capacity_column(self, client, sample_analysis):
+        sample_analysis["ds_channels"][0]["theoretical_bitrate"] = 55.62
+        sample_analysis["us_channels"][0]["theoretical_bitrate"] = 30.72
+        sample_analysis["summary"].update({
+            "ds_capacity_mbps": 55.6,
+            "us_capacity_mbps": 30.7,
+            "capacity_coverage": {
+                "downstream": {"calculated": 1, "total": 1, "unsupported": 0},
+                "upstream": {"calculated": 1, "total": 1, "unsupported": 0},
+            },
+        })
+        update_state(analysis=sample_analysis)
+
+        resp = client.get("/?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "Theoretical Layer-1 gross channel capacity" in html
+        assert "55.6 Mbit/s" in html
+        assert "30.7 Mbit/s" in html
+
+    def test_modulation_template_shows_capacity_vs_tariff_context(self):
+        template_path = (
+            Path(__file__).resolve().parents[2]
+            / "app" / "modules" / "modulation" / "templates" / "modulation_tab.html"
+        )
+        template = app.jinja_env.from_string(template_path.read_text(encoding="utf-8"))
+
+        html = template.render(
+            t={"docsight.modulation.capacity_status_below": "Below tariff"},
+            capacity_context={
+                "downstream": {
+                    "direction": "downstream",
+                    "capacity_mbps": 556.2,
+                    "tariff_mbps": 250,
+                    "ratio": 2.22,
+                    "calculated": 1,
+                    "total": 1,
+                    "unsupported": 0,
+                    "status": "headroom",
+                },
+                "upstream": {
+                    "direction": "upstream",
+                    "capacity_mbps": 30.7,
+                    "tariff_mbps": 40,
+                    "ratio": 0.77,
+                    "calculated": 1,
+                    "total": 1,
+                    "unsupported": 0,
+                    "status": "below",
+                },
+            },
+        )
+
+        assert 'id="modulation-capacity-panel"' in html
+        assert "Theoretical channel capacity (gross)" in html
+        assert "Layer-1 gross capacity" in html
+        assert "shared-medium" in html
+        assert "556.2" in html
+        assert "250 Mbit/s" in html
+        assert "2.22×" in html
+        assert "30.7" in html
+        assert "40 Mbit/s" in html
+        assert "Below tariff" in html
 
     def test_speed_kpi_card_links_to_speedtest_view_and_uses_rabbit_icon(self, client, config_mgr, sample_analysis):
         _configure_speedtest(config_mgr)


### PR DESCRIPTION
## Summary

- Estimate theoretical SC-QAM channel capacity for current downstream and upstream channels.
- Show per-channel capacity in the channel tables and add a Modulation Performance panel with tariff comparison, coverage, and status.
- Keep OFDM/OFDMA and unknown modulation unsupported rather than estimating them, and clearly caveat the metric as Layer-1 gross capacity for a shared medium.
- Bump the service-worker cache version so updated module styling is not held by the runtime cache.

Closes #644

## Validation

- `uv run --with-requirements requirements-test.txt pytest tests/analyzer/test_signal_metrics.py -q`
- `uv run --with-requirements requirements-test.txt pytest tests --ignore=tests/e2e`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `uv run --with-requirements requirements-test.txt --with pytest-playwright pytest tests/e2e/test_dashboard.py`
- Batched browser E2E by file: 423 collected / 423 passed
- `uv run --with-requirements requirements-test.txt pytest tests/test_pwa_contract.py tests/test_static_contracts.py`
- `uv run --with-requirements requirements-test.txt --with pytest-playwright pytest tests/e2e/test_pwa_gate.py`
- Captured visual smoke of the Modulation Performance capacity panel
