### PR TITLE
Fix capacity tariff context and English units

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -52,6 +52,8 @@ DEFAULTS = {
     "gaming_quality_enabled": True,
     "segment_utilization_enabled": True,
     "speedtest_tls_insecure": False,
+    "booked_download": 0,
+    "booked_upload": 0,
     "notify_webhook_url": "",
     "notify_webhook_token": "",
     "notify_apprise_enabled": False,
@@ -177,7 +179,7 @@ _LEGACY_KEY_MAP = {
     "fritz_password": "modem_password",
 }
 
-INT_KEYS = {"poll_interval", "web_port", "history_days", "notify_cooldown", "health_hysteresis",
+INT_KEYS = {"poll_interval", "web_port", "history_days", "booked_download", "booked_upload", "notify_cooldown", "health_hysteresis",
             "sc_global_cooldown", "sc_trigger_cooldown", "sc_max_actions_per_hour",
             "sc_speedtest_min_interval", "sc_speedtest_max_actions_per_day", "sc_speedtest_match_window",
             "sc_flapping_window", "sc_flapping_threshold",

--- a/app/modules/modulation/routes.py
+++ b/app/modules/modulation/routes.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from flask import Blueprint, request, jsonify
 
 from app.tz import to_local, utc_now, utc_cutoff
-from app.web import require_auth, get_storage, get_config_manager
+from app.web import require_auth, get_storage, get_config_manager, get_state
 
 from .engine import (
     compute_capacity_history,
@@ -28,12 +28,36 @@ def _get_tz():
     return ""
 
 
+def _positive_number(value):
+    """Return positive numeric config/state values, else None."""
+    if value in (None, ""):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
 def _get_capacity_tariffs():
-    """Return configured tariff values for capacity comparison."""
+    """Return configured or detected tariff values for capacity comparison."""
     cm = get_config_manager()
-    if not cm:
-        return None, None
-    return cm.get("booked_download"), cm.get("booked_upload")
+    booked_download = _positive_number(cm.get("booked_download")) if cm else None
+    booked_upload = _positive_number(cm.get("booked_upload")) if cm else None
+    if booked_download and booked_upload:
+        return booked_download, booked_upload
+
+    state = get_state()
+    conn_info = state.get("connection_info") if isinstance(state, dict) else {}
+    conn_info = conn_info or {}
+    detected_download = _positive_number(conn_info.get("max_downstream_kbps"))
+    detected_upload = _positive_number(conn_info.get("max_upstream_kbps"))
+    if detected_download is not None:
+        detected_download = detected_download / 1000
+    if detected_upload is not None:
+        detected_upload = detected_upload / 1000
+
+    return booked_download or detected_download, booked_upload or detected_upload
 
 
 @bp.route("/api/modulation/distribution")

--- a/app/modules/modulation/static/main.js
+++ b/app/modules/modulation/static/main.js
@@ -266,9 +266,13 @@ function updateOverviewKPIs(data) {
     }
 }
 
+function capacityUnitLabel() {
+    return currentLang === 'de' ? 'Mbit/s' : 'Mbps';
+}
+
 function formatCapacityMbps(value) {
     if (value === null || value === undefined) return '\u2014';
-    return Number(value).toFixed(1) + ' Mbit/s';
+    return Number(value).toFixed(1) + ' ' + capacityUnitLabel();
 }
 
 function rangeLabelForCapacity(data) {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v60';
+var CACHE_VERSION = 'v61';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1154,7 +1154,7 @@
                             <td data-health="{{ ch.power_health or 'good' }}">{{ ch.power if ch.power is not none else "—" }}{% if ch.power is not none %} dBmV{% endif %}</td>
                             <td data-health="{{ ch.snr_health or 'good' }}">{{ ch.snr if ch.snr is not none else "—" }}{% if ch.snr is not none %} dB{% endif %}</td>
                             <td data-health="{{ ch.modulation_health or 'good' }}">{{ ch.modulation }}</td>
-                            <td title="{{ t.get('docsight.modulation.capacity_tooltip', 'Theoretical Layer-1 gross channel capacity; not usable throughput') }}">{% if ch.theoretical_bitrate is defined and ch.theoretical_bitrate is not none %}{{ ch.theoretical_bitrate|round(1) }} Mbit/s{% else %}—{% endif %}</td>
+                            <td title="{{ t.get('docsight.modulation.capacity_tooltip', 'Theoretical Layer-1 gross channel capacity; not usable throughput') }}">{% if ch.theoretical_bitrate is defined and ch.theoretical_bitrate is not none %}{{ ch.theoretical_bitrate|round(1) }} {{ 'Mbit/s' if lang == 'de' else 'Mbps' }}{% else %}—{% endif %}</td>
                             <td>
                                 {% if ch.health == "good" %}<span class="badge badge-good">{{ health_labels.good }}</span>
                                 {% elif ch.health == "critical" %}<span class="badge badge-crit" title="{{ ch_tip_parts|join(', ') }}">{{ health_labels.crit }}</span>
@@ -1213,7 +1213,7 @@
                             <td>{{ ch.frequency }}{% if ch.frequency and 'MHz' not in ch.frequency|string %} MHz{% endif %}</td>
                             <td data-health="{{ ch.power_health or 'good' }}">{{ ch.power if ch.power is not none else "—" }}{% if ch.power is not none %} dBmV{% endif %}</td>
                             <td data-health="{{ ch.modulation_health or 'good' }}">{{ ch.modulation }}</td>
-                            <td title="{{ t.get('docsight.modulation.capacity_tooltip', 'Theoretical Layer-1 gross channel capacity; not usable throughput') }}">{% if ch.theoretical_bitrate is defined and ch.theoretical_bitrate is not none %}{{ ch.theoretical_bitrate|round(1) }} Mbit/s{% else %}—{% endif %}</td>
+                            <td title="{{ t.get('docsight.modulation.capacity_tooltip', 'Theoretical Layer-1 gross channel capacity; not usable throughput') }}">{% if ch.theoretical_bitrate is defined and ch.theoretical_bitrate is not none %}{{ ch.theoretical_bitrate|round(1) }} {{ 'Mbit/s' if lang == 'de' else 'Mbps' }}{% else %}—{% endif %}</td>
                             <td>
                                 {% if ch.health == "good" %}<span class="badge badge-good">{{ health_labels.good }}</span>
                                 {% elif ch.health == "critical" %}<span class="badge badge-crit" title="{{ ch_tip }}">{{ health_labels.crit }}</span>
@@ -2777,6 +2777,7 @@
 <script src="/static/js/chart-engine.js"></script>
 <script>
 var T = {{ t|tojson }};
+var currentLang = {{ lang|tojson }};
 var TEMPERATURE_UNIT = {{ temperature_unit|tojson }};
 
 (function() {

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -277,7 +277,7 @@ class TestModulationControls:
         panel = self.page.locator("#modulation-capacity-panel")
         expect(panel).to_be_visible()
         expect(self.page.locator("#mod-capacity-range-label")).to_contain_text("7d")
-        expect(self.page.locator("#mod-cap-ds-min")).to_contain_text("Mbit/s")
+        expect(self.page.locator("#mod-cap-ds-min")).to_contain_text("Mbps")
         expect(self.page.locator("#mod-cap-us-tariff")).not_to_have_text("—")
 
         today = self.page.locator('#modulation-range-tabs .trend-tab[data-days="1"]')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -194,6 +194,13 @@ class TestConfigEnvOverride:
         config = ConfigManager(tmp_data_dir)
         assert config.get("poll_interval") == 600
 
+    def test_booked_speed_env_overrides(self, tmp_data_dir, monkeypatch):
+        monkeypatch.setenv("BOOKED_DOWNLOAD", "1000")
+        monkeypatch.setenv("BOOKED_UPLOAD", "50")
+        config = ConfigManager(tmp_data_dir)
+        assert config.get("booked_download") == 1000
+        assert config.get("booked_upload") == 50
+
     def test_apprise_env_overrides(self, tmp_data_dir, monkeypatch):
         monkeypatch.setenv("NOTIFY_APPRISE_ENABLED", "true")
         monkeypatch.setenv("NOTIFY_APPRISE_URL", "http://apprise:8000")

--- a/tests/test_modulation_api.py
+++ b/tests/test_modulation_api.py
@@ -165,6 +165,34 @@ class TestDistributionEndpoint:
         assert us["capacity_max_mbps"] == 30.7
         assert us["tariff_met_pct"] == 50.0
 
+    def test_capacity_history_uses_detected_connection_speed_when_booked_tariff_empty(self, client_with_storage):
+        client, storage = client_with_storage
+        from app.web import reset_modem_state, update_state
+
+        update_state(connection_info={"max_downstream_kbps": 50000, "max_upstream_kbps": 25000})
+        day = _ts_days_ago(1)[:10]
+        _store_snapshot(
+            storage,
+            f"{day}T10:00:00Z",
+            ds_channels=[{"modulation": "64QAM", "channel_id": 1, "docsis_version": "3.0"}],
+            us_channels=[{"modulation": "16QAM", "channel_id": 1, "docsis_version": "3.0"}],
+        )
+
+        try:
+            resp = client.get("/api/modulation/distribution?days=7&direction=us")
+            data = resp.get_json()
+
+            ds = data["capacity_history"]["downstream"]
+            us = data["capacity_history"]["upstream"]
+            assert ds["tariff_mbps"] == 50.0
+            assert ds["tariff_met_pct"] == 0.0
+            assert ds["status"] == "below_some_samples"
+            assert us["tariff_mbps"] == 25.0
+            assert us["tariff_met_pct"] == 0.0
+            assert us["status"] == "below_some_samples"
+        finally:
+            reset_modem_state()
+
 
     def test_aggregate_low_qam_pct_weighted_across_protocol_sample_counts(self, client_with_storage):
         client, storage = client_with_storage

--- a/tests/test_modulation_static_contract.py
+++ b/tests/test_modulation_static_contract.py
@@ -49,6 +49,9 @@ def test_capacity_panel_updates_from_range_api_payload():
     assert "function updateCapacityHistory" in js
     assert "data.capacity_history" in js
     assert "updateCapacityHistory(data, rangeLabelForCapacity(data))" in js
+    assert "function capacityUnitLabel" in js
+    assert "currentLang === 'de'" in js
+    assert "Number(value).toFixed(1) + ' ' + capacityUnitLabel()" in js
     assert "above_tariff_throughout: 'Above tariff throughout selected period'" in js
 
 

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -222,8 +222,14 @@ class TestIndexRoute:
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
         assert "Theoretical Layer-1 gross channel capacity" in html
-        assert "55.6 Mbit/s" in html
-        assert "30.7 Mbit/s" in html
+        assert "55.6 Mbps" in html
+        assert "30.7 Mbps" in html
+
+        resp_de = client.get("/?lang=de")
+        assert resp_de.status_code == 200
+        html_de = resp_de.get_data(as_text=True)
+        assert "55.6 Mbit/s" in html_de
+        assert "30.7 Mbit/s" in html_de
 
     def test_modulation_template_shows_capacity_vs_tariff_context(self):
         template_path = (


### PR DESCRIPTION
## Summary
- use configured booked speeds or detected modem max rates for modulation capacity tariff context
- show Mbps in English capacity displays while keeping Mbit/s for German
- refresh service worker cache and add regressions for tariff fallback and units

## Tests
- uv run --with-requirements requirements-test.txt pytest tests/test_modulation_api.py tests/test_modulation_static_contract.py tests/web/test_index.py tests/test_static_contracts.py tests/test_config.py
- uv run --with-requirements requirements-test.txt --with pytest-playwright pytest tests/e2e/test_modulation.py tests/e2e/test_pwa_gate.py
- uv run --with-requirements requirements-test.txt pytest tests --ignore=tests/e2e
- git diff --check