### PR TITLE
Version static assets for safer PWA upgrades

### DIFF
--- a/app/modules/connection_monitor/templates/connection_monitor_card.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_card.html
@@ -40,4 +40,4 @@
     </div>
 </div>
 
-<script src="/modules/docsight.connection_monitor/static/js/connection-monitor-card.js"></script>
+<script src="/modules/docsight.connection_monitor/static/js/connection-monitor-card.js?v={{ version|urlencode }}"></script>

--- a/app/modules/connection_monitor/templates/connection_monitor_detail.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_detail.html
@@ -179,5 +179,5 @@
     </div>
 </div>
 
-<script src="/modules/docsight.connection_monitor/static/js/connection-monitor-charts.js"></script>
-<script src="/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js"></script>
+<script src="/modules/docsight.connection_monitor/static/js/connection-monitor-charts.js?v={{ version|urlencode }}"></script>
+<script src="/modules/docsight.connection_monitor/static/js/connection-monitor-detail.js?v={{ version|urlencode }}"></script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,16 +11,16 @@
     <link rel="icon" type="image/svg+xml" href="/static/logo.svg">
     <link rel="apple-touch-icon" href="/static/icon.png">
     <link rel="manifest" href="/static/manifest.json">
-    <link rel="stylesheet" href="/static/css/fonts.css">
-    <link rel="stylesheet" href="/static/css/tokens.css">
-    <link rel="stylesheet" href="/static/css/components.css">
-    <link rel="stylesheet" href="/static/css/main.css">
-    <link rel="stylesheet" href="/static/css/views.css">
-    <link rel="stylesheet" href="/static/css/modals.css">
-    <link rel="stylesheet" href="/static/css/glossary.css">
-    <link rel="stylesheet" href="/static/css/segment-utilization.css">
+    <link rel="stylesheet" href="/static/css/fonts.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/tokens.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/components.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/main.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/views.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/modals.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/glossary.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/segment-utilization.css?v={{ version|urlencode }}">
     {% for mod in modules|sort(attribute='menu.order') if mod.has_css %}
-    <link rel="stylesheet" href="/modules/{{ mod.id }}/static/style.css">
+    <link rel="stylesheet" href="/modules/{{ mod.id }}/static/style.css?v={{ version|urlencode }}">
     {% endfor %}
     {% if active_theme_data %}
     <style id="theme-module-vars">
@@ -39,7 +39,7 @@
     {% if config.font_family == 'system' %}
     <style id="font-override">:root { --font-sans: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; }</style>
     {% endif %}
-    <script src="/static/vendor/lucide.min.js"></script>
+    <script src="/static/vendor/lucide.min.js?v={{ version|urlencode }}"></script>
 </head>
 <body>
 <div id="offline-status-banner" class="offline-status-banner" role="status" aria-live="polite" hidden>
@@ -1093,7 +1093,7 @@
         {% endif %}
     </div>
     {% if modules|selectattr('id', 'equalto', 'docsight.connection_monitor')|list %}
-    <script src="/modules/docsight.connection_monitor/static/js/connection-monitor-card.js"></script>
+    <script src="/modules/docsight.connection_monitor/static/js/connection-monitor-card.js?v={{ version|urlencode }}"></script>
     {% endif %}
 
     {# ══════════════════════════════════════════════════════════════════════════
@@ -2689,10 +2689,10 @@
 </div>
 
 <div class="toast" id="toast"></div>
-<link rel="stylesheet" href="/static/vendor/uPlot.min.css">
-<script src="/static/vendor/uPlot.min.js"></script>
-<script src="{{ url_for('static', filename='js/hero-chart.js') }}"></script>
-<script src="{{ url_for('static', filename='js/sparklines.js') }}"></script>
+<link rel="stylesheet" href="/static/vendor/uPlot.min.css?v={{ version|urlencode }}">
+<script src="/static/vendor/uPlot.min.js?v={{ version|urlencode }}"></script>
+<script src="{{ url_for('static', filename='js/hero-chart.js') }}?v={{ version|urlencode }}"></script>
+<script src="{{ url_for('static', filename='js/sparklines.js') }}?v={{ version|urlencode }}"></script>
 
 {# ── Channel Health Donut Charts - Phase 3 Task 3.4 ── #}
 <script>
@@ -2774,7 +2774,7 @@
 })();
 </script>
 
-<script src="/static/js/chart-engine.js"></script>
+<script src="/static/js/chart-engine.js?v={{ version|urlencode }}"></script>
 <script>
 var T = {{ t|tojson }};
 var currentLang = {{ lang|tojson }};
@@ -3354,23 +3354,23 @@ var TEMPERATURE_UNIT = {{ temperature_unit|tojson }};
 })();
 
 </script>
-<script src="/static/js/modals.js"></script>
-<script src="/static/js/journal.js"></script>
-<script src="/modules/docsight.bqm/static/js/bqm-chart.js"></script>
-<script src="/static/js/bqm.js"></script>
-<script src="/static/js/trends.js"></script>
-<script src="/static/js/channels.js"></script>
-<script src="/static/js/integrations.js"></script>
-<script src="/static/js/events.js"></script>
-<script src="/static/js/utils.js"></script>
-<script src="/static/js/notices.js"></script>
-<script src="/static/js/speedtest.js"></script>
-<script src="/static/js/correlation.js"></script>
-<script src="/static/js/segment-utilization.js"></script>
-<script src="/static/js/glossary.js"></script>
+<script src="/static/js/modals.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/journal.js?v={{ version|urlencode }}"></script>
+<script src="/modules/docsight.bqm/static/js/bqm-chart.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/bqm.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/trends.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/channels.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/integrations.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/events.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/utils.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/notices.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/speedtest.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/correlation.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/segment-utilization.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/glossary.js?v={{ version|urlencode }}"></script>
 
 {% for mod in modules if mod.has_js %}
-<script src="/modules/{{ mod.id }}/static/main.js"></script>
+<script src="/modules/{{ mod.id }}/static/main.js?v={{ version|urlencode }}"></script>
 {% endfor %}
 
 <script>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -9,8 +9,8 @@
     <link rel="apple-touch-icon" href="/static/icon.png">
     <link rel="manifest" href="/static/manifest.json">
     <meta name="theme-color" content="#7c3aed">
-    <link rel="stylesheet" href="/static/css/fonts.css">
-    <link rel="stylesheet" href="/static/css/tokens.css">
+    <link rel="stylesheet" href="/static/css/fonts.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/tokens.css?v={{ version|urlencode }}">
     <style>
         *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
         body {

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -8,13 +8,13 @@
     <link rel="icon" type="image/svg+xml" href="/static/logo.svg">
     <link rel="apple-touch-icon" href="/static/icon.png">
     <link rel="manifest" href="/static/manifest.json">
-    <link rel="stylesheet" href="/static/css/fonts.css">
-    <link rel="stylesheet" href="/static/css/tokens.css">
-    <link rel="stylesheet" href="/static/css/components.css">
-    <link rel="stylesheet" href="/static/css/modals.css">
-    <link rel="stylesheet" href="/static/css/settings.css">
+    <link rel="stylesheet" href="/static/css/fonts.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/tokens.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/components.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/modals.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/settings.css?v={{ version|urlencode }}">
     {% for mod in modules|sort(attribute='menu.order') if mod.has_css %}
-    <link rel="stylesheet" href="/modules/{{ mod.id }}/static/style.css">
+    <link rel="stylesheet" href="/modules/{{ mod.id }}/static/style.css?v={{ version|urlencode }}">
     {% endfor %}
     {% if active_theme_data %}
     <style id="theme-module-vars">
@@ -30,7 +30,7 @@
     }
     </style>
     {% endif %}
-    <script src="/static/vendor/lucide.min.js"></script>
+    <script src="/static/vendor/lucide.min.js?v={{ version|urlencode }}"></script>
 </head>
 <body>
 
@@ -200,12 +200,12 @@ var currentTz = '{{ config.timezone|default("", true) }}';
 try { var savedCooldowns = JSON.parse({{ config.notify_cooldowns|default("{}")|tojson }}); } catch(e) { var savedCooldowns = {}; }
 var DRIVER_HINTS = {{ driver_hints | tojson }};
 </script>
-<script src="/static/js/modals.js"></script>
-<script src="/static/js/utils.js"></script>
-<script src="/static/js/notices.js"></script>
-<script src="/static/js/settings.js"></script>
+<script src="/static/js/modals.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/utils.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/notices.js?v={{ version|urlencode }}"></script>
+<script src="/static/js/settings.js?v={{ version|urlencode }}"></script>
 {% for mod in modules if mod.has_js %}
-<script src="/modules/{{ mod.id }}/static/main.js"></script>
+<script src="/modules/{{ mod.id }}/static/main.js?v={{ version|urlencode }}"></script>
 {% endfor %}
 
 </body>

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -9,11 +9,11 @@
     <link rel="apple-touch-icon" href="/static/icon.png">
     <link rel="manifest" href="/static/manifest.json">
     <meta name="theme-color" content="#7c3aed">
-    <link rel="stylesheet" href="/static/css/fonts.css">
-    <link rel="stylesheet" href="/static/css/tokens.css">
-    <link rel="stylesheet" href="/static/css/components.css">
-    <link rel="stylesheet" href="/static/css/setup.css">
-    <script src="/static/vendor/lucide.min.js"></script>
+    <link rel="stylesheet" href="/static/css/fonts.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/tokens.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/components.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/setup.css?v={{ version|urlencode }}">
+    <script src="/static/vendor/lucide.min.js?v={{ version|urlencode }}"></script>
 </head>
 <body>
 

--- a/tests/e2e/test_pwa_gate.py
+++ b/tests/e2e/test_pwa_gate.py
@@ -2,6 +2,8 @@
 
 from playwright.sync_api import expect
 
+from app.web import APP_VERSION
+
 
 def test_manifest_loads_and_service_worker_can_be_enabled_for_e2e(page, live_server):
     """Local E2E should be able to opt into the same service worker path production uses."""
@@ -31,6 +33,30 @@ def test_manifest_loads_and_service_worker_can_be_enabled_for_e2e(page, live_ser
         """
     )
     assert sw_ready is True
+
+
+def test_static_js_and_css_requests_include_app_version(page, live_server):
+    """Rendered shell should version cache-first JS/CSS requests with the app version."""
+    page.goto(f"{live_server}/")
+    page.wait_for_load_state("networkidle")
+
+    offenders = page.evaluate(
+        r"""
+        (expectedVersion) => Array.from(document.querySelectorAll('script[src], link[rel="stylesheet"][href]'))
+            .map((el) => el.getAttribute('src') || el.getAttribute('href'))
+            .filter(Boolean)
+            .filter((raw) => {
+                const url = new URL(raw, window.location.origin);
+                return url.origin === window.location.origin
+                    && (url.pathname.startsWith('/static/') || url.pathname.startsWith('/modules/'))
+                    && /\.(js|css)$/.test(url.pathname)
+                    && url.searchParams.get('v') !== expectedVersion;
+            })
+        """,
+        APP_VERSION,
+    )
+
+    assert offenders == []
 
 
 def test_offline_cached_shell_is_explicitly_read_only(page, context, live_server):

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -42,6 +42,14 @@ I18N_LEADING_SENTINEL_RE = re.compile(r"^\s*@")
 
 STATIC_URL_RE = re.compile(r"(?:href|src)=['\"](/(?:static|modules)/[^'\"?#]+)(?:\?[^'\"]*)?['\"]")
 QUOTED_ASSET_RE = re.compile(r"['\"](/(?:static|modules)/[^'\"?#]+)(?:\?[^'\"]*)?['\"]")
+STATIC_JS_CSS_TAG_RE = re.compile(
+    r"<(?:script|link)\b[^>]+(?:src|href)=['\"](/(?:static|modules)/[^'\"]+\.(?:js|css)(?:\?[^'\"]*)?)['\"]",
+    re.IGNORECASE,
+)
+STATIC_URL_FOR_JS_CSS_TAG_RE = re.compile(
+    r"<(?:script|link)\b[^>]+(?:src|href)=['\"](\{\{\s*url_for\('static',\s*filename='[^']+\.(?:js|css)'\)\s*\}\}(?:\?[^'\"]*)?)['\"]",
+    re.IGNORECASE,
+)
 MISMATCHED_HEADING_RE = re.compile(r"<(span|h2)\b[^>]*>[^\n]*</(?!\1>)(span|h2)>")
 
 
@@ -157,6 +165,21 @@ def test_templates_reference_existing_literal_static_assets() -> None:
                 missing.append(f"{source.relative_to(ROOT)} -> {url}")
 
     assert missing == []
+
+
+def test_template_static_js_and_css_urls_are_versioned() -> None:
+    """Cache-first static JS/CSS references must change when the app version changes."""
+    offenders = []
+    template_paths = sorted(TEMPLATES.rglob("*.html")) + sorted(MODULES.glob("*/templates/*.html"))
+
+    for path in template_paths:
+        text = path.read_text(encoding="utf-8")
+        for match in list(STATIC_JS_CSS_TAG_RE.finditer(text)) + list(STATIC_URL_FOR_JS_CSS_TAG_RE.finditer(text)):
+            url = match.group(1)
+            if "?v={{ version|urlencode }}" not in url:
+                offenders.append(f"{path.relative_to(ROOT)} -> {url}")
+
+    assert offenders == []
 
 
 def test_service_worker_precache_references_existing_public_assets() -> None:


### PR DESCRIPTION
## Summary
- Add the app version query to template-emitted static and module JavaScript/CSS asset URLs.
- Keep service-worker API/data and install-time critical asset caching behavior unchanged.
- Add source and browser regression coverage for versioned static asset URLs.

## Tests
- `.venv/bin/pytest tests/test_static_contracts.py -q`
- `.venv/bin/pytest tests/test_pwa_contract.py tests/test_static_contracts.py tests/e2e/test_pwa_gate.py -q`
- `.venv/bin/pytest tests/test_static_contracts.py::test_template_static_js_and_css_urls_are_versioned tests/test_pwa_contract.py tests/e2e/test_pwa_gate.py -q`
- `.venv/bin/pytest tests --ignore=tests/e2e -q`
- `TZ=UTC .venv/bin/pytest tests/e2e -q --tb=short`
- `git diff --check`
