### PR TITLE
Optimize API token validation for frequent requests

### DIFF
--- a/app/storage/tokens.py
+++ b/app/storage/tokens.py
@@ -2,10 +2,32 @@
 
 import secrets
 import sqlite3
+from datetime import datetime, timedelta, timezone
 
 from werkzeug.security import generate_password_hash, check_password_hash
 
 from ..tz import utc_now
+
+
+_TOKEN_PREFIX_LENGTH = 8
+_LAST_USED_WRITE_INTERVAL = timedelta(seconds=60)
+
+
+def _parse_utc_timestamp(value):
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def _should_refresh_last_used(previous, current):
+    previous_dt = _parse_utc_timestamp(previous)
+    current_dt = _parse_utc_timestamp(current)
+    if previous_dt is None or current_dt is None:
+        return True
+    return current_dt - previous_dt >= _LAST_USED_WRITE_INTERVAL
 
 
 class TokenMethods:
@@ -14,7 +36,7 @@ class TokenMethods:
         """Create a new API token. Returns (token_id, plaintext_token)."""
         raw = secrets.token_urlsafe(48)
         plaintext = "dsk_" + raw
-        prefix = plaintext[:8]
+        prefix = plaintext[:_TOKEN_PREFIX_LENGTH]
         token_hash = generate_password_hash(plaintext)
         created_at = utc_now()
         with self._connect() as conn:
@@ -26,15 +48,22 @@ class TokenMethods:
 
     def validate_api_token(self, token):
         """Validate a Bearer token. Returns token info dict or None."""
+        prefix = (token or "")[:_TOKEN_PREFIX_LENGTH]
         with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
-                "SELECT id, name, token_hash, token_prefix, created_at, last_used_at FROM api_tokens WHERE revoked = 0"
+                """
+                SELECT id, name, token_hash, token_prefix, created_at, last_used_at
+                FROM api_tokens
+                WHERE revoked = 0 AND token_prefix = ?
+                """,
+                (prefix,),
             ).fetchall()
             for row in rows:
                 if check_password_hash(row["token_hash"], token):
                     now = utc_now()
-                    conn.execute("UPDATE api_tokens SET last_used_at = ? WHERE id = ?", (now, row["id"]))
+                    if _should_refresh_last_used(row["last_used_at"], now):
+                        conn.execute("UPDATE api_tokens SET last_used_at = ? WHERE id = ?", (now, row["id"]))
                     return {
                         "id": row["id"],
                         "name": row["name"],

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,9 @@
 """Tests for web UI authentication."""
 
 import json
+import sqlite3
 import pytest
+from werkzeug.security import generate_password_hash
 from app.web import app, update_state, init_config, init_storage
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
@@ -184,6 +186,91 @@ class TestApiTokenAuth:
         assert resp.status_code == 401
         data = resp.get_json()
         assert "error" in data
+
+    def test_token_validation_filters_by_prefix_before_hash_check(self, storage, monkeypatch):
+        """Token validation should hash-check only rows with the presented token prefix."""
+        bearer = "dsk_match1"
+        checked_hashes = []
+
+        with sqlite3.connect(storage.db_path) as conn:
+            conn.execute(
+                "INSERT INTO api_tokens (name, token_hash, token_prefix, created_at, revoked) VALUES (?, ?, ?, ?, 0)",
+                ("wrong-prefix", "wrong-prefix-hash", "dsk_nope", "2026-01-01T00:00:00Z"),
+            )
+            conn.execute(
+                "INSERT INTO api_tokens (name, token_hash, token_prefix, created_at, revoked) VALUES (?, ?, ?, ?, 0)",
+                ("match", "match-hash", bearer[:8], "2026-01-01T00:00:00Z"),
+            )
+            conn.execute(
+                "INSERT INTO api_tokens (name, token_hash, token_prefix, created_at, revoked) VALUES (?, ?, ?, ?, 1)",
+                ("revoked-match", "revoked-hash", bearer[:8], "2026-01-01T00:00:00Z"),
+            )
+
+        def fake_check_password_hash(stored_hash, presented_token):
+            checked_hashes.append(stored_hash)
+            assert presented_token == bearer
+            return stored_hash == "match-hash"
+
+        monkeypatch.setattr("app.storage.tokens.check_password_hash", fake_check_password_hash)
+
+        token_info = storage.validate_api_token(bearer)
+
+        assert token_info is not None
+        assert token_info["name"] == "match"
+        assert checked_hashes == ["match-hash"]
+
+    def test_token_validation_throttles_recent_last_used_writes(self, storage, monkeypatch):
+        """A frequently used token remains valid without writing last_used_at every request."""
+        bearer = "dsk_throt1"
+        previous_last_used = "2026-01-01T00:00:30Z"
+        with sqlite3.connect(storage.db_path) as conn:
+            conn.execute(
+                "INSERT INTO api_tokens (name, token_hash, token_prefix, created_at, last_used_at, revoked) "
+                "VALUES (?, ?, ?, ?, ?, 0)",
+                (
+                    "recent",
+                    generate_password_hash(bearer),
+                    bearer[:8],
+                    "2026-01-01T00:00:00Z",
+                    previous_last_used,
+                ),
+            )
+
+        monkeypatch.setattr("app.storage.tokens.utc_now", lambda: "2026-01-01T00:01:00Z")
+
+        token_info = storage.validate_api_token(bearer)
+
+        assert token_info is not None
+        with sqlite3.connect(storage.db_path) as conn:
+            last_used_at = conn.execute(
+                "SELECT last_used_at FROM api_tokens WHERE token_prefix = ?", (bearer[:8],)
+            ).fetchone()[0]
+        assert last_used_at == previous_last_used
+
+    def test_token_validation_updates_stale_last_used(self, storage, monkeypatch):
+        """last_used_at still refreshes after the throttle window."""
+        bearer = "dsk_stale1"
+        with sqlite3.connect(storage.db_path) as conn:
+            conn.execute(
+                "INSERT INTO api_tokens (name, token_hash, token_prefix, created_at, last_used_at, revoked) "
+                "VALUES (?, ?, ?, ?, ?, 0)",
+                (
+                    "stale",
+                    generate_password_hash(bearer),
+                    bearer[:8],
+                    "2026-01-01T00:00:00Z",
+                    "2026-01-01T00:00:00Z",
+                ),
+            )
+
+        monkeypatch.setattr("app.storage.tokens.utc_now", lambda: "2026-01-01T00:01:01Z")
+
+        assert storage.validate_api_token(bearer) is not None
+        with sqlite3.connect(storage.db_path) as conn:
+            last_used_at = conn.execute(
+                "SELECT last_used_at FROM api_tokens WHERE token_prefix = ?", (bearer[:8],)
+            ).fetchone()[0]
+        assert last_used_at == "2026-01-01T00:01:01Z"
 
     def test_revoked_token_rejected(self, auth_client_with_storage):
         """A revoked token is no longer accepted."""


### PR DESCRIPTION
## Summary
- Use stored API token prefixes to avoid unnecessary password-hash checks during bearer token validation.
- Throttle successful token `last_used_at` updates so frequent API access does not write on every request.
- Add regression coverage for prefix-filtered validation and retained last-used behavior.

## Tests
- `.venv/bin/pytest tests/test_auth.py -q`
- `.venv/bin/pytest tests/test_config.py tests/test_security_hardening.py tests/test_static_contracts.py -q`
- `.venv/bin/pytest tests/test_auth.py tests/test_defensive_review_docs.py::test_public_docs_and_text_fixtures_do_not_contain_reusable_secret_examples -q`
- `.venv/bin/pytest tests --ignore=tests/e2e -q`
- `TZ=UTC .venv/bin/pytest tests/e2e/test_auth.py -q --tb=short`
- `git diff --check`

Docs: no user-facing documentation change needed; token format, API behavior, settings UI, and operator workflows are unchanged.
