### PR TITLE
Add route-level authentication coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,50 +1,42 @@
 """Shared test fixtures and setup for DOCSight tests."""
 
+import importlib
+import json
+import os
+
+from app.builtin_modules import BUILTIN_MODULE_DIRS
 from app.web import app
 
 
 def _register_module_blueprints():
-    """Register module blueprints with the Flask app for testing.
+    """Register built-in module blueprints with the Flask app for testing.
 
     Module blueprints are normally registered by the module loader at runtime.
-    In tests, we register them early so they're available before first request.
+    In tests, we register built-in routes early so they're available before the
+    first request and route-level coverage sees the same shipped module surface.
     """
-    blueprints_to_register = []
 
-    try:
-        from app.modules.speedtest.routes import bp as speedtest_bp
-        blueprints_to_register.append(("speedtest_module", speedtest_bp))
-    except ImportError:
-        pass
-
-    try:
-        from app.modules.bqm.routes import bp as bqm_bp
-        blueprints_to_register.append(("bqm_module", bqm_bp))
-    except ImportError:
-        pass
-
-    try:
-        from app.modules.bnetz.routes import bp as bnetz_bp
-        blueprints_to_register.append(("bnetz_module", bnetz_bp))
-    except ImportError:
-        pass
-
-    try:
-        from app.modules.comparison.routes import bp as comparison_bp
-        blueprints_to_register.append(("comparison_module", comparison_bp))
-    except ImportError:
-        pass
-
-    try:
-        from app.modules.evidence.routes import bp as evidence_bp
-        blueprints_to_register.append(("evidence_module", evidence_bp))
-    except ImportError:
-        pass
-
+    module_base = os.path.join(os.path.dirname(os.path.dirname(__file__)), "app", "modules")
     existing = {b.name for b in app.blueprints.values()}
-    for name, bp in blueprints_to_register:
-        if name not in existing:
-            app.register_blueprint(bp)
+
+    for module_dir in BUILTIN_MODULE_DIRS:
+        manifest_path = os.path.join(module_base, module_dir, "manifest.json")
+        try:
+            with open(manifest_path, "r", encoding="utf-8") as handle:
+                manifest = json.load(handle)
+        except OSError:
+            continue
+        if "routes" not in manifest.get("contributes", {}):
+            continue
+
+        try:
+            routes_module = importlib.import_module(f"app.modules.{module_dir}.routes")
+        except ImportError:
+            continue
+        blueprint = getattr(routes_module, "bp", None) or getattr(routes_module, "blueprint", None)
+        if blueprint is not None and blueprint.name not in existing:
+            app.register_blueprint(blueprint)
+            existing.add(blueprint.name)
 
 
 _register_module_blueprints()

--- a/tests/web/test_route_auth_coverage.py
+++ b/tests/web/test_route_auth_coverage.py
@@ -1,0 +1,150 @@
+"""Route-level authentication boundary coverage."""
+
+from __future__ import annotations
+
+import pytest
+from flask import url_for
+
+from app.config import ConfigManager
+from app.storage import SnapshotStorage
+from app.web import app, init_config, init_storage
+
+
+# Public routes are intentionally small and documented here so newly added
+# routes must make an explicit choice: require authentication or extend this
+# allowlist with a product reason.
+PUBLIC_ENDPOINT_METHODS = {
+    "health": {"GET"},  # container/runtime health probe
+    "metrics_bp.metrics": {"GET"},  # Prometheus scrape endpoint
+    "login": {"GET", "POST"},  # authentication entrypoint
+    "service_worker": {"GET"},  # PWA service-worker asset
+    "setup": {"GET"},  # first-run setup page
+    "static": {"GET"},  # Flask static assets
+}
+
+PUBLIC_ENDPOINT_PREFIX_METHODS = {
+    # Built-in module CSS/JS assets mounted by the module loader.
+    "module_static_": {"GET"},
+}
+
+_IGNORED_METHODS = {"HEAD", "OPTIONS"}
+
+
+_SAMPLE_VALUES = {
+    "attachment_id": 1,
+    "date": "2026-01-01",
+    "entry_id": 1,
+    "filename": "main.js",
+    "incident_id": 1,
+    "measurement_id": 1,
+    "result_id": 1,
+    "target": "example-target",
+    "target_id": 1,
+    "timespan": "24h",
+    "timestamp": "2026-01-01T00:00:00Z",
+    "trace_id": 1,
+}
+
+
+@pytest.fixture
+def auth_client(tmp_path):
+    """Unauthenticated client with admin auth enabled."""
+
+    config = ConfigManager(str(tmp_path / "data"))
+    config.save({
+        "admin_password": "route-auth-secret",
+        "modem_password": "test",
+        "modem_type": "fritzbox",
+    })
+    init_config(config)
+    init_storage(SnapshotStorage(str(tmp_path / "auth-routes.db"), max_days=7))
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def _is_public_route_method(rule, method: str) -> bool:
+    if method in PUBLIC_ENDPOINT_METHODS.get(rule.endpoint, set()):
+        return True
+    return any(
+        rule.endpoint.startswith(prefix) and method in methods
+        for prefix, methods in PUBLIC_ENDPOINT_PREFIX_METHODS.items()
+    )
+
+
+def _sample_value_for_rule(rule, argument: str):
+    if argument in _SAMPLE_VALUES:
+        return _SAMPLE_VALUES[argument]
+
+    converter_name = rule._converters[argument].__class__.__name__
+    if converter_name in {"IntegerConverter", "FloatConverter"}:
+        return 1
+    if converter_name == "PathConverter":
+        return "sample/path"
+    return "sample"
+
+
+def _path_for_rule(rule) -> str:
+    values = {argument: _sample_value_for_rule(rule, argument) for argument in rule.arguments}
+    with app.test_request_context():
+        return url_for(rule.endpoint, **values)
+
+
+def _assert_auth_boundary(rule, response) -> None:
+    if response.status_code in {301, 302, 303, 307, 308}:
+        assert "/login" in response.headers.get("Location", "")
+        return
+
+    assert response.status_code == 401
+    if rule.rule.startswith("/api/"):
+        assert response.is_json
+        assert response.get_json().get("error") == "Authentication required"
+
+
+def test_routes_require_authentication_unless_explicitly_public(auth_client):
+    """All protected route methods should enforce auth when admin_password is set."""
+
+    checked = []
+    for rule in sorted(app.url_map.iter_rules(), key=lambda item: item.rule):
+        path = _path_for_rule(rule)
+        for method in sorted(rule.methods - _IGNORED_METHODS):
+            if _is_public_route_method(rule, method):
+                continue
+
+            response = auth_client.open(path, method=method, follow_redirects=False)
+            _assert_auth_boundary(rule, response)
+            checked.append((method, rule.rule))
+
+    assert checked, "auth coverage should exercise protected route methods"
+
+
+def test_public_route_allowlist_matches_current_route_surface():
+    """Keep the intentional public surface explicit and easy to review."""
+
+    public_rules = sorted(
+        (rule.endpoint, rule.rule, tuple(sorted(rule.methods & methods)))
+        for rule in app.url_map.iter_rules()
+        for endpoint, methods in [(rule.endpoint, PUBLIC_ENDPOINT_METHODS.get(rule.endpoint, set()))]
+        if methods and rule.methods & methods
+    )
+    prefixed_public_rules = sorted(
+        (rule.endpoint, rule.rule, tuple(sorted(rule.methods & methods)))
+        for rule in app.url_map.iter_rules()
+        for prefix, methods in PUBLIC_ENDPOINT_PREFIX_METHODS.items()
+        if rule.endpoint.startswith(prefix) and rule.methods & methods
+    )
+
+    assert public_rules == [
+        ("health", "/health", ("GET",)),
+        ("login", "/login", ("GET", "POST")),
+        ("metrics_bp.metrics", "/metrics", ("GET",)),
+        ("service_worker", "/sw.js", ("GET",)),
+        ("setup", "/setup", ("GET",)),
+        ("static", "/static/<path:filename>", ("GET",)),
+    ]
+    assert all(
+        endpoint.startswith("module_static_")
+        and rule.startswith("/modules/")
+        and methods == ("GET",)
+        for endpoint, rule, methods in prefixed_public_rules
+    )


### PR DESCRIPTION
## Summary
- Add route-level authentication coverage that checks protected route methods when admin authentication is enabled.
- Keep the intentional public route surface explicit and method-scoped in the test allowlist.
- Register shipped built-in module route blueprints during test setup so coverage includes the module route surface.

## Tests
- `.venv/bin/pytest tests/web/test_route_auth_coverage.py -q --tb=short`
- `.venv/bin/pytest tests/web -q --tb=short`
- `.venv/bin/pytest tests/web/test_route_auth_coverage.py tests/web/test_security.py tests/test_auth.py tests/test_security_hardening.py -q --tb=short`
- `.venv/bin/pytest tests --ignore=tests/e2e -q`
- Mutation check: dummy unprotected GET and POST API route returned 200 and failed the auth-boundary helper as expected
- `git diff --cached --check`

Docs: no user-facing documentation change needed; this adds regression coverage without changing product behavior, setup, APIs, or operator workflows.
