### PR TITLE
Harden runtime and maintenance checks

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -1,0 +1,49 @@
+name: Full browser E2E
+
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  full-e2e:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'full-e2e')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --require-hashes -r requirements-test.txt
+          pip install pytest-playwright==0.7.2 playwright==1.58.0
+          python -m playwright install --with-deps chromium
+
+      - name: Run full browser E2E suite
+        run: TZ=UTC python -m pytest -q tests/e2e --tb=short
+
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: full-e2e-artifacts
+          if-no-files-found: ignore
+          path: |
+            test-results/
+            playwright-report/
+            tests/e2e/screenshots/

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,6 @@ COPY app/ ./app/
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 HEALTHCHECK --interval=60s --timeout=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8765/health')" || exit 1
+    CMD python -c "import os, urllib.request; port = os.environ.get('WEB_PORT', '8765'); urllib.request.urlopen(f'http://localhost:{port}/health')" || exit 1
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "-m", "app.main"]

--- a/app/blueprints/metrics_bp.py
+++ b/app/blueprints/metrics_bp.py
@@ -1,6 +1,6 @@
 """Flask blueprint for the Prometheus /metrics endpoint."""
 
-from flask import Blueprint, Response
+from flask import Blueprint, Response, request
 
 from app.web import get_state, get_modem_collector
 from app.prometheus import format_metrics
@@ -8,13 +8,40 @@ from app.prometheus import format_metrics
 metrics_bp = Blueprint("metrics_bp", __name__)
 
 
+def _metrics_token_required() -> bool:
+    """Return whether /metrics should require a Bearer API token."""
+    from app import web as _web
+
+    config = getattr(_web, "_config_manager", None)
+    return bool(config and config.get("metrics_require_token", False))
+
+
+def _has_valid_bearer_token() -> bool:
+    """Validate the request's Bearer token through DOCSight token storage."""
+    from app import web as _web
+
+    storage = getattr(_web, "_storage", None)
+    auth_header = request.headers.get("Authorization", "")
+    if not storage or not auth_header.startswith("Bearer "):
+        return False
+    token_info = storage.validate_api_token(auth_header[7:])
+    if token_info:
+        request._api_token = token_info
+        return True
+    return False
+
+
 @metrics_bp.route("/metrics")
 def metrics():
     """Expose DOCSight metrics in Prometheus text exposition format.
 
-    This endpoint is always accessible without authentication — same pattern as /health.
-    It reads only from existing in-memory state and never triggers modem queries.
+    The endpoint remains open by default for Prometheus compatibility. Operators
+    can enable token protection for deployments where metrics are exposed beyond
+    a trusted scrape network.
     """
+    if _metrics_token_required() and not _has_valid_bearer_token():
+        return Response("Authentication required\n", status=401, content_type="text/plain; charset=utf-8")
+
     state = get_state()
     analysis = state.get("analysis")
     device_info = state.get("device_info")

--- a/app/collectors/demo.py
+++ b/app/collectors/demo.py
@@ -7,6 +7,8 @@ import math
 import os
 import random
 import sqlite3
+
+from app.storage.sqlite import connect_sqlite
 import struct
 import time
 import zlib
@@ -290,7 +292,7 @@ class DemoCollector(Collector):
             ))
 
         # Bulk insert for speed
-        with sqlite3.connect(self._storage.db_path) as conn:
+        with connect_sqlite(self._storage.db_path) as conn:
             conn.executemany(
                 "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -826,7 +828,7 @@ class DemoCollector(Collector):
 
         # Bulk insert with is_demo=1 directly (save_speedtest_results doesn't support is_demo)
         if results:
-            with sqlite3.connect(self._storage.db_path) as conn:
+            with connect_sqlite(self._storage.db_path) as conn:
                 conn.executemany(
                     "INSERT OR IGNORE INTO speedtest_results "
                     "(id, timestamp, download_mbps, upload_mbps, download_human, "
@@ -854,7 +856,7 @@ class DemoCollector(Collector):
             date = (now - timedelta(days=d)).strftime("%Y-%m-%d")
             ts = (now - timedelta(days=d)).strftime("%Y-%m-%dT%H:%M:%SZ")
             png = self._generate_bqm_png(seed=d)
-            with sqlite3.connect(self._storage.db_path) as conn:
+            with connect_sqlite(self._storage.db_path) as conn:
                 conn.execute(
                     "INSERT OR IGNORE INTO bqm_graphs (date, timestamp, image_blob, is_demo) "
                     "VALUES (?, ?, ?, 1)",
@@ -942,7 +944,7 @@ class DemoCollector(Collector):
                 1,                    # is_demo
             ))
 
-        with sqlite3.connect(self._storage.db_path) as conn:
+        with connect_sqlite(self._storage.db_path) as conn:
             conn.executemany(
                 "INSERT INTO bnetz_measurements "
                 "(date, timestamp, provider, tariff, "
@@ -976,8 +978,7 @@ class DemoCollector(Collector):
                     "timestamp": ts.strftime("%Y-%m-%d %H:%M:%SZ"),
                     "temperature": temp,
                 })
-        import sqlite3 as _sqlite3
-        with _sqlite3.connect(self._storage.db_path) as conn:
+        with connect_sqlite(self._storage.db_path) as conn:
             conn.executemany(
                 "INSERT OR IGNORE INTO weather_data "
                 "(timestamp, temperature, is_demo) VALUES (?, ?, 1)",

--- a/app/config.py
+++ b/app/config.py
@@ -47,6 +47,7 @@ DEFAULTS = {
     "temperature_unit": "celsius",
     "isp_name": "",
     "admin_password": "",
+    "metrics_require_token": False,
     "dismissed_notice_ids": [],
     "update_check_enabled": False,
     "demo_mode": False,
@@ -114,6 +115,7 @@ ENV_MAP = {
     "history_days": "HISTORY_DAYS",
     "data_dir": "DATA_DIR",
     "admin_password": "ADMIN_PASSWORD",
+    "metrics_require_token": "METRICS_REQUIRE_TOKEN",
     "bqm_url": "BQM_URL",
     "speedtest_tracker_url": "SPEEDTEST_TRACKER_URL",
     "speedtest_tracker_token": "SPEEDTEST_TRACKER_TOKEN",
@@ -187,7 +189,7 @@ INT_KEYS = {"poll_interval", "web_port", "history_days", "booked_download", "boo
             "sc_flapping_window", "sc_flapping_threshold",
             "sc_trigger_error_spike_min_delta"}
 BOOL_KEYS = {"demo_mode", "update_check_enabled", "gaming_quality_enabled", "segment_utilization_enabled", "notify_apprise_enabled",
-             "notify_pwa_push_enabled",
+             "notify_pwa_push_enabled", "metrics_require_token",
              "speedtest_tls_insecure", "sc_enabled", "sc_trigger_modulation", "sc_trigger_snr",
              "sc_trigger_error_spike", "sc_trigger_health", "sc_trigger_packet_loss"}
 

--- a/app/module_download.py
+++ b/app/module_download.py
@@ -18,6 +18,28 @@ TRUSTED_HOSTS = {
 }
 
 
+def safe_url_label(url: str | None) -> str:
+    """Return a log-safe source label without user-controlled URL detail."""
+    if not url:
+        return "<empty-url>"
+    try:
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.hostname:
+            return "<invalid-url>"
+        _ = parsed.port  # validate malformed/out-of-range ports without logging them
+        # Return only fixed labels for known hosts. Unknown hosts may be private
+        # instance data, so keep them out of shareable logs.
+        if parsed.hostname == "raw.githubusercontent.com":
+            return "raw.githubusercontent.com"
+        if parsed.hostname == "api.github.com":
+            return "api.github.com"
+        if parsed.hostname == "github.com":
+            return "github.com"
+    except (TypeError, ValueError):
+        return "<invalid-url>"
+    return "<custom-endpoint>"
+
+
 def is_trusted_url(url: str) -> bool:
     """Check that a URL uses HTTPS and points to a trusted GitHub host."""
     try:
@@ -41,7 +63,7 @@ def fetch_registry(registry_url: str, key: str = "modules", timeout: int = 10) -
         timeout: request timeout in seconds
     """
     if not is_trusted_url(registry_url):
-        log.error("Refusing registry fetch: untrusted URL %s", registry_url)
+        log.error("Refusing registry fetch: untrusted endpoint %s", safe_url_label(registry_url))
         return []
     try:
         with urllib.request.urlopen(registry_url, timeout=timeout) as resp:
@@ -49,7 +71,7 @@ def fetch_registry(registry_url: str, key: str = "modules", timeout: int = 10) -
         entries = data.get(key, [])
         return [e for e in entries if validate_registry_entry(e)]
     except Exception as e:
-        log.warning("Failed to fetch registry from %s: %s", registry_url, e)
+        log.warning("Failed to fetch registry from %s: %s", safe_url_label(registry_url), type(e).__name__)
         return []
 
 
@@ -68,7 +90,7 @@ def download_github_directory(download_url: str, target_dir: str, timeout: int =
         True on success, False on failure (target_dir is cleaned up on failure)
     """
     if not is_trusted_url(download_url):
-        log.error("Refusing download: untrusted URL %s", download_url)
+        log.error("Refusing download: untrusted endpoint %s", safe_url_label(download_url))
         return False
 
     try:
@@ -93,7 +115,7 @@ def download_github_directory(download_url: str, target_dir: str, timeout: int =
             if entry_type == "file":
                 file_url = entry.get("download_url")
                 if not file_url or not is_trusted_url(file_url):
-                    log.warning("Skipping untrusted file URL: %s", file_url)
+                    log.warning("Skipping untrusted file endpoint: %s", safe_url_label(file_url))
                     continue
                 with urllib.request.urlopen(file_url, timeout=timeout) as resp:
                     with open(candidate, "wb") as f:
@@ -102,7 +124,7 @@ def download_github_directory(download_url: str, target_dir: str, timeout: int =
             elif entry_type == "dir":
                 subdir_url = entry.get("url", "")
                 if not is_trusted_url(subdir_url):
-                    log.warning("Skipping untrusted dir URL: %s", subdir_url)
+                    log.warning("Skipping untrusted dir endpoint: %s", safe_url_label(subdir_url))
                     continue
                 if not download_github_directory(subdir_url, candidate, timeout):
                     shutil.rmtree(target_dir, ignore_errors=True)
@@ -110,6 +132,6 @@ def download_github_directory(download_url: str, target_dir: str, timeout: int =
 
         return True
     except Exception as e:
-        log.error("Failed to download from %s: %s", download_url, e)
+        log.error("Failed to download from %s: %s", safe_url_label(download_url), type(e).__name__)
         shutil.rmtree(target_dir, ignore_errors=True)
         return False

--- a/app/modules/backup/backup.py
+++ b/app/modules/backup/backup.py
@@ -9,6 +9,8 @@ import logging
 import os
 import shutil
 import sqlite3
+
+from app.storage.sqlite import connect_sqlite
 import tarfile
 import tempfile
 from datetime import datetime, timezone
@@ -44,7 +46,7 @@ def _get_table_counts(db_path):
     """Return {table_name: row_count} for all user tables."""
     counts = {}
     try:
-        conn = sqlite3.connect(db_path)
+        conn = connect_sqlite(db_path)
         tables = [r[0] for r in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
         ).fetchall()]
@@ -65,13 +67,13 @@ def _vacuum_db(data_dir, db_name, dest_path):
     if not os.path.exists(src):
         return False
 
-    conn = sqlite3.connect(src)
+    conn = connect_sqlite(src)
     conn.execute(f"VACUUM INTO '{dest_path}'")
     conn.close()
 
     # Remove demo data from copy (only relevant for main DB)
     if db_name == "docsis_history.db":
-        copy_conn = sqlite3.connect(dest_path)
+        copy_conn = connect_sqlite(dest_path)
         demo_tables = [
             "snapshots", "events", "journal_entries", "incidents",
             "speedtest_results", "bqm_graphs", "bnetz_measurements",

--- a/app/modules/bnetz/storage.py
+++ b/app/modules/bnetz/storage.py
@@ -4,6 +4,8 @@ import json
 import logging
 import sqlite3
 
+from app.storage.sqlite import connect_sqlite
+
 from app.tz import utc_now
 
 log = logging.getLogger("docsis.storage.bnetz")
@@ -21,7 +23,7 @@ class BnetzStorage:
 
     def _ensure_table(self):
         """Create the bnetz_measurements table if it doesn't exist."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS bnetz_measurements ("
                 "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -63,7 +65,7 @@ class BnetzStorage:
             "download": parsed_data.get("measurements_download", []),
             "upload": parsed_data.get("measurements_upload", []),
         }
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             cur = conn.execute(
                 "INSERT INTO bnetz_measurements "
                 "(date, timestamp, provider, tariff, "
@@ -97,7 +99,7 @@ class BnetzStorage:
 
     def get_bnetz_measurements(self, limit=50):
         """Return list of BNetzA measurements (without PDF blob), newest first."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT id, date, timestamp, provider, tariff, "
@@ -124,7 +126,7 @@ class BnetzStorage:
 
     def get_bnetz_pdf(self, measurement_id):
         """Return the original PDF bytes for a BNetzA measurement, or None."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             row = conn.execute(
                 "SELECT pdf_blob FROM bnetz_measurements WHERE id = ?",
                 (measurement_id,),
@@ -133,7 +135,7 @@ class BnetzStorage:
 
     def delete_bnetz_measurement(self, measurement_id):
         """Delete a BNetzA measurement. Returns True if found."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             rowcount = conn.execute(
                 "DELETE FROM bnetz_measurements WHERE id = ?",
                 (measurement_id,),
@@ -142,7 +144,7 @@ class BnetzStorage:
 
     def get_bnetz_in_range(self, start_ts, end_ts):
         """Return BNetzA measurements within a time range, oldest first."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT id, date, timestamp, provider, tariff, "
@@ -158,7 +160,7 @@ class BnetzStorage:
 
     def get_latest_bnetz(self):
         """Return the most recent BNetzA measurement (without blob), or None."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
                 "SELECT id, date, timestamp, provider, tariff, "

--- a/app/modules/bqm/storage.py
+++ b/app/modules/bqm/storage.py
@@ -3,6 +3,8 @@
 import logging
 import sqlite3
 
+from app.storage.sqlite import connect_sqlite
+
 from app.tz import local_today, utc_now
 
 log = logging.getLogger("docsis.storage.bqm")
@@ -21,7 +23,7 @@ class BqmStorage:
 
     def _ensure_table(self):
         """Create the BQM tables if they don't exist."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS bqm_graphs ("
                 "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -68,7 +70,7 @@ class BqmStorage:
         if not rows:
             return
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with connect_sqlite(self.db_path) as conn:
                 conn.execute("PRAGMA busy_timeout = 5000")
                 conn.executemany(
                     "INSERT OR IGNORE INTO bqm_data "
@@ -95,7 +97,7 @@ class BqmStorage:
             raise
 
     def _rows_for_query(self, query, params):
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(query, params).fetchall()
         return [dict(r) for r in rows]
@@ -120,7 +122,7 @@ class BqmStorage:
 
     def get_csv_dates(self):
         """Return list of dates with CSV data (newest first)."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT DISTINCT date FROM bqm_data ORDER BY date DESC"
             ).fetchall()
@@ -128,7 +130,7 @@ class BqmStorage:
 
     def has_csv_data(self, target_date):
         """Return True if CSV data exists for the given date."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             row = conn.execute(
                 "SELECT 1 FROM bqm_data WHERE date = ? LIMIT 1",
                 (target_date,),
@@ -140,7 +142,7 @@ class BqmStorage:
         target_date = graph_date or local_today(self.tz_name)
         ts = utc_now()
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with connect_sqlite(self.db_path) as conn:
                 conn.execute(
                     "INSERT OR IGNORE INTO bqm_graphs (date, timestamp, image_blob) VALUES (?, ?, ?)",
                     (target_date, ts, image_data),
@@ -153,7 +155,7 @@ class BqmStorage:
         """Import a BQM graph for a specific date.
         Returns: 'imported', 'skipped', or 'replaced'."""
         ts = date + "T00:00:00"
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             existing = conn.execute(
                 "SELECT 1 FROM bqm_graphs WHERE date = ?", (date,)
             ).fetchone()
@@ -173,13 +175,13 @@ class BqmStorage:
 
     def delete_bqm_graph(self, date):
         """Delete a single BQM graph. Returns True if deleted."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             cur = conn.execute("DELETE FROM bqm_graphs WHERE date = ?", (date,))
         return cur.rowcount > 0
 
     def delete_bqm_graphs_range(self, start_date, end_date):
         """Delete BQM graphs in date range (inclusive). Returns count."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             cur = conn.execute(
                 "DELETE FROM bqm_graphs WHERE date >= ? AND date <= ?",
                 (start_date, end_date),
@@ -188,13 +190,13 @@ class BqmStorage:
 
     def delete_all_bqm_graphs(self):
         """Delete all BQM graphs. Returns count."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             cur = conn.execute("DELETE FROM bqm_graphs")
         return cur.rowcount
 
     def get_bqm_dates(self):
         """Return list of dates with BQM graphs (newest first)."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT date FROM bqm_graphs ORDER BY date DESC"
             ).fetchall()
@@ -202,7 +204,7 @@ class BqmStorage:
 
     def get_bqm_graph(self, date):
         """Return BQM graph PNG bytes for a date, or None."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             row = conn.execute(
                 "SELECT image_blob FROM bqm_graphs WHERE date = ?", (date,)
             ).fetchone()
@@ -210,7 +212,7 @@ class BqmStorage:
 
     def set_meta(self, key, value):
         """Persist a module metadata key."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.execute(
                 "INSERT INTO bqm_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -219,7 +221,7 @@ class BqmStorage:
 
     def get_collection_metadata(self):
         """Return persisted BQM collection metadata."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             rows = conn.execute("SELECT key, value FROM bqm_meta").fetchall()
         return {key: value for key, value in rows}
 
@@ -232,7 +234,7 @@ class BqmStorage:
             "last_success_mode": mode,
             "last_success_rows": rows,
         }
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.executemany(
                 "INSERT INTO bqm_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",

--- a/app/modules/connection_monitor/storage.py
+++ b/app/modules/connection_monitor/storage.py
@@ -4,6 +4,8 @@ import logging
 import math
 import os
 import sqlite3
+
+from app.storage.sqlite import connect_sqlite
 import time
 
 logger = logging.getLogger(__name__)
@@ -18,7 +20,7 @@ class ConnectionMonitorStorage:
         self._init_tables()
 
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path)
+        conn = connect_sqlite(self.db_path)
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA foreign_keys=ON")
         conn.row_factory = sqlite3.Row

--- a/app/modules/evidence/routes.py
+++ b/app/modules/evidence/routes.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
+
+from app.storage.sqlite import connect_sqlite
 from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -77,7 +79,7 @@ def _normalise_window_ts(value: str, tz_name: str) -> str:
 
 def _get_journal_entries_for_window(db_path: str, start_ts: str, end_ts: str) -> list[dict[str, Any]]:
     start_date, end_date = _local_date_bounds_for_window(start_ts, end_ts, _get_tz_name())
-    with sqlite3.connect(db_path) as conn:
+    with connect_sqlite(db_path) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
             "SELECT id, date, title, description, icon, incident_id, created_at, updated_at "
@@ -142,7 +144,7 @@ def _get_connection_latency_rows(start_ts: str, end_ts: str) -> list[dict[str, A
     end_epoch = _utc_ts_to_epoch(end_ts)
     rows: list[dict[str, Any]] = []
     try:
-        with sqlite3.connect(db_path) as conn:
+        with connect_sqlite(db_path) as conn:
             conn.row_factory = sqlite3.Row
             raw = conn.execute(
                 """

--- a/app/modules/journal/storage.py
+++ b/app/modules/journal/storage.py
@@ -3,6 +3,8 @@
 import logging
 import sqlite3
 
+from app.storage.sqlite import connect_sqlite
+
 from app.tz import utc_now
 
 log = logging.getLogger("docsis.storage.journal")
@@ -21,7 +23,7 @@ class JournalStorage:
 
     def _ensure_table(self):
         """Create the journal tables if they don't exist."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS journal_entries (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -71,7 +73,7 @@ class JournalStorage:
 
     def _connect(self):
         """Return a connection with foreign keys enabled."""
-        conn = sqlite3.connect(self.db_path)
+        conn = connect_sqlite(self.db_path)
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
 

--- a/app/modules/speedtest/routes.py
+++ b/app/modules/speedtest/routes.py
@@ -8,6 +8,7 @@ from flask import Blueprint, request, jsonify
 
 from app.web import require_auth, get_config_manager, get_state, get_storage, clear_speedtest_latest
 from app.i18n import get_translations
+from app.storage.sqlite import connect_sqlite
 
 from .client import SpeedtestClient
 from .storage import SpeedtestStorage
@@ -82,8 +83,7 @@ def _enrich_speedtest(result):
 def _annotate_smart_capture(results, db_path):
     """Annotate speedtest results with smart_capture flag."""
     try:
-        import sqlite3
-        with sqlite3.connect(db_path) as conn:
+        with connect_sqlite(db_path) as conn:
             rows = conn.execute(
                 "SELECT linked_result_id FROM smart_capture_executions "
                 "WHERE status = 'completed' AND linked_result_id IS NOT NULL"

--- a/app/modules/speedtest/storage.py
+++ b/app/modules/speedtest/storage.py
@@ -2,6 +2,8 @@
 
 import logging
 import sqlite3
+
+from app.storage.sqlite import connect_sqlite
 from datetime import datetime, timezone
 
 log = logging.getLogger("docsis.storage.speedtest")
@@ -19,7 +21,7 @@ class SpeedtestStorage:
 
     def _ensure_table(self):
         """Create the speedtest_results and speedtest_meta tables if they don't exist."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS speedtest_results ("
                 "  id INTEGER PRIMARY KEY,"
@@ -132,7 +134,7 @@ class SpeedtestStorage:
         if not results:
             return
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with connect_sqlite(self.db_path) as conn:
                 conn.executemany(
                     "INSERT INTO speedtest_results "
                     "(id, timestamp, download_mbps, upload_mbps, download_human, "
@@ -188,7 +190,7 @@ class SpeedtestStorage:
 
     def get_speedtest_results(self, limit=2000):
         """Return cached speedtest results, newest first."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT id, timestamp, download_mbps, upload_mbps, download_human, "
@@ -201,7 +203,7 @@ class SpeedtestStorage:
 
     def get_speedtest_by_id(self, result_id):
         """Return a single speedtest result by id, or None (includes enriched fields)."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
                 "SELECT id, timestamp, download_mbps, upload_mbps, download_human, "
@@ -218,13 +220,13 @@ class SpeedtestStorage:
 
     def get_speedtest_count(self):
         """Return number of cached speedtest results."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             row = conn.execute("SELECT COUNT(*) FROM speedtest_results").fetchone()
         return row[0] if row else 0
 
     def get_latest_speedtest_id(self):
         """Return the highest speedtest result id, or 0 if none."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             row = conn.execute(
                 "SELECT MAX(id) FROM speedtest_results"
             ).fetchone()
@@ -236,7 +238,7 @@ class SpeedtestStorage:
 
     def get_meta(self, key):
         """Return a metadata value, or None."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             row = conn.execute(
                 "SELECT value FROM speedtest_meta WHERE key = ?", (key,)
             ).fetchone()
@@ -244,7 +246,7 @@ class SpeedtestStorage:
 
     def set_meta(self, key, value):
         """Set a metadata value (upsert)."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.execute(
                 "INSERT INTO speedtest_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -290,7 +292,7 @@ class SpeedtestStorage:
 
     def clear_cache(self):
         """Delete all cached speedtest results (non-demo)."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             count = conn.execute(
                 "SELECT COUNT(*) FROM speedtest_results WHERE is_demo = 0"
             ).fetchone()[0]
@@ -300,7 +302,7 @@ class SpeedtestStorage:
 
     def get_speedtest_in_range(self, start_ts, end_ts):
         """Return speedtest results within a time range, oldest first."""
-        with sqlite3.connect(self.db_path) as conn:
+        with connect_sqlite(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
                 "SELECT id, timestamp, download_mbps, upload_mbps, download_human, "

--- a/app/modules/weather/storage.py
+++ b/app/modules/weather/storage.py
@@ -2,6 +2,8 @@
 
 import logging
 import sqlite3
+
+from app.storage.sqlite import DEFAULT_SQLITE_BUSY_TIMEOUT_MS, connect_sqlite
 import threading
 from collections import defaultdict
 from pathlib import Path
@@ -24,7 +26,7 @@ class WeatherStorage:
     Creates the weather_data table if it doesn't exist.
     """
 
-    BUSY_TIMEOUT_MS = 5000
+    BUSY_TIMEOUT_MS = DEFAULT_SQLITE_BUSY_TIMEOUT_MS
     _locks = defaultdict(threading.RLock)
 
     def __init__(self, db_path):
@@ -35,9 +37,8 @@ class WeatherStorage:
 
     def _connect(self):
         """Return a connection with WAL mode and busy timeout."""
-        conn = sqlite3.connect(self.db_path)
+        conn = connect_sqlite(self.db_path)
         conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute(f"PRAGMA busy_timeout={self.BUSY_TIMEOUT_MS}")
         return conn
 
     def _ensure_table(self):

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -3,6 +3,8 @@
 import logging
 import os
 import sqlite3
+
+from .sqlite import connect_sqlite
 from contextlib import contextmanager
 
 
@@ -212,7 +214,7 @@ class StorageBase:
     @contextmanager
     def _connect(self):
         """Yield a connection with foreign keys enabled and close it afterwards."""
-        conn = sqlite3.connect(self.db_path)
+        conn = connect_sqlite(self.db_path)
         conn.execute("PRAGMA foreign_keys = ON")
         try:
             yield conn

--- a/app/storage/segment_utilization.py
+++ b/app/storage/segment_utilization.py
@@ -1,6 +1,8 @@
 """Segment utilization storage (standalone, not a core mixin)."""
 
 import sqlite3
+
+from app.storage.sqlite import connect_sqlite
 import threading
 from datetime import datetime, timedelta, timezone
 
@@ -48,7 +50,7 @@ class SegmentUtilizationStorage:
         self._ensure_table()
 
     def _ensure_table(self):
-        conn = sqlite3.connect(self.db_path)
+        conn = connect_sqlite(self.db_path)
         try:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS segment_utilization (
@@ -88,7 +90,7 @@ class SegmentUtilizationStorage:
             conn.close()
 
     def _connect(self):
-        conn = sqlite3.connect(self.db_path)
+        conn = connect_sqlite(self.db_path)
         conn.row_factory = sqlite3.Row
         return conn
 

--- a/app/storage/sqlite.py
+++ b/app/storage/sqlite.py
@@ -1,0 +1,15 @@
+"""Shared SQLite connection helpers."""
+
+import sqlite3
+from typing import Any
+
+DEFAULT_SQLITE_TIMEOUT_SECONDS = 30
+DEFAULT_SQLITE_BUSY_TIMEOUT_MS = 30_000
+
+
+def connect_sqlite(db_path: str, **kwargs: Any) -> sqlite3.Connection:
+    """Open a SQLite connection with DOCSight's local-write busy timeout."""
+    kwargs.setdefault("timeout", DEFAULT_SQLITE_TIMEOUT_SECONDS)
+    conn = sqlite3.connect(db_path, **kwargs)
+    conn.execute(f"PRAGMA busy_timeout={DEFAULT_SQLITE_BUSY_TIMEOUT_MS}")
+    return conn

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -112,6 +112,7 @@
         <div class="error" role="alert">{{ error }}</div>
         {% endif %}
         <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <input type="password" id="login-password" name="password" placeholder="{{ t.password }}" aria-label="{{ t.password }}" autofocus required>
             <button type="submit">{{ t.login_button }}</button>
         </form>

--- a/app/web.py
+++ b/app/web.py
@@ -5,6 +5,7 @@ import logging
 import math
 import os
 import re
+import secrets
 import stat
 import subprocess
 import threading
@@ -128,6 +129,8 @@ _login_attempts = {}  # IP -> [timestamp, ...]
 _LOGIN_MAX_ATTEMPTS = 5
 _LOGIN_WINDOW = 900  # 15 min
 _LOGIN_LOCKOUT_BASE = 30  # seconds, doubles each excess attempt
+_LOGIN_MAX_TRACKED_IPS = 2048
+_LOGIN_CSRF_SESSION_KEY = "login_csrf_token"
 
 
 def _get_client_ip():
@@ -141,12 +144,32 @@ def _get_client_ip():
     return request.remote_addr or "unknown"
 
 
+def _prune_login_attempts(now=None):
+    """Drop expired and oldest login-attempt buckets to keep memory bounded."""
+    now = now or time.time()
+    expired = [ip for ip, attempts in _login_attempts.items() if not [t for t in attempts if now - t < _LOGIN_WINDOW]]
+    for ip in expired:
+        _login_attempts.pop(ip, None)
+
+    for ip, attempts in list(_login_attempts.items()):
+        _login_attempts[ip] = [t for t in attempts if now - t < _LOGIN_WINDOW]
+
+    if len(_login_attempts) <= _LOGIN_MAX_TRACKED_IPS:
+        return
+
+    oldest_first = sorted(
+        _login_attempts,
+        key=lambda ip: _login_attempts[ip][-1] if _login_attempts[ip] else 0,
+    )
+    for ip in oldest_first[: len(_login_attempts) - _LOGIN_MAX_TRACKED_IPS]:
+        _login_attempts.pop(ip, None)
+
+
 def _check_login_rate_limit(ip):
     """Return seconds until retry allowed, or 0 if not limited."""
     now = time.time()
+    _prune_login_attempts(now)
     attempts = _login_attempts.get(ip, [])
-    attempts = [t for t in attempts if now - t < _LOGIN_WINDOW]
-    _login_attempts[ip] = attempts
     if len(attempts) >= _LOGIN_MAX_ATTEMPTS:
         excess = len(attempts) - _LOGIN_MAX_ATTEMPTS
         lockout = _LOGIN_LOCKOUT_BASE * (2 ** min(excess, 8))
@@ -158,9 +181,28 @@ def _check_login_rate_limit(ip):
 
 def _record_failed_login(ip):
     """Record a failed login attempt."""
-    if ip not in _login_attempts:
-        _login_attempts[ip] = []
-    _login_attempts[ip].append(time.time())
+    now = time.time()
+    _prune_login_attempts(now)
+    _login_attempts.setdefault(ip, []).append(now)
+    _prune_login_attempts(now)
+
+
+def _get_login_csrf_token():
+    """Return the session-bound token used by the login form."""
+    token = session.get(_LOGIN_CSRF_SESSION_KEY)
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session[_LOGIN_CSRF_SESSION_KEY] = token
+    return token
+
+
+def _valid_login_csrf_token(candidate):
+    """Validate the submitted login CSRF token against the session token."""
+    token = session.get(_LOGIN_CSRF_SESSION_KEY)
+    return bool(
+        token and candidate
+        and secrets.compare_digest(token.encode("utf-8"), candidate.encode("utf-8"))
+    )
 
 def _get_version():
     """Get version from VERSION file, git tag, or fall back to 'dev'."""
@@ -619,13 +661,19 @@ def login():
     t = get_translations(lang)
     theme = _config_manager.get_theme() if _config_manager else "dark"
     error = None
+    csrf_token = _get_login_csrf_token()
     if request.method == "POST":
         ip = _get_client_ip()
+        if not _valid_login_csrf_token(request.form.get("csrf_token", "")):
+            _record_failed_login(ip)
+            audit_log.warning("Login rejected: invalid csrf token for ip=%s", ip)
+            error = t.get("login_failed", "Invalid password")
+            return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token), 400
         wait = _check_login_rate_limit(ip)
         if wait > 0:
             audit_log.warning("Login rate-limited: ip=%s (retry in %ds)", ip, int(wait))
             error = t.get("login_rate_limited", "Too many attempts. Try again later.")
-            return render_template("login.html", t=t, lang=lang, theme=theme, error=error)
+            return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token)
         pw = request.form.get("password", "")
         stored = _config_manager.get("admin_password", "")
         if stored.startswith(("scrypt:", "pbkdf2:")):
@@ -640,12 +688,13 @@ def login():
             _login_attempts.pop(ip, None)
             session.permanent = True
             session["authenticated"] = True
+            session.pop(_LOGIN_CSRF_SESSION_KEY, None)
             audit_log.info("Login successful: ip=%s", ip)
             return redirect("/")
         _record_failed_login(ip)
         audit_log.warning("Login failed: ip=%s", ip)
         error = t.get("login_failed", "Invalid password")
-    return render_template("login.html", t=t, lang=lang, theme=theme, error=error)
+    return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token)
 
 
 @app.route("/logout")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,21 @@
 #!/bin/sh
-# Fix volume permissions (may be root-owned from previous versions)
+# Prepare volume permissions. Repair recursively only when the mount root is not
+# owned by the runtime user, so normal restarts do not rescan large data trees.
+
+repair_owner_if_needed() {
+    target="$1"
+    [ -d "$target" ] || return 0
+
+    current_owner="$(stat -c '%u:%g' "$target" 2>/dev/null || true)"
+    desired_owner="$(id -u appuser):$(id -g appuser)"
+    if [ "$current_owner" != "$desired_owner" ]; then
+        chown -R appuser:appuser "$target" 2>/dev/null || true
+    fi
+}
+
 mkdir -p /data/modules 2>/dev/null || true
-chown -R appuser:appuser /data 2>/dev/null || true
-[ -d /modules ] && chown -R appuser:appuser /modules 2>/dev/null || true
-[ -d /backup ] && chown -R appuser:appuser /backup 2>/dev/null || true
+chown appuser:appuser /data/modules 2>/dev/null || true
+repair_owner_if_needed /data
+repair_owner_if_needed /modules
+repair_owner_if_needed /backup
 exec gosu appuser "$@"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,12 +1,20 @@
 """Tests for web UI authentication."""
 
 import json
+import re
 import sqlite3
 import pytest
 from werkzeug.security import generate_password_hash
-from app.web import app, update_state, init_config, init_storage
+from app.web import app, update_state, init_config, init_storage, _login_attempts, _LOGIN_MAX_TRACKED_IPS
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
+
+
+def _login_csrf(client):
+    resp = client.get("/login")
+    match = re.search(rb'name="csrf_token" value="([^"]+)"', resp.data)
+    assert match, "login form should include a CSRF token"
+    return match.group(1).decode("utf-8")
 
 
 @pytest.fixture
@@ -95,22 +103,22 @@ class TestAuthEnabled:
         assert b"DOCSight" in resp.data
 
     def test_login_wrong_password(self, auth_client):
-        resp = auth_client.post("/login", data={"password": "wrong"})
+        resp = auth_client.post("/login", data={"password": "wrong", "csrf_token": _login_csrf(auth_client)})
         assert resp.status_code == 200  # stays on login page
 
     def test_login_correct_password(self, auth_client):
-        resp = auth_client.post("/login", data={"password": "secret123"}, follow_redirects=False)
+        resp = auth_client.post("/login", data={"password": "secret123", "csrf_token": _login_csrf(auth_client)}, follow_redirects=False)
         assert resp.status_code == 302
         assert resp.headers["Location"] == "/"
 
     def test_session_persists(self, auth_client):
-        auth_client.post("/login", data={"password": "secret123"})
+        auth_client.post("/login", data={"password": "secret123", "csrf_token": _login_csrf(auth_client)})
         update_state(analysis={"summary": {"ds_total": 1, "us_total": 1, "ds_power_min": 0, "ds_power_max": 0, "ds_power_avg": 0, "us_power_min": 0, "us_power_max": 0, "us_power_avg": 0, "ds_snr_min": 0, "ds_snr_avg": 0, "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0, "health": "good", "health_issues": []}, "ds_channels": [], "us_channels": []})
         resp = auth_client.get("/")
         assert resp.status_code == 200
 
     def test_logout(self, auth_client):
-        auth_client.post("/login", data={"password": "secret123"})
+        auth_client.post("/login", data={"password": "secret123", "csrf_token": _login_csrf(auth_client)})
         auth_client.get("/logout")
         resp = auth_client.get("/")
         assert resp.status_code == 302
@@ -141,12 +149,28 @@ class TestAuthEnabled:
         assert stored != "secret123"
         assert stored.startswith(("scrypt:", "pbkdf2:"))
 
+    def test_login_rejects_missing_csrf_token(self, auth_client):
+        resp = auth_client.post("/login", data={"password": "secret123"})
+        assert resp.status_code == 400
+
+    def test_login_rejects_non_ascii_csrf_token_without_crashing(self, auth_client):
+        resp = auth_client.post("/login", data={"password": "secret123", "csrf_token": "ü"})
+        assert resp.status_code == 400
+
+    def test_login_attempt_tracking_is_bounded(self):
+        _login_attempts.clear()
+        for idx in range(_LOGIN_MAX_TRACKED_IPS + 25):
+            _login_attempts[f"198.51.100.{idx}"] = [idx + 1.0]
+        from app.web import _prune_login_attempts
+        _prune_login_attempts(now=10_000.0)
+        assert len(_login_attempts) <= _LOGIN_MAX_TRACKED_IPS
+
 
 class TestApiTokenAuth:
     """Tests for API token (Bearer) authentication."""
 
     def _login(self, client):
-        client.post("/login", data={"password": "secret123"})
+        client.post("/login", data={"password": "secret123", "csrf_token": _login_csrf(client)})
 
     def test_create_token_requires_session(self, auth_client_with_storage):
         """Token creation without session returns 401."""

--- a/tests/test_full_e2e_ci.py
+++ b/tests/test_full_e2e_ci.py
@@ -1,0 +1,17 @@
+"""Regression checks for the scheduled/labeled full browser E2E gate."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "full-e2e.yml"
+
+
+def test_full_e2e_workflow_is_scheduled_and_label_gated():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "contains(github.event.pull_request.labels.*.name, 'full-e2e')" in workflow
+    assert "TZ=UTC python -m pytest -q tests/e2e --tb=short" in workflow
+    assert "actions/upload-artifact" in workflow
+    assert "tests/e2e/screenshots/" in workflow

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -4,6 +4,7 @@ import pytest
 import app.web as _web
 from app.web import app, update_state, init_config, init_storage
 from app.config import ConfigManager
+from app.storage import SnapshotStorage
 
 
 @pytest.fixture(autouse=True)
@@ -41,6 +42,14 @@ def auth_config(tmp_path):
 
 
 @pytest.fixture
+def protected_metrics_config(tmp_path):
+    """Config with token-protected metrics enabled."""
+    mgr = ConfigManager(str(tmp_path / "protected-data"))
+    mgr.save({"modem_password": "test", "modem_type": "fritzbox", "metrics_require_token": True})
+    return mgr
+
+
+@pytest.fixture
 def metrics_client(noauth_config):
     """Flask test client with no authentication configured."""
     init_config(noauth_config)
@@ -57,6 +66,18 @@ def auth_client(auth_config):
     init_storage(None)
     app.config["TESTING"] = True
     with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def protected_metrics_client(protected_metrics_config, tmp_path):
+    """Flask test client with token-protected metrics enabled."""
+    storage = SnapshotStorage(str(tmp_path / "metrics-tokens.db"), max_days=7)
+    init_config(protected_metrics_config)
+    init_storage(storage)
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        client._docsight_storage = storage
         yield client
 
 
@@ -164,3 +185,18 @@ class TestMetricsEndpoint:
         resp = metrics_client.get("/metrics")
         body = resp.data.decode("utf-8")
         assert "docsight_last_poll_timestamp_seconds" in body
+
+    def test_token_protection_rejects_missing_token(self, protected_metrics_client):
+        resp = protected_metrics_client.get("/metrics")
+        assert resp.status_code == 401
+        assert b"Authentication required" in resp.data
+
+    def test_token_protection_rejects_invalid_token(self, protected_metrics_client):
+        resp = protected_metrics_client.get("/metrics", headers={"Authorization": "Bearer dsk_invalid"})
+        assert resp.status_code == 401
+
+    def test_token_protection_allows_valid_token(self, protected_metrics_client):
+        _, token = protected_metrics_client._docsight_storage.create_api_token("prometheus")
+        resp = protected_metrics_client.get("/metrics", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        assert resp.content_type == "text/plain; version=0.0.4; charset=utf-8"

--- a/tests/test_module_download_logging.py
+++ b/tests/test_module_download_logging.py
@@ -1,0 +1,73 @@
+"""Log redaction checks for community module registry/download URLs."""
+
+import logging
+
+from app import module_download
+
+
+def test_safe_url_label_removes_path_query_and_credentials():
+    label = module_download.safe_url_label("https://user:secret@example.com/private/path?token=abc")
+
+    assert label == "<custom-endpoint>"
+    assert "secret" not in label
+    assert "private" not in label
+    assert "token" not in label
+
+
+def test_safe_url_label_treats_malformed_ports_as_invalid():
+    assert module_download.safe_url_label("https://evil.example:999999/path?token=abc") == "<invalid-url>"
+
+
+def test_registry_fetch_handles_malformed_port_without_raising(caplog):
+    url = "https://evil.example:999999/private/registry.json?token=abc"
+
+    with caplog.at_level(logging.ERROR, logger="docsis.module_download"):
+        assert module_download.fetch_registry(url) == []
+
+    assert "<invalid-url>" in caplog.text
+    assert "999999" not in caplog.text
+    assert "private" not in caplog.text
+
+
+def test_registry_fetch_logs_redacted_untrusted_url(caplog):
+    url = "https://user:secret@evil.example/private/registry.json?token=abc"
+
+    with caplog.at_level(logging.ERROR, logger="docsis.module_download"):
+        assert module_download.fetch_registry(url) == []
+
+    rendered = caplog.text
+    assert "<custom-endpoint>" in rendered
+    assert "evil.example" not in rendered
+    assert "secret" not in rendered
+    assert "private" not in rendered
+    assert "token=abc" not in rendered
+
+
+def test_download_logs_redacted_untrusted_nested_urls(caplog, monkeypatch, tmp_path):
+    entries = [
+        {"name": "module.py", "type": "file", "download_url": "https://user:secret@evil.example/file.py?token=abc"},
+        {"name": "nested", "type": "dir", "url": "https://user:secret@evil.example/nested?token=abc"},
+    ]
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            import json
+            return json.dumps(entries).encode("utf-8")
+
+    monkeypatch.setattr(module_download.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse())
+
+    with caplog.at_level(logging.WARNING, logger="docsis.module_download"):
+        assert module_download.download_github_directory("https://api.github.com/repos/example/repo/contents", str(tmp_path)) is True
+
+    rendered = caplog.text
+    assert "<custom-endpoint>" in rendered
+    assert "evil.example" not in rendered
+    assert "secret" not in rendered
+    assert "file.py" not in rendered
+    assert "token=abc" not in rendered

--- a/tests/test_module_paths.py
+++ b/tests/test_module_paths.py
@@ -37,4 +37,15 @@ def test_container_prepares_community_module_storage():
     assert "mkdir -p /data/modules /modules" in dockerfile
     assert "chown -R appuser:appuser /data /modules" in dockerfile
     assert "mkdir -p /data/modules" in entrypoint
-    assert "chown -R appuser:appuser /data" in entrypoint
+    assert "chown appuser:appuser /data/modules" in entrypoint
+    assert "repair_owner_if_needed /data" in entrypoint
+    assert "stat -c '%u:%g'" in entrypoint
+    assert 'chown -R appuser:appuser "$target"' in entrypoint
+
+
+def test_docker_healthcheck_uses_configured_web_port():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "os.environ.get('WEB_PORT', '8765')" in dockerfile
+    assert "http://localhost:{port}/health" in dockerfile
+    assert "localhost:8765/health" not in dockerfile

--- a/tests/test_sqlite_busy_timeout.py
+++ b/tests/test_sqlite_busy_timeout.py
@@ -1,0 +1,30 @@
+"""SQLite busy-timeout contracts for local storage connections."""
+
+from app.modules.bqm.storage import BqmStorage
+from app.storage import SnapshotStorage
+from app.storage.sqlite import DEFAULT_SQLITE_BUSY_TIMEOUT_MS, connect_sqlite
+
+
+def test_shared_sqlite_helper_sets_busy_timeout(tmp_path):
+    with connect_sqlite(str(tmp_path / "helper.db")) as conn:
+        value = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+
+    assert value == DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+
+
+def test_core_storage_connections_set_busy_timeout(tmp_path):
+    storage = SnapshotStorage(str(tmp_path / "core.db"), max_days=7)
+
+    with storage._connect() as conn:
+        value = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+
+    assert value == DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+
+
+def test_module_storage_connections_use_shared_busy_timeout(tmp_path):
+    storage = BqmStorage(str(tmp_path / "bqm.db"))
+
+    with connect_sqlite(storage.db_path) as conn:
+        value = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+
+    assert value == DEFAULT_SQLITE_BUSY_TIMEOUT_MS


### PR DESCRIPTION
## Summary

- add a scheduled/manual full browser E2E workflow that can also run on pull requests labeled `full-e2e`
- add optional Bearer-token protection for `/metrics` while keeping the default scrape path open
- make Docker runtime hardening safer for custom ports, repeated starts, SQLite write contention, login attempts, login form submissions, and shareable module-download logs

## Validation

- `sh -n entrypoint.sh`
- `.venv/bin/python scripts/i18n_check.py --validate`
- workflow YAML parse smoke with PyYAML
- `.venv/bin/python -m pytest tests/ -q --tb=short --ignore=tests/e2e`
- `TZ=UTC .venv/bin/python -m pytest -q tests/e2e/test_auth.py tests/e2e/test_theme.py --tb=short`
- `TZ=UTC .venv/bin/python -m pytest -q tests/e2e --tb=short`
