### PR TITLE
Preserve unavailable DOCSIS measurements

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -456,7 +456,7 @@ def get_thresholds():
     return _strip(_t())
 
 
-def _parse_float(val, default=0.0):
+def _parse_float(val, default=None):
     try:
         return float(val)
     except (TypeError, ValueError):
@@ -786,19 +786,23 @@ def _assess_ds_channel(ch, docsis_ver, *, modulation_docsis_ver: str | None = No
 
     if raw_power is not None:
         power = _parse_float(raw_power)
-        pt = _get_ds_power_thresholds(modulation)
-        if power < pt["crit_min"] or power > pt["crit_max"]:
-            issues.append("power critical")
-        elif power < pt["warn_min"] or power > pt["warn_max"]:
-            issues.append("power warning")
-        elif power < pt["good_min"] or power > pt["good_max"]:
-            issues.append("power tolerated")
+        if power is not None:
+            pt = _get_ds_power_thresholds(modulation)
+            if power < pt["crit_min"] or power > pt["crit_max"]:
+                issues.append("power critical")
+            elif power < pt["warn_min"] or power > pt["warn_max"]:
+                issues.append("power warning")
+            elif power < pt["good_min"] or power > pt["good_max"]:
+                issues.append("power tolerated")
 
     snr_val = None
-    if docsis_ver == "3.0" and ch.get("mse"):
-        snr_val = abs(_parse_float(ch["mse"]))
-    elif docsis_ver == "3.1" and ch.get("mer"):
-        snr_val = _parse_float(ch["mer"])
+    raw_mse = ch.get("mse")
+    raw_mer = ch.get("mer")
+    if docsis_ver == "3.0" and raw_mse is not None:
+        parsed_mse = _parse_float(raw_mse)
+        snr_val = abs(parsed_mse) if parsed_mse is not None else None
+    elif docsis_ver == "3.1" and raw_mer is not None:
+        snr_val = _parse_float(raw_mer)
 
     if snr_val is not None:
         st = _get_snr_thresholds(modulation)
@@ -837,19 +841,20 @@ def _assess_us_channel(ch, docsis_ver="3.0"):
 
     if raw_power is not None:
         power = _parse_float(raw_power)
-        pt = _get_us_power_thresholds(channel_type)
-        if power < pt["crit_min"]:
-            issues.append("power critical low")
-        elif power > pt["crit_max"]:
-            issues.append("power critical high")
-        elif power < pt["warn_min"]:
-            issues.append("power warning low")
-        elif power > pt["warn_max"]:
-            issues.append("power warning high")
-        elif power < pt["good_min"]:
-            issues.append("power tolerated low")
-        elif power > pt["good_max"]:
-            issues.append("power tolerated high")
+        if power is not None:
+            pt = _get_us_power_thresholds(channel_type)
+            if power < pt["crit_min"]:
+                issues.append("power critical low")
+            elif power > pt["crit_max"]:
+                issues.append("power critical high")
+            elif power < pt["warn_min"]:
+                issues.append("power warning low")
+            elif power > pt["warn_max"]:
+                issues.append("power warning high")
+            elif power < pt["good_min"]:
+                issues.append("power tolerated low")
+            elif power > pt["good_max"]:
+                issues.append("power tolerated high")
     mod_health = _assess_us_modulation(ch, docsis_ver)
     mod_issue = _modulation_issue(mod_health)
     if mod_issue:
@@ -891,7 +896,9 @@ def analyze(data: DocsisData) -> AnalysisResult:
     ds_channels = []
     for ch in ds30:
         power = _parse_float(ch.get("powerLevel"))
-        snr = abs(_parse_float(ch.get("mse"))) if ch.get("mse") else None
+        raw_mse = ch.get("mse")
+        parsed_mse = _parse_float(raw_mse) if raw_mse is not None else None
+        snr = abs(parsed_mse) if parsed_mse is not None else None
         health, health_detail = _assess_ds_channel(ch, "3.0")
         metric_h = _metric_healths(health_detail.split(" + ") if health_detail else [])
         ds_modulation = ch.get("modulation") or ch.get("type", "")
@@ -923,7 +930,8 @@ def analyze(data: DocsisData) -> AnalysisResult:
     for ch in ds31:
         raw_power = ch.get("powerLevel")
         power = _parse_float(raw_power) if raw_power is not None else None
-        snr = _parse_float(ch.get("mer")) if ch.get("mer") else None
+        raw_mer = ch.get("mer")
+        snr = _parse_float(raw_mer) if raw_mer is not None else None
         ds_modulation = ch.get("modulation") or ch.get("type", "")
         profile_modulation = ch.get("profile_modulation") or ch.get("profileModulation")
         channel_family = _classify_ds_family({

--- a/app/modules/reports/report.py
+++ b/app/modules/reports/report.py
@@ -359,6 +359,16 @@ def _format_optional_count(value):
     return f"{value:,}" if value is not None else "N/A"
 
 
+def _format_optional_decimal(value):
+    """Format a decimal metric while preserving unavailable values."""
+    if value is None:
+        return "-"
+    try:
+        return f"{float(value):.1f}"
+    except (TypeError, ValueError):
+        return "-"
+
+
 def _compute_worst_values(snapshots):
     """Compute worst values across all snapshots in the range."""
     worst = {
@@ -589,8 +599,8 @@ def generate_report(
             pdf._table_row([
                 ch.get("channel_id", ""),
                 (ch.get("frequency") or "")[:10],
-                f"{ch.get('power') or 0:.1f}",
-                f"{ch.get('snr') or 0:.1f}" if ch.get("snr") else "-",
+                _format_optional_decimal(ch.get('power')),
+                _format_optional_decimal(ch.get("snr")),
                 str(ch.get("modulation") or "")[:10],
                 _format_optional_count(ch.get('correctable_errors')),
                 _format_optional_count(ch.get('uncorrectable_errors')),
@@ -607,7 +617,7 @@ def generate_report(
             pdf._table_row([
                 ch.get("channel_id", ""),
                 (ch.get("frequency") or "")[:12],
-                f"{ch.get('power') or 0:.1f}",
+                _format_optional_decimal(ch.get('power')),
                 str(ch.get("modulation") or "")[:12],
                 str(ch.get("multiplex") or "")[:15],
                 ch.get("health", ""),

--- a/tests/analyzer/test_health.py
+++ b/tests/analyzer/test_health.py
@@ -65,10 +65,10 @@ class TestParseFloat:
         assert _parse_float("-7.2") == -7.2
 
     def test_none(self):
-        assert _parse_float(None) == 0.0
+        assert _parse_float(None) is None
 
     def test_empty_string(self):
-        assert _parse_float("") == 0.0
+        assert _parse_float("") is None
 
     def test_custom_default(self):
         assert _parse_float("bad", default=-1.0) == -1.0

--- a/tests/analyzer/test_unavailable_measurements.py
+++ b/tests/analyzer/test_unavailable_measurements.py
@@ -1,0 +1,132 @@
+"""Regression tests for unavailable DOCSIS measurement semantics."""
+
+from app.analyzer import analyze
+
+
+def test_missing_and_invalid_power_values_remain_unavailable_and_excluded_from_summary():
+    result = analyze({
+        "channelDs": {
+            "docsis30": [
+                {
+                    "channelID": "1",
+                    "frequency": "602 MHz",
+                    "modulation": "256QAM",
+                    "mse": "-36.0",
+                    "corrErrors": 0,
+                    "nonCorrErrors": 0,
+                },
+                {
+                    "channelID": "2",
+                    "frequency": "610 MHz",
+                    "powerLevel": "not-a-number",
+                    "modulation": "256QAM",
+                    "mse": "-36.0",
+                    "corrErrors": 0,
+                    "nonCorrErrors": 0,
+                },
+                {
+                    "channelID": "3",
+                    "frequency": "618 MHz",
+                    "powerLevel": "4.0",
+                    "modulation": "256QAM",
+                    "mse": "-36.0",
+                    "corrErrors": 0,
+                    "nonCorrErrors": 0,
+                },
+            ],
+            "docsis31": [
+                {
+                    "channelID": "33",
+                    "frequency": "134.975 - 324.975 MHz",
+                    "powerLevel": "bad-value",
+                    "type": "OFDM",
+                    "modulation": "4096QAM",
+                    "mer": "38.0",
+                }
+            ],
+        },
+        "channelUs": {
+            "docsis30": [
+                {
+                    "channelID": "1",
+                    "frequency": "37 MHz",
+                    "modulation": "64QAM",
+                    "multiplex": "ATDMA",
+                },
+                {
+                    "channelID": "2",
+                    "frequency": "45 MHz",
+                    "powerLevel": "invalid",
+                    "modulation": "64QAM",
+                    "multiplex": "ATDMA",
+                },
+                {
+                    "channelID": "3",
+                    "frequency": "52 MHz",
+                    "powerLevel": "42.0",
+                    "modulation": "64QAM",
+                    "multiplex": "ATDMA",
+                },
+            ],
+            "docsis31": [
+                {
+                    "channelID": "5",
+                    "frequency": "18 - 44 MHz",
+                    "powerLevel": "bad-value",
+                    "type": "OFDMA",
+                    "modulation": "OFDMA",
+                    "profile_modulation": "256QAM",
+                    "multiplex": "OFDMA",
+                }
+            ],
+        },
+    })
+
+    ds_by_id = {channel["channel_id"]: channel for channel in result["ds_channels"]}
+    us_by_id = {channel["channel_id"]: channel for channel in result["us_channels"]}
+
+    assert ds_by_id[1]["power"] is None
+    assert ds_by_id[2]["power"] is None
+    assert ds_by_id[33]["power"] is None
+    assert "power" not in ds_by_id[1]["health_detail"]
+    assert "power" not in ds_by_id[2]["health_detail"]
+    assert "power" not in ds_by_id[33]["health_detail"]
+
+    assert us_by_id[1]["power"] is None
+    assert us_by_id[2]["power"] is None
+    assert us_by_id[5]["power"] is None
+    assert "power" not in us_by_id[1]["health_detail"]
+    assert "power" not in us_by_id[2]["health_detail"]
+    assert "power" not in us_by_id[5]["health_detail"]
+
+    assert result["summary"]["ds_power_min"] == 4.0
+    assert result["summary"]["ds_power_max"] == 4.0
+    assert result["summary"]["ds_power_avg"] == 4.0
+    assert result["summary"]["us_power_min"] == 42.0
+    assert result["summary"]["us_power_max"] == 42.0
+    assert result["summary"]["us_power_avg"] == 42.0
+
+
+def test_docsis_30_zero_mse_is_evaluated_as_real_snr_value():
+    result = analyze({
+        "channelDs": {
+            "docsis30": [{
+                "channelID": "1",
+                "frequency": "602 MHz",
+                "powerLevel": "2.0",
+                "modulation": "256QAM",
+                "mse": 0,
+                "corrErrors": 0,
+                "nonCorrErrors": 0,
+            }],
+            "docsis31": [],
+        },
+        "channelUs": {"docsis30": [], "docsis31": []},
+    })
+
+    channel = result["ds_channels"][0]
+    assert channel["snr"] == 0.0
+    assert channel.get("snr_health") == "critical"
+    assert channel["health"] == "critical"
+    assert "snr critical" in channel["health_detail"]
+    assert "snr_critical" in result["summary"]["health_issues"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -139,6 +139,14 @@ def test_generate_report_with_none_channel_values():
     assert isinstance(pdf, bytes)
     assert pdf[:5] == b"%PDF-"
 
+    text = "\n".join(
+        page.extract_text() or ""
+        for page in PdfReader(io.BytesIO(pdf)).pages
+    )
+    assert "1 - - N/A N/A good" in text
+    assert "1 - good" in text
+    assert "1 0.0" not in text
+
 
 def test_complaint_text_uses_real_thresholds():
     text = generate_complaint_text(MOCK_SNAPSHOTS)


### PR DESCRIPTION
## Summary

- Preserve unavailable or unparseable DOCSIS signal values as `None` instead of treating them as measured `0.0` values.
- Evaluate numeric DOCSIS 3.0 `mse=0` as a real SNR value.
- Render unavailable report table decimal fields as `-`.

## Validation

- `.venv/bin/pytest tests/analyzer/test_unavailable_measurements.py tests/analyzer/test_health.py::TestParseFloat tests/test_report.py::test_generate_report_with_none_channel_values -q`
- `.venv/bin/pytest tests/analyzer tests/test_analyzer_modulation.py tests/test_report.py tests/web/test_reports.py -q`
- `.venv/bin/pytest tests --ignore=tests/e2e -q`
- `git diff --check`
