### PR TITLE
Store analysis provenance with saved snapshots

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -17,6 +17,8 @@ log = logging.getLogger("docsis.analyzer")
 
 # --- Dynamic thresholds (set by module loader) ---
 _thresholds = {}
+ANALYZER_SCHEMA_VERSION = 1
+_threshold_profile = {"id": None, "version": None}
 
 # Hardcoded fallback (VFKD values) used if no threshold profile is loaded
 _FALLBACK_THRESHOLDS = {
@@ -45,11 +47,26 @@ _FALLBACK_THRESHOLDS = {
 }
 
 
-def set_thresholds(data: dict[str, object]) -> None:
+def set_thresholds(
+    data: dict[str, object],
+    *,
+    profile_id: str | None = None,
+    profile_version: str | None = None,
+) -> None:
     """Set thresholds from a loaded threshold profile."""
-    global _thresholds
+    global _thresholds, _threshold_profile
     _thresholds = data
+    _threshold_profile = {"id": profile_id, "version": profile_version}
     log.info("Thresholds updated (%d sections)", len(data))
+
+
+def get_analysis_metadata(app_version: str | None = None) -> dict[str, object]:
+    """Return provenance metadata for newly persisted analysis snapshots."""
+    return {
+        "analyzer_schema": ANALYZER_SCHEMA_VERSION,
+        "app_version": app_version,
+        "threshold_profile": dict(_threshold_profile),
+    }
 
 
 def _t():

--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -891,7 +891,11 @@ class ModuleLoader:
             else:
                 tdata = mod.thresholds_data
                 validate_thresholds(tdata)
-            _analyzer.set_thresholds(tdata)
+            _analyzer.set_thresholds(
+                tdata,
+                profile_id=mod.id,
+                profile_version=mod.version,
+            )
             log.info("Module '%s': loaded threshold profile", mod.id)
 
         # Theme

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -81,7 +81,8 @@ class StorageBase:
                     timestamp TEXT NOT NULL,
                     summary_json TEXT NOT NULL,
                     ds_channels_json TEXT NOT NULL,
-                    us_channels_json TEXT NOT NULL
+                    us_channels_json TEXT NOT NULL,
+                    analysis_meta_json TEXT
                 )
             """)
             conn.execute("""
@@ -130,6 +131,14 @@ class StorageBase:
                         log.info("Migration: added is_demo column to %s", tbl)
                 except Exception as e:
                     log.warning("Failed to add is_demo to %s: %s", tbl, e)
+
+            try:
+                cols = [r[1] for r in conn.execute("PRAGMA table_info(snapshots)").fetchall()]
+                if "analysis_meta_json" not in cols:
+                    conn.execute("ALTER TABLE snapshots ADD COLUMN analysis_meta_json TEXT")
+                    log.info("Migration: added analysis_meta_json column to snapshots")
+            except Exception as e:
+                log.warning("Failed to add analysis_meta_json to snapshots: %s", e)
 
             # ── Weather data table ──
             conn.execute("""

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -8,8 +8,10 @@ import sqlite3
 from datetime import timedelta
 from typing import cast
 
+from ..analyzer import get_analysis_metadata
 from ..types import AnalysisResult
 from ..tz import _parse_utc, local_date_to_utc_range, utc_cutoff, utc_now
+from ..version import get_available_app_version
 from .error_counters import unwrap_uint32_counter_series
 
 
@@ -28,6 +30,17 @@ def _normalize_summary_errors(summary):
         summary["ds_correctable_errors"] = None
         summary["ds_uncorrectable_errors"] = None
     return summary
+
+
+def _load_analysis_meta(raw: str | None) -> dict | None:
+    """Load optional snapshot provenance metadata."""
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
 
 
 def _timestamp_in_range(
@@ -63,16 +76,18 @@ class SnapshotMethods:
     def save_snapshot(self, analysis: AnalysisResult, is_demo: bool = False) -> None:
         """Save current analysis as a snapshot. Runs cleanup afterwards."""
         ts = utc_now()
+        analysis_meta = get_analysis_metadata(app_version=get_available_app_version())
         try:
             with self._connect() as conn:
                 conn.execute(
-                    "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo) VALUES (?, ?, ?, ?, ?)",
+                    "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo, analysis_meta_json) VALUES (?, ?, ?, ?, ?, ?)",
                     (
                         ts,
                         json.dumps(analysis["summary"]),
                         json.dumps(analysis["ds_channels"]),
                         json.dumps(analysis["us_channels"]),
                         int(is_demo),
+                        json.dumps(analysis_meta),
                     ),
                 )
             log.debug("Snapshot saved: %s", ts)
@@ -93,7 +108,7 @@ class SnapshotMethods:
         """Load the latest stored snapshot, or None when no baseline exists."""
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT summary_json, ds_channels_json, us_channels_json FROM snapshots ORDER BY timestamp DESC, rowid DESC LIMIT 1"
+                "SELECT summary_json, ds_channels_json, us_channels_json, analysis_meta_json FROM snapshots ORDER BY timestamp DESC, rowid DESC LIMIT 1"
             ).fetchone()
         if not row:
             return None
@@ -101,13 +116,14 @@ class SnapshotMethods:
             "summary": _normalize_summary_errors(json.loads(row[0])),
             "ds_channels": json.loads(row[1]),
             "us_channels": json.loads(row[2]),
+            "analysis_meta": _load_analysis_meta(row[3]),
         })
 
     def get_snapshot(self, timestamp: str) -> AnalysisResult | None:
         """Load a single snapshot by timestamp. Returns analysis dict or None."""
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT summary_json, ds_channels_json, us_channels_json FROM snapshots WHERE timestamp = ?",
+                "SELECT summary_json, ds_channels_json, us_channels_json, analysis_meta_json FROM snapshots WHERE timestamp = ?",
                 (timestamp,),
             ).fetchone()
         if not row:
@@ -116,6 +132,7 @@ class SnapshotMethods:
             "summary": _normalize_summary_errors(json.loads(row[0])),
             "ds_channels": json.loads(row[1]),
             "us_channels": json.loads(row[2]),
+            "analysis_meta": _load_analysis_meta(row[3]),
         })
 
     def get_range_data(self, start_ts: str, end_ts: str) -> list[dict]:

--- a/app/types.py
+++ b/app/types.py
@@ -261,6 +261,7 @@ class AnalysisResult(TypedDict):
     summary: AnalysisSummary
     ds_channels: list[DownstreamChannel]
     us_channels: list[UpstreamChannel]
+    analysis_meta: NotRequired[dict[str, Any] | None]
 
 
 # ── Event Types ──────────────────────────────────────────────────

--- a/app/version.py
+++ b/app/version.py
@@ -1,0 +1,43 @@
+"""Application version helpers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from functools import lru_cache
+
+
+def _read_version_file() -> str | None:
+    """Return a packaged VERSION value when present."""
+    for vpath in ("/app/VERSION", os.path.join(os.path.dirname(__file__), "..", "VERSION")):
+        try:
+            with open(vpath, encoding="utf-8") as f:
+                version = f.read().strip()
+                if version:
+                    return version
+        except FileNotFoundError:
+            pass
+    return None
+
+
+def _git_tag(*args: str) -> str | None:
+    try:
+        version = subprocess.check_output(
+            ["git", "describe", "--tags", *args],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+    return version or None
+
+
+@lru_cache(maxsize=1)
+def get_available_app_version() -> str | None:
+    """Return the exact running DOCSight version when available."""
+    return _read_version_file() or _git_tag("--exact-match")
+
+
+def get_app_version() -> str:
+    """Return the running DOCSight version, or ``dev`` for display fallback."""
+    return get_available_app_version() or _git_tag("--abbrev=0") or "dev"

--- a/app/web.py
+++ b/app/web.py
@@ -7,7 +7,6 @@ import os
 import re
 import secrets
 import stat
-import subprocess
 import threading
 import time
 from datetime import datetime, timedelta
@@ -27,6 +26,7 @@ from .gaming_index import compute_gaming_index
 from .i18n import get_translations, LANGUAGES, LANG_FLAGS
 from .maintainer_notices import coerce_dismissed_notice_ids, get_active_notices
 from .tz import guess_iana_timezone as _guess_iana_timezone, get_tz_name as _get_public_tz_name, to_local as _to_local
+from .version import get_app_version
 
 _IANA_REGIONS = {"Africa", "America", "Antarctica", "Arctic", "Asia",
                  "Atlantic", "Australia", "Europe", "Indian", "Pacific"}
@@ -204,27 +204,7 @@ def _valid_login_csrf_token(candidate):
         and secrets.compare_digest(token.encode("utf-8"), candidate.encode("utf-8"))
     )
 
-def _get_version():
-    """Get version from VERSION file, git tag, or fall back to 'dev'."""
-    # 1. Check VERSION file (written during Docker build)
-    for vpath in ("/app/VERSION", os.path.join(os.path.dirname(__file__), "..", "VERSION")):
-        try:
-            with open(vpath) as f:
-                v = f.read().strip()
-                if v:
-                    return v
-        except FileNotFoundError:
-            pass
-    # 2. Try git
-    try:
-        return subprocess.check_output(
-            ["git", "describe", "--tags", "--abbrev=0"],
-            stderr=subprocess.DEVNULL, text=True
-        ).strip()
-    except Exception:
-        return "dev"
-
-APP_VERSION = _get_version()
+APP_VERSION = get_app_version()
 
 # GitHub update check (background, never blocks page loads)
 _update_cache = {"latest": None, "checked_at": 0, "checking": False}

--- a/tests/analyzer/test_thresholds.py
+++ b/tests/analyzer/test_thresholds.py
@@ -80,10 +80,12 @@ class TestSetThresholds:
 
     def setup_method(self):
         self._orig = analyzer._thresholds.copy()
+        self._orig_profile = analyzer._threshold_profile.copy()
         analyzer.set_thresholds(_TEST_THRESHOLDS)
 
     def teardown_method(self):
         analyzer._thresholds = self._orig
+        analyzer._threshold_profile = self._orig_profile
 
     def test_set_thresholds_updates_global(self):
         assert "downstream_power" in analyzer._thresholds
@@ -127,10 +129,12 @@ class TestOFDMAUpstream:
 
     def setup_method(self):
         self._orig = analyzer._thresholds.copy()
+        self._orig_profile = analyzer._threshold_profile.copy()
         analyzer.set_thresholds(_TEST_THRESHOLDS)
 
     def teardown_method(self):
         analyzer._thresholds = self._orig
+        analyzer._threshold_profile = self._orig_profile
 
     def test_ofdma_channel_threshold_classifications(self):
         cases = [
@@ -222,10 +226,12 @@ class TestDownstreamModulationHealth:
 
     def setup_method(self):
         self._orig = analyzer._thresholds.copy()
+        self._orig_profile = analyzer._threshold_profile.copy()
         analyzer.set_thresholds(_TEST_THRESHOLDS)
 
     def teardown_method(self):
         analyzer._thresholds = self._orig
+        analyzer._threshold_profile = self._orig_profile
 
     @pytest.mark.parametrize(
         ("modulation", "expected_health"),
@@ -269,10 +275,12 @@ class TestPercentErrors:
 
     def setup_method(self):
         self._orig = analyzer._thresholds.copy()
+        self._orig_profile = analyzer._threshold_profile.copy()
         analyzer.set_thresholds(_TEST_THRESHOLDS)
 
     def teardown_method(self):
         analyzer._thresholds = self._orig
+        analyzer._threshold_profile = self._orig_profile
 
     def test_no_errors_healthy(self):
         data = _make_data(ds30=[_make_ds30(1, corr=1000, uncorr=0)])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,6 +4,8 @@ import json
 import sqlite3
 
 import pytest
+from app import analyzer
+from app.storage import snapshot as snapshot_module
 from app.storage import SnapshotStorage
 from app.modules.bnetz.storage import BnetzStorage
 
@@ -40,6 +42,101 @@ class TestSnapshotStorage:
         snap = storage.get_snapshot(ts)
         assert snap is not None
         assert snap["summary"]["ds_total"] == 33
+
+    def test_new_snapshot_stores_analysis_metadata(self, storage, sample_analysis, monkeypatch):
+        monkeypatch.setattr(snapshot_module, "get_available_app_version", lambda: "2026.7-test")
+        orig_thresholds = analyzer._thresholds.copy()
+        orig_profile = analyzer._threshold_profile.copy()
+        try:
+            analyzer.set_thresholds(
+                {"downstream_power": {}, "upstream_power": {}, "snr": {}},
+                profile_id="test.thresholds_alpha",
+                profile_version="1.2.3",
+            )
+
+            storage.save_snapshot(sample_analysis)
+            ts = storage.get_snapshot_list()[0]
+            snap = storage.get_snapshot(ts)
+            latest = storage.get_latest_snapshot()
+        finally:
+            analyzer._thresholds = orig_thresholds
+            analyzer._threshold_profile = orig_profile
+
+        assert snap is not None
+        assert latest is not None
+        assert snap["analysis_meta"] == latest["analysis_meta"]
+        assert snap["analysis_meta"] == {
+            "analyzer_schema": analyzer.ANALYZER_SCHEMA_VERSION,
+            "app_version": "2026.7-test",
+            "threshold_profile": {
+                "id": "test.thresholds_alpha",
+                "version": "1.2.3",
+            },
+        }
+
+    def test_unavailable_app_version_is_recorded_as_null(self, storage, sample_analysis, monkeypatch):
+        monkeypatch.setattr(snapshot_module, "get_available_app_version", lambda: None)
+
+        storage.save_snapshot(sample_analysis)
+        ts = storage.get_snapshot_list()[0]
+        snap = storage.get_snapshot(ts)
+
+        assert snap is not None
+        assert snap["analysis_meta"]["app_version"] is None
+
+    def test_old_snapshot_rows_read_with_null_analysis_metadata(self, tmp_path):
+        db_path = str(tmp_path / "legacy.db")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "CREATE TABLE snapshots ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "timestamp TEXT NOT NULL, "
+                "summary_json TEXT NOT NULL, "
+                "ds_channels_json TEXT NOT NULL, "
+                "us_channels_json TEXT NOT NULL"
+                ")"
+            )
+            conn.execute(
+                "INSERT INTO snapshots "
+                "(timestamp, summary_json, ds_channels_json, us_channels_json) "
+                "VALUES (?, ?, ?, ?)",
+                ("2026-07-02T00:00:00Z", json.dumps({"ds_total": 1}), "[]", "[]"),
+            )
+
+        storage = SnapshotStorage(db_path, max_days=7)
+        snap = storage.get_snapshot("2026-07-02T00:00:00Z")
+
+        assert snap is not None
+        assert snap["analysis_meta"] is None
+
+    def test_threshold_profile_change_applies_to_subsequent_snapshots(self, storage, sample_analysis, monkeypatch):
+        monkeypatch.setattr(snapshot_module, "get_available_app_version", lambda: "2026.7-test")
+        orig_thresholds = analyzer._thresholds.copy()
+        orig_profile = analyzer._threshold_profile.copy()
+        try:
+            analyzer.set_thresholds({}, profile_id="test.thresholds_alpha", profile_version="1.0.0")
+            storage.save_snapshot(sample_analysis)
+            analyzer.set_thresholds({}, profile_id="test.thresholds_beta", profile_version="2.0.0")
+            storage.save_snapshot(sample_analysis)
+        finally:
+            analyzer._thresholds = orig_thresholds
+            analyzer._threshold_profile = orig_profile
+
+        with sqlite3.connect(storage.db_path) as conn:
+            rows = conn.execute(
+                "SELECT analysis_meta_json FROM snapshots ORDER BY id"
+            ).fetchall()
+
+        first = json.loads(rows[0][0])
+        second = json.loads(rows[1][0])
+        assert first["threshold_profile"] == {
+            "id": "test.thresholds_alpha",
+            "version": "1.0.0",
+        }
+        assert second["threshold_profile"] == {
+            "id": "test.thresholds_beta",
+            "version": "2.0.0",
+        }
 
     def test_get_nonexistent_snapshot(self, storage):
         assert storage.get_snapshot("2099-01-01T00:00:00") is None

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,36 @@
+"""Tests for application version provenance helpers."""
+
+from app import version
+
+
+def test_available_app_version_uses_exact_sources_only(monkeypatch):
+    version.get_available_app_version.cache_clear()
+    calls = []
+
+    monkeypatch.setattr(version, "_read_version_file", lambda: None)
+
+    def fake_git_tag(*args):
+        calls.append(args)
+        if args == ("--exact-match",):
+            return None
+        if args == ("--abbrev=0",):
+            return "v2026-07-01.1"
+        return None
+
+    monkeypatch.setattr(version, "_git_tag", fake_git_tag)
+
+    assert version.get_available_app_version() is None
+    assert calls == [("--exact-match",)]
+
+
+def test_display_app_version_may_fall_back_to_nearest_tag(monkeypatch):
+    version.get_available_app_version.cache_clear()
+
+    monkeypatch.setattr(version, "_read_version_file", lambda: None)
+    monkeypatch.setattr(
+        version,
+        "_git_tag",
+        lambda *args: "v2026-07-01.1" if args == ("--abbrev=0",) else None,
+    )
+
+    assert version.get_app_version() == "v2026-07-01.1"


### PR DESCRIPTION
## Summary
- store additive analysis provenance metadata with saved snapshots
- record analyzer schema, exact app version when available, and active threshold profile identity
- keep legacy snapshots/databases compatible with null provenance metadata

## Verification
- uv run pytest tests/test_storage.py tests/analyzer/test_thresholds.py tests/test_modules_api.py tests/module_loader/test_thresholds.py tests/test_builtin_module_registry.py tests/web/test_snapshots.py tests/test_update_checks.py tests/test_version.py
- uv run pytest tests --ignore=tests/e2e
- git diff --cached --check

## Review
- Fable review: No blockers found
