### PR TITLE
Add replayable snapshot evidence metadata

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -73,6 +73,8 @@ Rules:
 The main DOCSight history is local SQLite data. It is evidence, not cache.
 
 - Raw modem counters, channel snapshots, incident records, and imported measurements should remain faithful to the source data.
+- Saved DOCSIS snapshots may include a bounded, local copy of the raw driver payload used to produce the analyzed snapshot. This is evidence for replaying future rule/analyzer changes, not telemetry sent to DOCSight maintainers.
+- Raw driver payload persistence applies simple privacy safeguards: obvious secret-bearing keys are redacted before storage and oversized/non-JSON payloads are skipped rather than forced into the history database.
 - Derived views may compute health windows, trends, ranges, summaries, and report sections, but they should not rewrite raw modem evidence just to fit a display model.
 - Unsupported or unknown fields should stay distinguishable from measured zero values.
 - Database migrations should preserve user-owned local data and document any rare destructive migration path before it runs.

--- a/app/collectors/modem.py
+++ b/app/collectors/modem.py
@@ -205,7 +205,7 @@ class ModemCollector(Collector):
 
         # Web state + persistent storage
         self._web.update_state(analysis=analysis)
-        self._storage.save_snapshot(analysis)
+        self._storage.save_snapshot(analysis, raw_data=data)
 
         # Event detection
         events = self._event_detector.check(analysis)

--- a/app/replay.py
+++ b/app/replay.py
@@ -1,0 +1,80 @@
+"""Helpers for replaying stored raw DOCSIS snapshot evidence."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypedDict, cast
+
+from .analyzer import analyze
+from .types import AnalysisResult, DocsisData
+
+
+class ReplayComparison(TypedDict):
+    """Result of replaying one stored raw payload through the analyzer."""
+
+    timestamp: str
+    available: bool
+    matches: bool
+    differences: list[str]
+    stored: AnalysisResult | None
+    replayed: AnalysisResult | None
+
+
+def _comparable(analysis: AnalysisResult) -> dict[str, Any]:
+    """Return analyzer-owned fields suitable for replay comparison."""
+    return {
+        "summary": analysis["summary"],
+        "ds_channels": analysis["ds_channels"],
+        "us_channels": analysis["us_channels"],
+    }
+
+
+def _differences(stored: AnalysisResult, replayed: AnalysisResult) -> list[str]:
+    differences = []
+    stored_cmp = _comparable(stored)
+    replayed_cmp = _comparable(replayed)
+    for section in ("summary", "ds_channels", "us_channels"):
+        if stored_cmp[section] != replayed_cmp[section]:
+            differences.append(section)
+    return differences
+
+
+def replay_snapshot(
+    storage: Any,
+    timestamp: str,
+    analyzer_fn: Callable[[DocsisData], AnalysisResult] = analyze,
+) -> ReplayComparison:
+    """Replay a snapshot's stored raw payload and compare it with stored output.
+
+    Snapshots created before raw payload persistence remain valid evidence but are
+    not replayable; those return ``available=False`` rather than raising.
+    """
+    stored = storage.get_snapshot(timestamp)
+    if stored is None:
+        return {
+            "timestamp": timestamp,
+            "available": False,
+            "matches": False,
+            "differences": ["snapshot_missing"],
+            "stored": None,
+            "replayed": None,
+        }
+    raw_data = stored.get("raw_data")
+    if raw_data is None:
+        return {
+            "timestamp": timestamp,
+            "available": False,
+            "matches": False,
+            "differences": ["raw_data_missing"],
+            "stored": stored,
+            "replayed": None,
+        }
+    replayed = analyzer_fn(cast(DocsisData, raw_data))
+    differences = _differences(stored, replayed)
+    return {
+        "timestamp": timestamp,
+        "available": True,
+        "matches": not differences,
+        "differences": differences,
+        "stored": stored,
+        "replayed": replayed,
+    }

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -82,6 +82,7 @@ class StorageBase:
                     summary_json TEXT NOT NULL,
                     ds_channels_json TEXT NOT NULL,
                     us_channels_json TEXT NOT NULL,
+                    raw_json TEXT,
                     analysis_meta_json TEXT
                 )
             """)
@@ -137,8 +138,11 @@ class StorageBase:
                 if "analysis_meta_json" not in cols:
                     conn.execute("ALTER TABLE snapshots ADD COLUMN analysis_meta_json TEXT")
                     log.info("Migration: added analysis_meta_json column to snapshots")
+                if "raw_json" not in cols:
+                    conn.execute("ALTER TABLE snapshots ADD COLUMN raw_json TEXT")
+                    log.info("Migration: added raw_json column to snapshots")
             except Exception as e:
-                log.warning("Failed to add analysis_meta_json to snapshots: %s", e)
+                log.warning("Failed to add optional snapshot metadata columns: %s", e)
 
             # ── Weather data table ──
             conn.execute("""

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -6,10 +6,10 @@ import json
 import logging
 import sqlite3
 from datetime import timedelta
-from typing import cast
+from typing import Any, cast
 
 from ..analyzer import get_analysis_metadata
-from ..types import AnalysisResult
+from ..types import AnalysisResult, DocsisData
 from ..tz import _parse_utc, local_date_to_utc_range, utc_cutoff, utc_now
 from ..version import get_available_app_version
 from .error_counters import unwrap_uint32_counter_series
@@ -19,6 +19,17 @@ _SUMMARY_ERROR_KEYS = ("ds_correctable_errors", "ds_uncorrectable_errors")
 _LONGEST_TREND_RANGE_DAYS = 90
 _UNWRAP_PRE_RANGE_ANCHOR_DAYS = 2
 _UNWRAP_ANCHOR_DAYS = _LONGEST_TREND_RANGE_DAYS + _UNWRAP_PRE_RANGE_ANCHOR_DAYS
+MAX_RAW_SNAPSHOT_BYTES = 512 * 1024
+_SENSITIVE_RAW_KEYS = {
+    "authorization",
+    "cookie",
+    "csrf",
+    "key",
+    "password",
+    "secret",
+    "session",
+    "token",
+}
 
 log = logging.getLogger("docsis.storage")
 
@@ -41,6 +52,50 @@ def _load_analysis_meta(raw: str | None) -> dict | None:
     except (json.JSONDecodeError, TypeError):
         return None
     return value if isinstance(value, dict) else None
+
+
+def _load_raw_data(raw: str | None) -> dict | None:
+    """Load optional raw snapshot evidence payload."""
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _redact_raw_value(value: Any) -> Any:
+    """Return a JSON-safe raw payload with obvious secret-bearing keys redacted."""
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, child in value.items():
+            key_text = str(key)
+            if any(marker in key_text.lower() for marker in _SENSITIVE_RAW_KEYS):
+                cleaned[key_text] = "[REDACTED]"
+            else:
+                cleaned[key_text] = _redact_raw_value(child)
+        return cleaned
+    if isinstance(value, list):
+        return [_redact_raw_value(child) for child in value]
+    if isinstance(value, tuple):
+        return [_redact_raw_value(child) for child in value]
+    return value
+
+
+def _dump_raw_data(raw_data: DocsisData | dict[str, Any] | None) -> str | None:
+    """Serialize raw snapshot evidence when it is JSON-safe and bounded."""
+    if raw_data is None:
+        return None
+    try:
+        payload = json.dumps(_redact_raw_value(raw_data), separators=(",", ":"), sort_keys=True)
+    except (TypeError, ValueError):
+        log.warning("Skipping raw snapshot payload: payload is not JSON serializable")
+        return None
+    if len(payload.encode("utf-8")) > MAX_RAW_SNAPSHOT_BYTES:
+        log.warning("Skipping raw snapshot payload: payload exceeds %d bytes", MAX_RAW_SNAPSHOT_BYTES)
+        return None
+    return payload
 
 
 def _timestamp_in_range(
@@ -73,20 +128,27 @@ def _unwrap_anchor_start(timestamp: str) -> str:
 
 class SnapshotMethods:
 
-    def save_snapshot(self, analysis: AnalysisResult, is_demo: bool = False) -> None:
+    def save_snapshot(
+        self,
+        analysis: AnalysisResult,
+        is_demo: bool = False,
+        raw_data: DocsisData | dict[str, Any] | None = None,
+    ) -> None:
         """Save current analysis as a snapshot. Runs cleanup afterwards."""
         ts = utc_now()
         analysis_meta = get_analysis_metadata(app_version=get_available_app_version())
+        raw_json = _dump_raw_data(raw_data)
         try:
             with self._connect() as conn:
                 conn.execute(
-                    "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo, analysis_meta_json) VALUES (?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo, raw_json, analysis_meta_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
                         ts,
                         json.dumps(analysis["summary"]),
                         json.dumps(analysis["ds_channels"]),
                         json.dumps(analysis["us_channels"]),
                         int(is_demo),
+                        raw_json,
                         json.dumps(analysis_meta),
                     ),
                 )
@@ -108,7 +170,7 @@ class SnapshotMethods:
         """Load the latest stored snapshot, or None when no baseline exists."""
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT summary_json, ds_channels_json, us_channels_json, analysis_meta_json FROM snapshots ORDER BY timestamp DESC, rowid DESC LIMIT 1"
+                "SELECT summary_json, ds_channels_json, us_channels_json, analysis_meta_json, raw_json FROM snapshots ORDER BY timestamp DESC, rowid DESC LIMIT 1"
             ).fetchone()
         if not row:
             return None
@@ -117,13 +179,14 @@ class SnapshotMethods:
             "ds_channels": json.loads(row[1]),
             "us_channels": json.loads(row[2]),
             "analysis_meta": _load_analysis_meta(row[3]),
+            "raw_data": _load_raw_data(row[4]),
         })
 
     def get_snapshot(self, timestamp: str) -> AnalysisResult | None:
         """Load a single snapshot by timestamp. Returns analysis dict or None."""
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT summary_json, ds_channels_json, us_channels_json, analysis_meta_json FROM snapshots WHERE timestamp = ?",
+                "SELECT summary_json, ds_channels_json, us_channels_json, analysis_meta_json, raw_json FROM snapshots WHERE timestamp = ?",
                 (timestamp,),
             ).fetchone()
         if not row:
@@ -133,7 +196,17 @@ class SnapshotMethods:
             "ds_channels": json.loads(row[1]),
             "us_channels": json.loads(row[2]),
             "analysis_meta": _load_analysis_meta(row[3]),
+            "raw_data": _load_raw_data(row[4]),
         })
+
+    def get_snapshot_raw_data(self, timestamp: str) -> dict | None:
+        """Return the raw driver payload stored with a snapshot, if available."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT raw_json FROM snapshots WHERE timestamp = ?",
+                (timestamp,),
+            ).fetchone()
+        return _load_raw_data(row[0]) if row else None
 
     def get_range_data(self, start_ts: str, end_ts: str) -> list[dict]:
         """Get all snapshots between two ISO timestamps (inclusive)."""

--- a/app/types.py
+++ b/app/types.py
@@ -262,6 +262,7 @@ class AnalysisResult(TypedDict):
     ds_channels: list[DownstreamChannel]
     us_channels: list[UpstreamChannel]
     analysis_meta: NotRequired[dict[str, Any] | None]
+    raw_data: NotRequired[DocsisData | dict[str, Any] | None]
 
 
 # ── Event Types ──────────────────────────────────────────────────

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,132 @@
+"""Tests for replaying stored raw snapshot evidence."""
+
+from app.analyzer import analyze
+from app.replay import replay_snapshot
+from app.storage import SnapshotStorage
+
+
+def _storage(tmp_path):
+    return SnapshotStorage(str(tmp_path / "replay.db"), max_days=7)
+
+
+def test_replay_snapshot_matches_fritz_style_payload(tmp_path):
+    storage = _storage(tmp_path)
+    raw_payload = {
+        "channelDs": {
+            "docsis30": [
+                {
+                    "channelID": 1,
+                    "frequency": "602 MHz",
+                    "powerLevel": "2.5",
+                    "modulation": "256QAM",
+                    "mse": "-38.0",
+                    "corrErrors": 10,
+                    "nonCorrErrors": 0,
+                    "symbolRate": 6952,
+                }
+            ],
+            "docsis31": [],
+        },
+        "channelUs": {
+            "docsis30": [
+                {
+                    "channelID": 1,
+                    "frequency": "45 MHz",
+                    "powerLevel": "42.0",
+                    "modulation": "64QAM",
+                    "multiplex": "ATDMA",
+                    "symbolRate": 5120,
+                }
+            ],
+            "docsis31": [],
+        },
+    }
+    analysis = analyze(raw_payload)
+
+    storage.save_snapshot(analysis, raw_data=raw_payload)
+    timestamp = storage.get_snapshot_list()[0]
+    comparison = replay_snapshot(storage, timestamp)
+
+    assert comparison["available"] is True
+    assert comparison["matches"] is True
+    assert comparison["differences"] == []
+
+
+def test_replay_snapshot_matches_flat_payload(tmp_path):
+    storage = _storage(tmp_path)
+    raw_payload = {
+        "docsis": "3.1",
+        "downstream": [
+            {
+                "channelID": 193,
+                "frequency": "794 MHz",
+                "powerLevel": "1.0",
+                "type": "OFDM",
+                "modulation": "OFDM",
+                "mer": "40.0",
+                "corrErrors": 0,
+                "nonCorrErrors": 0,
+            }
+        ],
+        "upstream": [
+            {
+                "channelID": 9,
+                "frequency": "37 MHz",
+                "powerLevel": "43.0",
+                "type": "OFDMA",
+                "modulation": "OFDMA",
+                "multiplex": "OFDMA",
+            }
+        ],
+    }
+    analysis = analyze(raw_payload)
+
+    storage.save_snapshot(analysis, raw_data=raw_payload)
+    timestamp = storage.get_snapshot_list()[0]
+    comparison = replay_snapshot(storage, timestamp)
+
+    assert comparison["available"] is True
+    assert comparison["matches"] is True
+    assert comparison["differences"] == []
+
+
+def test_replay_snapshot_reports_missing_raw_payload(tmp_path):
+    storage = _storage(tmp_path)
+    raw_payload = {
+        "docsis": "3.1",
+        "downstream": [],
+        "upstream": [],
+    }
+    storage.save_snapshot(analyze(raw_payload))
+    timestamp = storage.get_snapshot_list()[0]
+
+    comparison = replay_snapshot(storage, timestamp)
+
+    assert comparison["available"] is False
+    assert comparison["matches"] is False
+    assert comparison["differences"] == ["raw_data_missing"]
+    assert comparison["replayed"] is None
+
+
+def test_replay_snapshot_reports_changed_analysis(tmp_path):
+    storage = _storage(tmp_path)
+    raw_payload = {
+        "docsis": "3.1",
+        "downstream": [],
+        "upstream": [],
+    }
+    stored = analyze(raw_payload)
+    storage.save_snapshot(stored, raw_data=raw_payload)
+    timestamp = storage.get_snapshot_list()[0]
+
+    def changed_analyzer(_raw):
+        replayed = analyze(raw_payload)
+        replayed["summary"] = dict(replayed["summary"])
+        replayed["summary"]["health"] = "critical"
+        return replayed
+
+    comparison = replay_snapshot(storage, timestamp, analyzer_fn=changed_analyzer)
+
+    assert comparison["available"] is True
+    assert comparison["matches"] is False
+    assert comparison["differences"] == ["summary"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -84,6 +84,51 @@ class TestSnapshotStorage:
         assert snap is not None
         assert snap["analysis_meta"]["app_version"] is None
 
+    def test_new_snapshot_can_store_raw_payload(self, storage, sample_analysis):
+        raw_payload = {
+            "docsis": "3.1",
+            "downstream": [{"channelID": 1, "powerLevel": "3.0"}],
+            "upstream": [{"channelID": 1, "powerLevel": "42.0"}],
+        }
+
+        storage.save_snapshot(sample_analysis, raw_data=raw_payload)
+        ts = storage.get_snapshot_list()[0]
+        snap = storage.get_snapshot(ts)
+        latest = storage.get_latest_snapshot()
+
+        assert snap is not None
+        assert latest is not None
+        assert snap["raw_data"] == raw_payload
+        assert latest["raw_data"] == raw_payload
+        assert storage.get_snapshot_raw_data(ts) == raw_payload
+
+    def test_raw_payload_redacts_sensitive_keys(self, storage, sample_analysis):
+        raw_payload = {
+            "docsis": "3.1",
+            "password": "secret-value",
+            "nested": {"sessionToken": "token-value"},
+            "downstream": [],
+            "upstream": [],
+        }
+
+        storage.save_snapshot(sample_analysis, raw_data=raw_payload)
+        ts = storage.get_snapshot_list()[0]
+        raw = storage.get_snapshot_raw_data(ts)
+
+        assert raw is not None
+        assert raw["password"] == "[REDACTED]"
+        assert raw["nested"]["sessionToken"] == "[REDACTED]"
+
+    def test_oversized_raw_payload_is_not_stored(self, storage, sample_analysis, monkeypatch):
+        monkeypatch.setattr(snapshot_module, "MAX_RAW_SNAPSHOT_BYTES", 16)
+
+        storage.save_snapshot(sample_analysis, raw_data={"downstream": [{"frequency": "x" * 100}], "upstream": []})
+        ts = storage.get_snapshot_list()[0]
+        snap = storage.get_snapshot(ts)
+
+        assert snap is not None
+        assert snap["raw_data"] is None
+
     def test_old_snapshot_rows_read_with_null_analysis_metadata(self, tmp_path):
         db_path = str(tmp_path / "legacy.db")
         with sqlite3.connect(db_path) as conn:
@@ -108,6 +153,7 @@ class TestSnapshotStorage:
 
         assert snap is not None
         assert snap["analysis_meta"] is None
+        assert snap["raw_data"] is None
 
     def test_threshold_profile_change_applies_to_subsequent_snapshots(self, storage, sample_analysis, monkeypatch):
         monkeypatch.setattr(snapshot_module, "get_available_app_version", lambda: "2026.7-test")


### PR DESCRIPTION
## Summary
- store bounded raw DOCSIS driver payloads with saved snapshots when available
- redact obvious secret-bearing raw keys and skip oversized/non-JSON payloads
- add a replay helper to compare stored analyzer output with replayed raw evidence
- document local ownership and privacy implications in the data contract

## Verification
- uv run pytest tests/test_storage.py tests/test_replay.py tests/collectors/test_modem_collector.py tests/test_demo_mode.py tests/test_events.py tests/web/test_snapshots.py
- uv run pytest tests --ignore=tests/e2e
- git diff --cached --check

## Review
- Fable review: No blockers found
