### PR TITLE
Add DOCSIS evidence replay fixtures

### DIFF
--- a/tests/fixtures/docsis_cases/README.md
+++ b/tests/fixtures/docsis_cases/README.md
@@ -1,0 +1,19 @@
+# DOCSIS case fixtures
+
+This directory contains public-safe DOCSIS evidence fixtures used by `tests/test_docsis_case_fixtures.py`.
+
+Fixtures are synthetic and must not contain private IP addresses, MAC addresses, serial numbers, provider account data, cookies, tokens, passwords, or location-specific hints.
+
+Run the focused replay suite with:
+
+```bash
+uv run pytest tests/test_docsis_case_fixtures.py
+```
+
+Each JSON case may define:
+
+- `raw`: redacted raw DOCSIS input accepted by `app.analyzer.analyze()`.
+- `previous_raw`: optional prior raw input for event/baseline replay.
+- `postprocess`: optional collector-side post-processing to apply before assertions.
+- `checklist`: optional evidence-checklist input for non-DOCSIS capability cases.
+- `expect`: golden analyzer, event, or checklist expectations.

--- a/tests/fixtures/docsis_cases/counter_reset_baseline.json
+++ b/tests/fixtures/docsis_cases/counter_reset_baseline.json
@@ -1,0 +1,66 @@
+{
+  "description": "Counter wrap/reset case keeps cumulative deltas from fabricating a new spike.",
+  "expect": {
+    "summary": {
+      "ds_correctable_errors": 5,
+      "ds_uncorrectable_errors": 7,
+      "health": "good"
+    },
+    "summary_contains": {
+      "error_baseline": {
+        "active": true,
+        "counter_reset": true,
+        "ds_correctable_delta": 0,
+        "ds_uncorrectable_delta": 0
+      }
+    }
+  },
+  "id": "counter_reset_baseline",
+  "postprocess": "cumulative_error_baseline",
+  "previous_raw": {
+    "docsis": "3.1",
+    "downstream": [
+      {
+        "channelID": 1,
+        "corrErrors": 4294967290,
+        "frequency": "650 MHz",
+        "modulation": "256QAM",
+        "mse": "-38.0",
+        "nonCorrErrors": 4294967290,
+        "powerLevel": "1.0"
+      }
+    ],
+    "upstream": [
+      {
+        "channelID": 1,
+        "frequency": "42 MHz",
+        "modulation": "64QAM",
+        "multiplex": "ATDMA",
+        "powerLevel": "43.0"
+      }
+    ]
+  },
+  "raw": {
+    "docsis": "3.1",
+    "downstream": [
+      {
+        "channelID": 1,
+        "corrErrors": 5,
+        "frequency": "650 MHz",
+        "modulation": "256QAM",
+        "mse": "-38.0",
+        "nonCorrErrors": 7,
+        "powerLevel": "1.0"
+      }
+    ],
+    "upstream": [
+      {
+        "channelID": 1,
+        "frequency": "42 MHz",
+        "modulation": "64QAM",
+        "multiplex": "ATDMA",
+        "powerLevel": "43.0"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/docsis_cases/generic_router_not_applicable.json
+++ b/tests/fixtures/docsis_cases/generic_router_not_applicable.json
@@ -1,0 +1,26 @@
+{
+  "checklist": {
+    "bqm_rows": [],
+    "capabilities": {
+      "bqm_configured": false,
+      "docsis_supported": false,
+      "speedtest_configured": false
+    },
+    "connection_latency_rows": [],
+    "journal_entries": [],
+    "timeline": [],
+    "window": {
+      "from": "2026-07-02T12:00:00Z",
+      "to": "2026-07-02T13:00:00Z"
+    }
+  },
+  "description": "Generic router mode makes DOCSIS evidence items not applicable rather than missing.",
+  "expect": {
+    "checklist": {
+      "events": "not_applicable",
+      "signal": "not_applicable",
+      "speedtest": "optional"
+    }
+  },
+  "id": "generic_router_not_applicable"
+}

--- a/tests/fixtures/docsis_cases/null_gaps.json
+++ b/tests/fixtures/docsis_cases/null_gaps.json
@@ -1,0 +1,47 @@
+{
+  "description": "Missing/null signal metrics must stay null on channels instead of becoming measured zero.",
+  "expect": {
+    "ds_channels": [
+      {
+        "index": 0,
+        "power": null,
+        "snr": null
+      }
+    ],
+    "summary": {
+      "ds_correctable_errors": 0,
+      "ds_uncorrectable_errors": 0,
+      "errors_supported": true,
+      "health": "good"
+    },
+    "us_channels": [
+      {
+        "index": 0,
+        "power": null
+      }
+    ]
+  },
+  "id": "null_gaps",
+  "raw": {
+    "docsis": "3.1",
+    "downstream": [
+      {
+        "channelID": 1,
+        "corrErrors": 0,
+        "frequency": "650 MHz",
+        "modulation": "256QAM",
+        "mse": null,
+        "nonCorrErrors": 0,
+        "powerLevel": null
+      }
+    ],
+    "upstream": [
+      {
+        "channelID": 1,
+        "frequency": "42 MHz",
+        "modulation": "64QAM",
+        "multiplex": "ATDMA"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/docsis_cases/parse_errors.json
+++ b/tests/fixtures/docsis_cases/parse_errors.json
@@ -1,0 +1,48 @@
+{
+  "description": "Unparseable raw numeric strings are treated as unknown channel values.",
+  "expect": {
+    "ds_channels": [
+      {
+        "channel_id": 1,
+        "index": 0,
+        "power": null,
+        "snr": null
+      }
+    ],
+    "summary": {
+      "errors_supported": true,
+      "health": "good"
+    },
+    "us_channels": [
+      {
+        "channel_id": 2,
+        "index": 0,
+        "power": null
+      }
+    ]
+  },
+  "id": "parse_errors",
+  "raw": {
+    "docsis": "3.1",
+    "downstream": [
+      {
+        "channelID": "1",
+        "corrErrors": 0,
+        "frequency": "650 MHz",
+        "modulation": "256QAM",
+        "mse": "bad",
+        "nonCorrErrors": 0,
+        "powerLevel": "not-a-number"
+      }
+    ],
+    "upstream": [
+      {
+        "channelID": "2",
+        "frequency": "42 MHz",
+        "modulation": "64QAM",
+        "multiplex": "ATDMA",
+        "powerLevel": "bad"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/docsis_cases/stable_ds_degraded_us.json
+++ b/tests/fixtures/docsis_cases/stable_ds_degraded_us.json
@@ -1,0 +1,71 @@
+{
+  "description": "Downstream remains stable while upstream power degrades into a critical state.",
+  "expect": {
+    "events": [
+      "health_change",
+      "power_change"
+    ],
+    "summary": {
+      "health": "critical"
+    },
+    "summary_contains": {
+      "health_issues": [
+        "us_power_critical_high"
+      ]
+    },
+    "us_channels": [
+      {
+        "health": "critical",
+        "index": 0,
+        "power_health": "critical"
+      }
+    ]
+  },
+  "id": "stable_ds_degraded_us",
+  "previous_raw": {
+    "docsis": "3.1",
+    "downstream": [
+      {
+        "channelID": 1,
+        "corrErrors": 0,
+        "frequency": "650 MHz",
+        "modulation": "256QAM",
+        "mse": "-39.0",
+        "nonCorrErrors": 0,
+        "powerLevel": "1.0"
+      }
+    ],
+    "upstream": [
+      {
+        "channelID": 1,
+        "frequency": "42 MHz",
+        "modulation": "64QAM",
+        "multiplex": "ATDMA",
+        "powerLevel": "43.0"
+      }
+    ]
+  },
+  "raw": {
+    "docsis": "3.1",
+    "downstream": [
+      {
+        "channelID": 1,
+        "corrErrors": 0,
+        "frequency": "650 MHz",
+        "modulation": "256QAM",
+        "mse": "-39.0",
+        "nonCorrErrors": 0,
+        "powerLevel": "1.0"
+      }
+    ],
+    "upstream": [
+      {
+        "channelID": 1,
+        "frequency": "42 MHz",
+        "modulation": "64QAM",
+        "multiplex": "ATDMA",
+        "powerLevel": "57.0"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/docsis_cases/unsupported_counters.json
+++ b/tests/fixtures/docsis_cases/unsupported_counters.json
@@ -1,0 +1,51 @@
+{
+  "description": "DOCSIS snapshot with channel signal data but unsupported error counters.",
+  "expect": {
+    "ds_channels": [
+      {
+        "correctable_errors": null,
+        "index": 0,
+        "power": 1.5,
+        "snr": null,
+        "uncorrectable_errors": null
+      }
+    ],
+    "summary": {
+      "ds_correctable_errors": null,
+      "ds_total": 1,
+      "ds_uncorr_pct": null,
+      "ds_uncorrectable_errors": null,
+      "errors_supported": false,
+      "health": "good",
+      "us_total": 1
+    },
+    "us_channels": [
+      {
+        "index": 0,
+        "power": 43.0
+      }
+    ]
+  },
+  "id": "unsupported_counters",
+  "raw": {
+    "docsis": "3.1",
+    "downstream": [
+      {
+        "channelID": 1,
+        "frequency": "650 MHz",
+        "modulation": "256QAM",
+        "mse": "-38.5",
+        "powerLevel": "1.5"
+      }
+    ],
+    "upstream": [
+      {
+        "channelID": 1,
+        "frequency": "42 MHz",
+        "modulation": "64QAM",
+        "multiplex": "ATDMA",
+        "powerLevel": "43.0"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/docsis_cases/us31_low_qam.json
+++ b/tests/fixtures/docsis_cases/us31_low_qam.json
@@ -1,0 +1,56 @@
+{
+  "description": "OFDMA upstream with very low profile modulation is surfaced as critical.",
+  "expect": {
+    "ds_channels": [
+      {
+        "channel_family": "ofdm",
+        "index": 0,
+        "snr": 40.0
+      }
+    ],
+    "summary": {
+      "health": "critical"
+    },
+    "summary_contains": {
+      "health_issues": [
+        "us_modulation_critical"
+      ]
+    },
+    "us_channels": [
+      {
+        "channel_family": "ofdma",
+        "health": "critical",
+        "index": 0,
+        "modulation_health": "critical",
+        "profile_modulation": "QPSK"
+      }
+    ]
+  },
+  "id": "us31_low_qam",
+  "raw": {
+    "docsis": "3.1",
+    "downstream": [
+      {
+        "channelID": 193,
+        "corrErrors": 0,
+        "frequency": "794 MHz",
+        "mer": "40.0",
+        "modulation": "OFDM",
+        "nonCorrErrors": 0,
+        "powerLevel": "1.0",
+        "type": "OFDM"
+      }
+    ],
+    "upstream": [
+      {
+        "channelID": 9,
+        "frequency": "37 MHz",
+        "modulation": "OFDMA",
+        "multiplex": "OFDMA",
+        "powerLevel": "43.0",
+        "profile_modulation": "QPSK",
+        "type": "OFDMA"
+      }
+    ]
+  }
+}

--- a/tests/test_docsis_case_fixtures.py
+++ b/tests/test_docsis_case_fixtures.py
@@ -1,0 +1,136 @@
+"""Golden replay tests for public-safe DOCSIS evidence fixtures."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from app.analyzer import analyze, apply_cumulative_error_baseline
+from app.event_detector import EventDetector
+from app.modules.evidence.checklist import build_checklist
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "docsis_cases"
+FIXTURE_FILES = sorted(FIXTURE_DIR.glob("*.json"))
+
+_PRIVATE_PATTERNS = {
+    "ipv4": re.compile(r"\b(?:10|127|169\.254|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b"),
+    "mac": re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b"),
+}
+_SECRET_KEY_MARKERS = (
+    "account",
+    "authorization",
+    "cookie",
+    "mac",
+    "password",
+    "secret",
+    "serial",
+    "token",
+)
+
+
+def _load_case(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+ANALYZER_FIXTURE_FILES = [path for path in FIXTURE_FILES if "raw" in _load_case(path)]
+EVENT_FIXTURE_FILES = [path for path in FIXTURE_FILES if _load_case(path).get("expect", {}).get("events")]
+CHECKLIST_FIXTURE_FILES = [path for path in FIXTURE_FILES if _load_case(path).get("expect", {}).get("checklist")]
+
+
+def _assert_subset(actual: Any, expected: Any, path: str = "root") -> None:
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), path
+        for key, value in expected.items():
+            assert key in actual, f"{path}.{key} missing"
+            _assert_subset(actual[key], value, f"{path}.{key}")
+        return
+    if isinstance(expected, list):
+        assert isinstance(actual, list), path
+        for item in expected:
+            assert item in actual, f"{path} missing {item!r}"
+        return
+    assert actual == expected, path
+
+
+def _assert_channel_expectations(channels: Sequence[Mapping[str, Any]], expected_rows: list[dict[str, Any]], path: str) -> None:
+    for expected in expected_rows:
+        index = expected["index"]
+        expected_values = {k: v for k, v in expected.items() if k != "index"}
+        assert index < len(channels), f"{path}[{index}] missing"
+        _assert_subset(channels[index], expected_values, f"{path}[{index}]")
+
+
+@pytest.mark.parametrize("fixture_path", ANALYZER_FIXTURE_FILES, ids=lambda p: p.stem)
+def test_docsis_fixture_analyzer_golden_contracts(fixture_path: Path):
+    case = _load_case(fixture_path)
+    previous = analyze(case["previous_raw"]) if "previous_raw" in case else None
+    analysis = analyze(case["raw"])
+    if case.get("postprocess") == "cumulative_error_baseline":
+        apply_cumulative_error_baseline(analysis, previous, recent_spike_active=False)
+
+    expect = case["expect"]
+    _assert_subset(analysis["summary"], expect.get("summary", {}), f"{case['id']}.summary")
+    _assert_subset(analysis["summary"], expect.get("summary_contains", {}), f"{case['id']}.summary_contains")
+    _assert_channel_expectations(analysis["ds_channels"], expect.get("ds_channels", []), f"{case['id']}.ds_channels")
+    _assert_channel_expectations(analysis["us_channels"], expect.get("us_channels", []), f"{case['id']}.us_channels")
+
+
+@pytest.mark.parametrize("fixture_path", EVENT_FIXTURE_FILES, ids=lambda p: p.stem)
+def test_docsis_fixture_event_golden_contracts(fixture_path: Path):
+    case = _load_case(fixture_path)
+    expected_events = case.get("expect", {}).get("events")
+    detector = EventDetector()
+    detector.check(analyze(case["previous_raw"]))
+    events = detector.check(analyze(case["raw"]))
+    event_types = [event["event_type"] for event in events]
+
+    for expected in expected_events:
+        assert expected in event_types
+
+
+@pytest.mark.parametrize("fixture_path", CHECKLIST_FIXTURE_FILES, ids=lambda p: p.stem)
+def test_docsis_fixture_checklist_golden_contracts(fixture_path: Path):
+    case = _load_case(fixture_path)
+    checklist_input = case.get("checklist")
+    expected = case.get("expect", {}).get("checklist")
+    assert checklist_input is not None
+    assert expected is not None
+    checklist = build_checklist(
+        checklist_input["window"],
+        timeline=checklist_input.get("timeline", []),
+        journal_entries=checklist_input.get("journal_entries", []),
+        bqm_rows=checklist_input.get("bqm_rows", []),
+        connection_latency_rows=checklist_input.get("connection_latency_rows", []),
+        capabilities=checklist_input.get("capabilities", {}),
+    )
+    by_key = {item["key"]: item for item in checklist}
+
+    for key, status in expected.items():
+        assert by_key[key]["status"] == status
+
+
+def test_docsis_fixture_corpus_is_public_safe():
+    assert FIXTURE_FILES, "expected DOCSIS fixture corpus"
+    for path in FIXTURE_FILES:
+        text = path.read_text(encoding="utf-8")
+        for label, pattern in _PRIVATE_PATTERNS.items():
+            assert pattern.search(text) is None, f"{path.name} contains private-looking {label}"
+        case = json.loads(text)
+        _assert_no_secret_keys(case, path.name)
+
+
+def _assert_no_secret_keys(value: Any, fixture_name: str, path: str = "root") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_lower = str(key).lower()
+            assert not any(marker in key_lower for marker in _SECRET_KEY_MARKERS), (
+                f"{fixture_name} contains private-looking key {path}.{key}"
+            )
+            _assert_no_secret_keys(child, fixture_name, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _assert_no_secret_keys(child, fixture_name, f"{path}[{index}]")


### PR DESCRIPTION
## Summary
- add public-safe synthetic DOCSIS case fixtures
- cover analyzer golden contracts for unsupported counters, null gaps, parse errors, US3.1 low-QAM, degraded upstream, and counter reset/baseline behavior
- cover event and evidence-checklist behavior through fixture replay
- add a fixture privacy/static scan and focused run instructions

## Verification
- uv run pytest tests/test_docsis_case_fixtures.py tests/test_events.py tests/test_evidence_checklist.py tests/test_evidence_api.py tests/analyzer/test_unavailable_measurements.py tests/test_error_counter_unwrap.py
- uv run pytest tests --ignore=tests/e2e
- git diff --cached --check

## Review
- Fable review: No blockers found
