### PR TITLE
Make signal events traceable to snapshots

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -75,6 +75,7 @@ The main DOCSight history is local SQLite data. It is evidence, not cache.
 - Raw modem counters, channel snapshots, incident records, and imported measurements should remain faithful to the source data.
 - Saved DOCSIS snapshots may include a bounded, local copy of the raw driver payload used to produce the analyzed snapshot. This is evidence for replaying future rule/analyzer changes, not telemetry sent to DOCSight maintainers.
 - Raw driver payload persistence applies simple privacy safeguards: obvious secret-bearing keys are redacted before storage and oversized/non-JSON payloads are skipped rather than forced into the history database.
+- Signal events generated from a saved poll can carry local snapshot row references in their structured details so event evidence can be traced back to the source snapshot inside the same installation database.
 - Derived views may compute health windows, trends, ranges, summaries, and report sections, but they should not rewrite raw modem evidence just to fit a display model.
 - Unsupported or unknown fields should stay distinguishable from measured zero values.
 - Database migrations should preserve user-owned local data and document any rare destructive migration path before it runs.

--- a/app/collectors/demo.py
+++ b/app/collectors/demo.py
@@ -224,10 +224,10 @@ class DemoCollector(Collector):
 
         # Web state + persistent storage
         self._web.update_state(analysis=analysis)
-        self._storage.save_snapshot(analysis, is_demo=True)
+        snapshot_id = self._storage.save_snapshot(analysis, is_demo=True)
 
         # Event detection
-        events = self._event_detector.check(analysis)
+        events = self._event_detector.check(analysis, snapshot_id=snapshot_id)
         if events:
             self._storage.save_events_with_ids(events, is_demo=True)
             log.info("Demo: detected %d event(s)", len(events))

--- a/app/collectors/modem.py
+++ b/app/collectors/modem.py
@@ -50,6 +50,7 @@ class ModemCollector(Collector):
         self._device_info: DeviceInfo | None = None
         self._connection_info: ConnectionInfo | None = None
         self._discovery_published = False
+        self._event_detector.seed(self._storage.get_latest_snapshot())
 
     def collect(self) -> CollectorResult:
         self._driver.login()
@@ -205,10 +206,10 @@ class ModemCollector(Collector):
 
         # Web state + persistent storage
         self._web.update_state(analysis=analysis)
-        self._storage.save_snapshot(analysis, raw_data=data)
+        snapshot_id = self._storage.save_snapshot(analysis, raw_data=data)
 
         # Event detection
-        events = self._event_detector.check(analysis)
+        events = self._event_detector.check(analysis, snapshot_id=snapshot_id)
         if events:
             self._storage.save_events_with_ids(events)
             log.info("Detected %d event(s)", len(events))

--- a/app/event_detector.py
+++ b/app/event_detector.py
@@ -97,15 +97,46 @@ def _channel_type_label(direction: str, channel: dict, fallback: dict | None = N
 class EventDetector:
     """Compare consecutive analyses and emit event dicts."""
 
-    def __init__(self, hysteresis=0):
+    def __init__(self, hysteresis=0, baseline: AnalysisResult | None = None):
         self._prev = None
+        self._prev_snapshot_id = None
         self._lock = threading.Lock()
         self._hysteresis = max(0, int(hysteresis or 0))
         self._confirmed_health = None
         self._pending_health = None
         self._pending_count = 0
+        self.seed(baseline)
 
-    def check(self, analysis: AnalysisResult) -> list[EventDict]:
+    def seed(self, analysis: AnalysisResult | None, snapshot_id: int | None = None) -> None:
+        """Seed the detector with a persisted baseline snapshot after restart."""
+        if not analysis:
+            return
+        if snapshot_id is None:
+            snapshot_id = analysis.get("snapshot_id")
+        with self._lock:
+            self._prev = analysis
+            self._prev_snapshot_id = snapshot_id
+            if self._hysteresis >= 2:
+                self._confirmed_health = analysis.get("summary", {}).get("health", "good")
+            self._pending_health = None
+            self._pending_count = 0
+
+    @staticmethod
+    def _annotate_event_details(events, snapshot_id, previous_snapshot_id):
+        """Attach source snapshot provenance to generated event details."""
+        if snapshot_id is None and previous_snapshot_id is None:
+            return
+        for event in events:
+            details = event.get("details")
+            if not isinstance(details, dict):
+                details = {}
+                event["details"] = details
+            if snapshot_id is not None:
+                details.setdefault("snapshot_id", snapshot_id)
+            if previous_snapshot_id is not None:
+                details.setdefault("previous_snapshot_id", previous_snapshot_id)
+
+    def check(self, analysis: AnalysisResult, snapshot_id: int | None = None) -> list[EventDict]:
         """Compare current analysis with previous, return list of event dicts.
 
         Called after each poll. On first call (no previous), stores baseline
@@ -113,19 +144,23 @@ class EventDetector:
         """
         with self._lock:
             prev = self._prev
+            prev_snapshot_id = self._prev_snapshot_id
             self._prev = analysis
+            self._prev_snapshot_id = snapshot_id
         ts = utc_now()
 
         if prev is None:
             # First poll: generate baseline event
             health = analysis.get("summary", {}).get("health", "unknown")
-            return [{
+            events = [{
                 "timestamp": ts,
                 "severity": "info",
                 "event_type": "monitoring_started",
                 "message": f"Monitoring started (Health: {health})",
                 "details": {"health": health},
             }]
+            self._annotate_event_details(events, snapshot_id, prev_snapshot_id)
+            return events
 
         events = []
         cur_s = analysis.get("summary", {})
@@ -146,6 +181,7 @@ class EventDetector:
         # Error spike
         self._check_errors(events, ts, cur_s, prev_s)
 
+        self._annotate_event_details(events, snapshot_id, prev_snapshot_id)
         return events
 
     def _check_health(self, events, ts, cur, prev):
@@ -208,35 +244,45 @@ class EventDetector:
 
     def _check_power(self, events, ts, cur, prev):
         # Downstream power avg shift
-        ds_cur = cur.get("ds_power_avg", 0)
-        ds_prev = prev.get("ds_power_avg", 0)
-        if abs(ds_cur - ds_prev) > POWER_SHIFT_THRESHOLD:
+        ds_cur = _coerce_float(cur.get("ds_power_avg"))
+        ds_prev = _coerce_float(prev.get("ds_power_avg"))
+        if ds_cur is not None and ds_prev is not None and abs(ds_cur - ds_prev) > POWER_SHIFT_THRESHOLD:
             events.append({
                 "timestamp": ts,
                 "severity": "warning",
                 "event_type": "power_change",
                 "message": f"DS power avg shifted from {ds_prev} to {ds_cur} dBmV",
-                "details": {"direction": "downstream", "prev": ds_prev, "current": ds_cur},
+                "details": {
+                    "direction": "downstream",
+                    "prev": ds_prev,
+                    "current": ds_cur,
+                    "threshold_delta": POWER_SHIFT_THRESHOLD,
+                },
             })
 
         # Upstream power avg shift
-        us_cur = cur.get("us_power_avg", 0)
-        us_prev = prev.get("us_power_avg", 0)
-        if abs(us_cur - us_prev) > POWER_SHIFT_THRESHOLD:
+        us_cur = _coerce_float(cur.get("us_power_avg"))
+        us_prev = _coerce_float(prev.get("us_power_avg"))
+        if us_cur is not None and us_prev is not None and abs(us_cur - us_prev) > POWER_SHIFT_THRESHOLD:
             events.append({
                 "timestamp": ts,
                 "severity": "warning",
                 "event_type": "power_change",
                 "message": f"US power avg shifted from {us_prev} to {us_cur} dBmV",
-                "details": {"direction": "upstream", "prev": us_prev, "current": us_cur},
+                "details": {
+                    "direction": "upstream",
+                    "prev": us_prev,
+                    "current": us_cur,
+                    "threshold_delta": POWER_SHIFT_THRESHOLD,
+                },
             })
 
     def _check_snr(self, events, ts, cur_analysis, prev_analysis):
         cur = cur_analysis.get("summary", {})
         prev = prev_analysis.get("summary", {})
-        snr_cur = cur.get("ds_snr_min", 0)
-        snr_prev = prev.get("ds_snr_min", 0)
-        if snr_cur == snr_prev:
+        snr_cur = _coerce_float(cur.get("ds_snr_min"))
+        snr_prev = _coerce_float(prev.get("ds_snr_min"))
+        if snr_cur is None or snr_prev is None or snr_cur == snr_prev:
             return
 
         st = _snr_thresholds()
@@ -258,6 +304,7 @@ class EventDetector:
                     "prev": snr_prev,
                     "current": snr_cur,
                     "threshold": "critical",
+                    "threshold_value": snr_crit,
                     "affected_channels": affected_channels,
                 },
             })
@@ -276,6 +323,7 @@ class EventDetector:
                     "prev": snr_prev,
                     "current": snr_cur,
                     "threshold": "warning",
+                    "threshold_value": snr_warn,
                     "affected_channels": affected_channels,
                 },
             })
@@ -467,7 +515,11 @@ class EventDetector:
                 "severity": severity,
                 "event_type": "modulation_change",
                 "message": f"Modulation dropped on {len(downgrades)} channel(s)",
-                "details": {"changes": downgrades, "direction": "downgrade"},
+                "details": {
+                    "changes": downgrades,
+                    "direction": "downgrade",
+                    "critical_rank_drop": QAM_CRITICAL_DROP,
+                },
             })
         if upgrades:
             events.append({
@@ -493,7 +545,12 @@ class EventDetector:
                 "severity": "warning",
                 "event_type": "error_spike",
                 "message": f"Uncorrectable errors jumped by {delta:,} (from {uncorr_prev:,} to {uncorr_cur:,})",
-                "details": {"prev": uncorr_prev, "current": uncorr_cur, "delta": delta},
+                "details": {
+                    "prev": uncorr_prev,
+                    "current": uncorr_cur,
+                    "delta": delta,
+                    "threshold_delta": UNCORR_SPIKE_THRESHOLD,
+                },
             })
 
     def _check_restart(self, events, ts, cur, prev):
@@ -576,5 +633,7 @@ class EventDetector:
                 "prev_uncorr_total": prev_uncorr_total,
                 "current_corr_total": cur_corr_total,
                 "current_uncorr_total": cur_uncorr_total,
+                "declining_channel_ratio_threshold": RESTART_CHANNEL_THRESHOLD,
+                "minimum_overlap_channels": RESTART_MIN_OVERLAP,
             },
         })

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -133,14 +133,14 @@ class SnapshotMethods:
         analysis: AnalysisResult,
         is_demo: bool = False,
         raw_data: DocsisData | dict[str, Any] | None = None,
-    ) -> None:
-        """Save current analysis as a snapshot. Runs cleanup afterwards."""
+    ) -> int | None:
+        """Save current analysis as a snapshot and return the inserted row id."""
         ts = utc_now()
         analysis_meta = get_analysis_metadata(app_version=get_available_app_version())
         raw_json = _dump_raw_data(raw_data)
         try:
             with self._connect() as conn:
-                conn.execute(
+                cur = conn.execute(
                     "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo, raw_json, analysis_meta_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
                         ts,
@@ -152,11 +152,13 @@ class SnapshotMethods:
                         json.dumps(analysis_meta),
                     ),
                 )
+                snapshot_id = cur.lastrowid
             log.debug("Snapshot saved: %s", ts)
         except Exception as e:
             log.error("Failed to save snapshot: %s", e)
-            return
+            return None
         self._cleanup()
+        return snapshot_id
 
     def get_snapshot_list(self) -> list[str]:
         """Return list of available snapshot timestamps (newest first)."""
@@ -170,33 +172,37 @@ class SnapshotMethods:
         """Load the latest stored snapshot, or None when no baseline exists."""
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT summary_json, ds_channels_json, us_channels_json, analysis_meta_json, raw_json FROM snapshots ORDER BY timestamp DESC, rowid DESC LIMIT 1"
+                "SELECT id, timestamp, summary_json, ds_channels_json, us_channels_json, analysis_meta_json, raw_json FROM snapshots ORDER BY timestamp DESC, rowid DESC LIMIT 1"
             ).fetchone()
         if not row:
             return None
         return cast(AnalysisResult, {
-            "summary": _normalize_summary_errors(json.loads(row[0])),
-            "ds_channels": json.loads(row[1]),
-            "us_channels": json.loads(row[2]),
-            "analysis_meta": _load_analysis_meta(row[3]),
-            "raw_data": _load_raw_data(row[4]),
+            "snapshot_id": row[0],
+            "timestamp": row[1],
+            "summary": _normalize_summary_errors(json.loads(row[2])),
+            "ds_channels": json.loads(row[3]),
+            "us_channels": json.loads(row[4]),
+            "analysis_meta": _load_analysis_meta(row[5]),
+            "raw_data": _load_raw_data(row[6]),
         })
 
     def get_snapshot(self, timestamp: str) -> AnalysisResult | None:
         """Load a single snapshot by timestamp. Returns analysis dict or None."""
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT summary_json, ds_channels_json, us_channels_json, analysis_meta_json, raw_json FROM snapshots WHERE timestamp = ?",
+                "SELECT id, timestamp, summary_json, ds_channels_json, us_channels_json, analysis_meta_json, raw_json FROM snapshots WHERE timestamp = ?",
                 (timestamp,),
             ).fetchone()
         if not row:
             return None
         return cast(AnalysisResult, {
-            "summary": _normalize_summary_errors(json.loads(row[0])),
-            "ds_channels": json.loads(row[1]),
-            "us_channels": json.loads(row[2]),
-            "analysis_meta": _load_analysis_meta(row[3]),
-            "raw_data": _load_raw_data(row[4]),
+            "snapshot_id": row[0],
+            "timestamp": row[1],
+            "summary": _normalize_summary_errors(json.loads(row[2])),
+            "ds_channels": json.loads(row[3]),
+            "us_channels": json.loads(row[4]),
+            "analysis_meta": _load_analysis_meta(row[5]),
+            "raw_data": _load_raw_data(row[6]),
         })
 
     def get_snapshot_raw_data(self, timestamp: str) -> dict | None:

--- a/app/types.py
+++ b/app/types.py
@@ -248,19 +248,21 @@ class AnalysisSummary(TypedDict):
     error_baseline: NotRequired[ErrorBaseline]
 
 
-# ── Full Analysis Result ─────────────────────────────────────────
-
-
 class AnalysisResult(TypedDict):
-    """Complete result from analyzer.analyze().
+    """Complete output from analyzer.analyze().
 
-    This is the primary data structure flowing through the system:
-    analyzer -> collector -> storage/web/mqtt/events/prometheus.
+    This is the canonical structure consumed by:
+    - web.update_state(analysis=...)
+    - storage.save_snapshot()
+    - EventDetector.check()
+    - MQTT publisher
     """
 
     summary: AnalysisSummary
     ds_channels: list[DownstreamChannel]
     us_channels: list[UpstreamChannel]
+    snapshot_id: NotRequired[int]
+    timestamp: NotRequired[str]
     analysis_meta: NotRequired[dict[str, Any] | None]
     raw_data: NotRequired[DocsisData | dict[str, Any] | None]
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,6 +4,7 @@ import csv
 import io
 import json
 import shutil
+import sqlite3
 import subprocess
 import textwrap
 import pytest
@@ -199,6 +200,23 @@ class TestEventStorage:
         assert latest["summary"]["ds_uncorrectable_errors"] == 200
         assert latest["summary"]["ds_correctable_errors"] == 1000
 
+    def test_save_snapshot_returns_row_id(self, storage):
+        snapshot_id = storage.save_snapshot(_make_analysis())
+
+        assert isinstance(snapshot_id, int)
+        with sqlite3.connect(storage.db_path) as conn:
+            row = conn.execute("SELECT id FROM snapshots WHERE id = ?", (snapshot_id,)).fetchone()
+        assert row == (snapshot_id,)
+
+    def test_get_latest_snapshot_includes_snapshot_identity(self, storage):
+        snapshot_id = storage.save_snapshot(_make_analysis(ds_uncorrectable_errors=321))
+
+        latest = storage.get_latest_snapshot()
+
+        assert latest is not None
+        assert latest["snapshot_id"] == snapshot_id
+        assert latest["timestamp"]
+
 
 class TestEventExportApi:
     def test_events_export_csv_respects_filters_and_serializes_details(self, events_client, storage):
@@ -368,6 +386,58 @@ class TestEventDetector:
         events = detector.check(_make_analysis(ds_power_avg=3.0))
         power_events = [e for e in events if e["event_type"] == "power_change"]
         assert len(power_events) == 0
+
+    def test_power_change_skips_missing_power_values(self, detector):
+        detector.check(_make_analysis(ds_power_avg=2.5, us_power_avg=42.0))
+        current = _make_analysis(ds_power_avg=2.5, us_power_avg=42.0)
+        current["summary"]["ds_power_avg"] = None
+        del current["summary"]["us_power_avg"]
+
+        events = detector.check(current)
+
+        assert [e for e in events if e["event_type"] == "power_change"] == []
+
+    def test_snr_change_skips_missing_snr_values(self, detector):
+        detector.check(_make_analysis(ds_snr_min=35.0))
+        current = _make_analysis(ds_snr_min=35.0)
+        current["summary"]["ds_snr_min"] = None
+
+        events = detector.check(current)
+
+        assert [e for e in events if e["event_type"] == "snr_change"] == []
+
+    def test_event_details_include_snapshot_traceability(self, detector):
+        detector.check(_make_analysis(health="good"), snapshot_id=41)
+
+        events = detector.check(_make_analysis(health="critical"), snapshot_id=42)
+
+        health_event = next(e for e in events if e["event_type"] == "health_change")
+        assert health_event["details"]["snapshot_id"] == 42
+        assert health_event["details"]["previous_snapshot_id"] == 41
+
+    def test_seeded_detector_detects_degradation_after_restart(self, storage):
+        previous = _make_analysis(health="good")
+        previous_id = storage.save_snapshot(previous)
+        latest = storage.get_latest_snapshot()
+        detector = EventDetector()
+        detector.seed(latest)
+
+        events = detector.check(_make_analysis(health="critical"), snapshot_id=previous_id + 1)
+
+        assert [e for e in events if e["event_type"] == "monitoring_started"] == []
+        health_event = next(e for e in events if e["event_type"] == "health_change")
+        assert health_event["details"]["prev"] == "good"
+        assert health_event["details"]["current"] == "critical"
+        assert health_event["details"]["previous_snapshot_id"] == previous_id
+
+    def test_power_event_details_include_threshold_metadata(self, detector):
+        detector.check(_make_analysis(ds_power_avg=2.5), snapshot_id=10)
+
+        events = detector.check(_make_analysis(ds_power_avg=5.0), snapshot_id=11)
+
+        power_event = next(e for e in events if e["event_type"] == "power_change")
+        assert power_event["details"]["threshold_delta"] == 2.0
+        assert power_event["details"]["snapshot_id"] == 11
 
     def test_snr_drop_warning(self, detector):
         detector.check(_make_analysis(ds_snr_min=35.0))


### PR DESCRIPTION
## Summary

- return saved snapshot row ids from the snapshot persistence path
- attach current and previous snapshot references to generated signal event details
- seed signal event detection from the latest saved snapshot after process restart
- avoid power/SNR event comparisons when either side has missing values
- document the local event-to-snapshot traceability contract

## Validation

- `uv run pytest tests/test_events.py tests/test_docsis_case_fixtures.py tests/test_storage.py tests/test_demo_mode.py -q`
- `uv run pytest tests --ignore=tests/e2e -q`
- `uv run pytest tests/e2e/test_events.py tests/e2e/test_event_log_redesign.py -q`
- `git diff --check`
