### PR TITLE
Share DOCSIS channel semantics across evidence paths

### DIFF
--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from .docsis_utils import parse_qam_order as _parse_qam_order
+from .docsis_utils import (
+    classify_channel_family as _shared_classify_channel_family,
+    modulation_threshold_key as _modulation_threshold_key,
+    parse_qam_order as _parse_qam_order,
+)
 from .types import AnalysisResult, DocsisData, SignalFamilyHealthCause
 from .tz import utc_now, _parse_utc
 
@@ -82,9 +86,7 @@ _MODULATION_ALIASES = {
 
 def _resolve_modulation(modulation, section):
     """Resolve modulation string to a key in thresholds config."""
-    if modulation in section:
-        return modulation
-    return _MODULATION_ALIASES.get(modulation, section.get("_default", "256QAM"))
+    return _modulation_threshold_key(modulation, section)
 
 
 def _get_ds_power_thresholds(modulation=None):
@@ -629,70 +631,14 @@ def _family_health_driver(family, channels, *, direction, cause, family_health, 
     return max(candidates, key=lambda candidate: _HEALTH_RANK.get(candidate["health"], 0))
 
 
-def _channel_text(channel, *keys):
-    return " ".join(str(channel.get(key, "") or "") for key in keys).upper().replace("-", "")
-
-
 def _classify_ds_family(channel):
     """Classify downstream channels into SC-QAM, OFDM, or unknown families."""
-    docsis_version = str(channel.get("docsis_version", "") or "")
-    is_docsis31_plus = "3.1" in docsis_version or "4.0" in docsis_version
-    type_text = _channel_text(channel, "type")
-    modulation_text = _channel_text(channel, "modulation")
-    profile_text = _channel_text(channel, "profile_modulation")
-
-    if "OFDM" in type_text or "OFDMA" in type_text:
-        return "ofdm"
-    if "SCQAM" in type_text or type_text == "QAM":
-        return "sc_qam"
-    if "OFDM" in modulation_text or "OFDMA" in modulation_text:
-        return "ofdm"
-
-    modulation_rank = _parse_qam_order(modulation_text)
-    if modulation_rank:
-        if modulation_rank >= 1024 and is_docsis31_plus:
-            return "ofdm"
-        return "sc_qam"
-
-    # Profile modulation is an OFDM profile signal, not an SC-QAM channel type.
-    # A degraded DOCSIS 3.1 OFDM profile can be 256QAM/512QAM and must still
-    # remain on the OFDM/MER Home lane when explicit modulation/type is absent.
-    if profile_text and is_docsis31_plus:
-        return "ofdm"
-    if _parse_qam_order(profile_text):
-        return "sc_qam"
-
-    if is_docsis31_plus:
-        return "ofdm"
-    if "3.0" in docsis_version:
-        return "sc_qam"
-    return "unknown"
+    return _shared_classify_channel_family("ds", channel)
 
 
 def _classify_us_family(channel):
     """Classify upstream channels into SC-QAM, OFDMA, or unknown families."""
-    docsis_version = str(channel.get("docsis_version", "") or "")
-    is_docsis31_plus = "3.1" in docsis_version or "4.0" in docsis_version
-    type_text = _channel_text(channel, "type", "multiplex")
-    modulation_text = _channel_text(channel, "modulation")
-    profile_text = _channel_text(channel, "profile_modulation")
-
-    if "OFDMA" in type_text:
-        return "ofdma"
-    if any(token in type_text for token in ("ATDMA", "SCQAM", "TDMA")):
-        return "sc_qam"
-    if "OFDMA" in modulation_text:
-        return "ofdma"
-    if profile_text and is_docsis31_plus:
-        return "ofdma"
-    if is_docsis31_plus:
-        return "ofdma"
-    if _parse_qam_order(modulation_text):
-        return "sc_qam"
-
-    if "3.0" in docsis_version:
-        return "sc_qam"
-    return "unknown"
+    return _shared_classify_channel_family("us", channel)
 
 
 def _family_summary(family, channels, *, direction):

--- a/app/docsis_utils.py
+++ b/app/docsis_utils.py
@@ -1,8 +1,12 @@
-"""Shared DOCSIS utilities — QAM parsing, hierarchy, and modulation labels."""
+"""Shared DOCSIS utilities — channel families, QAM parsing, and modulation labels."""
 
 from __future__ import annotations
 
 import re
+from typing import Literal
+
+Direction = Literal["ds", "us", "downstream", "upstream", "DS", "US"]
+DocsisChannelFamily = Literal["sc_qam", "ofdm", "ofdma", "unknown"]
 
 # QAM hierarchy: higher value = better modulation
 QAM_ORDER = {
@@ -21,6 +25,23 @@ QAM_ORDER = {
 
 
 _QAM_RE = re.compile(r"(?:(\d+)\s*QAM|QAM\s*(\d+))")
+_MODULATION_THRESHOLD_ALIASES = {
+    "OFDM": "4096QAM",
+    "OFDMA": "4096QAM",
+}
+
+
+def _compact_text(*values: object) -> str:
+    return " ".join(str(value) for value in values if value not in (None, "")).upper().replace("-", "").replace("_", "")
+
+
+def _direction_key(direction: Direction) -> Literal["ds", "us"]:
+    value = str(direction).strip().lower()
+    if value in {"ds", "downstream"}:
+        return "ds"
+    if value in {"us", "upstream"}:
+        return "us"
+    raise ValueError(f"Unsupported DOCSIS direction: {direction!r}")
 
 
 def parse_qam_order(modulation: object) -> int | None:
@@ -71,3 +92,94 @@ def qam_rank(modulation):
     if qam_order is None:
         return 0
     return QAM_ORDER.get(f"{qam_order}QAM", 0)
+
+
+def classify_channel_family(direction: Direction, channel: dict) -> DocsisChannelFamily:
+    """Classify a DOCSIS channel into the shared signal family taxonomy.
+
+    This helper is the single interpretation point for downstream/upstream
+    channel-family semantics used by analyzer, events, reports, and modulation
+    analytics. It intentionally keeps degraded OFDM/OFDMA profile QAM labels on
+    the OFDM/OFDMA family when DOCSIS 3.1/4.0 context or profile metadata says
+    the channel is an OFDM-family carrier.
+    """
+    direction_key = _direction_key(direction)
+    docsis_version = str(channel.get("docsis_version", "") or "")
+    is_docsis31_plus = "3.1" in docsis_version or "4.0" in docsis_version
+    type_text = _compact_text(channel.get("type"), channel.get("channel_type"))
+    multiplex_text = _compact_text(channel.get("multiplex"))
+    modulation_text = _compact_text(channel.get("modulation"))
+    profile_text = _compact_text(channel.get("profile_modulation"), channel.get("profileModulation"))
+
+    if direction_key == "ds":
+        if "OFDM" in type_text or "OFDMA" in type_text:
+            return "ofdm"
+        if "SCQAM" in type_text or type_text == "QAM":
+            return "sc_qam"
+        if "OFDM" in modulation_text or "OFDMA" in modulation_text:
+            return "ofdm"
+
+        modulation_order = parse_qam_order(modulation_text)
+        if modulation_order:
+            if modulation_order >= 1024 and is_docsis31_plus:
+                return "ofdm"
+            return "sc_qam"
+
+        # Profile modulation is an OFDM profile signal, not necessarily an
+        # SC-QAM channel type. Degraded 3.1 OFDM profiles must remain on OFDM.
+        if profile_text and is_docsis31_plus:
+            return "ofdm"
+        if parse_qam_order(profile_text):
+            return "sc_qam"
+
+        if is_docsis31_plus:
+            return "ofdm"
+        if "3.0" in docsis_version:
+            return "sc_qam"
+        return "unknown"
+
+    if "OFDMA" in type_text or "OFDMA" in multiplex_text:
+        return "ofdma"
+    if any(token in f"{type_text} {multiplex_text}" for token in ("ATDMA", "SCQAM", "TDMA")):
+        return "sc_qam"
+    if "OFDMA" in modulation_text:
+        return "ofdma"
+    if profile_text and is_docsis31_plus:
+        return "ofdma"
+    if is_docsis31_plus:
+        return "ofdma"
+    if parse_qam_order(modulation_text):
+        return "sc_qam"
+    if "3.0" in docsis_version:
+        return "sc_qam"
+    return "unknown"
+
+
+def channel_type_label(direction: Direction, channel: dict, fallback: dict | None = None) -> str:
+    """Return a concise family label for event/report details."""
+    fallback = fallback or {}
+    merged = {**fallback, **{k: v for k, v in channel.items() if v not in (None, "")}}
+    family = classify_channel_family(direction, merged)
+    if family == "sc_qam":
+        return "SC-QAM"
+    if family == "ofdm":
+        return "OFDM"
+    if family == "ofdma":
+        return "OFDMA"
+    return ""
+
+
+def modulation_threshold_key(modulation: object, section: dict, *, default: str = "256QAM") -> str:
+    """Resolve a modulation value to the key used by a threshold section."""
+    value = str(modulation or "").upper().replace("-", "").replace("_", "").strip()
+    if value in section:
+        return value
+    fallback = section.get("_default", default)
+    if not isinstance(fallback, str) or not fallback:
+        fallback = default
+    return _MODULATION_THRESHOLD_ALIASES.get(value, fallback)
+
+
+def sc_qam_capacity_family(direction: Direction, channel: dict) -> Literal["sc_qam", "unsupported"]:
+    """Return whether a channel can use the SC-QAM Layer-1 capacity formula."""
+    return "sc_qam" if classify_channel_family(direction, channel) == "sc_qam" else "unsupported"

--- a/app/event_detector.py
+++ b/app/event_detector.py
@@ -8,7 +8,7 @@ import threading
 
 from app.analyzer import _get_snr_thresholds as _snr_thresholds
 
-from .docsis_utils import qam_rank as _qam_rank
+from .docsis_utils import channel_type_label as _shared_channel_type_label, qam_rank as _qam_rank
 from .types import AnalysisResult, EventDict
 from .tz import utc_now
 
@@ -69,29 +69,7 @@ def _coerce_float(value):
 
 def _channel_type_label(direction: str, channel: dict, fallback: dict | None = None) -> str:
     """Return a concise DOCSIS channel type label for event details."""
-    fallback = fallback or {}
-    raw_values = [
-        channel.get("channel_type"),
-        channel.get("multiplex"),
-        channel.get("modulation"),
-        fallback.get("channel_type"),
-        fallback.get("multiplex"),
-        fallback.get("modulation"),
-    ]
-    raw = " ".join(str(v) for v in raw_values if v).upper()
-    if "OFDMA" in raw:
-        return "OFDMA"
-    if "OFDM" in raw:
-        return "OFDM" if direction == "DS" else "OFDMA"
-    if "SC-QAM" in raw or "ATDMA" in raw or "TDMA" in raw:
-        return "SC-QAM"
-
-    docsis_version = str(channel.get("docsis_version") or fallback.get("docsis_version") or "").strip()
-    if docsis_version in {"3.1", "4.0"}:
-        return "OFDM" if direction == "DS" else "OFDMA"
-    if docsis_version == "3.0":
-        return "SC-QAM"
-    return ""
+    return _shared_channel_type_label(direction, channel, fallback)  # type: ignore[arg-type]
 
 
 class EventDetector:
@@ -285,11 +263,33 @@ class EventDetector:
         if snr_cur is None or snr_prev is None or snr_cur == snr_prev:
             return
 
+        health_affected = self._snr_affected_channels_by_health(cur_analysis, prev_analysis)
+        if health_affected:
+            worst = max(
+                health_affected,
+                key=lambda channel: {"good": 0, "tolerated": 1, "warning": 2, "critical": 3}.get(channel.get("current_health"), 0),
+            )
+            current_health = worst.get("current_health", "warning")
+            severity = "critical" if current_health == "critical" else "warning"
+            events.append({
+                "timestamp": ts,
+                "severity": severity,
+                "event_type": "snr_change",
+                "message": f"DS SNR/MER health changed to {current_health} (min: {snr_cur} dB)",
+                "details": {
+                    "prev": snr_prev,
+                    "current": snr_cur,
+                    "threshold": current_health,
+                    "affected_channels": health_affected,
+                },
+            })
+            return
+
         st = _snr_thresholds()
         snr_crit = st["crit_min"]
         snr_warn = st["good_min"]
 
-        # Crossed critical threshold — surface channels that crossed warning OR critical
+        # Fallback for legacy snapshots without analyzer-provided snr_health.
         if snr_cur < snr_crit and snr_prev >= snr_crit:
             affected_channels = self._snr_affected_channels(
                 cur_analysis, prev_analysis,
@@ -308,7 +308,6 @@ class EventDetector:
                     "affected_channels": affected_channels,
                 },
             })
-        # Crossed warning threshold
         elif snr_cur < snr_warn and snr_prev >= snr_warn:
             affected_channels = self._snr_affected_channels(
                 cur_analysis, prev_analysis,
@@ -327,6 +326,51 @@ class EventDetector:
                     "affected_channels": affected_channels,
                 },
             })
+
+    @staticmethod
+    def _snr_affected_channels_by_health(cur_analysis, prev_analysis):
+        """Identify SNR/MER health degradations from analyzer channel metadata."""
+        health_rank = {"missing": -1, "good": 0, "tolerated": 1, "warning": 2, "critical": 3}
+        prev_channels = {}
+        for ch in prev_analysis.get("ds_channels", []):
+            key = _normalize_channel_id(ch.get("channel_id"))
+            if key is not None:
+                prev_channels[key] = ch
+
+        affected = []
+        for cur_ch in cur_analysis.get("ds_channels", []):
+            key = _normalize_channel_id(cur_ch.get("channel_id"))
+            if key is None:
+                continue
+            prev_ch = prev_channels.get(key)
+            if not prev_ch:
+                continue
+            prev_health = prev_ch.get("snr_health")
+            cur_health = cur_ch.get("snr_health")
+            if not prev_health or not cur_health:
+                continue
+            if health_rank.get(cur_health, 0) <= health_rank.get(prev_health, 0):
+                continue
+            if health_rank.get(cur_health, 0) <= health_rank.get("good", 0):
+                continue
+            prev_snr = _coerce_float(prev_ch.get("snr"))
+            cur_snr = _coerce_float(cur_ch.get("snr"))
+            delta = None if prev_snr is None or cur_snr is None else round(cur_snr - prev_snr, 1)
+            affected.append({
+                "channel": cur_ch.get("channel_id"),
+                "frequency": cur_ch.get("frequency") or prev_ch.get("frequency") or "",
+                "docsis_version": cur_ch.get("docsis_version") or prev_ch.get("docsis_version") or "",
+                "channel_type": _channel_type_label("DS", cur_ch, prev_ch),
+                "modulation": cur_ch.get("modulation") or prev_ch.get("modulation") or "",
+                "prev": prev_snr,
+                "current": cur_snr,
+                "delta": None if delta is None else (0.0 if delta == -0.0 else delta),
+                "prev_health": prev_health,
+                "current_health": cur_health,
+                "threshold": cur_health,
+            })
+        affected.sort(key=lambda ch: ({"critical": 0, "warning": 1, "tolerated": 2}.get(ch.get("current_health"), 3), ch.get("current") is None, ch.get("current") or 0, str(ch.get("channel"))))
+        return affected
 
     @staticmethod
     def _snr_affected_channels(cur_analysis, prev_analysis, thresholds):
@@ -477,6 +521,12 @@ class EventDetector:
             }
             if docsis_version:
                 entry["docsis_version"] = docsis_version
+            prev_health = prev_ch.get("modulation_health")
+            cur_health = cur_ch.get("modulation_health")
+            if prev_health:
+                entry["prev_modulation_health"] = prev_health
+            if cur_health:
+                entry["current_modulation_health"] = cur_health
             channel_type = _channel_type_label(direction, cur_ch, prev_ch)
             if channel_type:
                 entry["channel_type"] = channel_type
@@ -508,8 +558,19 @@ class EventDetector:
                     upgrades.append(entry)
 
         if downgrades:
+            health_rank = {"good": 0, "tolerated": 1, "warning": 2, "critical": 3}
             max_drop = max(d["rank_drop"] for d in downgrades)
-            severity = "critical" if max_drop >= QAM_CRITICAL_DROP else "warning"
+            current_health_ranks = [
+                health_rank.get(d.get("current_modulation_health"), 0)
+                for d in downgrades
+                if d.get("current_modulation_health")
+            ]
+            max_current_health = max(current_health_ranks, default=0)
+            severity = (
+                "critical"
+                if max_current_health >= health_rank["critical"] or (not current_health_ranks and max_drop >= QAM_CRITICAL_DROP)
+                else "warning"
+            )
             events.append({
                 "timestamp": ts,
                 "severity": severity,

--- a/app/modules/modulation/engine.py
+++ b/app/modules/modulation/engine.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from app.docsis_utils import (
     canonical_modulation_label as _canonical_label,
     parse_qam_order as _parse_qam_order,
+    sc_qam_capacity_family as _sc_qam_capacity_family,
 )
 from app.tz import to_local
 
@@ -46,34 +47,9 @@ def _channel_modulation(ch):
     return ch.get("profile_modulation") or ch.get("modulation") or ch.get("type") or ""
 
 
-def _is_ofdm_like(ch):
-    values = [
-        ch.get("channel_family", ""),
-        ch.get("type", ""),
-        ch.get("multiplex", ""),
-        ch.get("modulation", ""),
-    ]
-    haystack = " ".join(str(v).lower() for v in values if v is not None)
-    return "ofdm" in haystack or "ofdma" in haystack
-
-
 def _capacity_channel_family(ch, direction):
     """Return whether channel capacity can use the SC-QAM formula."""
-    family = (ch.get("channel_family") or "").lower()
-    if family:
-        return "sc_qam" if family == "sc_qam" else "unsupported"
-    if _is_ofdm_like(ch):
-        return "unsupported"
-    docsis_version = str(ch.get("docsis_version", "3.0"))
-    if docsis_version == "3.0":
-        return "sc_qam"
-    multiplex = str(ch.get("multiplex", "")).replace("-", "").replace("_", "").upper()
-    type_value = str(ch.get("type", "")).replace("-", "").replace("_", "").upper()
-    if docsis_version == "3.1" and direction == "us" and multiplex in {"ATDMA", "TDMA", "SCQAM"}:
-        return "sc_qam"
-    if docsis_version == "3.1" and direction == "ds" and type_value in {"SCQAM", "QAM"}:
-        return "sc_qam"
-    return "unsupported"
+    return _sc_qam_capacity_family(direction, ch)
 
 
 def _capacity_symbol_rate(ch, direction):

--- a/app/modules/reports/report.py
+++ b/app/modules/reports/report.py
@@ -9,6 +9,11 @@ from datetime import datetime
 from fpdf import FPDF
 
 from app.analyzer import get_thresholds
+from app.docsis_utils import (
+    channel_type_label as _channel_type_label,
+    classify_channel_family as _classify_channel_family,
+    modulation_threshold_key as _modulation_threshold_key,
+)
 
 log = logging.getLogger("docsis.report")
 
@@ -93,10 +98,10 @@ def _default_warn_thresholds():
 
 
 def _build_diagnostic_notes(current_analysis):
-    """Check channels for out-of-spec values and return diagnostic notes.
+    """Build report notes from analyzer channel health and shared DOCSIS semantics.
 
-    Each note is a dict with keys: type, channel_id, metric, value, spec_max,
-    spec_min, deviation_pct, severity.
+    Analyzer-provided metric health is authoritative when present. Legacy
+    snapshots without metric health fall back to threshold comparisons.
     """
     if not current_analysis:
         return []
@@ -107,25 +112,27 @@ def _build_diagnostic_notes(current_analysis):
     ds_thresholds = t.get("downstream_power", {})
     snr_thresholds = t.get("snr", {})
 
-    _MOD_ALIASES = {"OFDM": "4096QAM", "OFDMA": "4096QAM"}
+    def metric_allows_note(ch, metric_key):
+        health = ch.get(metric_key)
+        if health is None:
+            return True
+        return health in {"tolerated", "warning", "critical"}
 
     for ch in current_analysis.get("us_channels", []):
         power = ch.get("power")
-        if power is None:
+        if power is None or not metric_allows_note(ch, "power_health"):
             continue
-        mod = (ch.get("modulation") or "").upper()
-        if mod in ("OFDMA",):
-            key = "ofdma"
-        else:
-            key = "sc_qam"
+        family = _classify_channel_family("us", ch)
+        key = "ofdma" if family == "ofdma" else "sc_qam"
         spec = us_thresholds.get(key, {})
         crit = spec.get("critical", [35.0, 53.0])
+        channel_label = _channel_type_label("us", ch) or (ch.get("modulation") or key.upper())
         if power > crit[1]:
             deviation = round((power - crit[1]) / crit[1] * 100)
             notes.append({
                 "type": "us_power_high",
                 "channel_id": ch.get("channel_id", "?"),
-                "channel_type": mod or key.upper(),
+                "channel_type": channel_label,
                 "metric": "upstream power",
                 "value": power,
                 "spec_max": crit[1],
@@ -137,7 +144,7 @@ def _build_diagnostic_notes(current_analysis):
             notes.append({
                 "type": "us_power_low",
                 "channel_id": ch.get("channel_id", "?"),
-                "channel_type": mod or key.upper(),
+                "channel_type": channel_label,
                 "metric": "upstream power",
                 "value": power,
                 "spec_min": crit[0],
@@ -146,18 +153,19 @@ def _build_diagnostic_notes(current_analysis):
             })
 
     for ch in current_analysis.get("ds_channels", []):
-        power = ch.get("power")
         mod = (ch.get("modulation") or "256QAM").upper()
-        lookup = _MOD_ALIASES.get(mod, mod)
-        spec = ds_thresholds.get(lookup, ds_thresholds.get("256QAM", {}))
-        crit = spec.get("critical", [-8.0, 20.0])
-        if power is not None:
+        lookup = _modulation_threshold_key(mod, ds_thresholds)
+        channel_label = _channel_type_label("ds", ch) or mod
+        power = ch.get("power")
+        if power is not None and metric_allows_note(ch, "power_health"):
+            spec = ds_thresholds.get(lookup, ds_thresholds.get("256QAM", {}))
+            crit = spec.get("critical", [-8.0, 20.0])
             if power > crit[1]:
                 deviation = round((power - crit[1]) / max(abs(crit[1]), 1) * 100)
                 notes.append({
                     "type": "ds_power_high",
                     "channel_id": ch.get("channel_id", "?"),
-                    "channel_type": mod,
+                    "channel_type": channel_label,
                     "metric": "downstream power",
                     "value": power,
                     "spec_max": crit[1],
@@ -169,7 +177,7 @@ def _build_diagnostic_notes(current_analysis):
                 notes.append({
                     "type": "ds_power_low",
                     "channel_id": ch.get("channel_id", "?"),
-                    "channel_type": mod,
+                    "channel_type": channel_label,
                     "metric": "downstream power",
                     "value": power,
                     "spec_min": crit[0],
@@ -178,15 +186,16 @@ def _build_diagnostic_notes(current_analysis):
                 })
 
         snr = ch.get("snr")
-        if snr is not None:
-            snr_spec = snr_thresholds.get(lookup, snr_thresholds.get("256QAM", {}))
+        if snr is not None and metric_allows_note(ch, "snr_health"):
+            snr_lookup = _modulation_threshold_key(mod, snr_thresholds)
+            snr_spec = snr_thresholds.get(snr_lookup, snr_thresholds.get("256QAM", {}))
             snr_crit = snr_spec.get("critical_min", 29.0)
             if snr < snr_crit:
                 deviation = round((snr_crit - snr) / max(snr_crit, 1) * 100)
                 notes.append({
                     "type": "snr_low",
                     "channel_id": ch.get("channel_id", "?"),
-                    "channel_type": mod,
+                    "channel_type": channel_label,
                     "metric": "SNR/MER",
                     "value": snr,
                     "spec_min": snr_crit,

--- a/tests/test_docsis_utils.py
+++ b/tests/test_docsis_utils.py
@@ -57,3 +57,28 @@ def test_canonical_modulation_label(value, expected):
 )
 def test_qam_rank_uses_shared_parser(value, rank):
     assert qam_rank(value) == rank
+
+
+def test_classify_channel_family_keeps_degraded_ofdm_profiles_on_ofdm_family():
+    from app.docsis_utils import classify_channel_family, channel_type_label
+
+    channel = {
+        "docsis_version": "3.1",
+        "profile_modulation": "256QAM",
+        "modulation": "",
+    }
+
+    assert classify_channel_family("ds", channel) == "ofdm"
+    assert channel_type_label("ds", channel) == "OFDM"
+
+
+def test_classify_channel_family_distinguishes_us31_sc_qam_from_ofdma():
+    from app.docsis_utils import classify_channel_family, sc_qam_capacity_family
+
+    sc_qam = {"docsis_version": "3.1", "multiplex": "ATDMA", "modulation": "64QAM"}
+    ofdma = {"docsis_version": "3.1", "type": "OFDMA", "profile_modulation": "64QAM"}
+
+    assert classify_channel_family("us", sc_qam) == "sc_qam"
+    assert sc_qam_capacity_family("us", sc_qam) == "sc_qam"
+    assert classify_channel_family("us", ofdma) == "ofdma"
+    assert sc_qam_capacity_family("us", ofdma) == "unsupported"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1562,3 +1562,81 @@ class TestEventsJsRendering:
         # Top-level SNR header must still render.
         assert "SNR" in html
         assert "TypeError" not in html
+
+
+def test_snr_change_uses_analyzer_channel_health_when_available(detector):
+    prev = _make_analysis(
+        ds_snr_min=35.0,
+        ds_channels=[{
+            "channel_id": 1,
+            "frequency": "602 MHz",
+            "docsis_version": "3.1",
+            "channel_family": "ofdm",
+            "modulation": "4096QAM",
+            "snr": 35.0,
+            "snr_health": "good",
+            "health": "good",
+            "health_detail": "",
+        }],
+    )
+    cur = _make_analysis(
+        ds_snr_min=24.0,
+        ds_channels=[{
+            "channel_id": 1,
+            "frequency": "602 MHz",
+            "docsis_version": "3.1",
+            "channel_family": "ofdm",
+            "modulation": "4096QAM",
+            "snr": 24.0,
+            "snr_health": "critical",
+            "health": "critical",
+            "health_detail": "snr critical",
+        }],
+    )
+
+    detector.check(prev)
+    events = detector.check(cur)
+
+    snr_events = [event for event in events if event["event_type"] == "snr_change"]
+    assert len(snr_events) == 1
+    assert snr_events[0]["severity"] == "critical"
+    assert "threshold_value" not in snr_events[0]["details"]
+    affected = snr_events[0]["details"]["affected_channels"][0]
+    assert affected["current_health"] == "critical"
+    assert affected["channel_type"] == "OFDM"
+
+
+def test_modulation_change_includes_analyzer_modulation_health(detector):
+    prev = _make_analysis(
+        us_channels=[{
+            "channel_id": 1,
+            "frequency": "37 MHz",
+            "docsis_version": "3.1",
+            "channel_family": "ofdma",
+            "modulation": "1024QAM",
+            "modulation_health": "good",
+            "health": "good",
+            "health_detail": "",
+        }],
+    )
+    cur = _make_analysis(
+        us_channels=[{
+            "channel_id": 1,
+            "frequency": "37 MHz",
+            "docsis_version": "3.1",
+            "channel_family": "ofdma",
+            "modulation": "64QAM",
+            "modulation_health": "warning",
+            "health": "warning",
+            "health_detail": "modulation warning",
+        }],
+    )
+
+    detector.check(prev)
+    events = detector.check(cur)
+
+    mod_event = next(event for event in events if event["event_type"] == "modulation_change")
+    change = mod_event["details"]["changes"][0]
+    assert mod_event["severity"] == "warning"
+    assert change["current_modulation_health"] == "warning"
+    assert change["channel_type"] == "OFDMA"

--- a/tests/web/test_reports.py
+++ b/tests/web/test_reports.py
@@ -69,6 +69,38 @@ class TestReportHelpers:
         assert _format_optional_count(0) == "0"
         assert _format_optional_count(1234) == "1,234"
 
+    def test_diagnostic_notes_trust_analyzer_metric_health(self):
+        from app.modules.reports.report import _build_diagnostic_notes
+
+        analysis = {
+            "ds_channels": [
+                {
+                    "channel_id": 1,
+                    "docsis_version": "3.0",
+                    "modulation": "256QAM",
+                    "power": 30.0,
+                    "snr": 20.0,
+                    "power_health": "good",
+                    "snr_health": "good",
+                }
+            ],
+            "us_channels": [
+                {
+                    "channel_id": 2,
+                    "docsis_version": "3.1",
+                    "type": "OFDMA",
+                    "profile_modulation": "64QAM",
+                    "power": 55.0,
+                    "power_health": "critical",
+                }
+            ],
+        }
+
+        notes = _build_diagnostic_notes(analysis)
+
+        assert [note["type"] for note in notes] == ["us_power_high"]
+        assert notes[0]["channel_type"] == "OFDMA"
+
 
 class TestComplaintRoutes:
     def test_api_report_passes_customer_details_to_pdf_generator(self):


### PR DESCRIPTION
## Summary
- move DOCSIS channel-family classification into shared utilities
- use the shared family semantics in analyzer, event details, modulation capacity checks, and report diagnostics
- prefer analyzer-provided channel health when building SNR/modulation events and report diagnostic notes

## Checks
- `uv run pytest tests/test_docsis_utils.py tests/test_analyzer_modulation.py tests/test_events.py tests/test_modulation_api.py tests/web/test_reports.py tests/test_docsis_case_fixtures.py -q`
- `uv run pytest tests --ignore=tests/e2e -q`
- `git diff --check`
- `python3 -m compileall app/analyzer.py app/docsis_utils.py app/event_detector.py app/modules/modulation/engine.py app/modules/reports/report.py`
