### PR TITLE
Harden storage migrations and retention cleanup

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -76,6 +76,8 @@ The main DOCSight history is local SQLite data. It is evidence, not cache.
 - Saved DOCSIS snapshots may include a bounded, local copy of the raw driver payload used to produce the analyzed snapshot. This is evidence for replaying future rule/analyzer changes, not telemetry sent to DOCSight maintainers.
 - Raw driver payload persistence applies simple privacy safeguards: obvious secret-bearing keys are redacted before storage and oversized/non-JSON payloads are skipped rather than forced into the history database.
 - Signal events generated from a saved poll can carry local snapshot row references in their structured details so event evidence can be traced back to the source snapshot inside the same installation database.
+- The main history database tracks DOCSight schema-version metadata in `_docsight_meta` so local upgrades can apply explicit, repeatable schema changes.
+- Retention cleanup should not delete snapshots or events that fall inside explicit incident windows; incident-linked evidence is treated as user-retained support context.
 - Derived views may compute health windows, trends, ranges, summaries, and report sections, but they should not rewrite raw modem evidence just to fit a display model.
 - Unsupported or unknown fields should stay distinguishable from measured zero values.
 - Database migrations should preserve user-owned local data and document any rare destructive migration path before it runs.

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -16,6 +16,37 @@ MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10 MB
 MAX_ATTACHMENTS_PER_ENTRY = 10
 
 log = logging.getLogger("docsis.storage")
+SCHEMA_VERSION = 2
+
+
+def _table_columns(conn, table):
+    return [row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()]
+
+
+def _table_exists(conn, table):
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _add_column_if_missing(conn, table, column, ddl):
+    if not _table_exists(conn, table):
+        return False
+    if column in _table_columns(conn, table):
+        return False
+    conn.execute(f"ALTER TABLE {table} ADD COLUMN {ddl}")
+    log.info("Migration: added %s column to %s", column, table)
+    return True
+
+
+def _set_schema_version(conn):
+    conn.execute(
+        "INSERT INTO _docsight_meta (key, value) VALUES ('schema_version', ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (str(SCHEMA_VERSION),),
+    )
 
 
 class StorageBase:
@@ -31,6 +62,12 @@ class StorageBase:
     def _init_db(self):
         with self._connect() as conn:
             conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS _docsight_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+            """)
 
             # ── Migration: rename incidents → journal_entries ──
             # Detect old schema: incidents table has a 'title' column
@@ -119,30 +156,24 @@ class StorageBase:
                 CREATE INDEX IF NOT EXISTS idx_events_ack
                 ON events(acknowledged)
             """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_events_type_ts
+                ON events(event_type, timestamp DESC)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_snapshots_ts_id
+                ON snapshots(timestamp DESC, id DESC)
+            """)
             # ── Migration: add is_demo column to demo-seeded tables ──
             # Note: speedtest_results, bqm_graphs, bnetz_measurements tables are
             # now created by their respective modules. We still try the migration
             # here because the tables may already exist from a previous version.
             _demo_tables = ["snapshots", "events", "journal_entries", "incidents", "speedtest_results", "bqm_graphs", "bnetz_measurements", "weather_data"]
             for tbl in _demo_tables:
-                try:
-                    cols = [r[1] for r in conn.execute(f"PRAGMA table_info({tbl})").fetchall()]
-                    if "is_demo" not in cols:
-                        conn.execute(f"ALTER TABLE {tbl} ADD COLUMN is_demo INTEGER NOT NULL DEFAULT 0")
-                        log.info("Migration: added is_demo column to %s", tbl)
-                except Exception as e:
-                    log.warning("Failed to add is_demo to %s: %s", tbl, e)
+                _add_column_if_missing(conn, tbl, "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0")
 
-            try:
-                cols = [r[1] for r in conn.execute("PRAGMA table_info(snapshots)").fetchall()]
-                if "analysis_meta_json" not in cols:
-                    conn.execute("ALTER TABLE snapshots ADD COLUMN analysis_meta_json TEXT")
-                    log.info("Migration: added analysis_meta_json column to snapshots")
-                if "raw_json" not in cols:
-                    conn.execute("ALTER TABLE snapshots ADD COLUMN raw_json TEXT")
-                    log.info("Migration: added raw_json column to snapshots")
-            except Exception as e:
-                log.warning("Failed to add optional snapshot metadata columns: %s", e)
+            _add_column_if_missing(conn, "snapshots", "analysis_meta_json", "analysis_meta_json TEXT")
+            _add_column_if_missing(conn, "snapshots", "raw_json", "raw_json TEXT")
 
             # ── Weather data table ──
             conn.execute("""
@@ -187,14 +218,6 @@ class StorageBase:
                 ON pwa_push_subscriptions(updated_at)
             """)
 
-            # ── Schema metadata (UTC migration tracking etc.) ──
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS _docsight_meta (
-                    key TEXT PRIMARY KEY,
-                    value TEXT NOT NULL
-                )
-            """)
-
             # ── Smart Capture executions ──
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS smart_capture_executions (
@@ -223,6 +246,7 @@ class StorageBase:
                 CREATE INDEX IF NOT EXISTS idx_sc_exec_created
                 ON smart_capture_executions(created_at)
             """)
+            _set_schema_version(conn)
 
     @contextmanager
     def _connect(self):

--- a/app/storage/cleanup.py
+++ b/app/storage/cleanup.py
@@ -6,7 +6,7 @@ import shutil
 import sqlite3
 from datetime import datetime, timedelta
 
-from ..tz import local_today, utc_now, utc_cutoff, local_to_utc
+from ..tz import local_today, utc_now, utc_cutoff, local_to_utc, local_date_to_utc_range
 
 log = logging.getLogger("docsis.storage")
 
@@ -105,6 +105,50 @@ class CleanupMethods:
         )
         return True
 
+    def _incident_retention_ranges(self, conn):
+        """Return UTC timestamp ranges for explicit incident windows."""
+        try:
+            rows = conn.execute(
+                "SELECT start_date, COALESCE(end_date, '') FROM incidents "
+                "WHERE start_date IS NOT NULL AND start_date != ''"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+
+        ranges = []
+        tz = getattr(self, 'tz_name', '')
+        today = local_today(tz)
+        for start_date, end_date in rows:
+            try:
+                start_ts, _ = local_date_to_utc_range(start_date, tz)
+                _, end_ts = local_date_to_utc_range(end_date or today, tz)
+            except Exception as exc:
+                log.warning("Retention skipped invalid incident window %r..%r: %s", start_date, end_date, exc)
+                continue
+            ranges.append((start_ts, end_ts))
+        return ranges
+
+    def _delete_expired_unprotected_rows(self, conn, table, timestamp_column, cutoff):
+        """Delete old rows unless their timestamp lies in an incident window."""
+        ranges = self._incident_retention_ranges(conn)
+        if not ranges:
+            return conn.execute(
+                f"DELETE FROM {table} WHERE {timestamp_column} < ?",
+                (cutoff,),
+            ).rowcount
+
+        protected = " OR ".join(
+            f"({timestamp_column} >= ? AND {timestamp_column} <= ?)"
+            for _ in ranges
+        )
+        params = [cutoff]
+        for start_ts, end_ts in ranges:
+            params.extend([start_ts, end_ts])
+        return conn.execute(
+            f"DELETE FROM {table} WHERE {timestamp_column} < ? AND NOT ({protected})",
+            params,
+        ).rowcount
+
     def purge_demo_data(self):
         """Delete all rows with is_demo=1 from all demo-seeded tables.
 
@@ -151,9 +195,9 @@ class CleanupMethods:
             return
         cutoff = utc_cutoff(days=self.max_days)
         with self._connect() as conn:
-            deleted = conn.execute(
-                "DELETE FROM snapshots WHERE timestamp < ?", (cutoff,)
-            ).rowcount
+            deleted = self._delete_expired_unprotected_rows(
+                conn, "snapshots", "timestamp", cutoff
+            )
         if deleted:
             log.info("Cleaned up %d old snapshots (before %s)", deleted, cutoff)
         tz = getattr(self, 'tz_name', '')

--- a/app/storage/events.py
+++ b/app/storage/events.py
@@ -169,9 +169,9 @@ class EventMethods:
             return 0
         cutoff = utc_cutoff(days=days)
         with self._connect() as conn:
-            deleted = conn.execute(
-                "DELETE FROM events WHERE timestamp < ?", (cutoff,)
-            ).rowcount
+            deleted = self._delete_expired_unprotected_rows(  # type: ignore[attr-defined]
+                conn, "events", "timestamp", cutoff
+            )
         return deleted
 
     def get_latest_spike_timestamp(self):

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -154,9 +154,9 @@ class SnapshotMethods:
                 )
                 snapshot_id = cur.lastrowid
             log.debug("Snapshot saved: %s", ts)
-        except Exception as e:
-            log.error("Failed to save snapshot: %s", e)
-            return None
+        except Exception:
+            log.exception("Failed to save snapshot")
+            raise
         self._cleanup()
         return snapshot_id
 
@@ -337,15 +337,18 @@ class SnapshotMethods:
 
         All timestamps are now stored as UTC with Z suffix.
         """
-        ts_param = timestamp
+        center = _parse_utc(timestamp)
+        start_ts = (center - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        end_ts = (center + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        ts_param = center.strftime("%Y-%m-%dT%H:%M:%SZ")
         with self._connect() as conn:
             row = conn.execute(
                 """SELECT timestamp, summary_json, ds_channels_json, us_channels_json
                    FROM snapshots
-                   WHERE ABS(julianday(REPLACE(timestamp, 'Z', '')) - julianday(REPLACE(?, 'Z', ''))) <= (2.0 / 24.0)
+                   WHERE timestamp >= ? AND timestamp <= ?
                    ORDER BY ABS(julianday(REPLACE(timestamp, 'Z', '')) - julianday(REPLACE(?, 'Z', '')))
                    LIMIT 1""",
-                (ts_param, ts_param),
+                (start_ts, end_ts, ts_param),
             ).fetchone()
         if not row:
             return None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -154,6 +154,32 @@ class TestSnapshotStorage:
         assert snap is not None
         assert snap["analysis_meta"] is None
         assert snap["raw_data"] is None
+        with sqlite3.connect(storage.db_path) as conn:
+            snapshot_cols = {row[1] for row in conn.execute("PRAGMA table_info(snapshots)")}
+            meta = conn.execute(
+                "SELECT value FROM _docsight_meta WHERE key = 'schema_version'"
+            ).fetchone()
+
+        assert {"is_demo", "raw_json", "analysis_meta_json"}.issubset(snapshot_cols)
+        assert meta == ("2",)
+
+    def test_storage_schema_creates_query_indexes(self, storage):
+        with sqlite3.connect(storage.db_path) as conn:
+            event_indexes = {row[1] for row in conn.execute("PRAGMA index_list(events)")}
+            snapshot_indexes = {row[1] for row in conn.execute("PRAGMA index_list(snapshots)")}
+            meta = conn.execute(
+                "SELECT value FROM _docsight_meta WHERE key = 'schema_version'"
+            ).fetchone()
+
+        assert "idx_events_type_ts" in event_indexes
+        assert "idx_snapshots_ts_id" in snapshot_indexes
+        assert meta == ("2",)
+
+    def test_save_snapshot_surfaces_storage_errors(self, tmp_path, storage, sample_analysis):
+        storage.db_path = str(tmp_path)
+
+        with pytest.raises(sqlite3.Error):
+            storage.save_snapshot(sample_analysis)
 
     def test_threshold_profile_change_applies_to_subsequent_snapshots(self, storage, sample_analysis, monkeypatch):
         monkeypatch.setattr(snapshot_module, "get_available_app_version", lambda: "2026.7-test")
@@ -332,6 +358,49 @@ class TestSnapshotStorage:
         s.save_snapshot(sample_analysis)
         s.save_snapshot(sample_analysis)
         assert len(s.get_snapshot_list()) == 2
+
+    def test_cleanup_preserves_snapshots_and_events_inside_incident_windows(self, tmp_path):
+        db_path = str(tmp_path / "retention.db")
+        storage = SnapshotStorage(db_path, max_days=1)
+        summary = json.dumps({"health": "good", "errors_supported": False})
+        channels = json.dumps([])
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "CREATE TABLE incidents ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "name TEXT NOT NULL, "
+                "status TEXT NOT NULL DEFAULT 'open', "
+                "start_date TEXT, "
+                "end_date TEXT, "
+                "created_at TEXT NOT NULL, "
+                "updated_at TEXT NOT NULL, "
+                "is_demo INTEGER NOT NULL DEFAULT 0"
+                ")"
+            )
+            conn.execute(
+                "INSERT INTO incidents (name, start_date, end_date, created_at, updated_at) "
+                "VALUES ('Protected incident', '2020-01-01', '2020-01-02', '2020-01-01T00:00:00Z', '2020-01-01T00:00:00Z')"
+            )
+            for ts in ("2019-12-31T12:00:00Z", "2020-01-01T12:00:00Z"):
+                conn.execute(
+                    "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) "
+                    "VALUES (?, ?, ?, ?)",
+                    (ts, summary, channels, channels),
+                )
+                conn.execute(
+                    "INSERT INTO events (timestamp, severity, event_type, message, details) "
+                    "VALUES (?, 'warning', 'error_spike', 'test', NULL)",
+                    (ts,),
+                )
+
+        storage._cleanup()
+
+        with sqlite3.connect(db_path) as conn:
+            snapshots = [row[0] for row in conn.execute("SELECT timestamp FROM snapshots ORDER BY timestamp")]
+            events = [row[0] for row in conn.execute("SELECT timestamp FROM events ORDER BY timestamp")]
+
+        assert snapshots == ["2020-01-01T12:00:00Z"]
+        assert events == ["2020-01-01T12:00:00Z"]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- track the local storage schema version in `_docsight_meta`
- make snapshot metadata migrations explicit and add useful event/snapshot indexes
- preserve snapshots and events inside explicit incident windows during retention cleanup
- surface snapshot persistence failures instead of silently returning `None`
- document the local schema-version and incident-retention evidence contract

## Checks
- `uv run pytest tests/test_storage.py -q`
- `uv run pytest tests/test_storage.py tests/test_events.py tests/test_utc_migration.py -q`
- `uv run pytest tests --ignore=tests/e2e -q`
- `git diff --check`
- `python3 -m compileall app/storage/base.py app/storage/cleanup.py app/storage/events.py app/storage/snapshot.py tests/test_storage.py`
