### PR TITLE
Share module entrypoint loading

### DIFF
--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -567,6 +567,42 @@ def load_module_routes(app, module_id: str, module_path: str, routes_file: str, 
             log.error("Module '%s': failed to register blueprint: %s", module_id, e)
 
 
+def _load_module_class(module_id: str, module_path: str, spec: str, kind: str):
+    """Load a contributed class from a module-owned Python file."""
+    if ":" not in spec:
+        log.warning("Module '%s': %s spec must be 'file.py:ClassName', got '%s'", module_id, kind, spec)
+        return None
+
+    filename, class_name = spec.rsplit(":", 1)
+    file_path = safe_manifest_ref(module_path, filename)
+
+    if not os.path.isfile(file_path):
+        log.warning("Module '%s': %s file not found: %s", module_id, kind, file_path)
+        return None
+
+    dir_name = os.path.basename(module_path)
+    mod_name = f"app.modules.{dir_name}.{kind}"
+    try:
+        im_spec = importlib.util.spec_from_file_location(mod_name, file_path)
+        if im_spec is None or im_spec.loader is None:
+            log.warning("Module '%s': could not create import spec for %s", module_id, file_path)
+            return None
+        mod = importlib.util.module_from_spec(im_spec)
+        sys.modules[mod_name] = mod
+        im_spec.loader.exec_module(mod)
+    except Exception as e:
+        log.error("Module '%s': failed to import %s: %s", module_id, kind, e)
+        return None
+
+    cls = getattr(mod, class_name, None)
+    if cls is None:
+        log.warning("Module '%s': class '%s' not found in %s", module_id, class_name, file_path)
+        return None
+
+    log.info("Module '%s': loaded %s class '%s'", module_id, kind, class_name)
+    return cls
+
+
 def load_module_collector(module_id: str, module_path: str, spec: str):
     """Load a Collector class from a module file.
 
@@ -578,38 +614,7 @@ def load_module_collector(module_id: str, module_path: str, spec: str):
     Returns:
         The Collector subclass, or None if loading failed.
     """
-    if ":" not in spec:
-        log.warning("Module '%s': collector spec must be 'file.py:ClassName', got '%s'", module_id, spec)
-        return None
-
-    filename, class_name = spec.rsplit(":", 1)
-    file_path = safe_manifest_ref(module_path, filename)
-
-    if not os.path.isfile(file_path):
-        log.warning("Module '%s': collector file not found: %s", module_id, file_path)
-        return None
-
-    dir_name = os.path.basename(module_path)
-    mod_name = f"app.modules.{dir_name}.collector"
-    try:
-        im_spec = importlib.util.spec_from_file_location(mod_name, file_path)
-        if im_spec is None or im_spec.loader is None:
-            log.warning("Module '%s': could not create import spec for %s", module_id, file_path)
-            return None
-        mod = importlib.util.module_from_spec(im_spec)
-        sys.modules[mod_name] = mod
-        im_spec.loader.exec_module(mod)
-    except Exception as e:
-        log.error("Module '%s': failed to import collector: %s", module_id, e)
-        return None
-
-    cls = getattr(mod, class_name, None)
-    if cls is None:
-        log.warning("Module '%s': class '%s' not found in %s", module_id, class_name, file_path)
-        return None
-
-    log.info("Module '%s': loaded collector class '%s'", module_id, class_name)
-    return cls
+    return _load_module_class(module_id, module_path, spec, "collector")
 
 
 def load_module_publisher(module_id: str, module_path: str, spec: str):
@@ -623,38 +628,7 @@ def load_module_publisher(module_id: str, module_path: str, spec: str):
     Returns:
         The Publisher class, or None if loading failed.
     """
-    if ":" not in spec:
-        log.warning("Module '%s': publisher spec must be 'file.py:ClassName', got '%s'", module_id, spec)
-        return None
-
-    filename, class_name = spec.rsplit(":", 1)
-    file_path = safe_manifest_ref(module_path, filename)
-
-    if not os.path.isfile(file_path):
-        log.warning("Module '%s': publisher file not found: %s", module_id, file_path)
-        return None
-
-    dir_name = os.path.basename(module_path)
-    mod_name = f"app.modules.{dir_name}.publisher"
-    try:
-        im_spec = importlib.util.spec_from_file_location(mod_name, file_path)
-        if im_spec is None or im_spec.loader is None:
-            log.warning("Module '%s': could not create import spec for %s", module_id, file_path)
-            return None
-        mod = importlib.util.module_from_spec(im_spec)
-        sys.modules[mod_name] = mod
-        im_spec.loader.exec_module(mod)
-    except Exception as e:
-        log.error("Module '%s': failed to import publisher: %s", module_id, e)
-        return None
-
-    cls = getattr(mod, class_name, None)
-    if cls is None:
-        log.warning("Module '%s': class '%s' not found in %s", module_id, class_name, file_path)
-        return None
-
-    log.info("Module '%s': loaded publisher class '%s'", module_id, class_name)
-    return cls
+    return _load_module_class(module_id, module_path, spec, "publisher")
 
 
 def setup_module_static(app, module_id: str, module_path: str, static_subdir: str) -> None:

--- a/tests/module_loader/test_loading_core.py
+++ b/tests/module_loader/test_loading_core.py
@@ -342,6 +342,33 @@ class TestPublisher:
         assert cls is None
 
 
+@pytest.mark.parametrize(
+    ("loader", "filename", "spec", "kind"),
+    [
+        (load_module_collector, "collector.py", "collector.py:MissingCollector", "collector"),
+        (load_module_publisher, "publisher.py", "publisher.py:MissingPublisher", "publisher"),
+    ],
+)
+def test_module_class_loader_keeps_kind_specific_contract(loader, filename, spec, kind, caplog):
+    """Collector and publisher wrappers retain kind-specific logging and failure behavior."""
+    with tempfile.TemporaryDirectory() as d:
+        mod_dir = os.path.join(d, "testmod")
+        os.makedirs(mod_dir)
+        with open(os.path.join(mod_dir, filename), "w") as f:
+            f.write("class OtherClass:\n    pass\n")
+
+        cls = loader("test.mod", mod_dir, spec)
+
+    assert cls is None
+    assert "class 'Missing" in caplog.text
+
+    caplog.clear()
+    cls = loader("test.bad", "/tmp", filename)
+
+    assert cls is None
+    assert f"{kind} spec must be 'file.py:ClassName'" in caplog.text
+
+
 class TestStaticAndTemplates:
     """Test static file serving and template path registration."""
 


### PR DESCRIPTION
## Summary

- share collector and publisher dynamic class-loading through one module-loader helper
- keep the existing public loader functions and kind-specific logging intact
- add parametrized regression coverage for both retained loader paths

## Checks

- `.venv/bin/python -m pytest tests/module_loader/test_loading_core.py::test_module_class_loader_keeps_kind_specific_contract tests/module_loader/test_loading_core.py::TestLoadModuleCollector tests/module_loader/test_loading_core.py::TestLoadModulePublisher -q`
- `.venv/bin/python -m pytest tests/module_loader tests/test_module_integration.py tests/test_builtin_module_registry.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `git diff --check`
