### PR TITLE
Simplify built-in module discovery

### DIFF
--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -9,7 +9,7 @@ import re
 import sys
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from flask import send_from_directory
 
@@ -253,37 +253,28 @@ def discover_builtin_theme_modules(disabled_ids: set[str] | None = None) -> list
     modules: list[ModuleInfo] = []
     seen_ids: set[str] = set()
     for theme in BUILTIN_THEMES:
-        raw = {
-            "id": theme["id"],
-            "name": theme["name"],
-            "description": theme["description"],
-            "version": theme["version"],
-            "author": theme["author"],
-            "minAppVersion": theme["minAppVersion"],
-            "type": "theme",
-            "contributes": {"theme": "builtin"},
-            "config": {},
-        }
-        if theme.get("homepage"):
-            raw["homepage"] = theme["homepage"]
-        if theme.get("license"):
-            raw["license"] = theme["license"]
-        try:
-            info = validate_manifest(raw, "", builtin=True)
-            tdata = theme["theme_data"]
-            if not isinstance(tdata, dict):
-                raise ManifestError("Built-in theme data must be an object")
-            validate_theme(tdata)
-        except ManifestError as e:
-            log.warning("Skipping built-in theme %s: invalid registry entry: %s", theme.get("id"), e)
-            continue
+        info = ModuleInfo(
+            id=theme["id"],
+            name=theme["name"],
+            description=theme["description"],
+            version=theme["version"],
+            author=theme["author"],
+            min_app_version=theme["minAppVersion"],
+            type="theme",
+            contributes={"theme": "builtin"},
+            path="",
+            builtin=True,
+            homepage=theme.get("homepage", ""),
+            license=theme.get("license", ""),
+            menu={"order": 999},
+            theme_data=theme["theme_data"],
+        )
 
         if info.id in seen_ids:
             log.warning("Skipping duplicate built-in theme '%s'", info.id)
             continue
 
         info.enabled = info.id not in disabled_ids
-        info.theme_data = tdata
         seen_ids.add(info.id)
         modules.append(info)
         log.info(
@@ -304,33 +295,26 @@ def discover_builtin_threshold_modules(disabled_ids: set[str] | None = None) -> 
     modules: list[ModuleInfo] = []
     seen_ids: set[str] = set()
     for profile in BUILTIN_THRESHOLD_PROFILES:
-        try:
-            raw = {
-                "id": profile["id"],
-                "name": profile["name"],
-                "description": profile["description"],
-                "version": profile["version"],
-                "author": profile["author"],
-                "minAppVersion": profile["minAppVersion"],
-                "type": "analysis",
-                "contributes": {"thresholds": "builtin"},
-                "config": {},
-            }
-            info = validate_manifest(raw, "", builtin=True)
-            tdata = profile["thresholds"]
-            if not isinstance(tdata, dict):
-                raise ManifestError("Built-in threshold data must be an object")
-            validate_thresholds(tdata)
-        except (KeyError, ManifestError) as e:
-            log.warning("Skipping built-in threshold profile %s: invalid registry entry: %s", profile.get("id"), e)
-            continue
+        info = ModuleInfo(
+            id=cast(str, profile["id"]),
+            name=cast(str, profile["name"]),
+            description=cast(str, profile["description"]),
+            version=cast(str, profile["version"]),
+            author=cast(str, profile["author"]),
+            min_app_version=cast(str, profile["minAppVersion"]),
+            type="analysis",
+            contributes={"thresholds": "builtin"},
+            path="",
+            builtin=True,
+            menu={"order": 999},
+            thresholds_data=deepcopy(cast(dict[str, object], profile["thresholds"])),
+        )
 
         if info.id in seen_ids:
             log.warning("Skipping duplicate built-in threshold profile '%s'", info.id)
             continue
 
         info.enabled = info.id not in disabled_ids
-        info.thresholds_data = deepcopy(tdata)
         seen_ids.add(info.id)
         modules.append(info)
         log.info(

--- a/tests/test_builtin_module_registry.py
+++ b/tests/test_builtin_module_registry.py
@@ -17,6 +17,9 @@ from app.module_loader import (
     discover_builtin_theme_modules,
     discover_modules,
     ModuleLoader,
+    validate_manifest,
+    validate_theme,
+    validate_thresholds,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -70,12 +73,56 @@ def test_builtin_theme_alias_tokens_are_centralized():
         assert f"{alias}: var({canonical});" in tokens_css
 
 
+def test_builtin_theme_registry_entries_match_expected_schema():
+    """Built-in themes are trusted at runtime but must stay schema-valid in tests."""
+    for theme in BUILTIN_THEMES:
+        validate_manifest(
+            {
+                "id": theme["id"],
+                "name": theme["name"],
+                "description": theme["description"],
+                "version": theme["version"],
+                "author": theme["author"],
+                "minAppVersion": theme["minAppVersion"],
+                "type": "theme",
+                "contributes": {"theme": "builtin"},
+                "homepage": theme.get("homepage", ""),
+                "license": theme.get("license", ""),
+            },
+            "",
+            builtin=True,
+        )
+        assert isinstance(theme["theme_data"], dict)
+        validate_theme(theme["theme_data"])
+
+
 def test_builtin_threshold_registry_replaces_wrapper_module_dir():
     """Shipped threshold profiles live in the analyzer profile registry."""
     assert len(BUILTIN_THRESHOLD_PROFILES) == 1
     assert BUILTIN_THRESHOLD_PROFILES[0]["id"] == "docsight.thresholds_vfkd"
     assert not (BUILTIN_MODULES_DIR / "thresholds_vfkd" / "manifest.json").exists()
     assert not (BUILTIN_MODULES_DIR / "thresholds_vfkd" / "thresholds.json").exists()
+
+
+def test_builtin_threshold_registry_entries_match_expected_schema():
+    """Built-in thresholds are trusted at runtime but must stay schema-valid in tests."""
+    for profile in BUILTIN_THRESHOLD_PROFILES:
+        validate_manifest(
+            {
+                "id": profile["id"],
+                "name": profile["name"],
+                "description": profile["description"],
+                "version": profile["version"],
+                "author": profile["author"],
+                "minAppVersion": profile["minAppVersion"],
+                "type": "analysis",
+                "contributes": {"thresholds": "builtin"},
+            },
+            "",
+            builtin=True,
+        )
+        assert isinstance(profile["thresholds"], dict)
+        validate_thresholds(profile["thresholds"])
 
 
 def test_discover_builtin_modules_uses_static_registry(monkeypatch):
@@ -150,6 +197,7 @@ def test_discover_builtin_theme_modules_uses_static_registry(monkeypatch):
     assert len(modules) == len(BUILTIN_THEMES)
     assert all(mod.builtin for mod in modules)
     assert all(mod.type == "theme" for mod in modules)
+    assert all(mod.menu["order"] == 999 for mod in modules)
     assert all(mod.theme_data for mod in modules)
     assert {mod.id for mod in modules} >= {"docsight.theme_classic", "docsight.theme_matrix"}
 
@@ -168,6 +216,7 @@ def test_discover_builtin_threshold_modules_uses_static_registry(monkeypatch):
     assert len(modules) == len(BUILTIN_THRESHOLD_PROFILES)
     assert all(mod.builtin for mod in modules)
     assert all(mod.type == "analysis" for mod in modules)
+    assert all(mod.menu["order"] == 999 for mod in modules)
     assert all(mod.thresholds_data for mod in modules)
     assert modules[0].id == "docsight.thresholds_vfkd"
     assert modules[0].contributes == {"thresholds": "builtin"}


### PR DESCRIPTION
## Summary

- construct built-in theme and threshold module metadata directly from the app-owned registries
- keep community manifest/theme/threshold validation unchanged
- move built-in registry schema checks into focused tests and preserve discovery metadata defaults

## Checks

- `.venv/bin/python -m pytest tests/test_builtin_module_registry.py::test_builtin_theme_registry_entries_match_expected_schema tests/test_builtin_module_registry.py::test_builtin_threshold_registry_entries_match_expected_schema tests/test_builtin_module_registry.py::test_discover_builtin_theme_modules_uses_static_registry tests/test_builtin_module_registry.py::test_discover_builtin_threshold_modules_uses_static_registry tests/test_builtin_module_registry.py::test_builtin_theme_duplicate_ids_are_skipped tests/test_builtin_module_registry.py::test_full_loader_prevents_community_threshold_shadowing_builtin_profile -q`
- `.venv/bin/python -m pytest tests/e2e/test_theme.py -q`
- `.venv/bin/python -m pytest tests/module_loader tests/test_theme_registry.py tests/test_builtin_module_registry.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `.venv/bin/python scripts/i18n_check.py`
- `git diff --check`
