### PR TITLE
Trim local maintainer notices

### DIFF
--- a/app/blueprints/notices_bp.py
+++ b/app/blueprints/notices_bp.py
@@ -9,7 +9,7 @@ from app.maintainer_notices import (
     get_active_notices,
     is_valid_notice_id,
 )
-from app.web import APP_VERSION, get_config_manager, require_auth
+from app.web import get_config_manager, require_auth
 
 notices_bp = Blueprint("notices_bp", __name__)
 
@@ -29,7 +29,6 @@ def api_notices_list():
 
     config_mgr = get_config_manager()
     notices = get_active_notices(
-        APP_VERSION,
         dismissed_ids=_dismissed_ids(config_mgr),
         location=location,
     )

--- a/app/maintainer_notices.py
+++ b/app/maintainer_notices.py
@@ -7,7 +7,6 @@ telemetry when displayed or dismissed.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import re
 from typing import Any
 from urllib.parse import urlparse
@@ -38,45 +37,6 @@ LOCAL_NOTICES: tuple[dict[str, Any], ...] = (
 
 class NoticeValidationError(ValueError):
     """Raised when a bundled notice violates the local notice contract."""
-
-
-def _parse_datetime(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    normalized = value.replace("Z", "+00:00")
-    parsed = datetime.fromisoformat(normalized)
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
-
-def _version_parts(value: str) -> tuple[tuple[int, Any], ...]:
-    raw = (value or "").strip().lstrip("v")
-    if not raw or raw == "dev":
-        return ()
-    parts: list[tuple[int, Any]] = []
-    for token in raw.replace("-", ".").split("."):
-        if token.isdigit():
-            parts.append((0, int(token)))
-        else:
-            parts.append((1, token))
-    return tuple(parts)
-
-
-def _version_gte(current: str, minimum: str) -> bool:
-    cur = _version_parts(current)
-    min_parts = _version_parts(minimum)
-    if not cur or not min_parts:
-        return True
-    return cur >= min_parts
-
-
-def _version_lte(current: str, maximum: str) -> bool:
-    cur = _version_parts(current)
-    max_parts = _version_parts(maximum)
-    if not cur or not max_parts:
-        return True
-    return cur <= max_parts
 
 
 def is_valid_notice_id(value: str) -> bool:
@@ -139,16 +99,6 @@ def validate_notice_schema(notice: dict[str, Any]) -> None:
     if not _is_safe_link(notice.get("link_url")):
         raise NoticeValidationError("Notice links must be relative or HTTPS URLs")
 
-    for key in ("starts_at", "expires_at"):
-        value = notice.get(key)
-        if value:
-            if not isinstance(value, str):
-                raise NoticeValidationError(f"Invalid {key} timestamp")
-            try:
-                _parse_datetime(value)
-            except ValueError as exc:
-                raise NoticeValidationError(f"Invalid {key} timestamp") from exc
-
 
 def coerce_dismissed_notice_ids(dismissed_ids: Any) -> list[str]:
     """Normalize persisted dismissal values into bounded stable IDs."""
@@ -169,34 +119,9 @@ def _coerce_dismissed_ids(dismissed_ids: Any) -> set[str]:
     return set(coerce_dismissed_notice_ids(dismissed_ids))
 
 
-def _matches_constraints(
-    notice: dict[str, Any],
-    *,
-    app_version: str,
-    location: str | None,
-    now: datetime,
-) -> bool:
+def _matches_location(notice: dict[str, Any], location: str | None) -> bool:
     locations = set(notice.get("locations", ("dashboard", "settings")))
-    if location and location not in locations:
-        return False
-
-    starts_at = _parse_datetime(notice.get("starts_at"))
-    if starts_at and starts_at > now:
-        return False
-
-    expires_at = _parse_datetime(notice.get("expires_at"))
-    if expires_at and expires_at <= now:
-        return False
-
-    min_version = notice.get("min_version")
-    if min_version and not _version_gte(app_version, str(min_version)):
-        return False
-
-    max_version = notice.get("max_version")
-    if max_version and not _version_lte(app_version, str(max_version)):
-        return False
-
-    return True
+    return location is None or location in locations
 
 
 def serialize_notice(notice: dict[str, Any]) -> dict[str, Any]:
@@ -208,18 +133,16 @@ def serialize_notice(notice: dict[str, Any]) -> dict[str, Any]:
         "title": notice["title"],
         "body": notice["body"],
     }
-    for key in ("link_label", "link_url", "min_version", "max_version"):
+    for key in ("link_label", "link_url"):
         if notice.get(key):
             data[key] = notice[key]
     return data
 
 
 def get_active_notices(
-    app_version: str,
     dismissed_ids: Any = None,
     location: str | None = None,
     *,
-    now: datetime | None = None,
     notices: tuple[dict[str, Any], ...] | list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Return active bundled notices after local filtering and dismissal."""
@@ -227,7 +150,6 @@ def get_active_notices(
         return []
 
     dismissed = _coerce_dismissed_ids(dismissed_ids)
-    evaluated_at = now or datetime.now(timezone.utc)
     source = LOCAL_NOTICES if notices is None else notices
     active: list[dict[str, Any]] = []
 
@@ -236,7 +158,7 @@ def get_active_notices(
             validate_notice_schema(notice)
             if notice["id"] in dismissed:
                 continue
-            if not _matches_constraints(notice, app_version=app_version, location=location, now=evaluated_at):
+            if not _matches_location(notice, location):
                 continue
             active.append(serialize_notice(notice))
         except (NoticeValidationError, AttributeError, TypeError, ValueError):

--- a/app/web.py
+++ b/app/web.py
@@ -1379,7 +1379,6 @@ def index():
         t=t, lang=lang, languages=LANGUAGES, lang_flags=LANG_FLAGS,
         temperature_unit=_config_manager.get("temperature_unit", "celsius") if _config_manager else "celsius",
         dashboard_notices=get_active_notices(
-            APP_VERSION,
             dismissed_ids=_get_dismissed_notice_ids(),
             location="dashboard",
         ),
@@ -1486,7 +1485,6 @@ def settings():
         built_in_features=built_in_features,
         app_version=APP_VERSION,
         settings_notices=get_active_notices(
-            APP_VERSION,
             dismissed_ids=_get_dismissed_notice_ids(),
             location="settings",
         ),

--- a/tests/test_maintainer_notices.py
+++ b/tests/test_maintainer_notices.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timezone
-
 import pytest
 
 from app.maintainer_notices import (
@@ -26,7 +24,6 @@ def test_active_notice_matches_location_and_excludes_dismissed_ids():
     notices = [_notice(id="visible"), _notice(id="dismissed")]
 
     active = get_active_notices(
-        "v2026-05-02.1",
         dismissed_ids=["dismissed"],
         location="dashboard",
         notices=notices,
@@ -42,23 +39,33 @@ def test_notice_severity_sorting_prioritizes_critical_then_warning_then_info():
         _notice(id="warning", severity="warning"),
     ]
 
-    active = get_active_notices("v2026-05-02.1", notices=notices)
+    active = get_active_notices(notices=notices)
 
     assert [notice["id"] for notice in active] == ["critical", "warning", "info"]
 
 
-def test_version_and_time_constraints_are_enforced():
-    now = datetime(2026, 5, 2, tzinfo=timezone.utc)
+def test_notice_payload_exposes_only_shipped_public_fields():
     notices = [
-        _notice(id="current", min_version="2026-05-01.1", max_version="2026-05-03.1"),
-        _notice(id="too-new", min_version="2026-05-03.1"),
-        _notice(id="expired", expires_at="2026-05-01T00:00:00Z"),
-        _notice(id="future", starts_at="2026-05-03T00:00:00Z"),
+        _notice(
+            id="linked",
+            link_label="Open",
+            link_url="/settings#about",
+            internal_note="operator-only",
+        )
     ]
 
-    active = get_active_notices("v2026-05-02.1", notices=notices, now=now)
+    active = get_active_notices(notices=notices)
 
-    assert [notice["id"] for notice in active] == ["current"]
+    assert active == [
+        {
+            "id": "linked",
+            "severity": "info",
+            "title": "Local notice",
+            "body": "Bundled with DOCSight.",
+            "link_label": "Open",
+            "link_url": "/settings#about",
+        }
+    ]
 
 
 def test_notices_reject_remote_html_and_unsafe_links():
@@ -77,25 +84,16 @@ def test_relative_and_https_links_are_allowed():
     validate_notice_schema(_notice(link_url="https://github.com/itsDNNS/docsight", link_label="Open"))
 
 
-def test_mixed_version_tokens_do_not_crash_filtering():
-    notices = [_notice(id="rc-notice", min_version="1.0.rc1")]
-
-    active = get_active_notices("1.0.2", notices=notices)
-
-    assert active == []
-
-
 def test_invalid_notices_are_ignored_so_notices_remain_non_blocking():
     notices = [
         _notice(id="visible"),
         _notice(id="bad-html", body="<strong>broken</strong>"),
         "not-a-mapping",
         _notice(id="bad-link", link_url=["https://example.com"], link_label="Open"),
-        _notice(id="bad-time", starts_at=123),
         _notice(id="bad-location", locations=(["dashboard"],)),
     ]
 
-    active = get_active_notices("v2026-05-02.1", notices=notices)
+    active = get_active_notices(notices=notices)
 
     assert [notice["id"] for notice in active] == ["visible"]
 


### PR DESCRIPTION
## Summary

- keep bundled maintainer notices focused on the shipped local-first contract
- remove unused version and time-window filtering from the local notice runtime
- update notice tests around retained validation, dismissal, sorting, placement, and public fields

## Checks

- `.venv/bin/python -m py_compile app/maintainer_notices.py app/blueprints/notices_bp.py app/web.py`
- `.venv/bin/python -m pytest tests/test_maintainer_notices.py tests/web/test_notices.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `.venv/bin/python scripts/i18n_check.py`
- `git diff --check`
