### PR TITLE
Refocus defensive documentation checks

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -187,36 +187,17 @@ Security-relevant events are logged to the `docsis.audit` logger:
 
 ## Defensive Review Checklist
 
-Maintainers use this checklist when reviewing changes that touch integration or export boundaries. Each boundary lists the regression tests that exercise it; those tests should pass before merging changes that affect the corresponding area.
+Maintainers use this checklist when reviewing changes that touch integration or export boundaries. Changes should include or update focused regression coverage for the affected boundary before merging.
 
 - **Modem/router response parsing** — driver code parses untrusted modem firmware output and must tolerate missing, malformed, or unexpected fields without crashing the poller.
-  - `tests/test_vodafone_station_tg.py`
-  - `tests/test_driver_registry.py`
 - **Import/export paths** — backup, history import, AI/LLM export, journal import, BQM image import, and report output handle user-supplied files or produce shareable evidence.
-  - `tests/test_import_parser.py`
-  - `tests/test_report.py`
-  - `tests/web/test_health_export.py`
-  - `tests/e2e/test_modals.py`
 - **Local authentication/session handling** — login, session cookies, the `require_auth` decorator, and Bearer token verification.
-  - `tests/test_auth.py`
-  - `tests/test_security_hardening.py`
 - **Token and credential storage** — Fernet-at-rest storage for modem, webhook, Apprise sidecar, and PWA Web Push VAPID private-key secrets, hash-only persistence for the admin password and API tokens, and config redaction.
-  - `tests/test_security_hardening.py`
-  - `tests/test_config.py`
-  - `tests/test_pwa_web_push.py`
 - **MQTT/Home Assistant integration payloads** — outbound notifier payload shaping, severity mapping, length limits, and log redaction for webhook URLs.
-  - `tests/test_notifier.py`
 - **Module/plugin manifest loading** — manifest validation and the install/list API surface.
-  - `tests/test_module_install_api.py`
-  - `tests/test_modules_api.py`
 - **Docker/self-hosted runtime defaults** — bundled image defaults, secret bootstrap, and end-to-end auth on a fresh deployment.
-  - `tests/test_config.py`
-  - `tests/e2e/test_auth.py`
 - **Rate limiting or abuse resistance** — login backoff and capture guardrails.
-  - `tests/test_auth.py`
-  - `tests/test_smart_capture_guardrails.py`
-- **Test fixtures and documentation examples** — keeps fixtures and public docs free of reusable-looking secrets so that example values cannot be mistaken for credentials.
-  - `tests/test_defensive_review_docs.py`
+- **Test fixtures and documentation examples** — fixtures and public docs should avoid reusable-looking secrets so that example values cannot be mistaken for credentials.
 
 ## Third-Party Dependencies
 

--- a/tests/test_defensive_review_docs.py
+++ b/tests/test_defensive_review_docs.py
@@ -1,4 +1,4 @@
-"""Regression tests for the maintainer defensive review checklist."""
+"""Regression tests for public defensive-review documentation fixtures."""
 
 from __future__ import annotations
 
@@ -6,43 +6,12 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-SECURITY_MD = ROOT / "SECURITY.md"
-
-REQUIRED_BOUNDARIES = {
-    "modem/router response parsing": ["tests/test_vodafone_station_tg.py", "tests/test_driver_registry.py"],
-    "import/export paths": ["tests/test_import_parser.py", "tests/test_report.py"],
-    "local authentication/session handling": ["tests/test_auth.py", "tests/test_security_hardening.py"],
-    "token and credential storage": ["tests/test_security_hardening.py", "tests/test_config.py"],
-    "mqtt/home assistant integration payloads": ["tests/test_notifier.py"],
-    "module/plugin manifest loading": ["tests/test_module_install_api.py", "tests/test_modules_api.py"],
-    "docker/self-hosted runtime defaults": ["tests/test_config.py", "tests/e2e/test_auth.py"],
-    "rate limiting or abuse resistance": ["tests/test_auth.py", "tests/test_smart_capture_guardrails.py"],
-    "test fixtures and documentation examples": ["tests/test_defensive_review_docs.py"],
-}
 
 SECRET_PATTERNS = [
     re.compile(r"dsk_[A-Za-z0-9_-]{12,}"),
     re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
     re.compile(r"(?i)(api[_-]?key|secret|password|token)\s*=\s*['\"][^'\"]{8,}['\"]"),
 ]
-
-
-def test_security_policy_has_defensive_review_checklist():
-    text = SECURITY_MD.read_text(encoding="utf-8").lower()
-
-    assert "defensive review checklist" in text
-    for boundary in REQUIRED_BOUNDARIES:
-        assert boundary in text
-
-
-def test_defensive_review_checklist_references_existing_tests():
-    text = SECURITY_MD.read_text(encoding="utf-8")
-
-    for boundary, test_paths in REQUIRED_BOUNDARIES.items():
-        for rel_path in test_paths:
-            assert rel_path in text, f"{boundary} should reference {rel_path}"
-            assert (ROOT / rel_path).exists(), f"referenced test path missing: {rel_path}"
-
 
 def test_public_docs_and_text_fixtures_do_not_contain_reusable_secret_examples():
     scanned = []


### PR DESCRIPTION
## Summary

- remove brittle checks that tie `SECURITY.md` wording to exact test file paths
- keep the reusable public-doc and fixture scanner for secret-like examples
- simplify the defensive review checklist so it describes durable security boundaries rather than implementation file names

## Tests

- `python -m pytest tests/test_defensive_review_docs.py -q`
- `python -m pytest tests/test_defensive_review_docs.py tests/test_public_launch_surface.py -q`
- `python -m pytest tests --ignore=tests/e2e -q`
- `git diff --check`
