### PR TITLE
Mask saved admin password in settings

### DIFF
--- a/app/templates/settings/security.html
+++ b/app/templates/settings/security.html
@@ -16,7 +16,7 @@
         <div class="form-grid">
             <div class="form-field">
                 <label class="form-label" for="admin_password">{{ t.admin_password }}</label>
-                <input class="form-input" type="password" id="admin_password" name="admin_password" value="{{ config.admin_password }}" placeholder="{{ t.admin_password_hint }}">
+                <input class="form-input" type="password" id="admin_password" name="admin_password" value="" placeholder="{% if config.admin_password %}{{ t.saved_ph }}{% else %}{{ t.admin_password_hint }}{% endif %}"{% if config.admin_password %} data-saved-secret="true"{% endif %}>
             </div>
         </div>
     </div>

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -6,6 +6,13 @@ import pytest
 from playwright.sync_api import expect
 
 
+def _login(auth_page, auth_server):
+    auth_page.goto(f"{auth_server}/login")
+    auth_page.fill('input[name="password"]', "e2e-test-password")
+    auth_page.click('button[type="submit"]')
+    auth_page.wait_for_load_state("networkidle")
+
+
 class TestSettingsLoad:
     """Settings page loads correctly."""
 
@@ -244,6 +251,49 @@ class TestSettingsDirtyState:
         expect(settings_page.locator("#save-footer")).not_to_have_class(re.compile(r".*\bvisible\b.*"))
 
         assert payloads[-1]["notify_pwa_push_vapid_private_key"] == "••••••••"
+
+    def test_saved_admin_password_is_masked_when_unrelated_setting_is_saved(self, auth_page, auth_server):
+        payloads = []
+
+        def capture_config(route):
+            payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        _login(auth_page, auth_server)
+        auth_page.goto(f"{auth_server}/settings")
+        auth_page.wait_for_load_state("networkidle")
+        auth_page.route("**/api/config", capture_config)
+
+        admin_password = auth_page.locator('#admin_password')
+        expect(admin_password).to_have_attribute("data-saved-secret", "true")
+        assert admin_password.input_value() == ""
+
+        auth_page.locator('button[data-section="general"]').click()
+        auth_page.locator('#poll_interval').fill('903')
+        auth_page.locator('#save-footer button[type="submit"]').click()
+        expect(auth_page.locator("#save-footer")).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+        assert payloads[-1]["admin_password"] == "••••••••"
+
+    def test_user_edited_admin_password_is_submitted_and_cleared_after_save(self, auth_page, auth_server):
+        payloads = []
+
+        def capture_config(route):
+            payloads.append(route.request.post_data_json)
+            route.fulfill(json={"success": True})
+
+        _login(auth_page, auth_server)
+        auth_page.goto(f"{auth_server}/settings")
+        auth_page.wait_for_load_state("networkidle")
+        auth_page.route("**/api/config", capture_config)
+
+        auth_page.locator('button[data-section="security"]').click()
+        auth_page.locator('#admin_password').fill('new-admin-secret')
+        auth_page.locator('#save-footer button[type="submit"]').click()
+        expect(auth_page.locator("#save-footer")).not_to_have_class(re.compile(r".*\bvisible\b.*"))
+
+        assert payloads[-1]["admin_password"] == "new-admin-secret"
+        assert auth_page.locator('#admin_password').input_value() == ""
 
     def test_user_edited_saved_secret_is_submitted_and_cleared_after_save(self, settings_page):
         payloads = []

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -1,5 +1,7 @@
 """Tests for settings and setup pages."""
 
+import re
+
 from app.web import init_config, app
 from app.config import ConfigManager
 
@@ -30,6 +32,24 @@ class TestSettingsRoute:
         assert resp.status_code == 200
         assert b"Segment Utilization" in resp.data
         assert b"Disabled" in resp.data
+
+    def test_settings_admin_password_field_uses_saved_secret_placeholder(self, client, config_mgr):
+        config_mgr.save({"admin_password": "admin-secret-value"})
+        init_config(config_mgr)
+        with client.session_transaction() as session:
+            session["authenticated"] = True
+
+        resp = client.get("/settings?lang=en")
+
+        assert resp.status_code == 200
+        html = resp.data.decode("utf-8")
+        admin_match = re.search(r'<input[^>]+id="admin_password"[^>]*>', html)
+        assert admin_match is not None
+        admin_input = admin_match.group(0)
+        assert "admin-secret-value" not in html
+        assert "••••••••" not in admin_input
+        assert 'value=""' in admin_input
+        assert 'data-saved-secret="true"' in admin_input
 
 
 class TestSetupRoute:


### PR DESCRIPTION
## Summary

- render the saved admin password field with an empty value and saved-secret placeholder
- keep unchanged saved admin passwords submitted as the existing password mask
- add web and browser regressions for rendered markup, unchanged saved passwords, and edited password submissions

## Tests

- `.venv/bin/python -m pytest tests/web/test_settings.py::TestSettingsRoute::test_settings_admin_password_field_uses_saved_secret_placeholder -q`
- `.venv/bin/python -m pytest tests/e2e/test_settings.py::TestSettingsDirtyState::test_saved_admin_password_is_masked_when_unrelated_setting_is_saved tests/e2e/test_settings.py::TestSettingsDirtyState::test_user_edited_admin_password_is_submitted_and_cleared_after_save -q`
- `.venv/bin/python -m pytest tests/web/test_settings.py tests/test_settings_secret_fields.py tests/test_config.py -q`
- `.venv/bin/python -m pytest tests/e2e/test_settings.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `git diff --check`
