### PR TITLE
Correct settings toast states

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -1694,11 +1694,11 @@ function applyTheme(themeId) {
                     _originalStyles = {};
                     location.reload();
                 } else {
-                    showToast(data.error || (T.theme_apply_failed || 'Failed to apply theme'), true);
+                    showToast(data.error || (T.theme_apply_failed || 'Failed to apply theme'), false);
                 }
             })
             .catch(function(err) {
-                showToast((T.error_prefix || 'Error') + ': ' + err.message, true);
+                showToast((T.error_prefix || 'Error') + ': ' + err.message, false);
             });
     });
 }
@@ -1790,14 +1790,14 @@ function installTheme(themeId, downloadUrl) {
         .then(function(r) { return r.json(); })
         .then(function(data) {
             if (data.success) {
-                showToast(T.theme_installed || 'Theme installed — restart required');
+                showToast(T.theme_installed || 'Theme installed — restart required', true);
                 refreshRegistry();
             } else {
-                showToast(data.error || (T.theme_install_failed || 'Install failed'), true);
+                showToast(data.error || (T.theme_install_failed || 'Install failed'), false);
             }
         })
         .catch(function(err) {
-            showToast((T.error_prefix || 'Error') + ': ' + err.message, true);
+            showToast((T.error_prefix || 'Error') + ': ' + err.message, false);
         });
 }
 
@@ -1940,7 +1940,7 @@ function refreshModuleRegistry() {
             if (loading) loading.style.display = 'none';
             gallery.style.display = 'none';
             if (empty) empty.style.display = '';
-            showToast(T.extensions_fetch_failed || 'Failed to load registry.', true);
+            showToast(T.extensions_fetch_failed || 'Failed to load registry.', false);
         })
         .finally(function() { _registryFetching = false; });
 }
@@ -2038,19 +2038,19 @@ function installModule(e, id, downloadUrl) {
     .then(function(r) { return r.json(); })
     .then(function(data) {
         if (data.success) {
-            showToast(T.extensions_install_success || 'Module installed successfully');
+            showToast(T.extensions_install_success || 'Module installed successfully', true);
             var banner = document.getElementById('module-restart-banner');
             if (banner) { banner.style.display = ''; if (typeof lucide !== 'undefined') lucide.createIcons({nodes: [banner]}); }
             refreshModuleRegistry();
         } else {
-            showToast(data.error || (T.extensions_install_failed || 'Installation failed'), true);
+            showToast(data.error || (T.extensions_install_failed || 'Installation failed'), false);
             btn.disabled = false;
             btn.className = 'btn btn-sm btn-install';
             btn.textContent = T.extensions_install || 'Install';
         }
     })
     .catch(function(err) {
-        showToast((T.extensions_install_failed || 'Installation failed') + ': ' + err.message, true);
+        showToast((T.extensions_install_failed || 'Installation failed') + ': ' + err.message, false);
         btn.disabled = false;
         btn.className = 'btn btn-sm btn-install';
         btn.textContent = T.extensions_install || 'Install';
@@ -2084,19 +2084,19 @@ function uninstallModule(e, id) {
     .then(function(r) { return r.json(); })
     .then(function(data) {
         if (data.success) {
-            showToast(T.extensions_uninstall_success || 'Module uninstalled');
+            showToast(T.extensions_uninstall_success || 'Module uninstalled', true);
             var banner = document.getElementById('module-restart-banner');
             if (banner) { banner.style.display = ''; if (typeof lucide !== 'undefined') lucide.createIcons({nodes: [banner]}); }
             refreshModuleRegistry();
         } else {
-            showToast(data.error || (T.extensions_uninstall_failed || 'Uninstall failed'), true);
+            showToast(data.error || (T.extensions_uninstall_failed || 'Uninstall failed'), false);
             btn.disabled = false;
             btn.className = 'btn btn-sm btn-uninstall';
             btn.textContent = T.extensions_uninstall || 'Uninstall';
         }
     })
     .catch(function(err) {
-        showToast((T.extensions_uninstall_failed || 'Uninstall failed') + ': ' + err.message, true);
+        showToast((T.extensions_uninstall_failed || 'Uninstall failed') + ': ' + err.message, false);
         btn.disabled = false;
         btn.className = 'btn btn-sm btn-uninstall';
         btn.textContent = T.extensions_uninstall || 'Uninstall';

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -113,6 +113,100 @@ class TestSettingsFormElements:
         ).to_have_count(1)
 
 
+def _assert_toast_state(page, ok):
+    toast = page.locator("#toast")
+    expect(toast).to_be_visible()
+    expected = "toast-ok" if ok else "toast-fail"
+    unexpected = "toast-fail" if ok else "toast-ok"
+    expect(toast).to_have_class(re.compile(rf".*\b{expected}\b.*"))
+    expect(toast).not_to_have_class(re.compile(rf".*\b{unexpected}\b.*"))
+
+
+def _theme_registry_payload():
+    return [
+        {
+            "id": "docsight.theme_test_registry",
+            "name": "Registry Test Theme",
+            "description": "Test theme from registry",
+            "version": "1.0.0",
+            "author": "DOCSight Tests",
+            "download_url": "https://example.invalid/theme.zip",
+        }
+    ]
+
+
+def _module_registry_payload(status="not_installed"):
+    return [
+        {
+            "id": "docsight.test_module",
+            "name": "Registry Test Module",
+            "description": "Test module from registry",
+            "author": "DOCSight Tests",
+            "version": "1.0.0",
+            "status": status,
+            "download_url": "https://example.invalid/module.zip",
+            "verified": True,
+        }
+    ]
+
+
+class TestSettingsToastStates:
+    """Theme and module registry operations report the correct toast polarity."""
+
+    @pytest.mark.parametrize("success", [True, False])
+    def test_theme_install_toast_state_matches_result(self, settings_page, success):
+        settings_page.route("**/api/themes/registry", lambda route: route.fulfill(json=_theme_registry_payload()))
+        settings_page.route(
+            "**/api/themes/install",
+            lambda route: route.fulfill(json={"success": success} if success else {"success": False, "error": "Theme failed"}),
+        )
+
+        settings_page.locator('button[data-section="appearance"]').click()
+        settings_page.locator('#panel-appearance button[onclick="refreshRegistry()"]').click()
+        install_button = settings_page.locator('#registry-gallery .theme-card button', has_text=re.compile("Install", re.I))
+        expect(install_button).to_have_count(1)
+        install_button.click()
+
+        _assert_toast_state(settings_page, success)
+
+    @pytest.mark.parametrize("success", [True, False])
+    def test_module_install_toast_state_matches_result(self, settings_page, success):
+        settings_page.route("**/api/modules/registry", lambda route: route.fulfill(json=_module_registry_payload()))
+        settings_page.route(
+            "**/api/modules/install",
+            lambda route: route.fulfill(json={"success": success} if success else {"success": False, "error": "Module failed"}),
+        )
+
+        settings_page.locator('button[data-section="extensions"]').click()
+        install_button = settings_page.locator('#module-registry-gallery button').first
+        expect(install_button).to_have_text(re.compile("Install", re.I))
+        install_button.click()
+        expect(install_button).to_have_text(re.compile("Confirm", re.I))
+        install_button.click()
+
+        _assert_toast_state(settings_page, success)
+
+    @pytest.mark.parametrize("success", [True, False])
+    def test_module_uninstall_toast_state_matches_result(self, settings_page, success):
+        settings_page.route(
+            "**/api/modules/registry",
+            lambda route: route.fulfill(json=_module_registry_payload(status="installed_enabled")),
+        )
+        settings_page.route(
+            "**/api/modules/uninstall",
+            lambda route: route.fulfill(json={"success": success} if success else {"success": False, "error": "Uninstall failed"}),
+        )
+
+        settings_page.locator('button[data-section="extensions"]').click()
+        uninstall_button = settings_page.locator('#module-registry-gallery button').first
+        expect(uninstall_button).to_have_text(re.compile("Uninstall", re.I))
+        uninstall_button.click()
+        expect(uninstall_button).to_have_text(re.compile("Confirm", re.I))
+        uninstall_button.click()
+
+        _assert_toast_state(settings_page, success)
+
+
 class TestSettingsDirtyState:
     """Unsaved-change prompts only appear for deliberate settings edits."""
 


### PR DESCRIPTION
## Summary

- make Settings toast calls pass explicit success/error polarity
- correct theme apply/install and module registry/install/uninstall failure toasts to use error styling
- keep successful theme and module install/uninstall operations using success styling
- add browser regressions for theme install and module install/uninstall success/failure toast classes

## Tests

- `.venv/bin/python -m pytest tests/e2e/test_settings.py::TestSettingsToastStates -q`
- `.venv/bin/python -m pytest tests/e2e/test_settings.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `git diff --check`
