### PR TITLE
Load appearance theme registry automatically

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -7,7 +7,7 @@
 
 /* ── Section Controller ── */
 var _currentSection = 'connection';
-var _saveHiddenSections = { support: true, themes: true, about: true };
+var _saveHiddenSections = { support: true, about: true };
 
 function switchSection(id) {
     _currentSection = id;
@@ -34,7 +34,7 @@ function switchSection(id) {
     /* Auto-load data for certain panels */
     if (id === 'security') loadApiTokens();
     if (target && target.querySelector('#backup-list')) loadBackupList();
-    if (id === 'themes') refreshRegistry();
+    if (id === 'appearance') loadThemeRegistryIfNeeded();
     if (id === 'smart_capture') loadSmartCaptureHistory();
     if (id === 'extensions') refreshModuleRegistry();
 
@@ -1705,9 +1705,18 @@ function applyTheme(themeId) {
 
 
 /* ── Theme Registry ── */
+var _themeRegistryFetching = false;
+var _themeRegistryLoaded = false;
+
+function loadThemeRegistryIfNeeded() {
+    if (_themeRegistryLoaded || _themeRegistryFetching) return;
+    refreshRegistry();
+}
+
 function refreshRegistry() {
     var gallery = document.getElementById('registry-gallery');
-    if (!gallery) return;
+    if (!gallery || _themeRegistryFetching) return;
+    _themeRegistryFetching = true;
     gallery.textContent = '';
     var p = document.createElement('p');
     p.textContent = T.loading || 'Loading...';
@@ -1720,6 +1729,7 @@ function refreshRegistry() {
         .then(function(r) { return r.json(); })
         .then(function(themes) {
             gallery.textContent = '';
+            _themeRegistryLoaded = true;
             if (!themes.length) {
                 var empty = document.createElement('div');
                 empty.className = 'empty-state';
@@ -1772,13 +1782,15 @@ function refreshRegistry() {
         })
         .catch(function() {
             gallery.textContent = '';
+            _themeRegistryLoaded = false;
             var err = document.createElement('div');
             err.className = 'empty-state';
             var msg = document.createElement('p');
             msg.textContent = T.theme_registry_failed || 'Failed to load registry';
             err.appendChild(msg);
             gallery.appendChild(err);
-        });
+        })
+        .finally(function() { _themeRegistryFetching = false; });
 }
 
 function installTheme(themeId, downloadUrl) {

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -150,6 +150,29 @@ def _module_registry_payload(status="not_installed"):
     ]
 
 
+class TestSettingsThemeRegistry:
+    """The Appearance panel loads available themes without manual refresh."""
+
+    def test_appearance_panel_loads_theme_registry_once_when_opened(self, settings_page):
+        registry_requests = []
+
+        def capture_registry(route):
+            registry_requests.append(route.request.url)
+            route.fulfill(json=_theme_registry_payload())
+
+        settings_page.route("**/api/themes/registry", capture_registry)
+
+        settings_page.locator('button[data-section="appearance"]').click()
+        expect(settings_page.locator('#registry-gallery .theme-card')).to_have_count(1)
+        expect(settings_page.locator('#registry-gallery')).to_contain_text("Registry Test Theme")
+        assert len(registry_requests) == 1
+
+        settings_page.locator('button[data-section="general"]').click()
+        settings_page.locator('button[data-section="appearance"]').click()
+        expect(settings_page.locator('#registry-gallery .theme-card')).to_have_count(1)
+        assert len(registry_requests) == 1
+
+
 class TestSettingsToastStates:
     """Theme and module registry operations report the correct toast polarity."""
 


### PR DESCRIPTION
## Summary

- load the available theme registry when the Appearance settings panel opens
- avoid duplicate automatic fetches when users revisit the panel while keeping manual refresh available
- add a browser regression for automatic loading and no-refetch revisit behavior

## Tests

- `.venv/bin/python -m pytest tests/e2e/test_settings.py::TestSettingsThemeRegistry -q`
- `.venv/bin/python -m pytest tests/e2e/test_settings.py::TestSettingsToastStates::test_theme_install_toast_state_matches_result -q`
- `.venv/bin/python -m pytest tests/e2e/test_settings.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `git diff --check`
