### PR TITLE
Keep mobile settings support visible

### DIFF
--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -211,6 +211,10 @@ html, body {
   margin: var(--space-md) var(--space-sm);
 }
 
+.sidebar-support {
+  margin-top: auto;
+}
+
 /* ─── Main Content ─── */
 .main-content {
   flex: 1;
@@ -1398,8 +1402,60 @@ html, body {
   .sidebar {
     transform: translateX(-100%);
     transition: transform 0.3s var(--ease-out-expo);
+    width: min(88vw, 320px);
+    padding: 12px;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+    overscroll-behavior: contain;
   }
   .sidebar.open { transform: translateX(0); }
+  .sidebar-header {
+    padding: 8px 8px 12px;
+    margin-bottom: 8px;
+  }
+  .nav-group {
+    margin-bottom: var(--space-sm);
+  }
+  .nav-item {
+    gap: 10px;
+    padding: 8px 10px;
+    min-height: 40px;
+    font-size: 0.84rem;
+  }
+  .nav-sub-item {
+    padding-left: 24px;
+    font-size: 0.78rem;
+  }
+  .nav-icon {
+    width: 18px;
+    height: 18px;
+  }
+  .nav-sub-item .nav-icon {
+    width: 14px;
+    height: 14px;
+  }
+  .nav-badge {
+    font-size: 0.6rem;
+    padding: 2px 6px;
+  }
+  .sidebar-support {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+    margin-top: var(--space-sm);
+    padding-top: 6px;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    background:
+      linear-gradient(to bottom, transparent, color-mix(in srgb, var(--void-deep) 92%, transparent) 18px),
+      color-mix(in srgb, var(--void-deep) 88%, transparent);
+  }
+  [data-theme="light"] .sidebar-support {
+    background:
+      linear-gradient(to bottom, transparent, color-mix(in srgb, var(--void-deep) 94%, transparent) 18px),
+      color-mix(in srgb, var(--void-deep) 92%, transparent);
+  }
+  .sidebar-support .nav-separator {
+    margin: 8px var(--space-sm);
+  }
   .main-content {
     margin-left: 0;
     padding: var(--space-lg);

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -100,7 +100,7 @@
         </div>
 
         <!-- Support (bottom) -->
-        <div style="margin-top: auto;">
+        <div class="sidebar-support">
             <div class="nav-separator"></div>
             <button class="nav-item" data-section="support" onclick="switchSection('support')">
                 <i data-lucide="heart-handshake" class="nav-icon"></i>

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -29,6 +29,40 @@ class TestSettingsLoad:
         assert "active" in btn.get_attribute("class")
 
 
+class TestSettingsMobileSidebar:
+    """Mobile sidebar keeps the full settings navigation reachable."""
+
+    def test_support_nav_stays_visible_when_mobile_sidebar_overflows(self, settings_page):
+        settings_page.set_viewport_size({"width": 390, "height": 844})
+        settings_page.reload(wait_until="networkidle")
+
+        settings_page.locator(".mobile-menu-btn").click()
+        sidebar = settings_page.locator("#settings-sidebar")
+        support = settings_page.locator('button[data-section="support"]')
+        expect(sidebar).to_have_class(re.compile(r".*\bopen\b.*"))
+        expect(support).to_be_visible()
+
+        metrics = settings_page.evaluate(
+            """
+            () => {
+              const sidebar = document.querySelector('#settings-sidebar');
+              const support = document.querySelector('button[data-section="support"]');
+              const sidebarRect = sidebar.getBoundingClientRect();
+              const supportRect = support.getBoundingClientRect();
+              return {
+                scrollHeight: sidebar.scrollHeight,
+                clientHeight: sidebar.clientHeight,
+                supportTop: supportRect.top - sidebarRect.top,
+                supportBottom: supportRect.bottom - sidebarRect.top,
+              };
+            }
+            """
+        )
+        assert metrics["scrollHeight"] > metrics["clientHeight"]
+        assert metrics["supportTop"] >= 0
+        assert metrics["supportBottom"] <= metrics["clientHeight"]
+
+
 class TestSettingsTabSwitching:
     """Clicking sidebar tabs shows the correct panel."""
 


### PR DESCRIPTION
## Summary

- move the settings Support nav wrapper styling into CSS
- keep the Support nav action reachable in the mobile sidebar with a sticky bottom treatment
- tighten mobile sidebar spacing so the full settings nav remains usable on small screens
- add a browser regression for the 390px mobile drawer overflow case

## Tests

- `.venv/bin/python -m pytest tests/e2e/test_settings.py::TestSettingsMobileSidebar -q`
- `.venv/bin/python -m pytest tests/e2e/test_settings.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `git diff --check`
