### PR TITLE
Group settings sidebar navigation

### DIFF
--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -69,7 +69,7 @@ html, body {
   -webkit-backdrop-filter: blur(32px) saturate(1.2);
   border-right: 1px solid var(--glass-border);
   padding: var(--space-md);
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 [data-theme="light"] .sidebar {
@@ -120,6 +120,13 @@ html, body {
 
 .nav-group {
   margin-bottom: var(--space-lg);
+}
+
+.sidebar-nav {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 2px;
 }
 
 .nav-group-label {
@@ -212,7 +219,17 @@ html, body {
 }
 
 .sidebar-support {
-  margin-top: auto;
+  flex-shrink: 0;
+  padding-top: 6px;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  background:
+    linear-gradient(to bottom, transparent, color-mix(in srgb, var(--void-deep) 92%, transparent) 18px),
+    color-mix(in srgb, var(--void-deep) 88%, transparent);
+}
+[data-theme="light"] .sidebar-support {
+  background:
+    linear-gradient(to bottom, transparent, color-mix(in srgb, var(--void-deep) 94%, transparent) 18px),
+    color-mix(in srgb, var(--void-deep) 92%, transparent);
 }
 
 /* ─── Main Content ─── */
@@ -1415,6 +1432,11 @@ html, body {
   .nav-group {
     margin-bottom: var(--space-sm);
   }
+  .nav-group-label {
+    font-size: 0.62rem;
+    padding: 0 10px;
+    margin-bottom: 4px;
+  }
   .nav-item {
     gap: 10px;
     padding: 8px 10px;
@@ -1438,20 +1460,7 @@ html, body {
     padding: 2px 6px;
   }
   .sidebar-support {
-    position: sticky;
-    bottom: 0;
-    z-index: 1;
     margin-top: var(--space-sm);
-    padding-top: 6px;
-    padding-bottom: env(safe-area-inset-bottom, 0px);
-    background:
-      linear-gradient(to bottom, transparent, color-mix(in srgb, var(--void-deep) 92%, transparent) 18px),
-      color-mix(in srgb, var(--void-deep) 88%, transparent);
-  }
-  [data-theme="light"] .sidebar-support {
-    background:
-      linear-gradient(to bottom, transparent, color-mix(in srgb, var(--void-deep) 94%, transparent) 18px),
-      color-mix(in srgb, var(--void-deep) 92%, transparent);
   }
   .sidebar-support .nav-separator {
     margin: 8px var(--space-sm);

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -53,50 +53,58 @@
         </a>
 
         <!-- Settings Navigation -->
-        <div class="nav-group">
-            <button class="nav-item active" data-section="connection" onclick="switchSection('connection')">
-                <i data-lucide="radio" class="nav-icon"></i>
-                {{ t.step_modem }}
-            </button>
-            <button class="nav-item" data-section="general" onclick="switchSection('general')">
-                <i data-lucide="settings" class="nav-icon"></i>
-                {{ t.general }}
-            </button>
-            <button class="nav-item" data-section="notifications" onclick="switchSection('notifications')">
-                <i data-lucide="bell" class="nav-icon"></i>
-                {{ t.notifications }}
-            </button>
-            <button class="nav-item" data-section="smart_capture" onclick="switchSection('smart_capture')">
-                <i data-lucide="zap" class="nav-icon"></i>
-                {{ t.get('smart_capture', 'Smart Capture') }}
-            </button>
-            <button class="nav-item" data-section="appearance" onclick="switchSection('appearance')">
-                <i data-lucide="palette" class="nav-icon"></i>
-                {{ t.appearance }}
-            </button>
-            <button class="nav-item" data-section="security" onclick="switchSection('security')">
-                <i data-lucide="shield" class="nav-icon"></i>
-                {{ t.security }}
-            </button>
-            <button class="nav-item" data-section="extensions" onclick="switchSection('extensions')">
-                <i data-lucide="package" class="nav-icon"></i>
-                {{ t.get('settings_extensions', 'Extensions') }}
-            </button>
-            <button class="nav-item" data-section="about" onclick="switchSection('about')">
-                <i data-lucide="info" class="nav-icon"></i>
-                {{ t.get('about_project', 'About Project') }}
-            </button>
+        <div class="sidebar-nav">
+            <div class="nav-group" aria-labelledby="settings-nav-core-label">
+                <div class="nav-group-label" id="settings-nav-core-label">{{ t.settings }}</div>
+                <button class="nav-item active" data-section="connection" onclick="switchSection('connection')">
+                    <i data-lucide="radio" class="nav-icon"></i>
+                    {{ t.step_modem }}
+                </button>
+                <button class="nav-item" data-section="general" onclick="switchSection('general')">
+                    <i data-lucide="settings" class="nav-icon"></i>
+                    {{ t.general }}
+                </button>
+                <button class="nav-item" data-section="notifications" onclick="switchSection('notifications')">
+                    <i data-lucide="bell" class="nav-icon"></i>
+                    {{ t.notifications }}
+                </button>
+                <button class="nav-item" data-section="smart_capture" onclick="switchSection('smart_capture')">
+                    <i data-lucide="zap" class="nav-icon"></i>
+                    {{ t.get('smart_capture', 'Smart Capture') }}
+                </button>
+                <button class="nav-item" data-section="appearance" onclick="switchSection('appearance')">
+                    <i data-lucide="palette" class="nav-icon"></i>
+                    {{ t.appearance }}
+                </button>
+                <button class="nav-item" data-section="security" onclick="switchSection('security')">
+                    <i data-lucide="shield" class="nav-icon"></i>
+                    {{ t.security }}
+                </button>
+                <button class="nav-item" data-section="extensions" onclick="switchSection('extensions')">
+                    <i data-lucide="package" class="nav-icon"></i>
+                    {{ t.get('settings_extensions', 'Extensions') }}
+                </button>
+                <button class="nav-item" data-section="about" onclick="switchSection('about')">
+                    <i data-lucide="info" class="nav-icon"></i>
+                    {{ t.get('about_project', 'About Project') }}
+                </button>
+            </div>
             {% set settings_modules = [] %}
             {% for mod in modules if mod.template_paths.get('settings') %}
                 {% if settings_modules.append(mod) %}{% endif %}
             {% endfor %}
-            {% for mod in settings_modules|sort(attribute='name') %}
-            <button class="nav-item nav-sub-item" data-section="mod-{{ mod.id|replace('.', '_') }}" onclick="switchSection('mod-{{ mod.id|replace('.', '_') }}')">
-                <i data-lucide="{{ mod.menu.get('icon', 'puzzle') }}" class="nav-icon"></i>
-                {{ t.get(mod.menu.label_key, mod.name) }}
-                <span class="nav-badge {{ 'success' if mod.enabled else 'info' }}">{{ 'ON' if mod.enabled else 'OFF' }}</span>
-            </button>
-            {% endfor %}
+            {% if settings_modules %}
+            <div class="nav-group" aria-labelledby="settings-nav-modules-label">
+                <div class="nav-group-label" id="settings-nav-modules-label">{{ t.modules }}</div>
+                {% for mod in settings_modules|sort(attribute='name') %}
+                <button class="nav-item nav-sub-item" data-section="mod-{{ mod.id|replace('.', '_') }}" onclick="switchSection('mod-{{ mod.id|replace('.', '_') }}')">
+                    <i data-lucide="{{ mod.menu.get('icon', 'puzzle') }}" class="nav-icon"></i>
+                    {{ t.get(mod.menu.label_key, mod.name) }}
+                    <span class="nav-badge {{ 'success' if mod.enabled else 'info' }}">{{ 'ON' if mod.enabled else 'OFF' }}</span>
+                </button>
+                {% endfor %}
+            </div>
+            {% endif %}
         </div>
 
         <!-- Support (bottom) -->

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -28,6 +28,15 @@ class TestSettingsLoad:
         btn = settings_page.locator('button[data-section="connection"]')
         assert "active" in btn.get_attribute("class")
 
+    def test_sidebar_navigation_has_group_labels(self, settings_page):
+        core_group = settings_page.locator('.nav-group[aria-labelledby="settings-nav-core-label"]')
+        module_group = settings_page.locator('.nav-group[aria-labelledby="settings-nav-modules-label"]')
+
+        expect(core_group.locator('#settings-nav-core-label')).to_have_text("Settings")
+        expect(module_group.locator('#settings-nav-modules-label')).to_have_text("Modules")
+        expect(core_group.locator('button[data-section="connection"]')).to_be_visible()
+        assert module_group.locator('.nav-sub-item').count() > 0
+
 
 class TestSettingsMobileSidebar:
     """Mobile sidebar keeps the full settings navigation reachable."""
@@ -46,21 +55,23 @@ class TestSettingsMobileSidebar:
             """
             () => {
               const sidebar = document.querySelector('#settings-sidebar');
+              const sidebarNav = document.querySelector('#settings-sidebar .sidebar-nav');
               const support = document.querySelector('button[data-section="support"]');
               const sidebarRect = sidebar.getBoundingClientRect();
               const supportRect = support.getBoundingClientRect();
               return {
-                scrollHeight: sidebar.scrollHeight,
-                clientHeight: sidebar.clientHeight,
+                navScrollHeight: sidebarNav.scrollHeight,
+                navClientHeight: sidebarNav.clientHeight,
                 supportTop: supportRect.top - sidebarRect.top,
                 supportBottom: supportRect.bottom - sidebarRect.top,
+                sidebarHeight: sidebarRect.height,
               };
             }
             """
         )
-        assert metrics["scrollHeight"] > metrics["clientHeight"]
+        assert metrics["navScrollHeight"] > metrics["navClientHeight"]
         assert metrics["supportTop"] >= 0
-        assert metrics["supportBottom"] <= metrics["clientHeight"]
+        assert metrics["supportBottom"] <= metrics["sidebarHeight"]
 
 
 class TestSettingsTabSwitching:

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -33,6 +33,18 @@ class TestSettingsRoute:
         assert b"Segment Utilization" in resp.data
         assert b"Disabled" in resp.data
 
+    def test_settings_sidebar_groups_core_and_module_navigation(self, client):
+        resp = client.get("/settings?lang=en")
+        assert resp.status_code == 200
+        html = resp.data.decode("utf-8")
+
+        assert 'aria-labelledby="settings-nav-core-label"' in html
+        assert 'id="settings-nav-core-label"' in html
+        assert re.search(
+            r'id="settings-nav-core-label"[^>]*>\s*Settings\s*</div>', html
+        )
+        assert html.index('id="settings-nav-core-label"') < html.index('data-section="connection"')
+
     def test_settings_admin_password_field_uses_saved_secret_placeholder(self, client, config_mgr):
         config_mgr.save({"admin_password": "admin-secret-value"})
         init_config(config_mgr)


### PR DESCRIPTION
## Summary

- add labeled Settings and Modules groups to the settings sidebar navigation
- split the sidebar into a scrollable navigation area plus a fixed Support action
- keep mobile Support reachable while module navigation scrolls independently
- add web and browser regressions for the grouped sidebar contract

## Tests

- `.venv/bin/python -m pytest tests/web/test_settings.py::TestSettingsRoute::test_settings_sidebar_groups_core_and_module_navigation -q`
- `.venv/bin/python -m pytest tests/e2e/test_settings.py::TestSettingsLoad::test_sidebar_navigation_has_group_labels tests/e2e/test_settings.py::TestSettingsMobileSidebar::test_support_nav_stays_visible_when_mobile_sidebar_overflows -q`
- `.venv/bin/python -m pytest tests/e2e/test_settings.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- `git diff --check`
