### PR TITLE
Make notification channel cards collapsible

### DIFF
--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -335,6 +335,74 @@ html, body {
   cursor: pointer;
   user-select: none;
 }
+button.card-collapse-toggle,
+button.notification-collapse-button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  padding: 0;
+}
+.notification-card-header {
+  align-items: flex-start;
+}
+.notification-card-toggle {
+  flex: 1;
+  min-width: 0;
+}
+.notification-channel-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+.channel-status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--glass-border);
+  background: var(--tint-subtle);
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+.channel-status-badge.status-enabled {
+  background: var(--good-muted);
+  border-color: color-mix(in srgb, var(--good) 28%, transparent);
+  color: var(--success);
+}
+.channel-status-badge.status-disabled,
+.channel-status-badge.status-muted {
+  background: color-mix(in srgb, var(--muted) 10%, transparent);
+  border-color: color-mix(in srgb, var(--muted) 18%, transparent);
+  color: var(--text-muted);
+}
+.notification-header-toggle {
+  flex-shrink: 0;
+}
+.notification-collapse-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  transition: background 0.2s var(--ease-out-expo), color 0.2s var(--ease-out-expo);
+}
+.notification-collapse-button:hover,
+.notification-collapse-button:focus-visible {
+  background: var(--tint-hover);
+  outline: none;
+}
 .card-collapse-icon {
   width: 18px;
   height: 18px;
@@ -354,7 +422,7 @@ html, body {
 .collapsible-card.collapsed .card-collapse-body {
   grid-template-rows: 0fr;
 }
-.collapsible-card.collapsed .card-collapse-toggle {
+.collapsible-card.collapsed .card-header {
   margin-bottom: 0;
 }
 .collapsible-card.collapsed .card-collapse-icon {
@@ -1479,6 +1547,21 @@ html, body {
   .save-footer { left: 0; }
   .mobile-header { display: flex !important; }
   .settings-card { padding: 18px; }
+  .notification-card-header {
+    align-items: flex-start;
+    gap: var(--space-sm);
+  }
+  .notification-channel-actions {
+    gap: 8px;
+  }
+  .channel-status-badge {
+    font-size: 0.62rem;
+    padding: 3px 8px;
+  }
+  .notification-card-toggle .card-icon {
+    width: 36px;
+    height: 36px;
+  }
 }
 
 /* ─── Backup List ─── */

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -61,12 +61,80 @@ function closeMobileSidebar() {
 }
 
 /* ── Collapsible Cards ── */
+function _syncCardCollapseAria(card) {
+    if (!card) return;
+    var expanded = !card.classList.contains('collapsed');
+    card.querySelectorAll('.card-collapse-toggle[aria-expanded]').forEach(function(toggle) {
+        toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    });
+    if (card.classList.contains('notification-channel-card')) {
+        var body = card.querySelector('.card-collapse-body');
+        if (body) {
+            body.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+            if (expanded) {
+                body.removeAttribute('inert');
+            } else {
+                body.setAttribute('inert', '');
+            }
+        }
+    }
+}
+
 function toggleCardCollapse(headerEl) {
     var card = headerEl.closest('.collapsible-card');
     if (card) {
         card.classList.toggle('collapsed');
+        _syncCardCollapseAria(card);
         if (typeof lucide !== 'undefined') lucide.createIcons();
     }
+}
+
+function expandNotificationChannelCard(controlEl) {
+    if (!controlEl || !controlEl.checked) return;
+    var card = controlEl.closest('.notification-channel-card');
+    if (card && card.classList.contains('collapsed')) {
+        card.classList.remove('collapsed');
+        _syncCardCollapseAria(card);
+    }
+}
+
+function _notificationLabel(key, fallback) {
+    return (typeof T !== 'undefined' && T[key]) ? T[key] : fallback;
+}
+
+function _setNotificationChannelBadge(channel, enabled, label) {
+    var badge = document.querySelector('[data-channel-badge="' + channel + '"]');
+    if (!badge) return;
+    badge.textContent = label;
+    badge.classList.toggle('status-enabled', enabled);
+    badge.classList.toggle('status-disabled', !enabled && channel !== 'webhook');
+    badge.classList.toggle('status-muted', !enabled && channel === 'webhook');
+}
+
+function updateNotificationChannelSummaries() {
+    var webhook = document.getElementById('notify_webhook_url');
+    var webhookConfigured = !!(webhook && webhook.value.trim() !== '');
+    _setNotificationChannelBadge(
+        'webhook',
+        webhookConfigured,
+        webhookConfigured ? _notificationLabel('enabled', 'Enabled') : _notificationLabel('not_configured', 'Not configured')
+    );
+
+    var apprise = document.getElementById('notify_apprise_enabled');
+    var appriseEnabled = !!(apprise && apprise.checked);
+    _setNotificationChannelBadge(
+        'apprise',
+        appriseEnabled,
+        appriseEnabled ? _notificationLabel('enabled', 'Enabled') : _notificationLabel('disabled', 'Disabled')
+    );
+
+    var pwa = document.getElementById('notify_pwa_push_enabled');
+    var pwaEnabled = !!(pwa && pwa.checked);
+    _setNotificationChannelBadge(
+        'pwa',
+        pwaEnabled,
+        pwaEnabled ? _notificationLabel('enabled', 'Enabled') : _notificationLabel('disabled', 'Disabled')
+    );
 }
 
 /* ── API Token Management ── */
@@ -1586,11 +1654,22 @@ document.addEventListener('DOMContentLoaded', function() {
     onIspChange();
     toggleUsernameField();
     updateStatusDots();
+    updateNotificationChannelSummaries();
 
-    /* Listen for input changes on integration fields to update dots */
+    /* Listen for input changes on integration fields to update dots and card summaries */
     ['notify_webhook_url'].forEach(function(id) {
         var el = document.getElementById(id);
-        if (el) el.addEventListener('input', updateStatusDots);
+        if (el) {
+            el.addEventListener('input', updateStatusDots);
+            el.addEventListener('input', updateNotificationChannelSummaries);
+        }
+    });
+    ['notify_apprise_enabled', 'notify_pwa_push_enabled'].forEach(function(id) {
+        var el = document.getElementById(id);
+        if (el) el.addEventListener('change', function() {
+            updateNotificationChannelSummaries();
+            expandNotificationChannelCard(el);
+        });
     });
 
     /* Modem type change */

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v62';
+var CACHE_VERSION = 'v63';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/settings/notifications.html
+++ b/app/templates/settings/notifications.html
@@ -1,9 +1,10 @@
 <!-- ═══ Panel: Notifications ═══ -->
 <div class="settings-panel" id="panel-notifications">
+    {% set webhook_configured = (config.notify_webhook_url|default('', true)|trim) %}
     <!-- Webhook Config Card -->
-    <div class="settings-card glass">
-        <div class="card-header">
-            <div class="card-title-group">
+    <div class="settings-card glass notification-channel-card collapsible-card{% if not webhook_configured %} collapsed{% endif %}" id="notification-webhook-card" data-channel-card="webhook">
+        <div class="card-header notification-card-header">
+            <button type="button" class="card-title-group card-collapse-toggle notification-card-toggle" onclick="toggleCardCollapse(this)" aria-controls="notification-webhook-body" aria-expanded="{{ 'true' if webhook_configured else 'false' }}">
                 <div class="card-icon purple">
                     <i data-lucide="bell"></i>
                 </div>
@@ -11,8 +12,15 @@
                     <div class="card-title">{{ t.notify_title }}</div>
                     <div class="card-subtitle">{{ t.notify_desc }}</div>
                 </div>
+            </button>
+            <div class="notification-channel-actions">
+                <span class="channel-status-badge {{ 'status-enabled' if webhook_configured else 'status-muted' }}" data-channel-badge="webhook">{{ t.enabled if webhook_configured else t.not_configured }}</span>
+                <button type="button" class="notification-collapse-button card-collapse-toggle" onclick="toggleCardCollapse(this)" aria-controls="notification-webhook-body" aria-expanded="{{ 'true' if webhook_configured else 'false' }}" aria-label="{{ t.notify_title }}">
+                    <i data-lucide="chevron-down" class="card-collapse-icon"></i>
+                </button>
             </div>
         </div>
+        <div class="card-collapse-body" id="notification-webhook-body"{% if not webhook_configured %} aria-hidden="true" inert{% else %} aria-hidden="false"{% endif %}>
         <div class="form-grid cols-2">
             <div class="form-field" style="grid-column: 1 / -1">
                 <label class="form-label" for="notify_webhook_url">{{ t.notify_webhook_url }}</label>
@@ -39,12 +47,13 @@
                 <span class="form-hint">{{ t.notify_cooldown_hint }}</span>
             </div>
         </div>
+        </div>
     </div>
 
     <!-- Apprise Config Card -->
-    <div class="settings-card glass">
-        <div class="card-header">
-            <div class="card-title-group">
+    <div class="settings-card glass notification-channel-card collapsible-card{% if not config.notify_apprise_enabled %} collapsed{% endif %}" id="notification-apprise-card" data-channel-card="apprise">
+        <div class="card-header notification-card-header">
+            <button type="button" class="card-title-group card-collapse-toggle notification-card-toggle" onclick="toggleCardCollapse(this)" aria-controls="notification-apprise-body" aria-expanded="{{ 'true' if config.notify_apprise_enabled else 'false' }}">
                 <div class="card-icon green">
                     <i data-lucide="radio-tower"></i>
                 </div>
@@ -52,18 +61,17 @@
                     <div class="card-title">{{ t.notify_apprise_title }}</div>
                     <div class="card-subtitle">{{ t.notify_apprise_desc }}</div>
                 </div>
+            </button>
+            <div class="notification-channel-actions">
+                <span class="channel-status-badge {{ 'status-enabled' if config.notify_apprise_enabled else 'status-disabled' }}" data-channel-badge="apprise">{{ t.enabled if config.notify_apprise_enabled else t.disabled }}</span>
+                <label class="toggle notification-header-toggle" aria-label="{{ t.notify_apprise_enabled }}"><input type="checkbox" id="notify_apprise_enabled" name="notify_apprise_enabled" value="true" {% if config.notify_apprise_enabled %}checked{% endif %}><span class="toggle-slider"></span></label>
+                <button type="button" class="notification-collapse-button card-collapse-toggle" onclick="toggleCardCollapse(this)" aria-controls="notification-apprise-body" aria-expanded="{{ 'true' if config.notify_apprise_enabled else 'false' }}" aria-label="{{ t.notify_apprise_title }}">
+                    <i data-lucide="chevron-down" class="card-collapse-icon"></i>
+                </button>
             </div>
         </div>
+        <div class="card-collapse-body" id="notification-apprise-body"{% if not config.notify_apprise_enabled %} aria-hidden="true" inert{% else %} aria-hidden="false"{% endif %}>
         <div class="form-grid cols-2">
-            <div class="form-field" style="grid-column: 1 / -1">
-                <div class="toggle-row">
-                    <span>
-                        <label class="form-label" for="notify_apprise_enabled">{{ t.notify_apprise_enabled }}</label>
-                        <span class="form-hint">{{ t.notify_apprise_enabled_hint }}</span>
-                    </span>
-                    <label class="toggle"><input type="checkbox" id="notify_apprise_enabled" name="notify_apprise_enabled" value="true" {% if config.notify_apprise_enabled %}checked{% endif %}><span class="toggle-slider"></span></label>
-                </div>
-            </div>
             <div class="form-field" style="grid-column: 1 / -1">
                 <label class="form-label" for="notify_apprise_url">{{ t.notify_apprise_url }}</label>
                 <input class="form-input" type="url" id="notify_apprise_url" name="notify_apprise_url" value="{{ config.notify_apprise_url }}" placeholder="http://apprise:8000">
@@ -85,12 +93,13 @@
                 <span class="form-hint">{{ t.notify_apprise_tag_hint }}</span>
             </div>
         </div>
+        </div>
     </div>
 
     <!-- PWA Web Push Config Card -->
-    <div class="settings-card glass" id="pwa-push-card">
-        <div class="card-header">
-            <div class="card-title-group">
+    <div class="settings-card glass notification-channel-card collapsible-card{% if not config.notify_pwa_push_enabled %} collapsed{% endif %}" id="pwa-push-card" data-channel-card="pwa">
+        <div class="card-header notification-card-header">
+            <button type="button" class="card-title-group card-collapse-toggle notification-card-toggle" onclick="toggleCardCollapse(this)" aria-controls="notification-pwa-push-body" aria-expanded="{{ 'true' if config.notify_pwa_push_enabled else 'false' }}">
                 <div class="card-icon blue">
                     <i data-lucide="smartphone"></i>
                 </div>
@@ -98,18 +107,17 @@
                     <div class="card-title">{{ t.notify_pwa_push_title }}</div>
                     <div class="card-subtitle">{{ t.notify_pwa_push_desc }}</div>
                 </div>
+            </button>
+            <div class="notification-channel-actions">
+                <span class="channel-status-badge {{ 'status-enabled' if config.notify_pwa_push_enabled else 'status-disabled' }}" data-channel-badge="pwa">{{ t.enabled if config.notify_pwa_push_enabled else t.disabled }}</span>
+                <label class="toggle notification-header-toggle" aria-label="{{ t.notify_pwa_push_enabled }}"><input type="checkbox" id="notify_pwa_push_enabled" name="notify_pwa_push_enabled" value="true" {% if config.notify_pwa_push_enabled %}checked{% endif %}><span class="toggle-slider"></span></label>
+                <button type="button" class="notification-collapse-button card-collapse-toggle" onclick="toggleCardCollapse(this)" aria-controls="notification-pwa-push-body" aria-expanded="{{ 'true' if config.notify_pwa_push_enabled else 'false' }}" aria-label="{{ t.notify_pwa_push_title }}">
+                    <i data-lucide="chevron-down" class="card-collapse-icon"></i>
+                </button>
             </div>
         </div>
+        <div class="card-collapse-body" id="notification-pwa-push-body"{% if not config.notify_pwa_push_enabled %} aria-hidden="true" inert{% else %} aria-hidden="false"{% endif %}>
         <div class="form-grid cols-2">
-            <div class="form-field" style="grid-column: 1 / -1">
-                <div class="toggle-row">
-                    <span>
-                        <label class="form-label" for="notify_pwa_push_enabled">{{ t.notify_pwa_push_enabled }}</label>
-                        <span class="form-hint">{{ t.notify_pwa_push_enabled_hint }}</span>
-                    </span>
-                    <label class="toggle"><input type="checkbox" id="notify_pwa_push_enabled" name="notify_pwa_push_enabled" value="true" {% if config.notify_pwa_push_enabled %}checked{% endif %}><span class="toggle-slider"></span></label>
-                </div>
-            </div>
             <div class="form-field">
                 <label class="form-label" for="notify_pwa_push_vapid_public_key">{{ t.notify_pwa_push_vapid_public_key }}</label>
                 <input class="form-input" type="text" id="notify_pwa_push_vapid_public_key" name="notify_pwa_push_vapid_public_key" value="{{ config.notify_pwa_push_vapid_public_key }}" placeholder="B...">
@@ -139,6 +147,7 @@
                 </div>
                 <span class="form-hint">{{ t.notify_pwa_push_permission_hint }}</span>
             </div>
+        </div>
         </div>
     </div>
 

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -130,6 +130,64 @@ class TestSettingsFormElements:
         expect(settings_page.locator('#notify_pwa_push_vapid_subject')).to_have_count(1)
         expect(settings_page.locator('#pwa-push-status')).to_have_count(1)
 
+    def test_notifications_channel_cards_are_collapsed_with_live_status_summaries(self, settings_page):
+        settings_page.locator('button[data-section="notifications"]').click()
+
+        for card_id in ["notification-webhook-card", "notification-apprise-card", "pwa-push-card"]:
+            card = settings_page.locator(f"#{card_id}")
+            expect(card).to_have_class(re.compile(r".*\bcollapsed\b.*"))
+            expect(card.locator('.card-collapse-body')).to_have_attribute("aria-hidden", "true")
+            expect(card.locator('.card-collapse-body')).to_have_attribute("inert", "")
+
+        expect(settings_page.locator('[data-channel-badge="webhook"]')).to_have_text("Not configured")
+        expect(settings_page.locator('[data-channel-badge="apprise"]')).to_have_text("Disabled")
+        expect(settings_page.locator('[data-channel-badge="pwa"]')).to_have_text("Disabled")
+
+        settings_page.locator('#notification-webhook-card .notification-collapse-button').click()
+        expect(settings_page.locator('#notification-webhook-card')).not_to_have_class(re.compile(r".*\bcollapsed\b.*"))
+        expect(settings_page.locator('#notification-webhook-card .notification-collapse-button')).to_have_attribute("aria-expanded", "true")
+        expect(settings_page.locator('#notification-webhook-body')).to_have_attribute("aria-hidden", "false")
+        expect(settings_page.locator('#notification-webhook-body')).not_to_have_attribute("inert", "")
+
+    def test_notifications_channel_badges_update_when_toggles_or_url_change(self, settings_page):
+        settings_page.route("**/api/config", lambda route: route.fulfill(json={"success": True}))
+        settings_page.locator('button[data-section="notifications"]').click()
+
+        settings_page.locator('#notify_webhook_url').evaluate("el => { el.value = 'https://ntfy.sh/docsight'; el.dispatchEvent(new Event('input', {bubbles: true})); }")
+        expect(settings_page.locator('[data-channel-badge="webhook"]')).to_have_text("Enabled")
+
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('#notify_apprise_enabled + .toggle-slider').click()
+        expect(settings_page.locator('[data-channel-badge="apprise"]')).to_have_text("Enabled")
+        expect(settings_page.locator('#notification-apprise-card')).not_to_have_class(re.compile(r".*\bcollapsed\b.*"))
+
+        with settings_page.expect_request("**/api/config"):
+            settings_page.locator('#notify_pwa_push_enabled + .toggle-slider').click()
+        expect(settings_page.locator('[data-channel-badge="pwa"]')).to_have_text("Enabled")
+        expect(settings_page.locator('#pwa-push-card')).not_to_have_class(re.compile(r".*\bcollapsed\b.*"))
+
+    def test_notifications_mobile_scroll_is_reduced_by_collapsed_channel_cards(self, settings_page):
+        settings_page.set_viewport_size({"width": 390, "height": 844})
+        settings_page.reload(wait_until="networkidle")
+        settings_page.evaluate("() => window.switchSection('notifications')")
+
+        metrics = settings_page.evaluate(
+            """
+            () => {
+              const panel = document.querySelector('#panel-notifications');
+              const main = document.querySelector('.main-content');
+              return {
+                panelScrollHeight: panel.scrollHeight,
+                mainClientHeight: main.clientHeight,
+                collapsedChannels: panel.querySelectorAll('.notification-channel-card.collapsed').length,
+              };
+            }
+            """
+        )
+        assert metrics["collapsedChannels"] == 3
+        assert metrics["panelScrollHeight"] < 2000
+        assert metrics["panelScrollHeight"] > metrics["mainClientHeight"]
+
     def test_notifications_panel_has_per_severity_cooldown_rows(self, settings_page):
         settings_page.locator('button[data-section="notifications"]').click()
 

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -45,6 +45,20 @@ class TestSettingsRoute:
         )
         assert html.index('id="settings-nav-core-label"') < html.index('data-section="connection"')
 
+    def test_settings_notifications_channel_cards_render_compact_status_headers(self, client):
+        resp = client.get("/settings?lang=en")
+        assert resp.status_code == 200
+        html = resp.data.decode("utf-8")
+
+        for card_id in ["notification-webhook-card", "notification-apprise-card", "pwa-push-card"]:
+            match = re.search(rf'<div class="[^"]*notification-channel-card[^"]*collapsed[^"]*" id="{card_id}"', html)
+            assert match is not None
+        assert 'data-channel-badge="webhook">Not configured</span>' in html
+        assert 'data-channel-badge="apprise">Disabled</span>' in html
+        assert 'data-channel-badge="pwa">Disabled</span>' in html
+        assert 'aria-controls="notification-webhook-body"' in html
+        assert 'id="notification-webhook-body" aria-hidden="true" inert' in html
+
     def test_settings_admin_password_field_uses_saved_secret_placeholder(self, client, config_mgr):
         config_mgr.save({"admin_password": "admin-secret-value"})
         init_config(config_mgr)


### PR DESCRIPTION
## Summary
- make notification channel cards collapsible with compact status summaries
- keep Apprise and PWA enable toggles visible in card headers and auto-expand when enabled
- add browser regressions for collapsed state, badge updates, mobile scroll height, and retained settings contracts
- bump the service-worker cache for the updated settings assets

## Tests
- `uv run pytest tests/web/test_settings.py::TestSettingsRoute::test_settings_notifications_channel_cards_render_compact_status_headers tests/e2e/test_settings.py::TestSettingsFormElements::test_notifications_channel_cards_are_collapsed_with_live_status_summaries tests/e2e/test_settings.py::TestSettingsFormElements::test_notifications_channel_badges_update_when_toggles_or_url_change tests/e2e/test_settings.py::TestSettingsFormElements::test_notifications_mobile_scroll_is_reduced_by_collapsed_channel_cards -q`
- `uv run pytest tests/e2e/test_settings.py -q`
- `uv run pytest tests/web/test_settings.py tests/test_settings_secret_fields.py tests/test_static_contracts.py -q`
- `uv run pytest -q --ignore=tests/e2e`
- `uv run python scripts/i18n_check.py`
- `git diff --check`
