### PR TITLE
Apply shared form styling to Smart Capture

### DIFF
--- a/app/templates/settings/smart_capture.html
+++ b/app/templates/settings/smart_capture.html
@@ -35,17 +35,17 @@
                 </div>
                 <div class="sc-sub-settings">
                     <div class="form-grid cols-2">
-                        <div class="form-group">
-                            <label for="sc_trigger_modulation_direction">{{ t.get('sc_trigger_direction', 'Direction') }}</label>
-                            <select id="sc_trigger_modulation_direction" name="sc_trigger_modulation_direction">
+                        <div class="form-field">
+                            <label class="form-label" for="sc_trigger_modulation_direction">{{ t.get('sc_trigger_direction', 'Direction') }}</label>
+                            <select class="form-input form-select" id="sc_trigger_modulation_direction" name="sc_trigger_modulation_direction">
                                 <option value="both" {{ 'selected' if config.get('sc_trigger_modulation_direction', 'both') == 'both' }}>{{ t.get('sc_trigger_direction_both', 'Both') }}</option>
                                 <option value="DS" {{ 'selected' if config.get('sc_trigger_modulation_direction') == 'DS' }}>{{ t.get('sc_trigger_direction_ds', 'Downstream only') }}</option>
                                 <option value="US" {{ 'selected' if config.get('sc_trigger_modulation_direction') == 'US' }}>{{ t.get('sc_trigger_direction_us', 'Upstream only') }}</option>
                             </select>
                         </div>
-                        <div class="form-group">
-                            <label for="sc_trigger_modulation_min_qam">{{ t.get('sc_trigger_min_qam', 'Min QAM level') }}</label>
-                            <select id="sc_trigger_modulation_min_qam" name="sc_trigger_modulation_min_qam">
+                        <div class="form-field">
+                            <label class="form-label" for="sc_trigger_modulation_min_qam">{{ t.get('sc_trigger_min_qam', 'Min QAM level') }}</label>
+                            <select class="form-input form-select" id="sc_trigger_modulation_min_qam" name="sc_trigger_modulation_min_qam">
                                 <option value="" {{ 'selected' if not config.get('sc_trigger_modulation_min_qam') }}>{{ t.get('sc_trigger_min_qam_any', 'Any downgrade') }}</option>
                                 <option value="4096QAM" {{ 'selected' if config.get('sc_trigger_modulation_min_qam') == '4096QAM' }}>{{ t.get('sc_trigger_min_qam_4096', 'At or below 4096QAM (DOCSIS 3.1)') }}</option>
                                 <option value="2048QAM" {{ 'selected' if config.get('sc_trigger_modulation_min_qam') == '2048QAM' }}>{{ t.get('sc_trigger_min_qam_2048', 'At or below 2048QAM') }}</option>
@@ -97,9 +97,9 @@
                 </div>
                 <div class="sc-sub-settings">
                     <div class="form-grid cols-2">
-                        <div class="form-group">
-                            <label for="sc_trigger_error_spike_min_delta">{{ t.get('sc_trigger_min_delta', 'Min error delta') }}</label>
-                            <input type="number" id="sc_trigger_error_spike_min_delta" name="sc_trigger_error_spike_min_delta"
+                        <div class="form-field">
+                            <label class="form-label" for="sc_trigger_error_spike_min_delta">{{ t.get('sc_trigger_min_delta', 'Min error delta') }}</label>
+                            <input class="form-input" type="number" id="sc_trigger_error_spike_min_delta" name="sc_trigger_error_spike_min_delta"
                                    value="{{ config.get('sc_trigger_error_spike_min_delta', 0) }}" min="0">
                             <div class="form-hint">{{ t.get('sc_trigger_min_delta_hint', '0 = trigger on any spike') }}</div>
                         </div>
@@ -124,9 +124,9 @@
                 </div>
                 <div class="sc-sub-settings">
                     <div class="form-grid cols-2">
-                        <div class="form-group">
-                            <label for="sc_trigger_health_level">{{ t.get('sc_trigger_health_level', 'Health level') }}</label>
-                            <select id="sc_trigger_health_level" name="sc_trigger_health_level">
+                        <div class="form-field">
+                            <label class="form-label" for="sc_trigger_health_level">{{ t.get('sc_trigger_health_level', 'Health level') }}</label>
+                            <select class="form-input form-select" id="sc_trigger_health_level" name="sc_trigger_health_level">
                                 <option value="any_degradation" {{ 'selected' if config.get('sc_trigger_health_level', 'any_degradation') == 'any_degradation' }}>{{ t.get('sc_trigger_health_level_any', 'Any degradation') }}</option>
                                 <option value="critical_only" {{ 'selected' if config.get('sc_trigger_health_level') == 'critical_only' }}>{{ t.get('sc_trigger_health_level_critical', 'Critical only') }}</option>
                             </select>
@@ -152,9 +152,9 @@
                 </div>
                 <div class="sc-sub-settings">
                     <div class="form-grid cols-2">
-                        <div class="form-group">
-                            <label for="sc_trigger_packet_loss_min_pct">{{ t.get('sc_trigger_packet_loss_min_pct', 'Min packet loss %') }}</label>
-                            <input type="number" id="sc_trigger_packet_loss_min_pct" name="sc_trigger_packet_loss_min_pct"
+                        <div class="form-field">
+                            <label class="form-label" for="sc_trigger_packet_loss_min_pct">{{ t.get('sc_trigger_packet_loss_min_pct', 'Min packet loss %') }}</label>
+                            <input class="form-input" type="number" id="sc_trigger_packet_loss_min_pct" name="sc_trigger_packet_loss_min_pct"
                                    value="{{ config.get('sc_trigger_packet_loss_min_pct', '5.0') }}" min="0" max="100" step="0.1">
                             <div class="form-hint">{{ t.get('sc_trigger_packet_loss_min_pct_hint', 'Requires Connection Monitor module. Only fires when packet loss exceeds both this threshold and the Connection Monitor warning threshold.') }}</div>
                         </div>
@@ -179,36 +179,36 @@
                 </div>
             </div>
             <div class="form-grid cols-2">
-                <div class="form-group">
-                    <label for="sc_global_cooldown">{{ t.get('sc_global_cooldown', 'Global cooldown (seconds)') }}</label>
-                    <input type="number" id="sc_global_cooldown" name="sc_global_cooldown"
+                <div class="form-field">
+                    <label class="form-label" for="sc_global_cooldown">{{ t.get('sc_global_cooldown', 'Global cooldown (seconds)') }}</label>
+                    <input class="form-input" type="number" id="sc_global_cooldown" name="sc_global_cooldown"
                            value="{{ config.get('sc_global_cooldown', 300) }}" min="0" max="86400">
                 </div>
-                <div class="form-group">
-                    <label for="sc_trigger_cooldown">{{ t.get('sc_trigger_cooldown_label', 'Per-trigger cooldown (seconds)') }}</label>
-                    <input type="number" id="sc_trigger_cooldown" name="sc_trigger_cooldown"
+                <div class="form-field">
+                    <label class="form-label" for="sc_trigger_cooldown">{{ t.get('sc_trigger_cooldown_label', 'Per-trigger cooldown (seconds)') }}</label>
+                    <input class="form-input" type="number" id="sc_trigger_cooldown" name="sc_trigger_cooldown"
                            value="{{ config.get('sc_trigger_cooldown', 900) }}" min="0" max="86400">
                 </div>
-                <div class="form-group">
-                    <label for="sc_max_actions_per_hour">{{ t.get('sc_max_actions_per_hour', 'Max actions per hour') }}</label>
-                    <input type="number" id="sc_max_actions_per_hour" name="sc_max_actions_per_hour"
+                <div class="form-field">
+                    <label class="form-label" for="sc_max_actions_per_hour">{{ t.get('sc_max_actions_per_hour', 'Max actions per hour') }}</label>
+                    <input class="form-input" type="number" id="sc_max_actions_per_hour" name="sc_max_actions_per_hour"
                            value="{{ config.get('sc_max_actions_per_hour', 4) }}" min="1" max="60">
                 </div>
-                <div class="form-group">
-                    <label for="sc_speedtest_min_interval">{{ t.get('sc_speedtest_min_interval', 'Speedtest min interval (seconds)') }}</label>
-                    <input type="number" id="sc_speedtest_min_interval" name="sc_speedtest_min_interval"
+                <div class="form-field">
+                    <label class="form-label" for="sc_speedtest_min_interval">{{ t.get('sc_speedtest_min_interval', 'Speedtest min interval (seconds)') }}</label>
+                    <input class="form-input" type="number" id="sc_speedtest_min_interval" name="sc_speedtest_min_interval"
                            value="{{ config.get('sc_speedtest_min_interval', 14400) }}" min="0" max="86400">
                     <div class="form-hint">{{ t.get('sc_speedtest_min_interval_hint', 'Blocks Smart Capture if Speedtest Tracker already ran recently, including its own schedule.') }}</div>
                 </div>
-                <div class="form-group">
-                    <label for="sc_speedtest_max_actions_per_day">{{ t.get('sc_speedtest_max_actions_per_day', 'Smart Capture speedtests per day') }}</label>
-                    <input type="number" id="sc_speedtest_max_actions_per_day" name="sc_speedtest_max_actions_per_day"
+                <div class="form-field">
+                    <label class="form-label" for="sc_speedtest_max_actions_per_day">{{ t.get('sc_speedtest_max_actions_per_day', 'Smart Capture speedtests per day') }}</label>
+                    <input class="form-input" type="number" id="sc_speedtest_max_actions_per_day" name="sc_speedtest_max_actions_per_day"
                            value="{{ config.get('sc_speedtest_max_actions_per_day', 4) }}" min="0" max="96">
                     <div class="form-hint">{{ t.get('sc_speedtest_max_actions_per_day_hint', 'Rolling 24h cap for extra Speedtest Tracker runs triggered by DOCSight. 0 disables this cap.') }}</div>
                 </div>
-                <div class="form-group">
-                    <label for="sc_speedtest_match_window">{{ t.get('sc_speedtest_match_window', 'Speedtest result match window (seconds)') }}</label>
-                    <input type="number" id="sc_speedtest_match_window" name="sc_speedtest_match_window"
+                <div class="form-field">
+                    <label class="form-label" for="sc_speedtest_match_window">{{ t.get('sc_speedtest_match_window', 'Speedtest result match window (seconds)') }}</label>
+                    <input class="form-input" type="number" id="sc_speedtest_match_window" name="sc_speedtest_match_window"
                            value="{{ config.get('sc_speedtest_match_window', 900) }}" min="60" max="3600">
                     <div class="form-hint">{{ t.get('sc_speedtest_match_window_hint', 'How long DOCSight waits to link a triggered Speedtest Tracker result before expiring it.') }}</div>
                 </div>

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -188,6 +188,52 @@ class TestSettingsFormElements:
         assert metrics["panelScrollHeight"] < 2000
         assert metrics["panelScrollHeight"] > metrics["mainClientHeight"]
 
+    def test_smart_capture_form_controls_use_shared_visual_contract(self, settings_page):
+        settings_page.locator('button[data-section="smart_capture"]').click()
+        controls = [
+            "sc_trigger_modulation_direction",
+            "sc_trigger_modulation_min_qam",
+            "sc_trigger_error_spike_min_delta",
+            "sc_trigger_health_level",
+            "sc_trigger_packet_loss_min_pct",
+            "sc_global_cooldown",
+            "sc_trigger_cooldown",
+            "sc_max_actions_per_hour",
+            "sc_speedtest_min_interval",
+            "sc_speedtest_max_actions_per_day",
+            "sc_speedtest_match_window",
+        ]
+
+        for control_id in controls:
+            control = settings_page.locator(f"#{control_id}")
+            expect(control).to_have_class(re.compile(r".*\bform-input\b.*"))
+            expect(settings_page.locator(f'label[for="{control_id}"]')).to_have_class(re.compile(r".*\bform-label\b.*"))
+
+        for control_id in [
+            "sc_trigger_modulation_direction",
+            "sc_trigger_modulation_min_qam",
+            "sc_trigger_health_level",
+        ]:
+            expect(settings_page.locator(f"#{control_id}")).to_have_class(re.compile(r".*\bform-select\b.*"))
+
+        metrics = settings_page.evaluate(
+            """
+            (ids) => ids.map((id) => {
+              const el = document.getElementById(id);
+              const styles = getComputedStyle(el);
+              return {
+                id,
+                height: el.getBoundingClientRect().height,
+                bg: styles.backgroundColor,
+                color: styles.color,
+              };
+            })
+            """,
+            controls,
+        )
+        assert all(item["height"] >= 44 for item in metrics)
+        assert all(item["bg"] != "rgb(255, 255, 255)" for item in metrics)
+
     def test_notifications_panel_has_per_severity_cooldown_rows(self, settings_page):
         settings_page.locator('button[data-section="notifications"]').click()
 

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -59,6 +59,35 @@ class TestSettingsRoute:
         assert 'aria-controls="notification-webhook-body"' in html
         assert 'id="notification-webhook-body" aria-hidden="true" inert' in html
 
+    def test_settings_smart_capture_uses_shared_form_classes(self, client):
+        resp = client.get("/settings?lang=en")
+        assert resp.status_code == 200
+        html = resp.data.decode("utf-8")
+        smart_capture = html[html.index('id="panel-smart_capture"'):html.index('id="sc-dependent-content"')]
+        guardrails = html[html.index('id="sc-dependent-content"'):html.index('id="sc-history-container"')]
+        scoped_html = smart_capture + guardrails
+
+        assert 'class="form-group"' not in scoped_html
+        for control_id in [
+            "sc_trigger_modulation_direction",
+            "sc_trigger_modulation_min_qam",
+            "sc_trigger_health_level",
+        ]:
+            assert re.search(rf'<select[^>]+class="form-input form-select"[^>]+id="{control_id}"', scoped_html)
+            assert re.search(rf'<label[^>]+class="form-label"[^>]+for="{control_id}"', scoped_html)
+        for control_id in [
+            "sc_trigger_error_spike_min_delta",
+            "sc_trigger_packet_loss_min_pct",
+            "sc_global_cooldown",
+            "sc_trigger_cooldown",
+            "sc_max_actions_per_hour",
+            "sc_speedtest_min_interval",
+            "sc_speedtest_max_actions_per_day",
+            "sc_speedtest_match_window",
+        ]:
+            assert re.search(rf'<input[^>]+class="form-input"[^>]+id="{control_id}"', scoped_html)
+            assert re.search(rf'<label[^>]+class="form-label"[^>]+for="{control_id}"', scoped_html)
+
     def test_settings_admin_password_field_uses_saved_secret_placeholder(self, client, config_mgr):
         config_mgr.save({"admin_password": "admin-secret-value"})
         init_config(config_mgr)


### PR DESCRIPTION
## Summary
- update Smart Capture settings controls to use the shared form field, label, input, and select classes
- preserve existing field IDs, names, values, options, and Smart Capture behavior
- add web and browser coverage for the shared visual form-control contract

## Tests
- `uv run pytest tests/web/test_settings.py::TestSettingsRoute::test_settings_smart_capture_uses_shared_form_classes tests/e2e/test_settings.py::TestSettingsFormElements::test_smart_capture_form_controls_use_shared_visual_contract -q`
- `uv run pytest tests/e2e/test_settings.py -q`
- `uv run pytest tests/web/test_settings.py tests/test_static_contracts.py -q`
- `uv run pytest -q --ignore=tests/e2e`
- `uv run python scripts/i18n_check.py`
- `git diff --check`
