### PR TITLE
Improve settings layout at tablet widths

### DIFF
--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -1483,7 +1483,20 @@ button.notification-collapse-button {
 }
 
 /* ─── Responsive ─── */
-@media (max-width: 640px) {
+@media (max-width: 900px) {
+  .main-content {
+    padding: var(--space-xl);
+    padding-bottom: calc(var(--space-xl) + 88px + env(safe-area-inset-bottom, 0px));
+    max-width: none;
+  }
+  .form-grid.cols-2 { grid-template-columns: 1fr; }
+  .support-grid { grid-template-columns: 1fr; }
+  .support-star { flex-wrap: wrap; }
+  .support-star-link { margin-left: 0; }
+  .save-footer { padding-inline: var(--space-xl); }
+}
+
+@media (max-width: 768px) {
   .sidebar {
     transform: translateX(-100%);
     transition: transform 0.3s var(--ease-out-expo);

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v63';
+var CACHE_VERSION = 'v64';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -122,7 +122,7 @@
 
     <!-- ═══ Main Content ═══ -->
     <div class="main-content">
-        <!-- Mobile header (visible < 768px) -->
+        <!-- Mobile header (visible at 768px and below) -->
         <div class="mobile-header">
             <button class="mobile-menu-btn" onclick="openMobileSidebar()">
                 <i data-lucide="menu"></i>

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -73,6 +73,50 @@ class TestSettingsMobileSidebar:
         assert metrics["supportTop"] >= 0
         assert metrics["supportBottom"] <= metrics["sidebarHeight"]
 
+    @pytest.mark.parametrize("width, expect_drawer", [(700, True), (850, False)])
+    @pytest.mark.parametrize("section, setup", [
+        ("connection", None),
+        ("notifications", "expand-webhook"),
+    ])
+    def test_tablet_widths_use_comfortable_single_column_settings_forms(self, settings_page, width, expect_drawer, section, setup):
+        settings_page.set_viewport_size({"width": width, "height": 844})
+        settings_page.reload(wait_until="networkidle")
+        settings_page.evaluate("section => window.switchSection(section)", section)
+        if setup == "expand-webhook":
+            settings_page.locator('#notification-webhook-card .notification-collapse-button').click()
+
+        metrics = settings_page.evaluate(
+            """
+            ({section, expectDrawer}) => {
+              const panel = document.querySelector(`#panel-${section}`);
+              const grids = Array.from(panel.querySelectorAll('.form-grid.cols-2'))
+                .filter((grid) => grid.getClientRects().length > 0 && !grid.closest('[inert]'));
+              const fieldWidths = grids.flatMap((grid) => Array.from(grid.querySelectorAll('.form-field'))
+                .filter((field) => field.getClientRects().length > 0)
+                .map((field) => field.getBoundingClientRect().width));
+              const mobileHeader = document.querySelector('.mobile-header');
+              const sidebar = document.querySelector('#settings-sidebar');
+              const sidebarRect = sidebar.getBoundingClientRect();
+              return {
+                gridColumns: grids.map((grid) => getComputedStyle(grid).gridTemplateColumns.trim().split(' ').filter(Boolean).length),
+                minFieldWidth: Math.min(...fieldWidths),
+                mobileHeaderVisible: getComputedStyle(mobileHeader).display !== 'none',
+                sidebarOffCanvas: sidebarRect.right <= 1,
+                docWidth: document.documentElement.scrollWidth,
+                viewportWidth: window.innerWidth,
+                expectDrawer,
+              };
+            }
+            """,
+            {"section": section, "expectDrawer": expect_drawer},
+        )
+        assert metrics["gridColumns"]
+        assert all(count == 1 for count in metrics["gridColumns"])
+        assert metrics["minFieldWidth"] >= 280
+        assert metrics["docWidth"] <= metrics["viewportWidth"]
+        assert metrics["mobileHeaderVisible"] is expect_drawer
+        assert metrics["sidebarOffCanvas"] is expect_drawer
+
 
 class TestSettingsTabSwitching:
     """Clicking sidebar tabs shows the correct panel."""


### PR DESCRIPTION
## Summary
- collapse two-column settings form grids at tablet widths where the fixed sidebar narrows the content area
- move the settings drawer/mobile header breakpoint to 768px and keep desktop sidebar behavior above that
- reduce tablet content spacing and bump the service worker cache version for CSS delivery
- add browser coverage for 700px and 850px settings layouts

## Tests
- `uv run pytest tests/e2e/test_settings.py::TestSettingsMobileSidebar::test_tablet_widths_use_comfortable_single_column_settings_forms -q`
- `uv run pytest tests/e2e/test_settings.py -q`
- `uv run pytest tests/web/test_settings.py tests/test_static_contracts.py -q`
- `uv run pytest -q --ignore=tests/e2e`
- `uv run python scripts/i18n_check.py`
- `git diff --check`
