### PR TITLE
Improve settings accessibility for icon-only buttons and mobile navigation

### DIFF
--- a/app/modules/backup/templates/backup_settings.html
+++ b/app/modules/backup/templates/backup_settings.html
@@ -38,18 +38,18 @@
 
         <div class="toggle-row">
             <div class="toggle-info">
-                <span class="toggle-title">{{ t.enabled }}</span>
+                <span class="toggle-title" id="backup-enabled-label">{{ t.enabled }}</span>
             </div>
             <input type="hidden" name="backup_enabled" value="false">
             <label class="toggle">
-                <input type="checkbox" id="backup_enabled" name="backup_enabled" value="true" {% if config.backup_enabled %}checked{% endif %}>
+                <input type="checkbox" id="backup_enabled" name="backup_enabled" value="true" aria-labelledby="backup-enabled-label" {% if config.backup_enabled %}checked{% endif %}>
                 <span class="toggle-slider"></span>
             </label>
         </div>
 
         <div id="backup-auto-settings" style="{% if not config.backup_enabled %}opacity:0.5;pointer-events:none;{% endif %}">
             <div class="form-field" style="margin-top: var(--space-md);">
-                <label class="form-label">{{ t['docsight.backup.backup_path'] or 'Backup Path' }}</label>
+                <label class="form-label" for="backup_path">{{ t['docsight.backup.backup_path'] or 'Backup Path' }}</label>
                 <div class="input-with-action">
                     <input class="form-input" type="text" id="backup_path" name="backup_path" value="{{ config.backup_path }}" readonly style="cursor:pointer;">
                     <button type="button" class="btn btn-ghost btn-sm" onclick="openBrowseModal(this)">
@@ -95,7 +95,7 @@
         <div class="browse-modal-header">
             <h3 id="browse-modal-title">{{ t['docsight.backup.backup_select_dir'] or 'Select Directory' }}</h3>
             <button type="button" class="btn-icon" onclick="closeBrowseModal()" aria-label="{{ t.close or 'Close' }}">
-                <i data-lucide="x"></i>
+                <i data-lucide="x" aria-hidden="true"></i>
             </button>
         </div>
         <div class="browse-modal-summary">

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -8,13 +8,41 @@
 /* ── Section Controller ── */
 var _currentSection = 'connection';
 var _saveHiddenSections = { support: true, about: true };
+var _mobileSidebarFocusReturn = null;
+var _mobileSidebarMedia = window.matchMedia ? window.matchMedia('(max-width: 768px)') : null;
+
+function _isMobileSidebarMode() {
+    return !!(_mobileSidebarMedia && _mobileSidebarMedia.matches);
+}
+
+function _setSidebarAccessibility(sidebar, isOpen) {
+    if (!sidebar) return;
+    if (_isMobileSidebarMode() && !isOpen) {
+        sidebar.setAttribute('aria-hidden', 'true');
+        sidebar.setAttribute('inert', '');
+    } else {
+        sidebar.removeAttribute('aria-hidden');
+        sidebar.removeAttribute('inert');
+    }
+}
+
+function syncMobileSidebarAccessibility() {
+    var sidebar = document.getElementById('settings-sidebar');
+    _setSidebarAccessibility(sidebar, !!(sidebar && sidebar.classList.contains('open')));
+}
 
 function switchSection(id) {
     _currentSection = id;
 
     /* Sidebar: update active link */
     document.querySelectorAll('.nav-item[data-section]').forEach(function(link) {
-        link.classList.toggle('active', link.getAttribute('data-section') === id);
+        var isActive = link.getAttribute('data-section') === id;
+        link.classList.toggle('active', isActive);
+        if (isActive) {
+            link.setAttribute('aria-current', 'page');
+        } else {
+            link.removeAttribute('aria-current');
+        }
     });
 
     /* Panels: show selected */
@@ -49,16 +77,51 @@ function switchSection(id) {
 function openMobileSidebar() {
     var sidebar = document.getElementById('settings-sidebar');
     var backdrop = document.getElementById('sidebar-backdrop');
-    if (sidebar) sidebar.classList.add('open');
+    var menuButton = document.getElementById('mobile-menu-button');
+    _mobileSidebarFocusReturn = document.activeElement || menuButton;
+    if (sidebar) {
+        sidebar.classList.add('open');
+        _setSidebarAccessibility(sidebar, true);
+    }
     if (backdrop) backdrop.classList.add('active');
+    if (menuButton) menuButton.setAttribute('aria-expanded', 'true');
+    var activeNav = sidebar ? sidebar.querySelector('.nav-item.active[data-section]') : null;
+    var firstNav = sidebar ? sidebar.querySelector('.nav-item[data-section]') : null;
+    var focusTarget = activeNav || firstNav;
+    if (focusTarget && typeof focusTarget.focus === 'function') focusTarget.focus();
 }
 
-function closeMobileSidebar() {
+function closeMobileSidebar(options) {
+    options = options || {};
     var sidebar = document.getElementById('settings-sidebar');
     var backdrop = document.getElementById('sidebar-backdrop');
-    if (sidebar) sidebar.classList.remove('open');
+    var menuButton = document.getElementById('mobile-menu-button');
+    var wasOpen = !!(sidebar && sidebar.classList.contains('open'));
+    if (sidebar) {
+        sidebar.classList.remove('open');
+        _setSidebarAccessibility(sidebar, false);
+    }
     if (backdrop) backdrop.classList.remove('active');
+    if (menuButton) menuButton.setAttribute('aria-expanded', 'false');
+    var shouldRestoreFocus = options.restoreFocus !== false;
+    if (wasOpen && shouldRestoreFocus) {
+        var focusTarget = _mobileSidebarFocusReturn;
+        if (!focusTarget || typeof focusTarget.focus !== 'function' || !document.contains(focusTarget)) {
+            focusTarget = menuButton;
+        }
+        if (focusTarget && typeof focusTarget.focus === 'function') focusTarget.focus();
+    }
+    _mobileSidebarFocusReturn = null;
 }
+
+document.addEventListener('keydown', function(event) {
+    if (event.key !== 'Escape') return;
+    var sidebar = document.getElementById('settings-sidebar');
+    if (sidebar && sidebar.classList.contains('open')) {
+        event.preventDefault();
+        closeMobileSidebar();
+    }
+});
 
 /* ── Collapsible Cards ── */
 function _syncCardCollapseAria(card) {
@@ -1373,10 +1436,14 @@ function loadBackupList() {
             delBtn.type = 'button';
             delBtn.className = 'btn btn-secondary';
             delBtn.style.cssText = 'padding:2px 8px;font-size:0.75em;';
+            var deleteLabel = ((T.backup_delete || T.bqm_delete || 'Delete backup') + ' ' + b.filename).trim();
             delBtn.setAttribute('data-filename', b.filename);
+            delBtn.setAttribute('aria-label', deleteLabel);
+            delBtn.setAttribute('title', deleteLabel);
             delBtn.addEventListener('click', function() { deleteBackup(this.getAttribute('data-filename')); });
             var icon = document.createElement('i');
             icon.setAttribute('data-lucide', 'trash-2');
+            icon.setAttribute('aria-hidden', 'true');
             icon.style.cssText = 'width:12px;height:12px;';
             delBtn.appendChild(icon);
             td4.appendChild(delBtn);
@@ -1655,6 +1722,14 @@ document.addEventListener('DOMContentLoaded', function() {
     toggleUsernameField();
     updateStatusDots();
     updateNotificationChannelSummaries();
+    syncMobileSidebarAccessibility();
+    if (_mobileSidebarMedia) {
+        if (typeof _mobileSidebarMedia.addEventListener === 'function') {
+            _mobileSidebarMedia.addEventListener('change', syncMobileSidebarAccessibility);
+        } else if (typeof _mobileSidebarMedia.addListener === 'function') {
+            _mobileSidebarMedia.addListener(syncMobileSidebarAccessibility);
+        }
+    }
 
     /* Listen for input changes on integration fields to update dots and card summaries */
     ['notify_webhook_url'].forEach(function(id) {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v64';
+var CACHE_VERSION = 'v65';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -56,8 +56,8 @@
         <div class="sidebar-nav">
             <div class="nav-group" aria-labelledby="settings-nav-core-label">
                 <div class="nav-group-label" id="settings-nav-core-label">{{ t.settings }}</div>
-                <button class="nav-item active" data-section="connection" onclick="switchSection('connection')">
-                    <i data-lucide="radio" class="nav-icon"></i>
+                <button class="nav-item active" data-section="connection" onclick="switchSection('connection')" aria-current="page">
+                    <i data-lucide="radio" class="nav-icon" aria-hidden="true"></i>
                     {{ t.step_modem }}
                 </button>
                 <button class="nav-item" data-section="general" onclick="switchSection('general')">
@@ -124,8 +124,8 @@
     <div class="main-content">
         <!-- Mobile header (visible at 768px and below) -->
         <div class="mobile-header">
-            <button class="mobile-menu-btn" onclick="openMobileSidebar()">
-                <i data-lucide="menu"></i>
+            <button class="mobile-menu-btn" id="mobile-menu-button" type="button" onclick="openMobileSidebar()" aria-label="{{ t.get('settings_open_navigation', 'Open settings navigation') }}" aria-controls="settings-sidebar" aria-expanded="false">
+                <i data-lucide="menu" aria-hidden="true"></i>
             </button>
             <span class="page-title" style="font-size: 1.1rem;" id="mobile-title">{{ t.step_modem }}</span>
         </div>

--- a/app/templates/settings/extensions.html
+++ b/app/templates/settings/extensions.html
@@ -94,8 +94,8 @@
                     <div class="card-subtitle">{{ t.get('extensions_community_desc', 'Browse and install modules from the community registry') }}</div>
                 </div>
             </div>
-            <button class="btn btn-ghost" onclick="refreshModuleRegistry()" id="module-registry-refresh" title="{{ t.get('extensions_refresh', 'Refresh') }}">
-                <i data-lucide="refresh-cw" style="width:16px;height:16px;"></i>
+            <button type="button" class="btn btn-ghost" onclick="refreshModuleRegistry()" id="module-registry-refresh" title="{{ t.get('extensions_refresh', t.refresh) }}" aria-label="{{ t.get('extensions_refresh', t.refresh) }}">
+                <i data-lucide="refresh-cw" style="width:16px;height:16px;" aria-hidden="true"></i>
             </button>
         </div>
         <div id="module-registry-container" style="padding: 0 var(--card-padding) var(--card-padding);">

--- a/app/templates/settings/security.html
+++ b/app/templates/settings/security.html
@@ -50,8 +50,8 @@
             <div style="font-weight: 600; margin-bottom: 6px;">{{ t.api_token_created }}</div>
             <div class="input-with-action">
                 <code id="api-token-plaintext" style="flex: 1; word-break: break-all; font-size: 0.82rem; padding: 10px 12px; background: rgba(255,255,255,0.04); border: 1px solid var(--glass-border); border-radius: var(--radius-sm); font-family: 'JetBrains Mono', monospace;"></code>
-                <button type="button" class="btn btn-ghost btn-sm" onclick="copyToken()">
-                    <i data-lucide="copy" style="width:14px;height:14px;"></i>
+                <button type="button" class="btn btn-ghost btn-sm" onclick="copyToken()" aria-label="{{ t.copy_clipboard }}" title="{{ t.copy_clipboard }}">
+                    <i data-lucide="copy" style="width:14px;height:14px;" aria-hidden="true"></i>
                 </button>
             </div>
             <div style="font-size: 0.78rem; color: var(--text-muted); margin-top: 8px;">{{ t.api_token_copy_warning }}</div>

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -73,6 +73,65 @@ class TestSettingsMobileSidebar:
         assert metrics["supportTop"] >= 0
         assert metrics["supportBottom"] <= metrics["sidebarHeight"]
 
+    def test_mobile_sidebar_escape_closes_drawer_and_restores_focus(self, settings_page):
+        settings_page.set_viewport_size({"width": 390, "height": 844})
+        settings_page.reload(wait_until="networkidle")
+
+        menu_button = settings_page.locator("#mobile-menu-button")
+        sidebar = settings_page.locator("#settings-sidebar")
+        expect(menu_button).to_have_attribute("aria-label", "Open settings navigation")
+        expect(menu_button).to_have_attribute("aria-controls", "settings-sidebar")
+        expect(menu_button).to_have_attribute("aria-expanded", "false")
+
+        menu_button.click()
+        expect(sidebar).to_have_class(re.compile(r".*\bopen\b.*"))
+        expect(sidebar).not_to_have_attribute("inert", "")
+        expect(sidebar).not_to_have_attribute("aria-hidden", "true")
+        expect(menu_button).to_have_attribute("aria-expanded", "true")
+        assert settings_page.evaluate("() => document.activeElement && document.activeElement.getAttribute('data-section')") == "connection"
+
+        settings_page.keyboard.press("Escape")
+        expect(sidebar).not_to_have_class(re.compile(r".*\bopen\b.*"))
+        expect(sidebar).to_have_attribute("inert", "")
+        expect(sidebar).to_have_attribute("aria-hidden", "true")
+        expect(menu_button).to_have_attribute("aria-expanded", "false")
+        assert settings_page.evaluate("() => document.activeElement && document.activeElement.id") == "mobile-menu-button"
+
+    def test_active_settings_navigation_item_is_announced(self, settings_page):
+        connection = settings_page.locator('button[data-section="connection"]')
+        notifications = settings_page.locator('button[data-section="notifications"]')
+        expect(connection).to_have_attribute("aria-current", "page")
+        expect(notifications).not_to_have_attribute("aria-current", "page")
+
+        notifications.click()
+        expect(notifications).to_have_attribute("aria-current", "page")
+        expect(connection).not_to_have_attribute("aria-current", "page")
+
+    def test_icon_only_settings_controls_have_accessible_names(self, settings_page):
+        settings_page.route(
+            "**/api/backup/list",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="application/json",
+                body='[{"filename":"docsight_backup_2026-03-14_120000.tar.gz","size":3145728,"modified":"2026-03-14T12:00:00"}]',
+            ),
+        )
+
+        expect(settings_page.locator("#mobile-menu-button")).to_have_attribute("aria-label", "Open settings navigation")
+
+        settings_page.locator('button[data-section="extensions"]').click()
+        refresh = settings_page.locator("#module-registry-refresh")
+        expect(refresh).to_have_attribute("aria-label", "Refresh")
+        expect(refresh).to_have_attribute("title", "Refresh")
+
+        settings_page.locator('button[data-section="mod-docsight_backup"]').click()
+        expect(settings_page.locator('#backup_enabled')).to_have_attribute("aria-labelledby", "backup-enabled-label")
+        expect(settings_page.locator('label[for="backup_path"]')).to_have_text("Backup Path")
+        delete_button = settings_page.locator('#backup-list button[aria-label^="Delete"]')
+        expect(delete_button).to_have_count(1)
+        expect(delete_button).to_have_attribute("aria-label", re.compile(r"Delete .*docsight_backup_2026-03-14_120000\.tar\.gz"))
+        expect(delete_button.locator('svg[aria-hidden="true"], i[aria-hidden="true"]')).to_have_count(1)
+
     @pytest.mark.parametrize("width, expect_drawer", [(700, True), (850, False)])
     @pytest.mark.parametrize("section, setup", [
         ("connection", None),

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -45,6 +45,23 @@ class TestSettingsRoute:
         )
         assert html.index('id="settings-nav-core-label"') < html.index('data-section="connection"')
 
+    def test_settings_icon_only_controls_have_accessible_names(self, client, config_mgr):
+        config_mgr.save({"admin_password": "admin-secret-value"})
+        init_config(config_mgr)
+        with client.session_transaction() as session:
+            session["authenticated"] = True
+
+        resp = client.get("/settings?lang=en")
+        assert resp.status_code == 200
+        html = resp.data.decode("utf-8")
+
+        assert re.search(r'<button[^>]+id="mobile-menu-button"[^>]+aria-label="Open settings navigation"', html)
+        assert 'aria-controls="settings-sidebar"' in html
+        assert 'aria-expanded="false"' in html
+        assert re.search(r'<button[^>]+data-section="connection"[^>]+aria-current="page"', html)
+        assert re.search(r'<button[^>]+onclick="copyToken\(\)"[^>]+aria-label="Copy to Clipboard"', html)
+        assert re.search(r'<button[^>]+id="module-registry-refresh"[^>]+aria-label="Refresh"', html)
+
     def test_settings_notifications_channel_cards_render_compact_status_headers(self, client):
         resp = client.get("/settings?lang=en")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add accessible names to icon-only settings controls and dynamic backup actions
- announce the active settings navigation item with `aria-current`
- add mobile drawer keyboard handling, focus restoration, and closed-drawer accessibility hiding
- label backup module controls that lacked explicit associations
- bump the service worker cache version for the settings script update

## Tests
- `uv run pytest tests/web/test_settings.py::TestSettingsRoute::test_settings_icon_only_controls_have_accessible_names tests/e2e/test_settings.py::TestSettingsMobileSidebar::test_mobile_sidebar_escape_closes_drawer_and_restores_focus tests/e2e/test_settings.py::TestSettingsMobileSidebar::test_active_settings_navigation_item_is_announced tests/e2e/test_settings.py::TestSettingsMobileSidebar::test_icon_only_settings_controls_have_accessible_names -q`
- `uv run pytest tests/e2e/test_settings.py -q`
- `uv run pytest tests/web/test_settings.py tests/test_static_contracts.py -q`
- `uv run pytest -q --ignore=tests/e2e`
- `uv run python scripts/i18n_check.py`
- `git diff --check`
