### PR TITLE
Show live modem connection status

### DIFF
--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -738,6 +738,14 @@ button.notification-collapse-button {
   font-size: 0.82rem;
   font-weight: 500;
 }
+.status-indicator[hidden] {
+  display: none;
+}
+.status-indicator.testing {
+  background: color-mix(in srgb, var(--text-muted) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-muted) 18%, transparent);
+  color: var(--text-muted);
+}
 .status-indicator.connected {
   background: color-mix(in srgb, var(--good) 8%, transparent);
   border: 1px solid var(--good-muted);
@@ -752,6 +760,8 @@ button.notification-collapse-button {
   width: 8px; height: 8px;
   border-radius: 50%;
   background: currentColor;
+}
+.status-indicator.testing .status-dot {
   animation: pulse 2s infinite;
 }
 
@@ -1560,6 +1570,20 @@ button.notification-collapse-button {
   .save-footer { left: 0; }
   .mobile-header { display: flex !important; }
   .settings-card { padding: 18px; }
+  .connection-card-header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  .connection-card-header .card-title-group {
+    flex: 1 1 100%;
+  }
+  .connection-card-header .status-indicator {
+    margin-left: 52px;
+    max-width: calc(100% - 52px);
+  }
+  .connection-card-header #modem-status-text {
+    overflow-wrap: anywhere;
+  }
   .notification-card-header {
     align-items: flex-start;
     gap: var(--space-sm);

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -304,18 +304,15 @@ function revokeToken(id, name) {
     }).catch(function() { showToast(T.error_prefix || 'Error', false); });
 }
 
-/* ── Status Dots ── */
-function updateStatusDots() {
-    var dots = {
-        notifications: 'notify_webhook_url'
-    };
-    for (var section in dots) {
-        var el = document.getElementById(dots[section]);
-        var dot = document.getElementById('dot-' + section);
-        if (el && dot) {
-            dot.classList.toggle('visible', el.value.trim() !== '');
-        }
-    }
+/* ── Modem Status Indicator ── */
+function setModemStatus(state, text) {
+    var box = document.getElementById('modem-status');
+    if (!box) return;
+    box.hidden = false;
+    box.classList.remove('testing', 'connected', 'disconnected');
+    box.classList.add(state);
+    var label = document.getElementById('modem-status-text');
+    if (label) label.textContent = text;
 }
 
 /* ── Theme Toggle ── */
@@ -466,6 +463,7 @@ function testModem() {
     span.textContent = '\u23F3';
     el.appendChild(span);
     el.appendChild(document.createTextNode(' ' + T.testing));
+    setModemStatus('testing', T.testing);
     var data = getFormData();
     fetch('/api/test-modem', {
         method: 'POST',
@@ -482,12 +480,14 @@ function testModem() {
             check.textContent = '\u2713';
             el.appendChild(check);
             el.appendChild(document.createTextNode(' ' + T.connected + ': ' + (res.model || 'OK')));
+            setModemStatus('connected', T.connected + ': ' + (res.model || 'OK'));
         } else {
             el.className = 'test-result test-fail';
             var x = document.createElement('span');
             x.textContent = '\u2717';
             el.appendChild(x);
             el.appendChild(document.createTextNode(' ' + T.error_prefix + ': ' + (res.error || T.unknown_error)));
+            setModemStatus('disconnected', T.error_prefix + ': ' + (res.error || T.unknown_error));
         }
     })
     .catch(function() {
@@ -497,6 +497,7 @@ function testModem() {
         x.textContent = '\u2717';
         el.appendChild(x);
         el.appendChild(document.createTextNode(' ' + T.network_error));
+        setModemStatus('disconnected', T.network_error);
     });
 }
 
@@ -1720,7 +1721,6 @@ document.addEventListener('DOMContentLoaded', function() {
     initTimezoneHint();
     onIspChange();
     toggleUsernameField();
-    updateStatusDots();
     updateNotificationChannelSummaries();
     syncMobileSidebarAccessibility();
     if (_mobileSidebarMedia) {
@@ -1735,7 +1735,6 @@ document.addEventListener('DOMContentLoaded', function() {
     ['notify_webhook_url'].forEach(function(id) {
         var el = document.getElementById(id);
         if (el) {
-            el.addEventListener('input', updateStatusDots);
             el.addEventListener('input', updateNotificationChannelSummaries);
         }
     });

--- a/app/templates/settings/connection.html
+++ b/app/templates/settings/connection.html
@@ -2,7 +2,7 @@
 <div class="settings-panel active" id="panel-connection">
     <!-- Modem Card -->
     <div class="settings-card glass">
-        <div class="card-header">
+        <div class="card-header connection-card-header">
             <div class="card-title-group">
                 <div class="card-icon purple">
                     <i data-lucide="radio"></i>
@@ -12,7 +12,7 @@
                     <div class="card-subtitle">{{ t.modem_user_hint }}</div>
                 </div>
             </div>
-            <div class="status-indicator" id="modem-status">
+            <div class="status-indicator" id="modem-status" role="status" aria-live="polite" hidden>
                 <span class="status-dot"></span>
                 <span id="modem-status-text"></span>
             </div>

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -207,6 +207,32 @@ class TestSettingsFormElements:
         select = settings_page.locator('select[name="modem_type"], #modem_type, #modem-type')
         assert select.count() > 0
 
+    def test_modem_status_updates_after_successful_connection_test(self, settings_page):
+        settings_page.route("**/api/test-modem", lambda route: route.fulfill(json={"success": True, "model": "Demo CM"}))
+
+        status = settings_page.locator("#modem-status")
+        expect(status).to_have_attribute("hidden", "")
+
+        settings_page.locator('button[onclick="testModem()"]').click()
+
+        expect(status).to_have_class(re.compile(r".*\bconnected\b.*"))
+        expect(status).not_to_have_class(re.compile(r".*\bdisconnected\b.*"))
+        expect(status).not_to_have_attribute("hidden", "")
+        expect(status.locator("#modem-status-text")).to_have_text("Connected: Demo CM")
+
+    def test_modem_status_updates_after_failed_connection_test(self, settings_page):
+        settings_page.route("**/api/test-modem", lambda route: route.fulfill(json={"success": False, "error": "Auth failed"}))
+
+        status = settings_page.locator("#modem-status")
+        expect(status).to_have_attribute("hidden", "")
+
+        settings_page.locator('button[onclick="testModem()"]').click()
+
+        expect(status).to_have_class(re.compile(r".*\bdisconnected\b.*"))
+        expect(status).not_to_have_class(re.compile(r".*\bconnected\b.*"))
+        expect(status).not_to_have_attribute("hidden", "")
+        expect(status.locator("#modem-status-text")).to_have_text("Error: Auth failed")
+
     def test_security_has_password_field(self, settings_page):
         settings_page.locator('button[data-section="security"]').click()
         pw = settings_page.locator('input[type="password"]')

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -76,6 +76,19 @@ class TestSettingsRoute:
         assert 'aria-controls="notification-webhook-body"' in html
         assert 'id="notification-webhook-body" aria-hidden="true" inert' in html
 
+    def test_settings_modem_status_indicator_starts_hidden_and_live(self, client):
+        resp = client.get("/settings?lang=en")
+        assert resp.status_code == 200
+        html = resp.data.decode("utf-8")
+
+        match = re.search(r'<div class="status-indicator" id="modem-status"[^>]*>', html)
+        assert match is not None
+        status_tag = match.group(0)
+        assert "hidden" in status_tag
+        assert 'role="status"' in status_tag
+        assert 'aria-live="polite"' in status_tag
+        assert 'id="dot-notifications"' not in html
+
     def test_settings_smart_capture_uses_shared_form_classes(self, client):
         resp = client.get("/settings?lang=en")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Hide the modem connection status badge until a connection test runs.
- Update the badge during the modem test flow for testing, connected, and disconnected outcomes.
- Remove unused status-dot wiring that no longer maps to any rendered Settings element.

## Validation
- `python -m pytest tests/web/test_settings.py -q`
- `TZ=UTC python -m pytest tests/e2e/test_settings.py -q`
- `python -m pytest tests/test_static_contracts.py tests/test_settings_secret_fields.py -q`
- `python -m pytest tests --ignore=tests/e2e -q`
- E2E by file: 23 files, 450 tests passed
- Desktop and mobile browser smoke for the Settings connection panel
