### PR TITLE
Restore previous settings section on browser back navigation

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -31,7 +31,7 @@ function syncMobileSidebarAccessibility() {
     _setSidebarAccessibility(sidebar, !!(sidebar && sidebar.classList.contains('open')));
 }
 
-function switchSection(id) {
+function _applySection(id) {
     _currentSection = id;
 
     /* Sidebar: update active link */
@@ -66,12 +66,40 @@ function switchSection(id) {
     if (id === 'smart_capture') loadSmartCaptureHistory();
     if (id === 'extensions') refreshModuleRegistry();
 
-    /* URL hash */
-    history.replaceState(null, '', '#' + id);
-
     /* Mobile: close sidebar after selection */
     closeMobileSidebar();
 }
+
+/* User-initiated section change: apply and add a browser history entry so
+   Back/Forward move between previously viewed settings sections. Re-selecting
+   the current section replaces state instead of stacking a duplicate entry. */
+function switchSection(id) {
+    var isNewSection = id !== _currentSection;
+    _applySection(id);
+    if (isNewSection) {
+        history.pushState(null, '', '#' + id);
+    } else {
+        history.replaceState(null, '', '#' + id);
+    }
+}
+
+/* Resolve the section referenced by the current URL hash (default: connection). */
+function _sectionFromHash() {
+    var hash = location.hash.replace('#', '');
+    return (hash && document.getElementById('panel-' + hash)) ? hash : 'connection';
+}
+
+/* Non-pushing variant for Back/Forward and manual hash edits: the browser has
+   already updated the URL, so only reflect it in the UI. The guard also makes
+   the popstate+hashchange double-fire on navigation a no-op the second time. */
+function _syncSectionFromHash() {
+    var id = _sectionFromHash();
+    if (id === _currentSection) return;
+    _applySection(id);
+}
+
+window.addEventListener('popstate', _syncSectionFromHash);
+window.addEventListener('hashchange', _syncSectionFromHash);
 
 /* ── Mobile Sidebar ── */
 function openMobileSidebar() {
@@ -1764,13 +1792,11 @@ document.addEventListener('DOMContentLoaded', function() {
     _formDirty = false;
     _manualDirty = false;
 
-    /* Restore section from URL hash, default to connection */
-    var hash = location.hash.replace('#', '');
-    if (hash && document.getElementById('panel-' + hash)) {
-        switchSection(hash);
-    } else {
-        switchSection('connection');
-    }
+    /* Restore section from URL hash (default: connection); replace state so the
+       initial load does not leave a spurious Back entry. */
+    var initialSection = _sectionFromHash();
+    _applySection(initialSection);
+    history.replaceState(null, '', '#' + initialSection);
 });
 
 /* ── Module Management ── */

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -199,6 +199,19 @@ class TestSettingsTabSwitching:
         panel = settings_page.locator("#panel-connection")
         assert panel.is_visible()
 
+    def test_section_changes_create_browser_history(self, settings_page):
+        settings_page.locator('button[data-section="general"]').click()
+        settings_page.locator('button[data-section="notifications"]').click()
+        expect(settings_page.locator("#panel-notifications")).to_be_visible()
+
+        settings_page.go_back()
+        expect(settings_page.locator("#panel-general")).to_be_visible()
+        assert settings_page.url.endswith("#general")
+
+        settings_page.go_forward()
+        expect(settings_page.locator("#panel-notifications")).to_be_visible()
+        assert settings_page.url.endswith("#notifications")
+
 
 class TestSettingsFormElements:
     """Form elements exist on settings panels."""


### PR DESCRIPTION
## Summary
- Add browser history entries when switching between Settings sections.
- Restore Settings sections from Back/Forward or hash navigation without adding duplicate history entries.
- Cover section Back/Forward behavior with browser E2E coverage.

## Validation
- `TZ=UTC .venv/bin/python -m pytest tests/e2e/test_settings.py::TestSettingsTabSwitching::test_section_changes_create_browser_history -q`
- `.venv/bin/python -m pytest tests/web/test_settings.py -q`
- `TZ=UTC .venv/bin/python -m pytest tests/e2e/test_settings.py -q`
- `.venv/bin/python -m pytest tests/test_static_contracts.py tests/test_settings_secret_fields.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- E2E by file: 23 files, 451 tests passed
- Desktop and mobile browser smoke for Settings Back navigation
