### PR TITLE
Deduplicate small-button styles in the settings stylesheet

### DIFF
--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -1759,11 +1759,6 @@ button.notification-collapse-button {
   color: var(--success);
 }
 
-.btn-sm {
-  padding: 6px 12px;
-  font-size: 0.8rem;
-}
-
 /* Theme Preview Overlay */
 .theme-preview-overlay {
   position: fixed;
@@ -2005,10 +2000,6 @@ button.notification-collapse-button {
   border-radius: 4px;
   font-size: 0.7em;
   vertical-align: middle;
-}
-.btn-sm {
-  padding: 4px 10px;
-  font-size: 0.8em;
 }
 .btn-install {
   background: var(--good-muted);

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -222,6 +222,16 @@ def test_dead_static_js_helpers_stay_removed() -> None:
     assert "toggleCard(" not in templates
 
 
+def test_settings_small_button_rule_is_defined_once() -> None:
+    """Settings small buttons share one .btn-sm size and touch target."""
+    css = (STATIC / "css" / "settings.css").read_text(encoding="utf-8")
+    definitions = re.findall(r"(?m)^\.btn-sm\s*\{[^}]*\}", css)
+    assert len(definitions) == 1
+    rule = definitions[0]
+    assert "padding: 8px 14px" in rule
+    assert "min-height: 36px" in rule
+
+
 def test_unused_inter_font_assets_stay_removed() -> None:
     for rel_path in [
         "fonts/inter-latin.woff2",


### PR DESCRIPTION
## Summary
- Remove duplicate Settings `.btn-sm` rule definitions so small buttons share one size contract.
- Add a static contract test that keeps the Settings small-button rule single-sourced with the expected padding and minimum height.

## Validation
- `.venv/bin/python -m pytest tests/test_static_contracts.py::test_settings_small_button_rule_is_defined_once -q`
- `.venv/bin/python -m pytest tests/test_static_contracts.py tests/web/test_settings.py -q`
- `TZ=UTC .venv/bin/python -m pytest tests/e2e/test_settings.py -q`
- `.venv/bin/python -m pytest tests --ignore=tests/e2e -q`
- E2E by file: 23 files, 451 tests passed
- Desktop and mobile browser smoke for Settings security, appearance, backup, and extensions small buttons in dark and light themes
