### PR TITLE
Show live MQTT connection status

### DIFF
--- a/app/modules/mqtt/templates/mqtt_settings.html
+++ b/app/modules/mqtt/templates/mqtt_settings.html
@@ -1,7 +1,7 @@
 <!-- ═══ Panel: MQTT ═══ -->
 <div class="settings-panel" id="panel-mod-docsight_mqtt">
     <div class="settings-card glass">
-        <div class="card-header">
+        <div class="card-header status-card-header">
             <div class="card-title-group">
                 <div class="card-icon purple">
                     <i data-lucide="radio-tower"></i>
@@ -11,7 +11,7 @@
                     <div class="card-subtitle">{{ t['docsight.mqtt.mqtt_optional_ha'] or 'optional - for Home Assistant' }}</div>
                 </div>
             </div>
-            <div class="status-indicator" id="mqtt-status">
+            <div class="status-indicator" id="mqtt-status" role="status" aria-live="polite" hidden>
                 <span class="status-dot"></span>
                 <span id="mqtt-status-text"></span>
             </div>

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -1508,6 +1508,7 @@ button.notification-collapse-button {
 
 @media (max-width: 768px) {
   .sidebar {
+    box-sizing: border-box;
     transform: translateX(-100%);
     transition: transform 0.3s var(--ease-out-expo);
     width: min(88vw, 320px);
@@ -1570,18 +1571,18 @@ button.notification-collapse-button {
   .save-footer { left: 0; }
   .mobile-header { display: flex !important; }
   .settings-card { padding: 18px; }
-  .connection-card-header {
+  .status-card-header {
     align-items: flex-start;
     flex-wrap: wrap;
   }
-  .connection-card-header .card-title-group {
+  .status-card-header .card-title-group {
     flex: 1 1 100%;
   }
-  .connection-card-header .status-indicator {
+  .status-card-header .status-indicator {
     margin-left: 52px;
     max-width: calc(100% - 52px);
   }
-  .connection-card-header #modem-status-text {
+  .status-card-header .status-indicator span:last-child {
     overflow-wrap: anywhere;
   }
   .notification-card-header {

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -332,15 +332,23 @@ function revokeToken(id, name) {
     }).catch(function() { showToast(T.error_prefix || 'Error', false); });
 }
 
-/* ── Modem Status Indicator ── */
-function setModemStatus(state, text) {
-    var box = document.getElementById('modem-status');
+/* ── Connection Test Status Indicators ── */
+function setConnectionTestStatus(boxId, labelId, state, text) {
+    var box = document.getElementById(boxId);
     if (!box) return;
     box.hidden = false;
     box.classList.remove('testing', 'connected', 'disconnected');
     box.classList.add(state);
-    var label = document.getElementById('modem-status-text');
+    var label = document.getElementById(labelId);
     if (label) label.textContent = text;
+}
+
+function setModemStatus(state, text) {
+    setConnectionTestStatus('modem-status', 'modem-status-text', state, text);
+}
+
+function setMqttStatus(state, text) {
+    setConnectionTestStatus('mqtt-status', 'mqtt-status-text', state, text);
 }
 
 /* ── Theme Toggle ── */
@@ -539,6 +547,7 @@ function testMqtt() {
     span.textContent = '\u23F3';
     el.appendChild(span);
     el.appendChild(document.createTextNode(' ' + T.testing));
+    setMqttStatus('testing', T.testing);
     var data = getFormData();
     fetch('/api/test-mqtt', {
         method: 'POST',
@@ -555,12 +564,14 @@ function testMqtt() {
             check.textContent = '\u2713';
             el.appendChild(check);
             el.appendChild(document.createTextNode(' ' + T.connected));
+            setMqttStatus('connected', T.connected);
         } else {
             el.className = 'test-result test-fail';
             var x = document.createElement('span');
             x.textContent = '\u2717';
             el.appendChild(x);
             el.appendChild(document.createTextNode(' ' + T.error_prefix + ': ' + (res.error || T.unknown_error)));
+            setMqttStatus('disconnected', T.error_prefix + ': ' + (res.error || T.unknown_error));
         }
     })
     .catch(function() {
@@ -570,6 +581,7 @@ function testMqtt() {
         x.textContent = '\u2717';
         el.appendChild(x);
         el.appendChild(document.createTextNode(' ' + T.network_error));
+        setMqttStatus('disconnected', T.network_error);
     });
 }
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v65';
+var CACHE_VERSION = 'v66';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/settings/connection.html
+++ b/app/templates/settings/connection.html
@@ -2,7 +2,7 @@
 <div class="settings-panel active" id="panel-connection">
     <!-- Modem Card -->
     <div class="settings-card glass">
-        <div class="card-header connection-card-header">
+        <div class="card-header status-card-header connection-card-header">
             <div class="card-title-group">
                 <div class="card-icon purple">
                     <i data-lucide="radio"></i>

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -300,6 +300,87 @@ class TestSettingsFormElements:
         expect(status).not_to_have_attribute("hidden", "")
         expect(status.locator("#modem-status-text")).to_have_text("Error: Auth failed")
 
+    def test_mqtt_status_updates_while_testing_and_after_success(self, settings_page):
+        pending_routes = []
+
+        def hold_mqtt(route):
+            pending_routes.append(route)
+
+        settings_page.route("**/api/test-mqtt", hold_mqtt)
+        settings_page.locator('button[data-section="mod-docsight_mqtt"]').click()
+        status = settings_page.locator("#mqtt-status")
+        expect(status).to_have_attribute("hidden", "")
+
+        with settings_page.expect_request("**/api/test-mqtt"):
+            settings_page.locator('#panel-mod-docsight_mqtt button[onclick="testMqtt()"]').click()
+
+        expect(status).to_have_class(re.compile(r".*\btesting\b.*"))
+        expect(status).not_to_have_attribute("hidden", "")
+        expect(status.locator("#mqtt-status-text")).to_have_text(re.compile("Testing", re.I))
+        assert len(pending_routes) == 1
+
+        pending_routes[0].fulfill(json={"success": True})
+
+        expect(status).to_have_class(re.compile(r".*\bconnected\b.*"))
+        expect(status).not_to_have_class(re.compile(r".*\bdisconnected\b.*"))
+        expect(status.locator("#mqtt-status-text")).to_have_text("Connected")
+
+    def test_mqtt_status_updates_after_failed_connection_test(self, settings_page):
+        settings_page.route(
+            "**/api/test-mqtt",
+            lambda route: route.fulfill(json={"success": False, "error": "MQTT auth failed"}),
+        )
+        settings_page.locator('button[data-section="mod-docsight_mqtt"]').click()
+        status = settings_page.locator("#mqtt-status")
+        expect(status).to_have_attribute("hidden", "")
+
+        settings_page.locator('#panel-mod-docsight_mqtt button[onclick="testMqtt()"]').click()
+
+        expect(status).to_have_class(re.compile(r".*\bdisconnected\b.*"))
+        expect(status).not_to_have_class(re.compile(r".*\bconnected\b.*"))
+        expect(status).not_to_have_attribute("hidden", "")
+        expect(status.locator("#mqtt-status-text")).to_have_text("Error: MQTT auth failed")
+
+    def test_mqtt_status_updates_after_network_error(self, settings_page):
+        settings_page.route("**/api/test-mqtt", lambda route: route.abort())
+        settings_page.locator('button[data-section="mod-docsight_mqtt"]').click()
+        status = settings_page.locator("#mqtt-status")
+        expect(status).to_have_attribute("hidden", "")
+
+        settings_page.locator('#panel-mod-docsight_mqtt button[onclick="testMqtt()"]').click()
+
+        expect(status).to_have_class(re.compile(r".*\bdisconnected\b.*"))
+        expect(status).not_to_have_attribute("hidden", "")
+        expect(status.locator("#mqtt-status-text")).to_have_text("Network error")
+
+    def test_mqtt_status_wraps_without_mobile_overflow(self, settings_page):
+        settings_page.set_viewport_size({"width": 390, "height": 844})
+        settings_page.reload(wait_until="networkidle")
+        settings_page.route(
+            "**/api/test-mqtt",
+            lambda route: route.fulfill(
+                json={
+                    "success": False,
+                    "error": "Connection refused by broker at mqtt.example.invalid:1883",
+                }
+            ),
+        )
+        settings_page.evaluate("() => window.switchSection('mod-docsight_mqtt')")
+        settings_page.locator('#panel-mod-docsight_mqtt button[onclick="testMqtt()"]').click()
+
+        expect(settings_page.locator("#mqtt-status")).to_have_class(
+            re.compile(r".*\bdisconnected\b.*")
+        )
+        metrics = settings_page.evaluate(
+            """
+            () => ({
+              docWidth: document.documentElement.scrollWidth,
+              viewportWidth: window.innerWidth,
+            })
+            """
+        )
+        assert metrics["docWidth"] <= metrics["viewportWidth"]
+
     def test_security_has_password_field(self, settings_page):
         settings_page.locator('button[data-section="security"]').click()
         pw = settings_page.locator('input[type="password"]')

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -142,6 +142,16 @@ class TestSettingsRoute:
         assert 'aria-live="polite"' in status_tag
         assert 'id="dot-notifications"' not in html
 
+    def test_settings_mqtt_status_indicator_starts_hidden_and_live(self):
+        template = Path("app/modules/mqtt/templates/mqtt_settings.html").read_text()
+        status = BeautifulSoup(template, "html.parser").select_one("#mqtt-status")
+
+        assert status is not None
+        assert "hidden" in status.attrs
+        assert status.get("role") == "status"
+        assert status.get("aria-live") == "polite"
+        assert status.select_one("#mqtt-status-text") is not None
+
     def test_settings_smart_capture_uses_shared_form_classes(self, client):
         resp = client.get("/settings?lang=en")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- keep the MQTT settings header status hidden until a connection test runs
- update the header status for in-flight, successful, failed, and network-error MQTT test outcomes
- share the mobile status-header wrapping behavior with modem and MQTT cards

## Tests
- `uv run --with-requirements requirements-test.txt python -m pytest tests/web/test_settings.py -q`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/test_static_contracts.py -q`
- `uv run --with-requirements requirements-test.txt python -m pytest tests -q --ignore=tests/e2e`
- `TZ=UTC uv run --with-requirements requirements-test.txt --with pytest-playwright==0.7.2 --with playwright==1.58.0 python -m pytest tests/e2e/test_settings.py -q --browser chromium`
