### PR TITLE
Add in-app glossary foundation

### DIFF
--- a/app/glossary.py
+++ b/app/glossary.py
@@ -1,0 +1,265 @@
+"""Canonical in-app glossary data model and loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+GLOSSARY_LEVELS: tuple[str, ...] = ("eli5", "basic", "advanced", "technician")
+
+
+@dataclass(frozen=True)
+class GlossaryTerm:
+    """A canonical glossary term with stable IDs and multi-level explanations."""
+
+    id: str
+    category: str
+    title: dict[str, str]
+    aliases: dict[str, tuple[str, ...]]
+    levels: dict[str, dict[str, str]]
+    misconceptions: dict[str, tuple[str, ...]]
+    related: tuple[str, ...]
+    protected_terms: tuple[str, ...]
+
+    def localized(self, lang: str = "en") -> dict[str, Any]:
+        """Return a template-friendly localized term, falling back to English."""
+        title = self.title.get(lang) or self.title["en"]
+        aliases = self.aliases.get(lang) or self.aliases.get("en", ())
+        levels = self.levels.get(lang) or self.levels["en"]
+        misconceptions = self.misconceptions.get(lang) or self.misconceptions.get("en", ())
+        return {
+            "id": self.id,
+            "category": self.category,
+            "title": title,
+            "aliases": list(aliases),
+            "levels": dict(levels),
+            "misconceptions": list(misconceptions),
+            "related": list(self.related),
+            "protected_terms": list(self.protected_terms),
+        }
+
+
+@dataclass(frozen=True)
+class GlossaryCategory:
+    """A glossary category for browsing and future filtering."""
+
+    id: str
+    title: dict[str, str]
+    description: dict[str, str]
+
+    def localized(self, lang: str = "en") -> dict[str, str]:
+        return {
+            "id": self.id,
+            "title": self.title.get(lang) or self.title["en"],
+            "description": self.description.get(lang) or self.description["en"],
+        }
+
+
+_CATEGORIES: tuple[GlossaryCategory, ...] = (
+    GlossaryCategory(
+        id="cable_basics",
+        title={"en": "Cable/DOCSIS basics"},
+        description={
+            "en": "Core terms for understanding cable internet and what DOCSight can observe.",
+        },
+    ),
+    GlossaryCategory(
+        id="modulation_channels",
+        title={"en": "Modulation and channels"},
+        description={
+            "en": "How DOCSIS channels carry data and why channel technology matters.",
+        },
+    ),
+    GlossaryCategory(
+        id="capacity_throughput",
+        title={"en": "Capacity and throughput"},
+        description={
+            "en": "Boundaries between channel diagnostics, gross capacity, tariff speed, and speedtests.",
+        },
+    ),
+)
+
+_TERMS: tuple[GlossaryTerm, ...] = (
+    GlossaryTerm(
+        id="docsis",
+        category="cable_basics",
+        title={"en": "DOCSIS"},
+        aliases={"en": ("Cable internet", "Data Over Cable Service Interface Specification")},
+        protected_terms=("DOCSIS", "DSL", "DOCSight"),
+        related=("shared_medium", "sc_qam", "capacity_vs_throughput"),
+        levels={
+            "en": {
+                "eli5": "DOCSIS is the language a cable modem uses to talk to the cable network. It is cable internet, not DSL over a phone line.",
+                "basic": "DOCSIS carries internet service over coax cable. DOCSight reads modem, channel, and signal data from supported cable devices, so its diagnostics describe the cable link rather than a DSL line.",
+                "advanced": "DOCSIS networks combine downstream and upstream channels such as SC-QAM, OFDM, and OFDMA. DOCSight can interpret local modem-visible signal and channel data, but it cannot see every provider-side segment or routing condition.",
+                "technician": "DOCSIS defines the cable modem access layer between the CM and CMTS over the HFC/coax segment. Local channel telemetry is useful for RF and MAC-layer diagnostics, but provider provisioning, segment load, CMTS policy, and IP routing remain outside the modem-only evidence boundary.",
+            }
+        },
+        misconceptions={
+            "en": (
+                "DOCSIS is not DSL; DSL values and cable channel values should not be compared one-to-one.",
+            )
+        },
+    ),
+    GlossaryTerm(
+        id="shared_medium",
+        category="cable_basics",
+        title={"en": "Shared medium"},
+        aliases={"en": ("Segment", "Cable segment", "Node")},
+        protected_terms=("DOCSIS", "CMTS", "DOCSight"),
+        related=("docsis", "capacity_vs_throughput"),
+        levels={
+            "en": {
+                "eli5": "A cable segment is like a road that several homes use. Your modem can have a clean signal even when the road is busy.",
+                "basic": "Cable networks share parts of the access network between multiple users. Segment load can affect real speeds, and DOCSight cannot directly measure every other modem on the segment.",
+                "advanced": "DOCSIS capacity is shared across channels and service groups. Local modem stats show your channel and signal state, while contention and scheduling happen at the provider side.",
+                "technician": "Shared-medium behavior depends on service-group sizing, CMTS scheduling, OFDMA/OFDM profiles, provisioning, and active subscriber demand. DOCSight can highlight local RF/channel symptoms but should not infer complete segment utilization unless a supported data source exposes it.",
+            }
+        },
+        misconceptions={
+            "en": (
+                "A good signal level does not prove that the provider segment is uncongested.",
+            )
+        },
+    ),
+    GlossaryTerm(
+        id="sc_qam",
+        category="modulation_channels",
+        title={"en": "SC-QAM"},
+        aliases={"en": ("Single-carrier QAM", "DOCSIS 3.0 channel")},
+        protected_terms=("SC-QAM", "DOCSIS", "QAM", "Layer-1"),
+        related=("docsis", "ofdm", "capacity_vs_throughput"),
+        levels={
+            "en": {
+                "eli5": "SC-QAM is one kind of cable channel. Think of it as one lane that can carry data between the cable network and your modem.",
+                "basic": "SC-QAM channels are traditional DOCSIS channels. DOCSight can often estimate their gross Layer-1 capacity from modulation and channel details.",
+                "advanced": "SC-QAM uses a single carrier with a fixed channel width and QAM modulation order. Higher modulation can carry more bits per symbol, but the estimate is still gross channel capacity, not IP throughput.",
+                "technician": "For DOCSIS SC-QAM channels, modulation order, symbol rate, channel width, and PHY overhead determine gross Layer-1 estimates. FEC, MAC framing, scheduling, bonding, and IP overhead separate that estimate from usable application throughput.",
+            }
+        },
+        misconceptions={
+            "en": (
+                "An SC-QAM capacity estimate is not a speedtest result.",
+            )
+        },
+    ),
+    GlossaryTerm(
+        id="ofdm",
+        category="modulation_channels",
+        title={"en": "OFDM/OFDMA"},
+        aliases={"en": ("DOCSIS 3.1 channel", "OFDM", "OFDMA")},
+        protected_terms=("OFDM", "OFDMA", "DOCSIS", "SC-QAM"),
+        related=("docsis", "sc_qam", "capacity_vs_throughput"),
+        levels={
+            "en": {
+                "eli5": "OFDM and OFDMA are newer cable channel types that split a wide channel into many tiny pieces.",
+                "basic": "DOCSIS 3.1 uses OFDM downstream and OFDMA upstream for flexible, high-capacity channels. DOCSight may show their signal state even when it cannot calculate the same simple capacity number as SC-QAM.",
+                "advanced": "OFDM/OFDMA channels use many subcarriers and profiles. Their real capacity depends on profile assignment, subcarrier health, exclusion bands, and provider-side scheduling.",
+                "technician": "OFDM/OFDMA telemetry requires profile/subcarrier context to estimate capacity safely. Without sufficient profile data, DOCSight should treat these channels as observed but not included in SC-QAM-only gross capacity sums.",
+            }
+        },
+        misconceptions={
+            "en": (
+                "Missing OFDM/OFDMA capacity does not mean the channel is unused; it may mean DOCSight lacks safe profile-level data.",
+            )
+        },
+    ),
+    GlossaryTerm(
+        id="capacity_vs_throughput",
+        category="capacity_throughput",
+        title={"en": "Capacity vs. speedtest"},
+        aliases={"en": ("Throughput", "Tariff speed", "Gross capacity", "IP speed")},
+        protected_terms=("Layer-1", "SC-QAM", "Speedtest", "IP", "DOCSight"),
+        related=("docsis", "sc_qam", "shared_medium"),
+        levels={
+            "en": {
+                "eli5": "Capacity is what the cable lane could carry in theory. A speedtest is what your connection delivers right now after many other things are included.",
+                "basic": "DOCSight capacity estimates describe channel-level gross capacity, especially for supported SC-QAM channels. They are not your tariff speed, not a speedtest, and not guaranteed real IP throughput.",
+                "advanced": "Layer-1 channel capacity is before MAC, FEC, scheduling, bonding, segment load, traffic shaping, and IP/application overhead. Speedtests measure an end-to-end path at one moment in time.",
+                "technician": "Do not equate PHY gross capacity with service-flow rate limits or TCP/UDP goodput. CMTS scheduling, provisioning, OFDM/OFDMA profile availability, RF impairment, queueing, peering, and test-server behavior can all dominate observed throughput.",
+            }
+        },
+        misconceptions={
+            "en": (
+                "A channel capacity sum is not proof that a customer should see the same number in a speedtest.",
+                "Tariff speed is a product configuration; DOCSight channel diagnostics are local evidence.",
+            )
+        },
+    ),
+)
+
+
+def _category_ids() -> set[str]:
+    return {category.id for category in _CATEGORIES}
+
+
+def _term_ids() -> set[str]:
+    return {term.id for term in _TERMS}
+
+
+def validate_glossary_catalog(terms: Iterable[GlossaryTerm] = _TERMS) -> list[str]:
+    """Return schema/link validation errors for the glossary catalog."""
+    errors: list[str] = []
+    seen: set[str] = set()
+    term_list = list(terms)
+    term_ids = {term.id for term in term_list}
+    category_ids = _category_ids()
+
+    for term in term_list:
+        if not term.id:
+            errors.append("term id is required")
+        if term.id in seen:
+            errors.append(f"duplicate term id: {term.id}")
+        seen.add(term.id)
+        if term.category not in category_ids:
+            errors.append(f"{term.id}: unknown category {term.category}")
+        if not term.title.get("en"):
+            errors.append(f"{term.id}: missing English title")
+        if "en" not in term.levels:
+            errors.append(f"{term.id}: missing English levels")
+            continue
+        for level in GLOSSARY_LEVELS:
+            text = term.levels["en"].get(level, "").strip()
+            if not text:
+                errors.append(f"{term.id}: missing {level} level")
+        for related_id in term.related:
+            if related_id not in term_ids:
+                errors.append(f"{term.id}: unknown related term {related_id}")
+        for token in term.protected_terms:
+            if not token:
+                errors.append(f"{term.id}: empty protected term")
+
+    return errors
+
+
+def get_glossary_categories(lang: str = "en") -> list[dict[str, str]]:
+    """Return localized glossary categories."""
+    return [category.localized(lang) for category in _CATEGORIES]
+
+
+def get_glossary_terms(lang: str = "en") -> list[dict[str, Any]]:
+    """Return localized glossary terms sorted by category order and title."""
+    localized = [term.localized(lang) for term in _TERMS]
+    category_order = {category.id: index for index, category in enumerate(_CATEGORIES)}
+    return sorted(
+        localized,
+        key=lambda item: (category_order.get(item["category"], 999), item["title"].lower()),
+    )
+
+
+def get_glossary_term(term_id: str, lang: str = "en") -> dict[str, Any] | None:
+    """Return one localized glossary term by stable ID."""
+    for term in _TERMS:
+        if term.id == term_id:
+            return term.localized(lang)
+    return None
+
+
+def get_related_terms(term: dict[str, Any], lang: str = "en") -> list[dict[str, Any]]:
+    """Resolve related term IDs for a localized term dict."""
+    related = []
+    for term_id in term.get("related", []):
+        resolved = get_glossary_term(term_id, lang)
+        if resolved:
+            related.append(resolved)
+    return related

--- a/app/static/css/glossary.css
+++ b/app/static/css/glossary.css
@@ -137,3 +137,263 @@ body > .glossary-popover.above::before {
     display: none;
   }
 }
+
+/* Standalone glossary page */
+.glossary-page-body {
+  min-height: 100vh;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text-primary);
+}
+
+.glossary-page {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0 56px;
+}
+
+.glossary-page-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  gap: 24px;
+  align-items: stretch;
+  margin-bottom: 24px;
+}
+
+.glossary-page-hero,
+.glossary-article,
+.glossary-index,
+.glossary-level-card {
+  background: var(--surface);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.glossary-page-hero {
+  padding: 28px;
+}
+
+.glossary-back-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.glossary-back-link:hover,
+.glossary-index a:hover,
+.glossary-related a:hover {
+  color: var(--amethyst-light);
+}
+
+.glossary-page h1,
+.glossary-page h2,
+.glossary-page h3,
+.glossary-page h4,
+.glossary-page p {
+  margin-top: 0;
+}
+
+.glossary-page h1 {
+  margin-bottom: 12px;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: -0.04em;
+}
+
+.glossary-page-intro {
+  max-width: 680px;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.glossary-level-card {
+  padding: 18px;
+}
+
+.glossary-levels {
+  display: grid;
+  gap: 10px;
+}
+
+.glossary-level,
+.glossary-index a,
+.glossary-related a {
+  display: block;
+  text-decoration: none;
+  color: var(--text-primary);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-subtle, rgba(255,255,255,0.03));
+}
+
+.glossary-level {
+  padding: 12px;
+}
+
+.glossary-level span,
+.glossary-related span {
+  display: block;
+  font-weight: 700;
+}
+
+.glossary-level small,
+.glossary-related small,
+.glossary-index p,
+.glossary-term-id {
+  color: var(--text-muted);
+}
+
+.glossary-level.active,
+.glossary-index a.active,
+.glossary-level-summary.active {
+  border-color: var(--amethyst);
+  background: color-mix(in srgb, var(--amethyst) 14%, transparent);
+}
+
+.glossary-layout {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: 24px;
+}
+
+.glossary-index,
+.glossary-article {
+  padding: 24px;
+}
+
+.glossary-index {
+  align-self: start;
+  position: sticky;
+  top: 16px;
+}
+
+.glossary-index-section + .glossary-index-section {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--glass-border);
+}
+
+.glossary-index ul {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+}
+
+.glossary-index li + li {
+  margin-top: 8px;
+}
+
+.glossary-index a {
+  padding: 10px 12px;
+}
+
+.glossary-term-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.glossary-term-header h2 {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  letter-spacing: -0.03em;
+}
+
+.glossary-term-id {
+  padding: 6px 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.8rem;
+}
+
+.glossary-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 20px;
+}
+
+.glossary-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: rgba(255,255,255,0.04);
+  font-size: 0.85rem;
+}
+
+.glossary-chip-technical {
+  color: var(--amethyst-light);
+}
+
+.glossary-level-panel,
+.glossary-callout,
+.glossary-protected,
+.glossary-related {
+  margin-top: 22px;
+  padding: 18px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: rgba(255,255,255,0.03);
+}
+
+.glossary-level-panel p,
+.glossary-level-summary p,
+.glossary-callout li {
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.glossary-level-grid,
+.glossary-related-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.glossary-level-summary {
+  padding: 14px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: rgba(255,255,255,0.025);
+}
+
+.glossary-related-grid a {
+  padding: 14px;
+}
+
+@media (max-width: 900px) {
+  .glossary-page-hero,
+  .glossary-layout,
+  .glossary-level-grid,
+  .glossary-related-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .glossary-index {
+    position: static;
+  }
+}
+
+@media (max-width: 560px) {
+  .glossary-page {
+    width: min(100vw - 20px, 1180px);
+    padding-top: 12px;
+  }
+
+  .glossary-page-hero,
+  .glossary-index,
+  .glossary-article {
+    padding: 18px;
+  }
+
+  .glossary-term-header {
+    flex-direction: column;
+  }
+}

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v68';
+var CACHE_VERSION = 'v69';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/glossary.html
+++ b/app/templates/glossary.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="{{ lang }}" data-theme="{{ theme|default('dark') }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#06080f">
+    <title>{{ t.get('glossary_page_title', 'Glossary') }} · DOCSight</title>
+    <link rel="icon" type="image/svg+xml" href="/static/logo.svg">
+    <link rel="apple-touch-icon" href="/static/icon.png">
+    <link rel="manifest" href="/static/manifest.json">
+    <link rel="stylesheet" href="/static/css/fonts.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/tokens.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/components.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/main.css?v={{ version|urlencode }}">
+    <link rel="stylesheet" href="/static/css/glossary.css?v={{ version|urlencode }}">
+    <script src="/static/vendor/lucide.min.js?v={{ version|urlencode }}"></script>
+</head>
+<body class="glossary-page-body">
+<main class="glossary-page" aria-labelledby="glossary-title">
+    <header class="glossary-page-hero">
+        <div>
+            <a class="glossary-back-link" href="/">← {{ t.get('home', 'Home') }}</a>
+            <p class="eyebrow">DOCSight knowledge base</p>
+            <h1 id="glossary-title">{{ t.get('glossary_page_title', 'Glossary') }}</h1>
+            <p class="glossary-page-intro">
+                {{ t.get('glossary_page_intro', 'Canonical DOCSIS and cable terms with explanation levels from beginner-friendly to technician detail.') }}
+            </p>
+        </div>
+        <div class="glossary-level-card" aria-labelledby="glossary-level-title">
+            <h2 id="glossary-level-title">{{ t.get('glossary_level_selector', 'Explanation level') }}</h2>
+            <div class="glossary-levels" role="list">
+                {% for item in level_options %}
+                <a class="glossary-level {{ 'active' if item.id == selected_level else '' }}" role="listitem" href="{{ url_for('glossary_page', lang=lang, level=item.id, term=selected_term.id if selected_term else None) }}" aria-current="{{ 'true' if item.id == selected_level else 'false' }}">
+                    <span>{{ item.label }}</span>
+                    <small>{{ item.description }}</small>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </header>
+
+    <section class="glossary-layout" aria-label="Glossary terms">
+        <aside class="glossary-index" aria-label="Term index">
+            {% for category in categories %}
+            <section class="glossary-index-section">
+                <h2>{{ category.title }}</h2>
+                <p>{{ category.description }}</p>
+                <ul>
+                    {% for term in terms if term.category == category.id %}
+                    <li>
+                        <a class="{{ 'active' if selected_term and selected_term.id == term.id else '' }}" href="{{ url_for('glossary_page', lang=lang, level=selected_level, term=term.id) }}" aria-current="{{ 'page' if selected_term and selected_term.id == term.id else 'false' }}">
+                            {{ term.title }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </section>
+            {% endfor %}
+        </aside>
+
+        <article class="glossary-article" aria-labelledby="glossary-term-title">
+            {% if selected_term %}
+            <div class="glossary-term-header">
+                <div>
+                    <p class="eyebrow">{{ category_by_id[selected_term.category].title }}</p>
+                    <h2 id="glossary-term-title">{{ selected_term.title }}</h2>
+                </div>
+                <span class="glossary-term-id">{{ selected_term.id }}</span>
+            </div>
+
+            {% if selected_term.aliases %}
+            <div class="glossary-chip-row" aria-label="Aliases">
+                {% for alias in selected_term.aliases %}
+                <span class="glossary-chip">{{ alias }}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+
+            <section class="glossary-level-panel" aria-labelledby="selected-level-heading">
+                <h3 id="selected-level-heading">{{ selected_level_label }}</h3>
+                <p>{{ selected_term.levels[selected_level] }}</p>
+            </section>
+
+            <section class="glossary-all-levels" aria-labelledby="all-levels-heading">
+                <h3 id="all-levels-heading">All explanation levels</h3>
+                <div class="glossary-level-grid">
+                    {% for item in level_options %}
+                    <section class="glossary-level-summary {{ 'active' if item.id == selected_level else '' }}">
+                        <h4>{{ item.label }}</h4>
+                        <p>{{ selected_term.levels[item.id] }}</p>
+                    </section>
+                    {% endfor %}
+                </div>
+            </section>
+
+            {% if selected_term.misconceptions %}
+            <section class="glossary-callout" aria-labelledby="misconceptions-heading">
+                <h3 id="misconceptions-heading">Common misconceptions</h3>
+                <ul>
+                    {% for item in selected_term.misconceptions %}
+                    <li>{{ item }}</li>
+                    {% endfor %}
+                </ul>
+            </section>
+            {% endif %}
+
+            {% if selected_term.protected_terms %}
+            <section class="glossary-protected" aria-labelledby="protected-heading">
+                <h3 id="protected-heading">Protected technical terms</h3>
+                <div class="glossary-chip-row">
+                    {% for token in selected_term.protected_terms %}
+                    <span class="glossary-chip glossary-chip-technical">{{ token }}</span>
+                    {% endfor %}
+                </div>
+            </section>
+            {% endif %}
+
+            {% if related_terms %}
+            <section class="glossary-related" aria-labelledby="related-heading">
+                <h3 id="related-heading">Related terms</h3>
+                <div class="glossary-related-grid">
+                    {% for term in related_terms %}
+                    <a href="{{ url_for('glossary_page', lang=lang, level=selected_level, term=term.id) }}">
+                        <span>{{ term.title }}</span>
+                        <small>{{ term.id }}</small>
+                    </a>
+                    {% endfor %}
+                </div>
+            </section>
+            {% endif %}
+            {% else %}
+            <h2 id="glossary-term-title">No glossary term selected</h2>
+            {% endif %}
+        </article>
+    </section>
+</main>
+<script>
+if (window.lucide) window.lucide.createIcons();
+</script>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -211,6 +211,9 @@
                     <i data-lucide="file-text"></i> {{ t.incident_report }}
                 </button>
                 {% endif %}
+                <a class="nav-item" href="/glossary?lang={{ lang|urlencode }}" data-nav-icon="book-open" data-nav-title="{{ t.get('glossary_page_title', 'Glossary') }}">
+                    <i data-lucide="book-open"></i> {{ t.get('glossary_page_title', 'Glossary') }}
+                </a>
             </div>
         </div>
         {% set tab_modules = [] %}

--- a/app/web.py
+++ b/app/web.py
@@ -23,6 +23,13 @@ from .config import POLL_MIN, POLL_MAX
 from .analyzer import get_thresholds
 from .docsis_utils import qam_rank
 from .gaming_index import compute_gaming_index
+from .glossary import (
+    GLOSSARY_LEVELS,
+    get_glossary_categories,
+    get_glossary_term,
+    get_glossary_terms,
+    get_related_terms,
+)
 from .i18n import get_translations, LANGUAGES, LANG_FLAGS
 from .maintainer_notices import coerce_dismissed_notice_ids, get_active_notices
 from .tz import guess_iana_timezone as _guess_iana_timezone, get_tz_name as _get_public_tz_name, to_local as _to_local
@@ -1281,6 +1288,66 @@ def _build_capacity_context(analysis, booked_download=0, booked_upload=0):
 @app.route("/sw.js")
 def service_worker():
     return send_from_directory(app.static_folder, "sw.js", mimetype="application/javascript")
+
+
+_GLOSSARY_LEVEL_LABELS = {
+    "eli5": {
+        "label": "ELI5",
+        "description": "Plain-language first explanation",
+    },
+    "basic": {
+        "label": "Basic",
+        "description": "Practical meaning for end users",
+    },
+    "advanced": {
+        "label": "Advanced",
+        "description": "Technical context without provider-only assumptions",
+    },
+    "technician": {
+        "label": "Technician",
+        "description": "Precise DOCSIS and diagnostics boundaries",
+    },
+}
+
+
+@app.route("/glossary")
+@require_auth
+def glossary_page():
+    """Render the canonical in-app glossary foundation."""
+    lang = _get_lang()
+    t = get_translations(lang)
+    theme = _config_manager.get_theme() if _config_manager else "dark"
+    terms = get_glossary_terms(lang)
+    categories = get_glossary_categories(lang)
+    selected_level = request.args.get("level", "basic")
+    if selected_level not in GLOSSARY_LEVELS:
+        selected_level = "basic"
+    selected_term_id = request.args.get("term") or (terms[0]["id"] if terms else "")
+    selected_term = get_glossary_term(selected_term_id, lang) or (terms[0] if terms else None)
+    related_terms = get_related_terms(selected_term, lang) if selected_term else []
+    level_options = [
+        {"id": level, **_GLOSSARY_LEVEL_LABELS[level]}
+        for level in GLOSSARY_LEVELS
+    ]
+    selected_level_label = _GLOSSARY_LEVEL_LABELS[selected_level]["label"]
+    category_by_id = {category["id"]: category for category in categories}
+    return render_template(
+        "glossary.html",
+        t=t,
+        lang=lang,
+        languages=LANGUAGES,
+        lang_flags=LANG_FLAGS,
+        theme=theme,
+        version=APP_VERSION,
+        categories=categories,
+        category_by_id=category_by_id,
+        terms=terms,
+        selected_term=selected_term,
+        selected_level=selected_level,
+        selected_level_label=selected_level_label,
+        level_options=level_options,
+        related_terms=related_terms,
+    )
 
 
 @app.route("/")

--- a/tests/e2e/test_glossary_page.py
+++ b/tests/e2e/test_glossary_page.py
@@ -1,0 +1,41 @@
+"""E2E tests for the standalone glossary page."""
+
+import re
+
+from playwright.sync_api import expect
+
+
+def test_standalone_glossary_page_renders_terms_and_levels(page, live_server):
+    page.goto(f"{live_server}/glossary?lang=en&term=docsis&level=basic")
+    page.wait_for_load_state("networkidle")
+
+    expect(page.locator("h1", has_text="Glossary")).to_be_visible()
+    expect(page.locator("#glossary-term-title", has_text="DOCSIS")).to_be_visible()
+    expect(page.locator(".glossary-level", has_text="ELI5")).to_be_visible()
+    expect(page.locator(".glossary-level", has_text="Technician")).to_be_visible()
+    expect(page.locator(".glossary-index", has_text="Cable/DOCSIS basics")).to_be_visible()
+    expect(page.locator(".glossary-related", has_text="SC-QAM")).to_be_visible()
+
+
+def test_glossary_level_and_related_term_navigation(page, live_server):
+    page.goto(f"{live_server}/glossary?lang=en&term=sc_qam&level=basic")
+    page.wait_for_load_state("networkidle")
+
+    page.locator(".glossary-level", has_text="Technician").click()
+    expect(page).to_have_url(re.compile(r"level=technician"))
+    expect(page.locator("#selected-level-heading", has_text="Technician")).to_be_visible()
+    expect(page.locator(".glossary-level-panel", has_text="gross Layer-1 estimates")).to_be_visible()
+
+    page.locator(".glossary-related a", has_text="Capacity vs. speedtest").click()
+    expect(page).to_have_url(re.compile(r"term=capacity_vs_throughput"))
+    expect(page.locator("#glossary-term-title", has_text="Capacity vs. speedtest")).to_be_visible()
+
+
+def test_glossary_mobile_layout_has_no_horizontal_overflow(page, live_server):
+    page.set_viewport_size({"width": 393, "height": 852})
+    page.goto(f"{live_server}/glossary?lang=en&term=capacity_vs_throughput&level=eli5")
+    page.wait_for_load_state("networkidle")
+
+    expect(page.locator("#glossary-term-title", has_text="Capacity vs. speedtest")).to_be_visible()
+    has_overflow = page.evaluate("document.documentElement.scrollWidth > document.documentElement.clientWidth")
+    assert has_overflow is False

--- a/tests/test_glossary_catalog.py
+++ b/tests/test_glossary_catalog.py
@@ -1,0 +1,62 @@
+"""Tests for the canonical in-app glossary catalog."""
+
+from app.glossary import (
+    GLOSSARY_LEVELS,
+    get_glossary_categories,
+    get_glossary_term,
+    get_glossary_terms,
+    get_related_terms,
+    validate_glossary_catalog,
+)
+
+
+def test_glossary_catalog_schema_is_valid():
+    assert validate_glossary_catalog() == []
+
+
+def test_minimal_vertical_slice_contains_required_foundation_terms():
+    terms = {term["id"]: term for term in get_glossary_terms("en")}
+
+    for term_id in {"docsis", "shared_medium", "sc_qam", "ofdm", "capacity_vs_throughput"}:
+        assert term_id in terms
+        term = terms[term_id]
+        assert term["title"]
+        assert term["category"]
+        assert term["aliases"]
+        assert term["protected_terms"]
+        assert set(term["levels"]) == set(GLOSSARY_LEVELS)
+        for level in GLOSSARY_LEVELS:
+            assert len(term["levels"][level]) > 60
+
+
+def test_related_glossary_terms_resolve_to_existing_terms():
+    for term in get_glossary_terms("en"):
+        related = get_related_terms(term, "en")
+        assert len(related) == len(term["related"])
+        assert all(item["id"] in term["related"] for item in related)
+
+
+def test_categories_are_localized_and_used_by_terms():
+    categories = {category["id"]: category for category in get_glossary_categories("en")}
+    assert {"cable_basics", "modulation_channels", "capacity_throughput"}.issubset(categories)
+    for category in categories.values():
+        assert category["title"]
+        assert category["description"]
+    for term in get_glossary_terms("en"):
+        assert term["category"] in categories
+
+
+def test_glossary_lookup_falls_back_to_english_for_untranslated_locale():
+    term = get_glossary_term("docsis", "de")
+    assert term is not None
+    assert term["title"] == "DOCSIS"
+    assert "DOCSIS is the language" in term["levels"]["eli5"]
+
+
+def test_capacity_term_preserves_no_speedtest_overclaim_boundary():
+    term = get_glossary_term("capacity_vs_throughput", "en")
+    assert term is not None
+    joined = " ".join(term["levels"].values())
+    assert "not your tariff speed" in joined
+    assert "not a speedtest" in joined
+    assert "not guaranteed real IP throughput" in joined

--- a/tests/web/test_glossary_route.py
+++ b/tests/web/test_glossary_route.py
@@ -1,0 +1,55 @@
+"""Tests for the standalone glossary route."""
+
+from app.glossary import GLOSSARY_LEVELS
+from app.web import update_state
+
+
+def test_glossary_route_renders_canonical_terms(client, sample_analysis):
+    update_state(analysis=sample_analysis)
+
+    resp = client.get("/glossary?lang=en")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Glossary" in html
+    assert "Cable/DOCSIS basics" in html
+    assert "DOCSIS" in html
+    assert "SC-QAM" in html
+    assert "Capacity vs. speedtest" in html
+    assert "docsis" in html
+
+
+def test_glossary_route_supports_all_explanation_levels(client, sample_analysis):
+    update_state(analysis=sample_analysis)
+
+    resp = client.get("/glossary?lang=en&term=sc_qam&level=technician")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    for label in ("ELI5", "Basic", "Advanced", "Technician"):
+        assert label in html
+    assert "aria-current=\"true\"" in html
+    assert "Layer-1 estimates" in html or "gross Layer-1 estimates" in html
+
+
+def test_glossary_route_falls_back_from_invalid_term_and_level(client, sample_analysis):
+    update_state(analysis=sample_analysis)
+
+    resp = client.get("/glossary?lang=en&term=missing&level=invalid")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Basic" in html
+    assert any(level in html for level in GLOSSARY_LEVELS)
+    assert "No glossary term selected" not in html
+
+
+def test_dashboard_links_to_standalone_glossary(client, sample_analysis):
+    update_state(analysis=sample_analysis)
+
+    resp = client.get("/?lang=en")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'href="/glossary?lang=en"' in html
+    assert "Glossary" in html


### PR DESCRIPTION
## Summary

- add a canonical in-app glossary catalog with stable term IDs, categories, aliases, related terms, protected technical terms, and four explanation levels
- add a standalone `/glossary` page and dashboard navigation entry
- seed a minimal DOCSIS/cable vertical slice for DOCSIS, shared medium, SC-QAM, OFDM/OFDMA, and capacity vs. speedtest
- add schema, route, and E2E coverage for glossary rendering, level switching, related-term navigation, and mobile overflow

## Verification

- `uv run --with-requirements requirements-test.txt python -m pytest tests/test_glossary_catalog.py tests/web/test_glossary_route.py tests/e2e/test_glossary_page.py -q` → `13 passed`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/test_glossary_catalog.py tests/web tests/test_glossary_i18n.py tests/test_static_contracts.py -q` → `164 passed`
- `uv run --with-requirements requirements-test.txt python -m pytest -q --ignore=tests/e2e` → `2782 passed, 1 skipped, 2 warnings`
- `uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright python -m pytest tests/e2e -q` → `467 passed in 842.55s (0:14:02)`
- `python3 scripts/i18n_check.py --validate` → `All 69 language file(s) are in sync with en.json.`
- `git diff --check` → clean
- independent blocker-only review → PASS
