### PR TITLE
Add glossary search and contextual links

### DIFF
--- a/app/static/css/glossary.css
+++ b/app/static/css/glossary.css
@@ -101,6 +101,19 @@ body > .glossary-popover.above::before {
   border-bottom: 1px solid var(--glass-border);
 }
 
+body > .glossary-popover .glossary-popover-link {
+  display: block;
+  margin-top: 10px;
+  color: var(--amethyst-light);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+body > .glossary-popover .glossary-popover-link:hover,
+body > .glossary-popover .glossary-popover-link:focus-visible {
+  text-decoration: underline;
+}
+
 /* Mobile: full width bottom sheet */
 @media (max-width: 768px) {
   .glossary-hint {
@@ -282,6 +295,73 @@ body > .glossary-popover.above::before {
 
 .glossary-index li + li {
   margin-top: 8px;
+}
+
+.glossary-filter-card {
+  padding-bottom: 18px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.glossary-filter-card label {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.glossary-search {
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  padding: 10px 12px;
+  color: var(--text-primary);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  font: inherit;
+}
+
+.glossary-search:focus-visible,
+.glossary-category-filters button:focus-visible {
+  outline: 2px solid var(--amethyst);
+  outline-offset: 2px;
+}
+
+.glossary-category-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.glossary-category-filters button {
+  min-height: 34px;
+  padding: 6px 10px;
+  color: var(--text-secondary);
+  background: rgba(255,255,255,0.03);
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.glossary-category-filters button.active,
+.glossary-category-filters button:hover {
+  color: var(--text-primary);
+  border-color: var(--amethyst);
+  background: color-mix(in srgb, var(--amethyst) 14%, transparent);
+}
+
+.glossary-result-count,
+.glossary-no-results {
+  margin: 12px 0 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.glossary-no-results {
+  color: var(--amber, #fbbf24);
 }
 
 .glossary-index a {

--- a/app/static/js/glossary-page.js
+++ b/app/static/js/glossary-page.js
@@ -1,0 +1,65 @@
+/* glossary-page.js — Search and category filtering for the standalone glossary */
+
+(function () {
+  'use strict';
+
+  var searchInput = document.getElementById('glossary-search');
+  var categoryButtons = Array.prototype.slice.call(document.querySelectorAll('[data-category-filter]'));
+  var termItems = Array.prototype.slice.call(document.querySelectorAll('[data-glossary-term]'));
+  var categorySections = Array.prototype.slice.call(document.querySelectorAll('[data-category-section]'));
+  var resultCount = document.getElementById('glossary-result-count');
+  var noResults = document.getElementById('glossary-no-results');
+  var activeCategory = 'all';
+
+  if (!searchInput || !termItems.length) return;
+
+  function normalize(value) {
+    return (value || '').toLocaleLowerCase().trim();
+  }
+
+  function updateCategoryButtons() {
+    categoryButtons.forEach(function (button) {
+      var isActive = button.getAttribute('data-category-filter') === activeCategory;
+      button.classList.toggle('active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  function filterTerms() {
+    var query = normalize(searchInput.value);
+    var visibleCount = 0;
+
+    termItems.forEach(function (item) {
+      var matchesCategory = activeCategory === 'all' || item.getAttribute('data-category') === activeCategory;
+      var haystack = normalize(item.getAttribute('data-search'));
+      var matchesSearch = !query || haystack.indexOf(query) !== -1;
+      var isVisible = matchesCategory && matchesSearch;
+      item.hidden = !isVisible;
+      if (isVisible) visibleCount += 1;
+    });
+
+    categorySections.forEach(function (section) {
+      var hasVisibleTerm = !!section.querySelector('[data-glossary-term]:not([hidden])');
+      section.hidden = !hasVisibleTerm;
+    });
+
+    if (resultCount) {
+      resultCount.textContent = visibleCount + (visibleCount === 1 ? ' term shown' : ' terms shown');
+    }
+    if (noResults) {
+      noResults.hidden = visibleCount !== 0;
+    }
+    updateCategoryButtons();
+  }
+
+  categoryButtons.forEach(function (button) {
+    button.addEventListener('click', function () {
+      activeCategory = button.getAttribute('data-category-filter') || 'all';
+      filterTerms();
+      searchInput.focus({ preventScroll: true });
+    });
+  });
+
+  searchInput.addEventListener('input', filterTerms);
+  filterTerms();
+})();

--- a/app/static/js/glossary.js
+++ b/app/static/js/glossary.js
@@ -30,7 +30,18 @@
     var source = hint.querySelector('.glossary-popover');
     if (!source) return;
     var isDashboardMeta = hint.matches('.dashboard-view .insights-meta .hero-meta-item');
-    overlay.textContent = source.textContent;
+    var targetTermId = hint.getAttribute('data-glossary-term-id');
+    var targetLevel = hint.getAttribute('data-glossary-term-level') || 'basic';
+    overlay.textContent = '';
+    overlay.appendChild(document.createTextNode(source.textContent.trim()));
+    if (targetTermId && /^[a-z0-9_]+$/.test(targetTermId) && /^(eli5|basic|advanced|technician)$/.test(targetLevel)) {
+      var link = document.createElement('a');
+      var lang = document.documentElement.getAttribute('lang') || 'en';
+      link.className = 'glossary-popover-link';
+      link.href = '/glossary?lang=' + encodeURIComponent(lang) + '&term=' + encodeURIComponent(targetTermId) + '&level=' + encodeURIComponent(targetLevel);
+      link.textContent = hint.getAttribute('data-glossary-term-label') || 'Open glossary article';
+      overlay.appendChild(link);
+    }
     overlay.style.display = 'block';
     overlay.classList.remove('above');
     overlay.classList.toggle('dashboard-meta-popover', isDashboardMeta);

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v69';
+var CACHE_VERSION = 'v70';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/glossary.html
+++ b/app/templates/glossary.html
@@ -41,13 +41,26 @@
 
     <section class="glossary-layout" aria-label="Glossary terms">
         <aside class="glossary-index" aria-label="Term index">
+            <div class="glossary-filter-card" aria-labelledby="glossary-filter-title">
+                <h2 id="glossary-filter-title">Find a term</h2>
+                <label for="glossary-search">Search by term, alias, category, or ID</label>
+                <input id="glossary-search" class="glossary-search" type="search" autocomplete="off" placeholder="Search DOCSIS, SNR, Speedtest…" aria-describedby="glossary-result-count">
+                <div class="glossary-category-filters" aria-label="Filter by category">
+                    <button type="button" class="active" data-category-filter="all" aria-pressed="true">All</button>
+                    {% for category in categories %}
+                    <button type="button" data-category-filter="{{ category.id }}" aria-pressed="false">{{ category.title }}</button>
+                    {% endfor %}
+                </div>
+                <p id="glossary-result-count" class="glossary-result-count" aria-live="polite">{{ terms|length }} terms shown</p>
+                <p id="glossary-no-results" class="glossary-no-results" hidden>No matching glossary terms. Try a broader word such as DOCSIS, signal, speed, or errors.</p>
+            </div>
             {% for category in categories %}
-            <section class="glossary-index-section">
+            <section class="glossary-index-section" data-category-section="{{ category.id }}">
                 <h2>{{ category.title }}</h2>
                 <p>{{ category.description }}</p>
                 <ul>
                     {% for term in terms if term.category == category.id %}
-                    <li>
+                    <li data-glossary-term data-category="{{ term.category }}" data-search="{{ (term.title ~ ' ' ~ term.id ~ ' ' ~ category.title ~ ' ' ~ (term.aliases|join(' ')))|e }}">
                         <a class="{{ 'active' if selected_term and selected_term.id == term.id else '' }}" href="{{ url_for('glossary_page', lang=lang, level=selected_level, term=term.id) }}" aria-current="{{ 'page' if selected_term and selected_term.id == term.id else 'false' }}">
                             {{ term.title }}
                         </a>
@@ -137,5 +150,6 @@
 <script>
 if (window.lucide) window.lucide.createIcons();
 </script>
+<script src="/static/js/glossary-page.js?v={{ version|urlencode }}" defer></script>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -520,7 +520,9 @@
                             <i data-lucide="radio"></i> {{ s.ds_total }}/{{ s.us_total }} Ch
                         </span>
                         <span class="hero-meta-item glossary-hint" style="cursor:help;"
-                            title="{{ t.get('docsis_basics_label', 'DOCSIS basics') }}">
+                            title="{{ t.get('docsis_basics_label', 'DOCSIS basics') }}"
+                            data-glossary-term-id="docsis" data-glossary-term-level="basic"
+                            data-glossary-term-label="{{ t.get('glossary_page_title', 'Glossary') }}">
                             <i data-lucide="book-open"></i>
                             <span class="hero-meta-label">{{ t.get('docsis_basics_label', 'DOCSIS basics') }}</span>
                             <span class="glossary-popover">{{ t.get('glossary_docsis_basics', 'Cable internet uses DOCSIS, not DSL. DOCSight reads modem, channel, and signal data from supported cable gateways. Signal health, modulation, and SC-QAM capacity estimates are Layer-1/channel diagnostics, not Speedtest/IP throughput or tariff speed. Cable is a shared medium; segment utilization and provider/network conditions can affect real speeds.') }}</span>
@@ -895,7 +897,7 @@
         {% if not has_signal_family_metric_cards %}
         {# Card 1: DS Power (legacy aggregate fallback) #}
         <div class="metric-card glass">
-            <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_ds_power }}</div></span>
+            <span class="glossary-hint" data-glossary-term-id="power_level" data-glossary-term-level="basic" data-glossary-term-label="{{ t.get('glossary_page_title', 'Glossary') }}"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_ds_power }}</div></span>
             <div class="metric-header">
                 <span class="metric-label">{{ t.signal_ds_power }}</span>
                 <div class="metric-icon purple"><i data-lucide="arrow-down"></i></div>
@@ -915,7 +917,7 @@
 
         {# Card 2: US Power (legacy aggregate fallback) #}
         <div class="metric-card glass">
-            <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_us_power }}</div></span>
+            <span class="glossary-hint" data-glossary-term-id="power_level" data-glossary-term-level="basic" data-glossary-term-label="{{ t.get('glossary_page_title', 'Glossary') }}"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_us_power }}</div></span>
             <div class="metric-header">
                 <span class="metric-label">{{ t.signal_us_power }}</span>
                 <div class="metric-icon blue"><i data-lucide="arrow-up"></i></div>
@@ -940,7 +942,7 @@
         {% set snr_min = snr_display.min if snr_display.min is defined and snr_display.min is not none else s.ds_snr_min %}
         {% set snr_max = snr_display.max if snr_display.max is defined and snr_display.max is not none else s.ds_snr_max %}
         <div class="metric-card glass">
-            <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_snr }}</div></span>
+            <span class="glossary-hint" data-glossary-term-id="snr_mer" data-glossary-term-level="basic" data-glossary-term-label="{{ t.get('glossary_page_title', 'Glossary') }}"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_snr }}</div></span>
             <div class="metric-header">
                 <span class="metric-label">{{ snr_label }}</span>
                 <div class="metric-icon green"><i data-lucide="signal"></i></div>
@@ -982,7 +984,7 @@
         {# Card 4: Errors #}
         {% if (s.errors_supported is not defined or s.errors_supported) and s.ds_uncorr_pct is not none %}
         <div class="metric-card glass" id="metric-errors-card">
-            <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_errors }}</div></span>
+            <span class="glossary-hint" data-glossary-term-id="uncorrectable_errors" data-glossary-term-level="basic" data-glossary-term-label="{{ t.get('glossary_page_title', 'Glossary') }}"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_errors }}</div></span>
             <div class="metric-header">
                 <span class="metric-label">{{ t.card_errors }}</span>
                 <div class="metric-icon amber"><i data-lucide="alert-triangle"></i></div>
@@ -1143,7 +1145,7 @@
         <div class="docsis-group">
             <div class="docsis-group-header" role="button" tabindex="0" aria-expanded="false" aria-controls="ds-docsis-group-{{ loop.index }}" onclick="if(!event.target.closest('.glossary-hint')){var open=this.parentElement.classList.toggle('open');this.setAttribute('aria-expanded', open ? 'true' : 'false')}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                 <i data-lucide="chevron-right"></i>
-                DOCSIS {{ group.grouper }} {{ 'OFDM' if group.grouper == '3.1' else 'SC-QAM' }} <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_ofdm if group.grouper == '3.1' else t.glossary_scqam }}</div></span> · {{ group.list|length }} {{ t.channel if group.list|length == 1 else t.channels }}
+                DOCSIS {{ group.grouper }} {{ 'OFDM' if group.grouper == '3.1' else 'SC-QAM' }} <span class="glossary-hint" data-glossary-term-id="{{ 'ofdm' if group.grouper == '3.1' else 'sc_qam' }}" data-glossary-term-level="basic" data-glossary-term-label="{{ t.get('glossary_page_title', 'Glossary') }}"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_ofdm if group.grouper == '3.1' else t.glossary_scqam }}</div></span> · {{ group.list|length }} {{ t.channel if group.list|length == 1 else t.channels }}
             </div>
             <div class="table-scroll-wrapper" id="ds-docsis-group-{{ loop.index }}">
                 <div class="table-scroll">
@@ -1202,7 +1204,7 @@
         <div class="docsis-group">
             <div class="docsis-group-header" role="button" tabindex="0" aria-expanded="false" aria-controls="us-docsis-group-{{ loop.index }}" onclick="if(!event.target.closest('.glossary-hint')){var open=this.parentElement.classList.toggle('open');this.setAttribute('aria-expanded', open ? 'true' : 'false')}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                 <i data-lucide="chevron-right"></i>
-                DOCSIS {{ group.grouper }} {{ 'OFDMA' if group.grouper == '3.1' else 'SC-QAM' }} <span class="glossary-hint"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_ofdm if group.grouper == '3.1' else t.glossary_scqam }}</div></span> · {{ group.list|length }} {{ t.channel if group.list|length == 1 else t.channels }}
+                DOCSIS {{ group.grouper }} {{ 'OFDMA' if group.grouper == '3.1' else 'SC-QAM' }} <span class="glossary-hint" data-glossary-term-id="{{ 'ofdma' if group.grouper == '3.1' else 'sc_qam' }}" data-glossary-term-level="basic" data-glossary-term-label="{{ t.get('glossary_page_title', 'Glossary') }}"><i data-lucide="info"></i><div class="glossary-popover">{{ t.glossary_ofdm if group.grouper == '3.1' else t.glossary_scqam }}</div></span> · {{ group.list|length }} {{ t.channel if group.list|length == 1 else t.channels }}
             </div>
             <div class="table-scroll-wrapper" id="us-docsis-group-{{ loop.index }}">
                 <div class="table-scroll">

--- a/tests/e2e/test_glossary_page.py
+++ b/tests/e2e/test_glossary_page.py
@@ -39,3 +39,30 @@ def test_glossary_mobile_layout_has_no_horizontal_overflow(page, live_server):
     expect(page.locator("#glossary-term-title", has_text="Capacity vs. speedtest")).to_be_visible()
     has_overflow = page.evaluate("document.documentElement.scrollWidth > document.documentElement.clientWidth")
     assert has_overflow is False
+
+
+def test_glossary_search_and_category_filter(page, live_server):
+    page.goto(f"{live_server}/glossary?lang=en&term=docsis&level=basic")
+    page.wait_for_load_state("networkidle")
+
+    search = page.locator("#glossary-search")
+    search.fill("CMTS")
+    expect(page.locator("[data-glossary-term]", has_text="CMTS")).to_be_visible()
+    expect(page.locator("[data-glossary-term][data-search^='Speedtest ']")).to_be_hidden()
+    expect(page.locator("#glossary-result-count")).to_contain_text("1 term shown")
+
+    search.fill("")
+    page.locator("[data-category-filter='signal_quality']").click()
+    expect(page.locator("[data-glossary-term]", has_text="Power level")).to_be_visible()
+    expect(page.locator("[data-glossary-term]", has_text="CMTS")).to_be_hidden()
+    expect(page.locator("[data-category-filter='signal_quality']")).to_have_attribute("aria-pressed", "true")
+
+
+def test_dashboard_contextual_help_links_to_matching_glossary_term(page, live_server):
+    page.goto(f"{live_server}/?lang=en")
+    page.wait_for_load_state("networkidle")
+
+    page.locator(".hero-meta-item.glossary-hint", has_text="DOCSIS basics").click()
+    link = page.locator("#glossary-popover-overlay .glossary-popover-link")
+    expect(link).to_be_visible()
+    expect(link).to_have_attribute("href", re.compile(r"/glossary\?lang=en&term=docsis&level=basic"))

--- a/tests/web/test_glossary_route.py
+++ b/tests/web/test_glossary_route.py
@@ -1,6 +1,8 @@
 """Tests for the standalone glossary route."""
 
-from app.glossary import GLOSSARY_LEVELS
+import re
+
+from app.glossary import GLOSSARY_LEVELS, get_glossary_terms
 from app.web import update_state
 
 
@@ -53,3 +55,53 @@ def test_dashboard_links_to_standalone_glossary(client, sample_analysis):
     html = resp.get_data(as_text=True)
     assert 'href="/glossary?lang=en"' in html
     assert "Glossary" in html
+    assert 'data-glossary-term-id="docsis" data-glossary-term-level="basic"' in html
+
+
+def test_glossary_route_exposes_search_and_category_filter_metadata(client, sample_analysis):
+    update_state(analysis=sample_analysis)
+
+    resp = client.get("/glossary?lang=en&term=docsis")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'id="glossary-search"' in html
+    assert 'data-category-filter="signal_quality"' in html
+    assert 'data-glossary-term data-category="capacity_throughput"' in html
+    assert 'data-search="CMTS cmts Cable/DOCSIS basics' in html
+    assert '/static/js/glossary-page.js?v=' in html
+
+
+def test_contextual_glossary_links_target_existing_terms(client, sample_analysis):
+    docsis31_analysis = {
+        **sample_analysis,
+        "ds_channels": [
+            *sample_analysis["ds_channels"],
+            {**sample_analysis["ds_channels"][0], "channel_id": 32, "docsis_version": "3.1", "modulation": "OFDM"},
+        ],
+        "us_channels": [
+            *sample_analysis["us_channels"],
+            {
+                **sample_analysis["us_channels"][0],
+                "channel_id": 5,
+                "docsis_version": "3.1",
+                "multiplex": "OFDMA",
+                "modulation": "OFDMA",
+            },
+        ],
+    }
+    update_state(analysis=docsis31_analysis)
+    valid_terms = {term["id"] for term in get_glossary_terms("en")}
+
+    resp = client.get("/?lang=en")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    ids = re.findall(r'data-glossary-term-id="([^"]+)"', html)
+    assert ids
+    targeted_terms = set()
+    for term in ids:
+        assert term in valid_terms
+        targeted_terms.add(term)
+
+    assert {"docsis", "power_level", "snr_mer", "uncorrectable_errors", "ofdm", "ofdma", "sc_qam"}.issubset(targeted_terms)


### PR DESCRIPTION
## Summary

- add search and category filters to the standalone in-app glossary
- add contextual glossary links from dashboard and channel help into matching glossary terms
- add browser and route coverage for search, filtering, contextual links, and mobile layout

## Tests

- `uv run --with-requirements requirements-test.txt python -m pytest tests/web/test_glossary_route.py tests/test_static_contracts.py -q`
- `uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright python -m pytest tests/e2e/test_glossary_page.py -q`
- `uv run --with-requirements requirements-test.txt python -m pytest -q --ignore=tests/e2e`
- `uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright python -m pytest tests/e2e -q`
- `python3 scripts/i18n_check.py --validate`
- `git diff --check`
