### PR TITLE
Make glossary popover links keyboard reachable

### DIFF
--- a/app/static/js/glossary.js
+++ b/app/static/js/glossary.js
@@ -114,13 +114,17 @@
         e.preventDefault();
         e.stopImmediatePropagation();
         hint.click();
+        var link = overlay.querySelector('.glossary-popover-link');
+        if (link && hint === activeHint) {
+          link.focus();
+        }
       }
     }
   }, true);
 
   document.addEventListener('click', function (e) {
-    // Ignore clicks on the overlay itself
-    if (e.target === overlay) return;
+    // Keep overlay interactions alive so keyboard and pointer users can activate popover links.
+    if (overlay.contains(e.target)) return;
 
     var hint = e.target.closest('.glossary-hint');
     if (hint) {
@@ -155,8 +159,16 @@
   });
 
   document.addEventListener('focusout', function (e) {
-    var hint = e.target.closest('.glossary-hint');
-    if (hint && hint === activeHint) closeAll();
+    if (!activeHint) return;
+    var leavingHint = e.target.closest('.glossary-hint') === activeHint;
+    var leavingOverlay = overlay.contains(e.target);
+    if (!leavingHint && !leavingOverlay) return;
+    window.setTimeout(function () {
+      var focused = document.activeElement;
+      if (activeHint && !activeHint.contains(focused) && !overlay.contains(focused)) {
+        closeAll();
+      }
+    }, 0);
   });
 
   document.addEventListener('keydown', function (e) {

--- a/tests/e2e/test_glossary_page.py
+++ b/tests/e2e/test_glossary_page.py
@@ -66,3 +66,20 @@ def test_dashboard_contextual_help_links_to_matching_glossary_term(page, live_se
     link = page.locator("#glossary-popover-overlay .glossary-popover-link")
     expect(link).to_be_visible()
     expect(link).to_have_attribute("href", re.compile(r"/glossary\?lang=en&term=docsis&level=basic"))
+
+
+def test_dashboard_contextual_glossary_link_is_keyboard_reachable(page, live_server):
+    page.goto(f"{live_server}/?lang=en")
+    page.wait_for_load_state("networkidle")
+
+    hint = page.locator(".hero-meta-item.glossary-hint", has_text="DOCSIS basics")
+    hint.focus()
+    page.keyboard.press("Enter")
+
+    link = page.locator("#glossary-popover-overlay .glossary-popover-link")
+    expect(link).to_be_visible()
+    expect(link).to_be_focused()
+
+    page.keyboard.press("Enter")
+    expect(page).to_have_url(re.compile(r"/glossary\?lang=en&term=docsis&level=basic"))
+    expect(page.locator("#glossary-term-title", has_text="DOCSIS")).to_be_visible()


### PR DESCRIPTION
## Summary

- keep contextual glossary popovers open while focus moves between the help chip and shared overlay
- focus the popover article link after keyboard activation so glossary links are reachable without a mouse
- add an E2E regression for keyboard navigation from the dashboard help chip into the glossary article

## Tests

- `node --check app/static/js/glossary.js`
- `uv run --with-requirements requirements-test.txt --with playwright --with pytest-playwright python -m pytest tests/e2e/test_glossary_page.py -q`
- `uv run --with-requirements requirements-test.txt python -m pytest tests/web/test_glossary_route.py tests/test_static_contracts.py -q`
- `uv run --with-requirements requirements-test.txt python -m pytest -q --ignore=tests/e2e`
- `python3 scripts/i18n_check.py --validate`
