### PR TITLE
Simplify glossary usability

### DIFF
--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Диапазон на латентността",
   "speed_contract_good_label": "≥ 80% от договора",
   "glossary_page_title": "Речник",
-  "glossary_page_intro": "Канонични DOCSIS и кабелни термини с нива на обяснение от начинаещ до техник.",
+  "glossary_page_intro": "Търсете кабелни и DOCSIS термини, после прочетете кратко резюме и обяснението.",
   "glossary_level_selector": "Ниво на обяснение",
   "glossary_knowledge_eyebrow": "База знания на DOCSight",
   "glossary_filter_title": "Намери термин",
-  "glossary_search_label": "Търсене по термин, псевдоним, категория или ID",
+  "glossary_search_label": "Търсене на термини",
   "glossary_search_placeholder": "Търсене DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Филтър по категория",
   "glossary_all_categories": "Всички",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Технически контекст без предположения само от оператора",
   "glossary_level_technician": "Техник",
   "glossary_level_technician_desc": "Точни граници на DOCSIS и диагностиката",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Кратко обяснение",
+  "glossary_explanation_heading": "Обяснение",
+  "glossary_change_term": "Търсене или смяна на термин",
+  "glossary_selected_term": "Избран термин",
+  "glossary_alphabetical_terms": "Азбучно",
+  "glossary_close_picker": "Затваряне на избора на термин",
+  "glossary_not_confuse_heading": "Не бъркайте",
+  "glossary_aliases_heading": "Търси се и като"
 }

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Rozsah latence",
   "speed_contract_good_label": "≥ 80 % smlouvy",
   "glossary_page_title": "Glosář",
-  "glossary_page_intro": "Kanonické pojmy DOCSIS a kabelu s úrovněmi vysvětlení od začátečníka po technika.",
+  "glossary_page_intro": "Vyhledejte kabelové a DOCSIS pojmy a přečtěte si krátké shrnutí i vlastní vysvětlení.",
   "glossary_level_selector": "Úroveň vysvětlení",
   "glossary_knowledge_eyebrow": "Znalostní báze DOCSight",
   "glossary_filter_title": "Najít pojem",
-  "glossary_search_label": "Hledat podle pojmu, aliasu, kategorie nebo ID",
+  "glossary_search_label": "Hledat pojmy",
   "glossary_search_placeholder": "Hledat DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrovat podle kategorie",
   "glossary_all_categories": "Vše",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Technický kontext bez předpokladů jen na straně operátora",
   "glossary_level_technician": "Technik",
   "glossary_level_technician_desc": "Přesné hranice DOCSIS a diagnostiky",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Krátce vysvětleno",
+  "glossary_explanation_heading": "Vysvětlení",
+  "glossary_change_term": "Hledat nebo změnit pojem",
+  "glossary_selected_term": "Vybraný pojem",
+  "glossary_alphabetical_terms": "Abecedně",
+  "glossary_close_picker": "Zavřít výběr pojmu",
+  "glossary_not_confuse_heading": "Nezaměňovat",
+  "glossary_aliases_heading": "Hledáno také jako"
 }

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Forsinkelsesinterval",
   "speed_contract_good_label": "≥ 80 % af kontrakten",
   "glossary_page_title": "Ordliste",
-  "glossary_page_intro": "Kanoniske DOCSIS- og kabelbegreber med forklaringsniveauer fra begynder til tekniker.",
+  "glossary_page_intro": "Søg efter kabel- og DOCSIS-begreber, og læs derefter en kort opsummering og forklaringen.",
   "glossary_level_selector": "Forklaringsniveau",
   "glossary_knowledge_eyebrow": "DOCSight-vidensbase",
   "glossary_filter_title": "Find et begreb",
-  "glossary_search_label": "Søg efter begreb, alias, kategori eller ID",
+  "glossary_search_label": "Søg efter begreber",
   "glossary_search_placeholder": "Søg DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrer efter kategori",
   "glossary_all_categories": "Alle",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Teknisk kontekst uden rene udbyderantagelser",
   "glossary_level_technician": "Tekniker",
   "glossary_level_technician_desc": "Præcise DOCSIS- og diagnosegrænser",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Kort forklaret",
+  "glossary_explanation_heading": "Forklaring",
+  "glossary_change_term": "Søg eller skift begreb",
+  "glossary_selected_term": "Valgt begreb",
+  "glossary_alphabetical_terms": "Alfabetisk",
+  "glossary_close_picker": "Luk begrebsvælger",
+  "glossary_not_confuse_heading": "Må ikke forveksles",
+  "glossary_aliases_heading": "Søges også som"
 }

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Latenzbereich",
   "speed_contract_good_label": "≥ 80 % des Vertrags",
   "glossary_page_title": "Glossar",
-  "glossary_page_intro": "Kanonische DOCSIS- und Kabelbegriffe mit Erklärungsebenen vom Einsteiger bis zum Techniker.",
+  "glossary_page_intro": "Kabel- und DOCSIS-Begriffe suchen, dann eine kurze Zusammenfassung und die eigentliche Erklärung lesen.",
   "glossary_level_selector": "Erklärungstiefe",
   "glossary_knowledge_eyebrow": "DOCSight-Wissensbasis",
   "glossary_filter_title": "Begriff finden",
-  "glossary_search_label": "Nach Begriff, Alias, Kategorie oder ID suchen",
+  "glossary_search_label": "Begriffe suchen",
   "glossary_search_placeholder": "DOCSIS, SNR, Speedtest suchen…",
   "glossary_category_filter_label": "Nach Kategorie filtern",
   "glossary_all_categories": "Alle",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced": "Fortgeschritten",
   "glossary_level_advanced_desc": "Technischer Kontext ohne reine Provider-Annahmen",
   "glossary_level_technician": "Techniker",
-  "glossary_level_technician_desc": "Präzise DOCSIS- und Diagnosegrenzen"
+  "glossary_level_technician_desc": "Präzise DOCSIS- und Diagnosegrenzen",
+  "glossary_summary_heading": "Kurz erklärt",
+  "glossary_explanation_heading": "Erklärung",
+  "glossary_change_term": "Begriff suchen oder wechseln",
+  "glossary_selected_term": "Ausgewählter Begriff",
+  "glossary_alphabetical_terms": "Alphabetisch",
+  "glossary_close_picker": "Begriffsauswahl schließen",
+  "glossary_not_confuse_heading": "Nicht verwechseln",
+  "glossary_aliases_heading": "Auch gesucht als"
 }

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Εύρος καθυστέρησης",
   "speed_contract_good_label": "≥ 80% του συμβολαίου",
   "glossary_page_title": "Γλωσσάρι",
-  "glossary_page_intro": "Κανονικοί όροι DOCSIS και καλωδίου με επίπεδα εξήγησης από αρχάριο έως τεχνικό.",
+  "glossary_page_intro": "Αναζητήστε όρους καλωδίου και DOCSIS και διαβάστε μια σύντομη σύνοψη και την εξήγηση.",
   "glossary_level_selector": "Επίπεδο εξήγησης",
   "glossary_knowledge_eyebrow": "Βάση γνώσης DOCSight",
   "glossary_filter_title": "Βρείτε όρο",
-  "glossary_search_label": "Αναζήτηση ανά όρο, ψευδώνυμο, κατηγορία ή ID",
+  "glossary_search_label": "Αναζήτηση όρων",
   "glossary_search_placeholder": "Αναζήτηση DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Φιλτράρισμα ανά κατηγορία",
   "glossary_all_categories": "Όλα",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Τεχνικό πλαίσιο χωρίς υποθέσεις μόνο του παρόχου",
   "glossary_level_technician": "Τεχνικός",
   "glossary_level_technician_desc": "Ακριβή όρια DOCSIS και διαγνωστικών",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Σύντομη σύνοψη",
+  "glossary_explanation_heading": "Εξήγηση",
+  "glossary_change_term": "Αναζήτηση ή αλλαγή όρου",
+  "glossary_selected_term": "Επιλεγμένος όρος",
+  "glossary_alphabetical_terms": "Αλφαβητικά",
+  "glossary_close_picker": "Κλείσιμο επιλογέα όρων",
+  "glossary_not_confuse_heading": "Να μη συγχέεται",
+  "glossary_aliases_heading": "Αναζητείται και ως"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Latency range",
   "speed_contract_good_label": "≥ 80% of contract",
   "glossary_page_title": "Glossary",
-  "glossary_page_intro": "Canonical DOCSIS and cable terms with explanation levels from beginner-friendly to technician detail.",
+  "glossary_page_intro": "Search cable and DOCSIS terms, then read a short summary and the actual explanation.",
   "glossary_level_selector": "Explanation level",
   "glossary_knowledge_eyebrow": "DOCSight knowledge base",
   "glossary_filter_title": "Find a term",
-  "glossary_search_label": "Search by term, alias, category, or ID",
+  "glossary_search_label": "Search terms",
   "glossary_search_placeholder": "Search DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filter by category",
   "glossary_all_categories": "All",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced": "Advanced",
   "glossary_level_advanced_desc": "Technical context without provider-only assumptions",
   "glossary_level_technician": "Technician",
-  "glossary_level_technician_desc": "Precise DOCSIS and diagnostics boundaries"
+  "glossary_level_technician_desc": "Precise DOCSIS and diagnostics boundaries",
+  "glossary_summary_heading": "Quick summary",
+  "glossary_explanation_heading": "Explanation",
+  "glossary_change_term": "Search or change term",
+  "glossary_selected_term": "Selected term",
+  "glossary_alphabetical_terms": "Alphabetical",
+  "glossary_close_picker": "Close term picker",
+  "glossary_not_confuse_heading": "Do not confuse",
+  "glossary_aliases_heading": "Also searched as"
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1076,11 +1076,11 @@
   "cm_latency_range": "Rango de latencia",
   "speed_contract_good_label": "≥ 80 % del contrato",
   "glossary_page_title": "Glosario",
-  "glossary_page_intro": "Términos canónicos de DOCSIS y cable con niveles de explicación desde principiantes hasta técnicos.",
+  "glossary_page_intro": "Busca términos de cable y DOCSIS y lee una breve síntesis y la explicación.",
   "glossary_level_selector": "Nivel de explicación",
   "glossary_knowledge_eyebrow": "Base de conocimiento de DOCSight",
   "glossary_filter_title": "Buscar un término",
-  "glossary_search_label": "Buscar por término, alias, categoría o ID",
+  "glossary_search_label": "Buscar términos",
   "glossary_search_placeholder": "Buscar DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrar por categoría",
   "glossary_all_categories": "Todos",
@@ -1099,5 +1099,13 @@
   "glossary_level_advanced": "Avanzado",
   "glossary_level_advanced_desc": "Contexto técnico sin asumir datos del operador",
   "glossary_level_technician": "Técnico",
-  "glossary_level_technician_desc": "Límites precisos de DOCSIS y diagnóstico"
+  "glossary_level_technician_desc": "Límites precisos de DOCSIS y diagnóstico",
+  "glossary_summary_heading": "Resumen breve",
+  "glossary_explanation_heading": "Explicación",
+  "glossary_change_term": "Buscar o cambiar término",
+  "glossary_selected_term": "Término seleccionado",
+  "glossary_alphabetical_terms": "Alfabético",
+  "glossary_close_picker": "Cerrar selector de términos",
+  "glossary_not_confuse_heading": "No confundir",
+  "glossary_aliases_heading": "También buscado como"
 }

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Latentsuse vahemik",
   "speed_contract_good_label": "≥ 80% lepingust",
   "glossary_page_title": "Sõnastik",
-  "glossary_page_intro": "Kanoonilised DOCSIS-i ja kaabli terminid koos selgitustasemetega algajast tehnikuni.",
+  "glossary_page_intro": "Otsi kaabli ja DOCSIS termineid ning loe lühikokkuvõtet ja selgitust.",
   "glossary_level_selector": "Selgituse tase",
   "glossary_knowledge_eyebrow": "DOCSighti teadmistebaas",
   "glossary_filter_title": "Leia termin",
-  "glossary_search_label": "Otsi termini, aliase, kategooria või ID järgi",
+  "glossary_search_label": "Otsi termineid",
   "glossary_search_placeholder": "Otsi DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtreeri kategooria järgi",
   "glossary_all_categories": "Kõik",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Tehniline kontekst ilma ainult teenusepakkuja eeldusteta",
   "glossary_level_technician": "Tehnik",
   "glossary_level_technician_desc": "Täpsed DOCSIS-i ja diagnostika piirid",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Lühidalt",
+  "glossary_explanation_heading": "Selgitus",
+  "glossary_change_term": "Otsi või vaheta terminit",
+  "glossary_selected_term": "Valitud termin",
+  "glossary_alphabetical_terms": "Tähestikuliselt",
+  "glossary_close_picker": "Sulge terminivalik",
+  "glossary_not_confuse_heading": "Ära aja segi",
+  "glossary_aliases_heading": "Otsitakse ka kui"
 }

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Viivealue",
   "speed_contract_good_label": "≥ 80 % sopimuksesta",
   "glossary_page_title": "Sanasto",
-  "glossary_page_intro": "Kanoniset DOCSIS- ja kaapeliter termit selitystasoilla aloittelijasta teknikolle.",
+  "glossary_page_intro": "Hae kaapeli- ja DOCSIS-termejä ja lue lyhyt yhteenveto sekä varsinainen selitys.",
   "glossary_level_selector": "Selitystaso",
   "glossary_knowledge_eyebrow": "DOCSight-tietopohja",
   "glossary_filter_title": "Etsi termi",
-  "glossary_search_label": "Hae termillä, aliaksella, kategorialla tai ID:llä",
+  "glossary_search_label": "Hae termejä",
   "glossary_search_placeholder": "Hae DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Suodata kategorian mukaan",
   "glossary_all_categories": "Kaikki",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Tekninen konteksti ilman vain operaattoriin liittyviä oletuksia",
   "glossary_level_technician": "Teknikko",
   "glossary_level_technician_desc": "Tarkat DOCSIS- ja diagnostiikkarajat",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Lyhyesti",
+  "glossary_explanation_heading": "Selitys",
+  "glossary_change_term": "Hae tai vaihda termi",
+  "glossary_selected_term": "Valittu termi",
+  "glossary_alphabetical_terms": "Aakkosjärjestys",
+  "glossary_close_picker": "Sulje termivalitsin",
+  "glossary_not_confuse_heading": "Älä sekoita",
+  "glossary_aliases_heading": "Haetaan myös nimellä"
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -1073,11 +1073,11 @@
   "cm_latency_range": "Plage de latence",
   "speed_contract_good_label": "≥ 80 % du contrat",
   "glossary_page_title": "Glossaire",
-  "glossary_page_intro": "Termes DOCSIS et câble de référence, avec des niveaux d’explication du débutant au technicien.",
+  "glossary_page_intro": "Recherchez des termes câble et DOCSIS, puis lisez un court résumé et l’explication.",
   "glossary_level_selector": "Niveau d’explication",
   "glossary_knowledge_eyebrow": "Base de connaissances DOCSight",
   "glossary_filter_title": "Trouver un terme",
-  "glossary_search_label": "Rechercher par terme, alias, catégorie ou ID",
+  "glossary_search_label": "Rechercher des termes",
   "glossary_search_placeholder": "Rechercher DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrer par catégorie",
   "glossary_all_categories": "Tous",
@@ -1096,5 +1096,13 @@
   "glossary_level_advanced": "Avancé",
   "glossary_level_advanced_desc": "Contexte technique sans suppositions côté opérateur",
   "glossary_level_technician": "Technicien",
-  "glossary_level_technician_desc": "Limites DOCSIS et diagnostic précises"
+  "glossary_level_technician_desc": "Limites DOCSIS et diagnostic précises",
+  "glossary_summary_heading": "Résumé rapide",
+  "glossary_explanation_heading": "Explication",
+  "glossary_change_term": "Rechercher ou changer de terme",
+  "glossary_selected_term": "Terme sélectionné",
+  "glossary_alphabetical_terms": "Alphabétique",
+  "glossary_close_picker": "Fermer le sélecteur de termes",
+  "glossary_not_confuse_heading": "Ne pas confondre",
+  "glossary_aliases_heading": "Aussi recherché comme"
 }

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Raon moille",
   "speed_contract_good_label": "≥ 80% den chonradh",
   "glossary_page_title": "Gluais",
-  "glossary_page_intro": "Téarmaí canónacha DOCSIS agus cábla le leibhéil mhínithe ó thosaitheoir go teicneoir.",
+  "glossary_page_intro": "Cuardaigh téarmaí cábla agus DOCSIS, ansin léigh achoimre ghearr agus an míniú.",
   "glossary_level_selector": "Leibhéal míniúcháin",
   "glossary_knowledge_eyebrow": "Bunachar eolais DOCSight",
   "glossary_filter_title": "Aimsigh téarma",
-  "glossary_search_label": "Cuardaigh de réir téarma, ailias, catagóire nó ID",
+  "glossary_search_label": "Cuardaigh téarmaí",
   "glossary_search_placeholder": "Cuardaigh DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Scag de réir catagóire",
   "glossary_all_categories": "Gach ceann",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Comhthéacs teicniúil gan toimhdí soláthraí amháin",
   "glossary_level_technician": "Teicneoir",
   "glossary_level_technician_desc": "Teorainneacha beachta DOCSIS agus diagnóisice",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Achoimre ghearr",
+  "glossary_explanation_heading": "Míniú",
+  "glossary_change_term": "Cuardaigh nó athraigh téarma",
+  "glossary_selected_term": "Téarma roghnaithe",
+  "glossary_alphabetical_terms": "In ord aibítre",
+  "glossary_close_picker": "Dún roghnóir téarmaí",
+  "glossary_not_confuse_heading": "Ná measctar le",
+  "glossary_aliases_heading": "Cuardaítear freisin mar"
 }

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Raspon latencije",
   "speed_contract_good_label": "≥ 80 % ugovora",
   "glossary_page_title": "Pojmovnik",
-  "glossary_page_intro": "Kanoniski DOCSIS i kabelski pojmovi s razinama objašnjenja od početnika do tehničara.",
+  "glossary_page_intro": "Pretražite kabelske i DOCSIS pojmove, zatim pročitajte kratak sažetak i objašnjenje.",
   "glossary_level_selector": "Razina objašnjenja",
   "glossary_knowledge_eyebrow": "Baza znanja DOCSight",
   "glossary_filter_title": "Pronađi pojam",
-  "glossary_search_label": "Traži po pojmu, aliasu, kategoriji ili ID-u",
+  "glossary_search_label": "Pretraži pojmove",
   "glossary_search_placeholder": "Traži DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtriraj po kategoriji",
   "glossary_all_categories": "Sve",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Tehnički kontekst bez pretpostavki samo o operateru",
   "glossary_level_technician": "Tehničar",
   "glossary_level_technician_desc": "Precizne granice DOCSIS-a i dijagnostike",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Kratko objašnjenje",
+  "glossary_explanation_heading": "Objašnjenje",
+  "glossary_change_term": "Pretraži ili promijeni pojam",
+  "glossary_selected_term": "Odabrani pojam",
+  "glossary_alphabetical_terms": "Abecedno",
+  "glossary_close_picker": "Zatvori odabir pojma",
+  "glossary_not_confuse_heading": "Ne miješati s",
+  "glossary_aliases_heading": "Traži se i kao"
 }

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Késleltetési tartomány",
   "speed_contract_good_label": "≥ 80% a szerződésből",
   "glossary_page_title": "Fogalomtár",
-  "glossary_page_intro": "Kanonikus DOCSIS- és kábelkifejezések magyarázati szintekkel kezdőtől technikusig.",
+  "glossary_page_intro": "Keressen kábeles és DOCSIS fogalmakat, majd olvassa el a rövid összefoglalót és a magyarázatot.",
   "glossary_level_selector": "Magyarázati szint",
   "glossary_knowledge_eyebrow": "DOCSight tudásbázis",
   "glossary_filter_title": "Kifejezés keresése",
-  "glossary_search_label": "Keresés kifejezés, alias, kategória vagy ID alapján",
+  "glossary_search_label": "Fogalmak keresése",
   "glossary_search_placeholder": "Keresés DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Szűrés kategória szerint",
   "glossary_all_categories": "Mind",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Technikai kontextus szolgáltatói feltételezések nélkül",
   "glossary_level_technician": "Technikus",
   "glossary_level_technician_desc": "Pontos DOCSIS- és diagnosztikai határok",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Röviden",
+  "glossary_explanation_heading": "Magyarázat",
+  "glossary_change_term": "Fogalom keresése vagy váltása",
+  "glossary_selected_term": "Kiválasztott fogalom",
+  "glossary_alphabetical_terms": "Ábécé szerint",
+  "glossary_close_picker": "Fogalomválasztó bezárása",
+  "glossary_not_confuse_heading": "Nem összetévesztendő",
+  "glossary_aliases_heading": "Így is keresik"
 }

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Intervallo di latenza",
   "speed_contract_good_label": "≥ 80% del contratto",
   "glossary_page_title": "Glossario",
-  "glossary_page_intro": "Termini canonici DOCSIS e via cavo con livelli di spiegazione da principiante a tecnico.",
+  "glossary_page_intro": "Cerca termini cavo e DOCSIS, poi leggi un breve riepilogo e la spiegazione.",
   "glossary_level_selector": "Livello di spiegazione",
   "glossary_knowledge_eyebrow": "Base di conoscenza DOCSight",
   "glossary_filter_title": "Trova un termine",
-  "glossary_search_label": "Cerca per termine, alias, categoria o ID",
+  "glossary_search_label": "Cerca termini",
   "glossary_search_placeholder": "Cerca DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtra per categoria",
   "glossary_all_categories": "Tutti",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Contesto tecnico senza ipotesi solo lato operatore",
   "glossary_level_technician": "Tecnico",
   "glossary_level_technician_desc": "Confini precisi DOCSIS e diagnostici",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "In breve",
+  "glossary_explanation_heading": "Spiegazione",
+  "glossary_change_term": "Cerca o cambia termine",
+  "glossary_selected_term": "Termine selezionato",
+  "glossary_alphabetical_terms": "Alfabetico",
+  "glossary_close_picker": "Chiudi selettore dei termini",
+  "glossary_not_confuse_heading": "Non confondere",
+  "glossary_aliases_heading": "Cercato anche come"
 }

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Delsos intervalas",
   "speed_contract_good_label": "≥ 80 % sutarties",
   "glossary_page_title": "Žodynas",
-  "glossary_page_intro": "Kanoniniai DOCSIS ir kabelio terminai su paaiškinimo lygiais nuo pradedančiojo iki techniko.",
+  "glossary_page_intro": "Ieškokite kabelio ir DOCSIS terminų, tada skaitykite trumpą santrauką ir paaiškinimą.",
   "glossary_level_selector": "Paaiškinimo lygis",
   "glossary_knowledge_eyebrow": "DOCSight žinių bazė",
   "glossary_filter_title": "Rasti terminą",
-  "glossary_search_label": "Ieškoti pagal terminą, aliasą, kategoriją arba ID",
+  "glossary_search_label": "Ieškoti terminų",
   "glossary_search_placeholder": "Ieškoti DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtruoti pagal kategoriją",
   "glossary_all_categories": "Visi",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Techninis kontekstas be vien tiekėjo prielaidų",
   "glossary_level_technician": "Technikas",
   "glossary_level_technician_desc": "Tikslios DOCSIS ir diagnostikos ribos",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Trumpai",
+  "glossary_explanation_heading": "Paaiškinimas",
+  "glossary_change_term": "Ieškoti arba keisti terminą",
+  "glossary_selected_term": "Pasirinktas terminas",
+  "glossary_alphabetical_terms": "Abėcėlės tvarka",
+  "glossary_close_picker": "Uždaryti terminų parinkiklį",
+  "glossary_not_confuse_heading": "Nepainioti",
+  "glossary_aliases_heading": "Taip pat ieškoma kaip"
 }

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Latences diapazons",
   "speed_contract_good_label": "≥ 80% no līguma",
   "glossary_page_title": "Glosārijs",
-  "glossary_page_intro": "Kanoniski DOCSIS un kabeļa termini ar skaidrojuma līmeņiem no iesācēja līdz tehniķim.",
+  "glossary_page_intro": "Meklējiet kabeļa un DOCSIS terminus, pēc tam lasiet īsu kopsavilkumu un skaidrojumu.",
   "glossary_level_selector": "Skaidrojuma līmenis",
   "glossary_knowledge_eyebrow": "DOCSight zināšanu bāze",
   "glossary_filter_title": "Atrast terminu",
-  "glossary_search_label": "Meklēt pēc termina, aizstājvārda, kategorijas vai ID",
+  "glossary_search_label": "Meklēt terminus",
   "glossary_search_placeholder": "Meklēt DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrēt pēc kategorijas",
   "glossary_all_categories": "Visi",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Tehnisks konteksts bez tikai operatora pieņēmumiem",
   "glossary_level_technician": "Tehniķis",
   "glossary_level_technician_desc": "Precīzas DOCSIS un diagnostikas robežas",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Īsumā",
+  "glossary_explanation_heading": "Skaidrojums",
+  "glossary_change_term": "Meklēt vai mainīt terminu",
+  "glossary_selected_term": "Atlasītais termins",
+  "glossary_alphabetical_terms": "Alfabētiski",
+  "glossary_close_picker": "Aizvērt terminu izvēli",
+  "glossary_not_confuse_heading": "Nejaukt ar",
+  "glossary_aliases_heading": "Meklē arī kā"
 }

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Latensområde",
   "speed_contract_good_label": "≥ 80 % av avtalen",
   "glossary_page_title": "Ordliste",
-  "glossary_page_intro": "Kanoniske DOCSIS- og kabelbegreper med forklaringsnivåer fra nybegynner til tekniker.",
+  "glossary_page_intro": "Søk etter kabel- og DOCSIS-begreper, og les deretter en kort oppsummering og forklaringen.",
   "glossary_level_selector": "Forklaringsnivå",
   "glossary_knowledge_eyebrow": "DOCSight-kunnskapsbase",
   "glossary_filter_title": "Finn et begrep",
-  "glossary_search_label": "Søk etter begrep, alias, kategori eller ID",
+  "glossary_search_label": "Søk etter begreper",
   "glossary_search_placeholder": "Søk DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrer etter kategori",
   "glossary_all_categories": "Alle",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Teknisk kontekst uten rene operatørantakelser",
   "glossary_level_technician": "Tekniker",
   "glossary_level_technician_desc": "Presise DOCSIS- og diagnosegrenser",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Kort forklart",
+  "glossary_explanation_heading": "Forklaring",
+  "glossary_change_term": "Søk eller bytt begrep",
+  "glossary_selected_term": "Valgt begrep",
+  "glossary_alphabetical_terms": "Alfabetisk",
+  "glossary_close_picker": "Lukk begrepsvelger",
+  "glossary_not_confuse_heading": "Ikke forveksle",
+  "glossary_aliases_heading": "Søkes også som"
 }

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Latentiebereik",
   "speed_contract_good_label": "≥ 80% van contract",
   "glossary_page_title": "Woordenlijst",
-  "glossary_page_intro": "Canonieke DOCSIS- en kabelbegrippen met uitleg­niveaus van beginner tot technicus.",
+  "glossary_page_intro": "Zoek kabel- en DOCSIS-termen en lees daarna een korte samenvatting en de uitleg.",
   "glossary_level_selector": "Uitlegniveau",
   "glossary_knowledge_eyebrow": "DOCSight-kennisbank",
   "glossary_filter_title": "Term zoeken",
-  "glossary_search_label": "Zoek op term, alias, categorie of ID",
+  "glossary_search_label": "Termen zoeken",
   "glossary_search_placeholder": "Zoek DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filter op categorie",
   "glossary_all_categories": "Alle",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Technische context zonder alleen provider-aannames",
   "glossary_level_technician": "Technicus",
   "glossary_level_technician_desc": "Precieze DOCSIS- en diagnosegrenzen",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Kort uitgelegd",
+  "glossary_explanation_heading": "Uitleg",
+  "glossary_change_term": "Term zoeken of wijzigen",
+  "glossary_selected_term": "Geselecteerde term",
+  "glossary_alphabetical_terms": "Alfabetisch",
+  "glossary_close_picker": "Termkiezer sluiten",
+  "glossary_not_confuse_heading": "Niet verwarren met",
+  "glossary_aliases_heading": "Ook gezocht als"
 }

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Zakres opóźnienia",
   "speed_contract_good_label": "≥ 80% umowy",
   "glossary_page_title": "Glosariusz",
-  "glossary_page_intro": "Kanononiczne terminy DOCSIS i kablowe z poziomami wyjaśnień od początkującego do technika.",
+  "glossary_page_intro": "Wyszukaj terminy kablowe i DOCSIS, a potem przeczytaj krótkie podsumowanie i wyjaśnienie.",
   "glossary_level_selector": "Poziom wyjaśnienia",
   "glossary_knowledge_eyebrow": "Baza wiedzy DOCSight",
   "glossary_filter_title": "Znajdź termin",
-  "glossary_search_label": "Szukaj według terminu, aliasu, kategorii lub ID",
+  "glossary_search_label": "Szukaj terminów",
   "glossary_search_placeholder": "Szukaj DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtruj według kategorii",
   "glossary_all_categories": "Wszystkie",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Kontekst techniczny bez założeń tylko po stronie operatora",
   "glossary_level_technician": "Technik",
   "glossary_level_technician_desc": "Precyzyjne granice DOCSIS i diagnostyki",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Krótko wyjaśnione",
+  "glossary_explanation_heading": "Wyjaśnienie",
+  "glossary_change_term": "Szukaj lub zmień termin",
+  "glossary_selected_term": "Wybrany termin",
+  "glossary_alphabetical_terms": "Alfabetycznie",
+  "glossary_close_picker": "Zamknij wybór terminu",
+  "glossary_not_confuse_heading": "Nie mylić z",
+  "glossary_aliases_heading": "Wyszukiwane także jako"
 }

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Intervalo de latência",
   "speed_contract_good_label": "≥ 80% do contrato",
   "glossary_page_title": "Glossário",
-  "glossary_page_intro": "Termos canónicos de DOCSIS e cabo com níveis de explicação de iniciante a técnico.",
+  "glossary_page_intro": "Pesquise termos de cabo e DOCSIS e leia um breve resumo e a explicação.",
   "glossary_level_selector": "Nível de explicação",
   "glossary_knowledge_eyebrow": "Base de conhecimento DOCSight",
   "glossary_filter_title": "Encontrar termo",
-  "glossary_search_label": "Pesquisar por termo, alias, categoria ou ID",
+  "glossary_search_label": "Pesquisar termos",
   "glossary_search_placeholder": "Pesquisar DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrar por categoria",
   "glossary_all_categories": "Todos",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Contexto técnico sem pressupostos apenas do operador",
   "glossary_level_technician": "Técnico",
   "glossary_level_technician_desc": "Limites precisos de DOCSIS e diagnóstico",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Resumo rápido",
+  "glossary_explanation_heading": "Explicação",
+  "glossary_change_term": "Pesquisar ou mudar termo",
+  "glossary_selected_term": "Termo selecionado",
+  "glossary_alphabetical_terms": "Alfabético",
+  "glossary_close_picker": "Fechar seletor de termos",
+  "glossary_not_confuse_heading": "Não confundir",
+  "glossary_aliases_heading": "Também pesquisado como"
 }

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Interval de latență",
   "speed_contract_good_label": "≥ 80% din contract",
   "glossary_page_title": "Glosar",
-  "glossary_page_intro": "Termeni canonici DOCSIS și de cablu cu niveluri de explicație de la începător la tehnician.",
+  "glossary_page_intro": "Caută termeni de cablu și DOCSIS, apoi citește un scurt rezumat și explicația.",
   "glossary_level_selector": "Nivel de explicație",
   "glossary_knowledge_eyebrow": "Baza de cunoștințe DOCSight",
   "glossary_filter_title": "Găsește un termen",
-  "glossary_search_label": "Caută după termen, alias, categorie sau ID",
+  "glossary_search_label": "Caută termeni",
   "glossary_search_placeholder": "Caută DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrează după categorie",
   "glossary_all_categories": "Toate",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Context tehnic fără presupuneri doar de operator",
   "glossary_level_technician": "Tehnician",
   "glossary_level_technician_desc": "Limite precise DOCSIS și de diagnostic",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Pe scurt",
+  "glossary_explanation_heading": "Explicație",
+  "glossary_change_term": "Caută sau schimbă termenul",
+  "glossary_selected_term": "Termen selectat",
+  "glossary_alphabetical_terms": "Alfabetic",
+  "glossary_close_picker": "Închide selectorul de termeni",
+  "glossary_not_confuse_heading": "A nu se confunda",
+  "glossary_aliases_heading": "Căutat și ca"
 }

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Rozsah latencie",
   "speed_contract_good_label": "≥ 80 % zmluvy",
   "glossary_page_title": "Glosár",
-  "glossary_page_intro": "Kanonické pojmy DOCSIS a káblovej siete s úrovňami vysvetlenia od začiatočníka po technika.",
+  "glossary_page_intro": "Vyhľadajte káblové a DOCSIS pojmy a prečítajte si krátke zhrnutie aj vysvetlenie.",
   "glossary_level_selector": "Úroveň vysvetlenia",
   "glossary_knowledge_eyebrow": "Znalostná báza DOCSight",
   "glossary_filter_title": "Nájsť pojem",
-  "glossary_search_label": "Hľadať podľa pojmu, aliasu, kategórie alebo ID",
+  "glossary_search_label": "Hľadať pojmy",
   "glossary_search_placeholder": "Hľadať DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrovať podľa kategórie",
   "glossary_all_categories": "Všetky",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Technický kontext bez čisto operátorských predpokladov",
   "glossary_level_technician": "Technik",
   "glossary_level_technician_desc": "Presné hranice DOCSIS a diagnostiky",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Krátke vysvetlenie",
+  "glossary_explanation_heading": "Vysvetlenie",
+  "glossary_change_term": "Hľadať alebo zmeniť pojem",
+  "glossary_selected_term": "Vybraný pojem",
+  "glossary_alphabetical_terms": "Abecedne",
+  "glossary_close_picker": "Zavrieť výber pojmu",
+  "glossary_not_confuse_heading": "Nezamieňať",
+  "glossary_aliases_heading": "Hľadané aj ako"
 }

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Obseg zakasnitve",
   "speed_contract_good_label": "≥ 80 % pogodbe",
   "glossary_page_title": "Slovar",
-  "glossary_page_intro": "Kanončni DOCSIS in kabelski izrazi z ravnmi razlage od začetnika do tehnika.",
+  "glossary_page_intro": "Poiščite kabelske in DOCSIS izraze, nato preberite kratek povzetek in razlago.",
   "glossary_level_selector": "Raven razlage",
   "glossary_knowledge_eyebrow": "Baza znanja DOCSight",
   "glossary_filter_title": "Poišči izraz",
-  "glossary_search_label": "Išči po izrazu, vzdevku, kategoriji ali ID-ju",
+  "glossary_search_label": "Išči izraze",
   "glossary_search_placeholder": "Išči DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtriraj po kategoriji",
   "glossary_all_categories": "Vse",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Tehnični kontekst brez predpostavk samo o operaterju",
   "glossary_level_technician": "Tehnik",
   "glossary_level_technician_desc": "Natančne meje DOCSIS in diagnostike",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Kratko pojasnilo",
+  "glossary_explanation_heading": "Razlaga",
+  "glossary_change_term": "Poišči ali zamenjaj izraz",
+  "glossary_selected_term": "Izbrani izraz",
+  "glossary_alphabetical_terms": "Abecedno",
+  "glossary_close_picker": "Zapri izbiro izraza",
+  "glossary_not_confuse_heading": "Ne zamenjuj",
+  "glossary_aliases_heading": "Išče se tudi kot"
 }

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -1081,11 +1081,11 @@
   "cm_latency_range": "Latensintervall",
   "speed_contract_good_label": "≥ 80 % av avtalet",
   "glossary_page_title": "Ordlista",
-  "glossary_page_intro": "Kanoniska DOCSIS- och kabeltermer med förklaringsnivåer från nybörjare till tekniker.",
+  "glossary_page_intro": "Sök efter kabel- och DOCSIS-termer och läs sedan en kort sammanfattning och förklaringen.",
   "glossary_level_selector": "Förklaringsnivå",
   "glossary_knowledge_eyebrow": "DOCSight-kunskapsbas",
   "glossary_filter_title": "Hitta en term",
-  "glossary_search_label": "Sök efter term, alias, kategori eller ID",
+  "glossary_search_label": "Sök termer",
   "glossary_search_placeholder": "Sök DOCSIS, SNR, Speedtest…",
   "glossary_category_filter_label": "Filtrera efter kategori",
   "glossary_all_categories": "Alla",
@@ -1104,5 +1104,13 @@
   "glossary_level_advanced_desc": "Teknisk kontext utan rena operatörsantaganden",
   "glossary_level_technician": "Tekniker",
   "glossary_level_technician_desc": "Precisa DOCSIS- och diagnostikgränser",
-  "glossary_level_eli5": "ELI5"
+  "glossary_level_eli5": "ELI5",
+  "glossary_summary_heading": "Kort förklarat",
+  "glossary_explanation_heading": "Förklaring",
+  "glossary_change_term": "Sök eller byt term",
+  "glossary_selected_term": "Vald term",
+  "glossary_alphabetical_terms": "Alfabetiskt",
+  "glossary_close_picker": "Stäng termväljaren",
+  "glossary_not_confuse_heading": "Förväxla inte",
+  "glossary_aliases_heading": "Söks även som"
 }

--- a/app/static/css/glossary.css
+++ b/app/static/css/glossary.css
@@ -162,153 +162,96 @@ body > .glossary-popover .glossary-popover-link:focus-visible {
 .glossary-page {
   width: min(1180px, calc(100vw - 32px));
   margin: 0 auto;
-  padding: 32px 0 56px;
+  padding: 28px 0 56px;
 }
 
-.glossary-page-hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
-  gap: 24px;
-  align-items: stretch;
-  margin-bottom: 24px;
-}
-
-.glossary-page-hero,
-.glossary-article,
+.glossary-page-header,
 .glossary-index,
-.glossary-level-card {
+.glossary-article,
+.glossary-card,
+.glossary-mobile-picker-trigger,
+.glossary-mobile-picker-sheet {
   background: var(--surface);
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
 }
 
-.glossary-page-hero {
-  padding: 28px;
+.glossary-page-header {
+  padding: 24px;
+  margin-bottom: 20px;
 }
 
 .glossary-back-link {
+  display: inline-flex;
+  margin-bottom: 12px;
   color: var(--text-secondary);
   text-decoration: none;
   font-size: 0.9rem;
 }
 
 .glossary-back-link:hover,
-.glossary-index a:hover,
-.glossary-related a:hover {
+.glossary-term-link:hover,
+.glossary-chip-link:hover {
   color: var(--amethyst-light);
 }
 
 .glossary-page h1,
 .glossary-page h2,
 .glossary-page h3,
-.glossary-page h4,
-.glossary-page p {
+.glossary-page p,
+.glossary-mobile-picker h2 {
   margin-top: 0;
 }
 
 .glossary-page h1 {
-  margin-bottom: 12px;
-  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin-bottom: 10px;
+  font-size: clamp(2rem, 5vw, 3.2rem);
   letter-spacing: -0.04em;
 }
 
 .glossary-page-intro {
-  max-width: 680px;
+  max-width: 760px;
+  margin-bottom: 0;
   color: var(--text-secondary);
-  font-size: 1.05rem;
-  line-height: 1.6;
-}
-
-.glossary-level-card {
-  padding: 18px;
-}
-
-.glossary-levels {
-  display: grid;
-  gap: 10px;
-}
-
-.glossary-level,
-.glossary-index a,
-.glossary-related a {
-  display: block;
-  text-decoration: none;
-  color: var(--text-primary);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-sm);
-  background: var(--surface-subtle, rgba(255,255,255,0.03));
-}
-
-.glossary-level {
-  padding: 12px;
-}
-
-.glossary-level span,
-.glossary-related span {
-  display: block;
-  font-weight: 700;
-}
-
-.glossary-level small,
-.glossary-related small,
-.glossary-index p,
-.glossary-term-id {
-  color: var(--text-muted);
-}
-
-.glossary-level.active,
-.glossary-index a.active,
-.glossary-level-summary.active {
-  border-color: var(--amethyst);
-  background: color-mix(in srgb, var(--amethyst) 14%, transparent);
+  font-size: 1rem;
+  line-height: 1.55;
 }
 
 .glossary-layout {
   display: grid;
-  grid-template-columns: 300px minmax(0, 1fr);
-  gap: 24px;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
 }
 
 .glossary-index,
 .glossary-article {
-  padding: 24px;
+  min-width: 0;
+  padding: 22px;
 }
 
 .glossary-index {
-  align-self: start;
   position: sticky;
   top: 16px;
+  align-self: start;
+  max-height: calc(100vh - 32px);
+  overflow: hidden;
 }
 
-.glossary-index-section + .glossary-index-section {
-  margin-top: 24px;
-  padding-top: 20px;
-  border-top: 1px solid var(--glass-border);
+.glossary-index h2,
+.glossary-mobile-picker h2 {
+  margin-bottom: 16px;
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
 }
 
-.glossary-index ul {
-  list-style: none;
-  padding: 0;
-  margin: 12px 0 0;
-}
-
-.glossary-index li + li {
-  margin-top: 8px;
-}
-
-.glossary-filter-card {
-  padding-bottom: 18px;
-  margin-bottom: 20px;
-  border-bottom: 1px solid var(--glass-border);
-}
-
-.glossary-filter-card label {
+.glossary-search-block label {
   display: block;
   margin-bottom: 8px;
   color: var(--text-secondary);
-  font-weight: 700;
   font-size: 0.9rem;
+  font-weight: 700;
 }
 
 .glossary-search {
@@ -324,37 +267,17 @@ body > .glossary-popover .glossary-popover-link:focus-visible {
 }
 
 .glossary-search:focus-visible,
-.glossary-category-filters button:focus-visible {
+.glossary-term-link:focus-visible,
+.glossary-mobile-picker-trigger:focus-visible,
+.glossary-mobile-picker-close:focus-visible,
+.glossary-chip-link:focus-visible {
   outline: 2px solid var(--amethyst);
   outline-offset: 2px;
 }
 
-.glossary-category-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 12px;
-}
-
-.glossary-category-filters button {
-  min-height: 34px;
-  padding: 6px 10px;
-  color: var(--text-secondary);
-  background: rgba(255,255,255,0.03);
-  border: 1px solid var(--glass-border);
-  border-radius: 999px;
-  cursor: pointer;
-}
-
-.glossary-category-filters button.active,
-.glossary-category-filters button:hover {
-  color: var(--text-primary);
-  border-color: var(--amethyst);
-  background: color-mix(in srgb, var(--amethyst) 14%, transparent);
-}
-
 .glossary-result-count,
-.glossary-no-results {
+.glossary-no-results,
+.glossary-list-label {
   margin: 12px 0 0;
   color: var(--text-muted);
   font-size: 0.85rem;
@@ -364,41 +287,116 @@ body > .glossary-popover .glossary-popover-link:focus-visible {
   color: var(--amber, #fbbf24);
 }
 
-.glossary-index a {
-  padding: 10px 12px;
+.glossary-list-label {
+  margin-top: 18px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  font-weight: 800;
 }
 
-.glossary-term-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  align-items: flex-start;
-  margin-bottom: 16px;
+.glossary-term-list {
+  display: grid;
+  gap: 8px;
+  max-height: calc(100vh - 250px);
+  margin-top: 10px;
+  overflow: auto;
+  padding-right: 4px;
 }
 
-.glossary-term-header h2 {
-  font-size: clamp(1.8rem, 4vw, 2.8rem);
-  letter-spacing: -0.03em;
+.glossary-term-link {
+  display: block;
+  min-height: 44px;
+  padding: 11px 12px;
+  color: var(--text-primary);
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
-.glossary-term-id {
-  padding: 6px 10px;
-  border: 1px solid var(--glass-border);
-  border-radius: 999px;
-  font-family: var(--font-mono, monospace);
-  font-size: 0.8rem;
+.glossary-term-link[hidden] {
+  display: none !important;
+}
+
+.glossary-term-link.active {
+  border-color: var(--amethyst);
+  background: color-mix(in srgb, var(--amethyst) 14%, transparent);
+}
+
+.glossary-article {
+  display: grid;
+  gap: 18px;
+}
+
+.glossary-card {
+  min-width: 0;
+  padding: 22px;
+  overflow: hidden;
+}
+
+.glossary-term-header-card h2 {
+  margin-bottom: 12px;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  overflow-wrap: anywhere;
+}
+
+.glossary-term-header-card p:last-child,
+.glossary-summary-card p,
+.glossary-explanation-card p,
+.glossary-callout li {
+  margin-bottom: 0;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.glossary-summary-card {
+  border-color: color-mix(in srgb, var(--success, #10b981) 35%, var(--glass-border));
+  background: color-mix(in srgb, var(--success, #10b981) 10%, var(--surface));
+}
+
+.glossary-summary-card h3 {
+  color: var(--success, #10b981);
+}
+
+.glossary-explanation-card p {
+  color: var(--text-primary);
+}
+
+.glossary-callout {
+  border-color: color-mix(in srgb, var(--amber, #fbbf24) 40%, var(--glass-border));
+  background: color-mix(in srgb, var(--amber, #fbbf24) 10%, var(--surface));
+}
+
+.glossary-callout ul {
+  margin: 0;
+  padding-left: 1.15rem;
+}
+
+.glossary-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
 }
 
 .glossary-chip-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin: 0 0 20px;
+  margin: 0;
 }
 
 .glossary-chip {
   display: inline-flex;
   align-items: center;
+  min-width: 0;
+  max-width: 100%;
   min-height: 28px;
   padding: 4px 10px;
   border: 1px solid var(--glass-border);
@@ -406,74 +404,147 @@ body > .glossary-popover .glossary-popover-link:focus-visible {
   color: var(--text-secondary);
   background: rgba(255,255,255,0.04);
   font-size: 0.85rem;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-.glossary-chip-technical {
-  color: var(--amethyst-light);
+.glossary-chip-link {
+  color: var(--text-primary);
+  text-decoration: none;
 }
 
-.glossary-level-panel,
-.glossary-callout,
-.glossary-protected,
-.glossary-related {
-  margin-top: 22px;
-  padding: 18px;
+.glossary-mobile-picker-trigger,
+.glossary-mobile-picker {
+  display: none;
+}
+
+.glossary-mobile-picker[hidden] {
+  display: none !important;
+}
+
+.glossary-mobile-picker-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 40px;
+  height: 40px;
   border: 1px solid var(--glass-border);
-  border-radius: var(--radius-md);
-  background: rgba(255,255,255,0.03);
+  border-radius: 999px;
+  color: var(--text-primary);
+  background: rgba(255,255,255,0.04);
+  font: inherit;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
 }
 
-.glossary-level-panel p,
-.glossary-level-summary p,
-.glossary-callout li {
-  color: var(--text-secondary);
-  line-height: 1.65;
-}
-
-.glossary-level-grid,
-.glossary-related-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.glossary-level-summary {
-  padding: 14px;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-md);
-  background: rgba(255,255,255,0.025);
-}
-
-.glossary-related-grid a {
-  padding: 14px;
+.glossary-mobile-picker-handle {
+  width: 72px;
+  height: 5px;
+  margin: 0 auto 18px;
+  border-radius: 999px;
+  background: var(--glass-border);
 }
 
 @media (max-width: 900px) {
-  .glossary-page-hero,
-  .glossary-layout,
-  .glossary-level-grid,
-  .glossary-related-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .glossary-index {
-    position: static;
-  }
-}
-
-@media (max-width: 560px) {
   .glossary-page {
     width: min(100vw - 20px, 1180px);
     padding-top: 12px;
   }
 
-  .glossary-page-hero,
-  .glossary-index,
-  .glossary-article {
+  .glossary-page-header {
     padding: 18px;
+    margin-bottom: 12px;
   }
 
-  .glossary-term-header {
-    flex-direction: column;
+  .glossary-page h1 {
+    font-size: 2rem;
+  }
+
+  .glossary-layout {
+    display: block;
+  }
+
+  .glossary-index-desktop {
+    display: none;
+  }
+
+  .glossary-mobile-picker-trigger {
+    display: grid;
+    width: 100%;
+    gap: 4px;
+    margin: 0 0 12px;
+    padding: 16px 18px;
+    color: var(--text-primary);
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .glossary-mobile-picker-trigger span {
+    color: var(--text-muted);
+    font-size: 0.88rem;
+  }
+
+  .glossary-mobile-picker-trigger strong {
+    color: var(--amethyst-light);
+    font-size: 1rem;
+  }
+
+  .glossary-article {
+    padding: 0;
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    gap: 14px;
+  }
+
+  .glossary-card {
+    padding: 18px;
+    border-radius: var(--radius-lg);
+  }
+
+  .glossary-term-header-card h2 {
+    font-size: 2rem;
+  }
+
+  .glossary-meta-grid {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+
+  .glossary-aliases {
+    display: none;
+  }
+
+  .glossary-mobile-picker {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: block;
+  }
+
+  .glossary-mobile-picker-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0.58);
+  }
+
+  .glossary-mobile-picker-sheet {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    max-height: min(82vh, 720px);
+    padding: 18px;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    overflow: hidden;
+  }
+
+  .glossary-term-panel-mobile .glossary-term-list {
+    max-height: calc(min(82vh, 720px) - 230px);
   }
 }

--- a/app/static/js/glossary-page.js
+++ b/app/static/js/glossary-page.js
@@ -1,68 +1,83 @@
-/* glossary-page.js — Search and category filtering for the standalone glossary */
+/* glossary-page.js — Simple glossary search and mobile term picker */
 
 (function () {
   'use strict';
 
-  var searchInput = document.getElementById('glossary-search');
-  var categoryButtons = Array.prototype.slice.call(document.querySelectorAll('[data-category-filter]'));
-  var termItems = Array.prototype.slice.call(document.querySelectorAll('[data-glossary-term]'));
-  var categorySections = Array.prototype.slice.call(document.querySelectorAll('[data-category-section]'));
-  var resultCount = document.getElementById('glossary-result-count');
-  var noResults = document.getElementById('glossary-no-results');
-  var activeCategory = 'all';
-
-  if (!searchInput || !termItems.length) return;
+  var panels = Array.prototype.slice.call(document.querySelectorAll('[data-glossary-panel]'));
+  var picker = document.querySelector('[data-glossary-picker]');
+  var openButton = document.querySelector('[data-glossary-picker-open]');
+  var closeButtons = Array.prototype.slice.call(document.querySelectorAll('[data-glossary-picker-close]'));
+  var lastFocused = null;
 
   function normalize(value) {
     return (value || '').toLocaleLowerCase().trim();
   }
 
-  function updateCategoryButtons() {
-    categoryButtons.forEach(function (button) {
-      var isActive = button.getAttribute('data-category-filter') === activeCategory;
-      button.classList.toggle('active', isActive);
-      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-    });
+  function setCount(resultCount, visibleCount) {
+    if (!resultCount) return;
+    var template = visibleCount === 1
+      ? resultCount.getAttribute('data-singular-template')
+      : resultCount.getAttribute('data-plural-template');
+    resultCount.textContent = (template || '{count} terms shown').replace('{count}', String(visibleCount));
   }
 
-  function filterTerms() {
-    var query = normalize(searchInput.value);
-    var visibleCount = 0;
+  function filterPanel(panel) {
+    var input = panel.querySelector('[data-glossary-search]');
+    var terms = Array.prototype.slice.call(panel.querySelectorAll('[data-glossary-term]'));
+    var resultCount = panel.querySelector('.glossary-result-count');
+    var noResults = panel.querySelector('.glossary-no-results');
+    if (!input || !terms.length) return;
 
-    termItems.forEach(function (item) {
-      var matchesCategory = activeCategory === 'all' || item.getAttribute('data-category') === activeCategory;
+    var query = normalize(input.value);
+    var visibleCount = 0;
+    terms.forEach(function (item) {
       var haystack = normalize(item.getAttribute('data-search'));
-      var matchesSearch = !query || haystack.indexOf(query) !== -1;
-      var isVisible = matchesCategory && matchesSearch;
+      var isVisible = !query || haystack.indexOf(query) !== -1;
       item.hidden = !isVisible;
       if (isVisible) visibleCount += 1;
     });
-
-    categorySections.forEach(function (section) {
-      var hasVisibleTerm = !!section.querySelector('[data-glossary-term]:not([hidden])');
-      section.hidden = !hasVisibleTerm;
-    });
-
-    if (resultCount) {
-      var template = visibleCount === 1
-        ? resultCount.getAttribute('data-singular-template')
-        : resultCount.getAttribute('data-plural-template');
-      resultCount.textContent = (template || '{count} terms shown').replace('{count}', String(visibleCount));
-    }
-    if (noResults) {
-      noResults.hidden = visibleCount !== 0;
-    }
-    updateCategoryButtons();
+    setCount(resultCount, visibleCount);
+    if (noResults) noResults.hidden = visibleCount !== 0;
   }
 
-  categoryButtons.forEach(function (button) {
-    button.addEventListener('click', function () {
-      activeCategory = button.getAttribute('data-category-filter') || 'all';
-      filterTerms();
-      searchInput.focus({ preventScroll: true });
+  panels.forEach(function (panel) {
+    var input = panel.querySelector('[data-glossary-search]');
+    if (!input) return;
+    input.addEventListener('input', function () {
+      filterPanel(panel);
     });
+    filterPanel(panel);
   });
 
-  searchInput.addEventListener('input', filterTerms);
-  filterTerms();
+  function openPicker() {
+    if (!picker) return;
+    lastFocused = document.activeElement;
+    picker.hidden = false;
+    if (openButton) openButton.setAttribute('aria-expanded', 'true');
+    var search = picker.querySelector('[data-glossary-search]');
+    if (search) search.focus({ preventScroll: true });
+  }
+
+  function closePicker() {
+    if (!picker) return;
+    picker.hidden = true;
+    if (openButton) openButton.setAttribute('aria-expanded', 'false');
+    if (lastFocused && typeof lastFocused.focus === 'function') {
+      lastFocused.focus({ preventScroll: true });
+    }
+  }
+
+  if (openButton) {
+    openButton.addEventListener('click', openPicker);
+  }
+
+  closeButtons.forEach(function (button) {
+    button.addEventListener('click', closePicker);
+  });
+
+  document.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape' && picker && !picker.hidden) {
+      closePicker();
+    }
+  });
 })();

--- a/app/static/js/glossary-page.js
+++ b/app/static/js/glossary-page.js
@@ -7,6 +7,14 @@
   var picker = document.querySelector('[data-glossary-picker]');
   var openButton = document.querySelector('[data-glossary-picker-open]');
   var closeButtons = Array.prototype.slice.call(document.querySelectorAll('[data-glossary-picker-close]'));
+  var focusableSelector = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])'
+  ].join(',');
   var lastFocused = null;
 
   function normalize(value) {
@@ -38,6 +46,52 @@
     });
     setCount(resultCount, visibleCount);
     if (noResults) noResults.hidden = visibleCount !== 0;
+  }
+
+  function isVisible(element) {
+    var style = window.getComputedStyle(element);
+    var rect = element.getBoundingClientRect();
+    return style.display !== 'none'
+      && style.visibility !== 'hidden'
+      && rect.width > 0
+      && rect.height > 0;
+  }
+
+  function getPickerFocusableElements() {
+    if (!picker || picker.hidden) return [];
+    var dialog = picker.querySelector('[role="dialog"]') || picker;
+    return Array.prototype.slice.call(dialog.querySelectorAll(focusableSelector)).filter(isVisible);
+  }
+
+  function trapPickerFocus(event) {
+    if (event.key !== 'Tab' || !picker || picker.hidden) return;
+
+    var focusableElements = getPickerFocusableElements();
+    if (!focusableElements.length) {
+      event.preventDefault();
+      return;
+    }
+
+    var first = focusableElements[0];
+    var last = focusableElements[focusableElements.length - 1];
+    var active = document.activeElement;
+
+    if (focusableElements.indexOf(active) === -1) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+      return;
+    }
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus({ preventScroll: true });
+      return;
+    }
+
+    if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
   }
 
   panels.forEach(function (panel) {
@@ -78,6 +132,8 @@
   document.addEventListener('keydown', function (event) {
     if (event.key === 'Escape' && picker && !picker.hidden) {
       closePicker();
+      return;
     }
+    trapPickerFocus(event);
   });
 })();

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v70';
+var CACHE_VERSION = 'v71';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/glossary.html
+++ b/app/templates/glossary.html
@@ -16,99 +16,68 @@
     <script src="/static/vendor/lucide.min.js?v={{ version|urlencode }}"></script>
 </head>
 <body class="glossary-page-body">
+{% macro term_list(panel_id, search_id, count_id, no_results_id, extra_class='') -%}
+<div class="glossary-term-panel {{ extra_class }}" data-glossary-panel>
+    <div class="glossary-search-block">
+        <label for="{{ search_id }}">{{ t.get('glossary_search_label', 'Search terms') }}</label>
+        <input id="{{ search_id }}" class="glossary-search" data-glossary-search type="search" autocomplete="off" placeholder="{{ t.get('glossary_search_placeholder', 'Search DOCSIS, SNR, Speedtest…') }}" aria-describedby="{{ count_id }}">
+        <p id="{{ count_id }}" class="glossary-result-count" aria-live="polite" data-singular-template="{{ t.get('glossary_result_singular', '{count} term shown') }}" data-plural-template="{{ t.get('glossary_result_plural', '{count} terms shown') }}">{{ t.get('glossary_result_plural', '{count} terms shown').replace('{count}', terms|length|string) }}</p>
+        <p id="{{ no_results_id }}" class="glossary-no-results" hidden>{{ t.get('glossary_no_results', 'No matching glossary terms. Try a broader word such as DOCSIS, signal, speed, or errors.') }}</p>
+    </div>
+    <p class="glossary-list-label">{{ t.get('glossary_alphabetical_terms', 'Alphabetical') }}</p>
+    <nav class="glossary-term-list" id="{{ panel_id }}" aria-label="{{ t.get('glossary_alphabetical_terms', 'Alphabetical') }}">
+        {% for term in terms %}
+        <a data-glossary-term data-category="{{ term.category }}" data-search="{{ (term.title ~ ' ' ~ term.id ~ ' ' ~ category_by_id[term.category].title ~ ' ' ~ (term.aliases|join(' ')))|e }}" class="glossary-term-link {{ 'active' if selected_term and selected_term.id == term.id else '' }}" href="{{ url_for('glossary_page', lang=lang, term=term.id) }}" aria-current="{{ 'page' if selected_term and selected_term.id == term.id else 'false' }}">
+            {{ term.title }}
+        </a>
+        {% endfor %}
+    </nav>
+</div>
+{%- endmacro %}
+
 <main class="glossary-page" aria-labelledby="glossary-title">
-    <header class="glossary-page-hero">
-        <div>
-            <a class="glossary-back-link" href="/">← {{ t.get('home', 'Home') }}</a>
-            <p class="eyebrow">{{ t.get('glossary_knowledge_eyebrow', 'DOCSight knowledge base') }}</p>
-            <h1 id="glossary-title">{{ t.get('glossary_page_title', 'Glossary') }}</h1>
-            <p class="glossary-page-intro">
-                {{ t.get('glossary_page_intro', 'Canonical DOCSIS and cable terms with explanation levels from beginner-friendly to technician detail.') }}
-            </p>
-        </div>
-        <div class="glossary-level-card" aria-labelledby="glossary-level-title">
-            <h2 id="glossary-level-title">{{ t.get('glossary_level_selector', 'Explanation level') }}</h2>
-            <div class="glossary-levels" role="list">
-                {% for item in level_options %}
-                <a class="glossary-level {{ 'active' if item.id == selected_level else '' }}" role="listitem" href="{{ url_for('glossary_page', lang=lang, level=item.id, term=selected_term.id if selected_term else None) }}" aria-current="{{ 'true' if item.id == selected_level else 'false' }}">
-                    <span>{{ item.label }}</span>
-                    <small>{{ item.description }}</small>
-                </a>
-                {% endfor %}
-            </div>
-        </div>
+    <header class="glossary-page-header">
+        <a class="glossary-back-link" href="/">← {{ t.get('home', 'Home') }}</a>
+        <p class="eyebrow">{{ t.get('glossary_knowledge_eyebrow', 'DOCSight knowledge base') }}</p>
+        <h1 id="glossary-title">{{ t.get('glossary_page_title', 'Glossary') }}</h1>
+        <p class="glossary-page-intro">
+            {{ t.get('glossary_page_intro', 'Search cable and DOCSIS terms, then read a short summary and the actual explanation.') }}
+        </p>
     </header>
 
-    <section class="glossary-layout" aria-label="Glossary terms">
-        <aside class="glossary-index" aria-label="Term index">
-            <div class="glossary-filter-card" aria-labelledby="glossary-filter-title">
-                <h2 id="glossary-filter-title">{{ t.get('glossary_filter_title', 'Find a term') }}</h2>
-                <label for="glossary-search">{{ t.get('glossary_search_label', 'Search by term, alias, category, or ID') }}</label>
-                <input id="glossary-search" class="glossary-search" type="search" autocomplete="off" placeholder="{{ t.get('glossary_search_placeholder', 'Search DOCSIS, SNR, Speedtest…') }}" aria-describedby="glossary-result-count">
-                <div class="glossary-category-filters" aria-label="{{ t.get('glossary_category_filter_label', 'Filter by category') }}">
-                    <button type="button" class="active" data-category-filter="all" aria-pressed="true">{{ t.get('glossary_all_categories', 'All') }}</button>
-                    {% for category in categories %}
-                    <button type="button" data-category-filter="{{ category.id }}" aria-pressed="false">{{ category.title }}</button>
-                    {% endfor %}
-                </div>
-                <p id="glossary-result-count" class="glossary-result-count" aria-live="polite" data-singular-template="{{ t.get('glossary_result_singular', '{count} term shown') }}" data-plural-template="{{ t.get('glossary_result_plural', '{count} terms shown') }}">{{ t.get('glossary_result_plural', '{count} terms shown').replace('{count}', terms|length|string) }}</p>
-                <p id="glossary-no-results" class="glossary-no-results" hidden>{{ t.get('glossary_no_results', 'No matching glossary terms. Try a broader word such as DOCSIS, signal, speed, or errors.') }}</p>
-            </div>
-            {% for category in categories %}
-            <section class="glossary-index-section" data-category-section="{{ category.id }}">
-                <h2>{{ category.title }}</h2>
-                <p>{{ category.description }}</p>
-                <ul>
-                    {% for term in terms if term.category == category.id %}
-                    <li data-glossary-term data-category="{{ term.category }}" data-search="{{ (term.title ~ ' ' ~ term.id ~ ' ' ~ category.title ~ ' ' ~ (term.aliases|join(' ')))|e }}">
-                        <a class="{{ 'active' if selected_term and selected_term.id == term.id else '' }}" href="{{ url_for('glossary_page', lang=lang, level=selected_level, term=term.id) }}" aria-current="{{ 'page' if selected_term and selected_term.id == term.id else 'false' }}">
-                            {{ term.title }}
-                        </a>
-                    </li>
-                    {% endfor %}
-                </ul>
-            </section>
-            {% endfor %}
+    {% if selected_term %}
+    <button type="button" class="glossary-mobile-picker-trigger" data-glossary-picker-open aria-controls="glossary-mobile-picker" aria-expanded="false">
+        <span>{{ t.get('glossary_selected_term', 'Selected term') }}: {{ selected_term.title }}</span>
+        <strong>{{ t.get('glossary_change_term', 'Search or change term') }}</strong>
+    </button>
+    {% endif %}
+
+    <section class="glossary-layout" aria-label="{{ t.get('glossary_page_title', 'Glossary') }}">
+        <aside class="glossary-index glossary-index-desktop" aria-label="{{ t.get('glossary_filter_title', 'Find a term') }}">
+            <h2>{{ t.get('glossary_filter_title', 'Find a term') }}</h2>
+            {{ term_list('glossary-desktop-terms', 'glossary-search', 'glossary-result-count', 'glossary-no-results') }}
         </aside>
 
         <article class="glossary-article" aria-labelledby="glossary-term-title">
             {% if selected_term %}
-            <div class="glossary-term-header">
-                <div>
-                    <p class="eyebrow">{{ category_by_id[selected_term.category].title }}</p>
-                    <h2 id="glossary-term-title">{{ selected_term.title }}</h2>
-                </div>
-                <span class="glossary-term-id">{{ selected_term.id }}</span>
-            </div>
-
-            {% if selected_term.aliases %}
-            <div class="glossary-chip-row" aria-label="Aliases">
-                {% for alias in selected_term.aliases %}
-                <span class="glossary-chip">{{ alias }}</span>
-                {% endfor %}
-            </div>
-            {% endif %}
-
-            <section class="glossary-level-panel" aria-labelledby="selected-level-heading">
-                <h3 id="selected-level-heading">{{ selected_level_label }}</h3>
-                <p>{{ selected_term.levels[selected_level] }}</p>
+            <section class="glossary-card glossary-term-header-card">
+                <p class="eyebrow">{{ category_by_id[selected_term.category].title }}</p>
+                <h2 id="glossary-term-title">{{ selected_term.title }}</h2>
             </section>
 
-            <section class="glossary-all-levels" aria-labelledby="all-levels-heading">
-                <h3 id="all-levels-heading">{{ t.get('glossary_all_levels_heading', 'All explanation levels') }}</h3>
-                <div class="glossary-level-grid">
-                    {% for item in level_options %}
-                    <section class="glossary-level-summary {{ 'active' if item.id == selected_level else '' }}">
-                        <h4>{{ item.label }}</h4>
-                        <p>{{ selected_term.levels[item.id] }}</p>
-                    </section>
-                    {% endfor %}
-                </div>
+            <section class="glossary-card glossary-summary-card" aria-labelledby="summary-heading">
+                <h3 id="summary-heading">{{ t.get('glossary_summary_heading', 'Quick summary') }}</h3>
+                <p>{{ selected_term.levels.eli5 }}</p>
+            </section>
+
+            <section class="glossary-card glossary-explanation-card" aria-labelledby="explanation-heading">
+                <h3 id="explanation-heading">{{ t.get('glossary_explanation_heading', 'Explanation') }}</h3>
+                <p>{{ selected_term.levels.basic }}</p>
             </section>
 
             {% if selected_term.misconceptions %}
-            <section class="glossary-callout" aria-labelledby="misconceptions-heading">
-                <h3 id="misconceptions-heading">{{ t.get('glossary_misconceptions_heading', 'Common misconceptions') }}</h3>
+            <section class="glossary-card glossary-callout" aria-labelledby="misconceptions-heading">
+                <h3 id="misconceptions-heading">{{ t.get('glossary_not_confuse_heading', 'Do not confuse') }}</h3>
                 <ul>
                     {% for item in selected_term.misconceptions %}
                     <li>{{ item }}</li>
@@ -117,36 +86,48 @@
             </section>
             {% endif %}
 
-            {% if selected_term.protected_terms %}
-            <section class="glossary-protected" aria-labelledby="protected-heading">
-                <h3 id="protected-heading">{{ t.get('glossary_protected_heading', 'Protected technical terms') }}</h3>
-                <div class="glossary-chip-row">
-                    {% for token in selected_term.protected_terms %}
-                    <span class="glossary-chip glossary-chip-technical">{{ token }}</span>
-                    {% endfor %}
-                </div>
-            </section>
-            {% endif %}
+            <div class="glossary-meta-grid">
+                {% if selected_term.aliases %}
+                <section class="glossary-card glossary-aliases" aria-labelledby="aliases-heading">
+                    <h3 id="aliases-heading">{{ t.get('glossary_aliases_heading', 'Also searched as') }}</h3>
+                    <div class="glossary-chip-row">
+                        {% for alias in selected_term.aliases %}
+                        <span class="glossary-chip">{{ alias }}</span>
+                        {% endfor %}
+                    </div>
+                </section>
+                {% endif %}
 
-            {% if related_terms %}
-            <section class="glossary-related" aria-labelledby="related-heading">
-                <h3 id="related-heading">{{ t.get('glossary_related_heading', 'Related terms') }}</h3>
-                <div class="glossary-related-grid">
-                    {% for term in related_terms %}
-                    <a href="{{ url_for('glossary_page', lang=lang, level=selected_level, term=term.id) }}">
-                        <span>{{ term.title }}</span>
-                        <small>{{ term.id }}</small>
-                    </a>
-                    {% endfor %}
-                </div>
-            </section>
-            {% endif %}
+                {% if related_terms %}
+                <section class="glossary-card glossary-related" aria-labelledby="related-heading">
+                    <h3 id="related-heading">{{ t.get('glossary_related_heading', 'Related terms') }}</h3>
+                    <div class="glossary-chip-row">
+                        {% for term in related_terms %}
+                        <a class="glossary-chip glossary-chip-link" href="{{ url_for('glossary_page', lang=lang, term=term.id) }}">{{ term.title }}</a>
+                        {% endfor %}
+                    </div>
+                </section>
+                {% endif %}
+            </div>
             {% else %}
-            <h2 id="glossary-term-title">{{ t.get('glossary_no_term_selected', 'No glossary term selected') }}</h2>
+            <section class="glossary-card">
+                <h2 id="glossary-term-title">{{ t.get('glossary_no_term_selected', 'No glossary term selected') }}</h2>
+            </section>
             {% endif %}
         </article>
     </section>
 </main>
+
+<div id="glossary-mobile-picker" class="glossary-mobile-picker" data-glossary-picker hidden>
+    <div class="glossary-mobile-picker-backdrop" data-glossary-picker-close></div>
+    <section class="glossary-mobile-picker-sheet" role="dialog" aria-modal="true" aria-labelledby="glossary-mobile-picker-title">
+        <button type="button" class="glossary-mobile-picker-close" data-glossary-picker-close aria-label="{{ t.get('glossary_close_picker', 'Close term picker') }}">×</button>
+        <div class="glossary-mobile-picker-handle" aria-hidden="true"></div>
+        <h2 id="glossary-mobile-picker-title">{{ t.get('glossary_filter_title', 'Find a term') }}</h2>
+        {{ term_list('glossary-mobile-terms', 'glossary-mobile-search', 'glossary-mobile-result-count', 'glossary-mobile-no-results', 'glossary-term-panel-mobile') }}
+    </section>
+</div>
+
 <script>
 if (window.lucide) window.lucide.createIcons();
 </script>

--- a/app/web.py
+++ b/app/web.py
@@ -1325,7 +1325,7 @@ def glossary_page():
     lang = _get_lang()
     t = get_translations(lang)
     theme = _config_manager.get_theme() if _config_manager else "dark"
-    terms = get_glossary_terms(lang)
+    terms = sorted(get_glossary_terms(lang), key=lambda term: term["title"].casefold())
     categories = get_glossary_categories(lang)
     selected_level = request.args.get("level", "basic")
     if selected_level not in GLOSSARY_LEVELS:

--- a/tests/e2e/test_glossary_page.py
+++ b/tests/e2e/test_glossary_page.py
@@ -93,6 +93,19 @@ def test_glossary_mobile_uses_picker_instead_of_inline_long_list(page, live_serv
     expect(page.locator("#glossary-mobile-picker [data-glossary-term]", has_text="CMTS")).to_be_visible()
     expect(page.locator("#glossary-mobile-picker [data-search^='Speedtest ']")).to_be_hidden()
 
+    page.keyboard.press("Shift+Tab")
+    expect(page.locator(".glossary-mobile-picker-close")).to_be_focused()
+    for _ in range(8):
+        page.keyboard.press("Tab")
+        focus_inside_picker = page.evaluate(
+            "document.querySelector('#glossary-mobile-picker').contains(document.activeElement)"
+        )
+        assert focus_inside_picker is True
+
+    page.keyboard.press("Escape")
+    expect(page.locator("#glossary-mobile-picker")).to_be_hidden()
+    expect(page.locator(".glossary-mobile-picker-trigger")).to_be_focused()
+
 
 def test_dashboard_contextual_help_links_to_matching_glossary_term(page, live_server):
     page.goto(f"{live_server}/?lang=en")

--- a/tests/e2e/test_glossary_page.py
+++ b/tests/e2e/test_glossary_page.py
@@ -5,26 +5,49 @@ import re
 from playwright.sync_api import expect
 
 
-def test_standalone_glossary_page_renders_terms_and_levels(page, live_server):
+def _assert_visible_boxes_do_not_overlap(page, selector):
+    boxes = page.locator(selector).evaluate_all(
+        """nodes => nodes
+            .filter(node => {
+              const style = window.getComputedStyle(node);
+              const rect = node.getBoundingClientRect();
+              return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+            })
+            .map((node, index) => {
+              const rect = node.getBoundingClientRect();
+              return { index, left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom };
+            })"""
+    )
+    for i, first in enumerate(boxes):
+        for second in boxes[i + 1:]:
+            overlaps = not (
+                first["right"] <= second["left"]
+                or second["right"] <= first["left"]
+                or first["bottom"] <= second["top"]
+                or second["bottom"] <= first["top"]
+            )
+            assert not overlaps, f"{selector} boxes overlap: {first} vs {second}"
+
+
+def test_standalone_glossary_page_renders_simple_summary_and_explanation(page, live_server):
     page.goto(f"{live_server}/glossary?lang=en&term=docsis&level=basic")
     page.wait_for_load_state("networkidle")
 
     expect(page.locator("h1", has_text="Glossary")).to_be_visible()
     expect(page.locator("#glossary-term-title", has_text="DOCSIS")).to_be_visible()
-    expect(page.locator(".glossary-level", has_text="ELI5")).to_be_visible()
-    expect(page.locator(".glossary-level", has_text="Technician")).to_be_visible()
-    expect(page.locator(".glossary-index", has_text="Cable/DOCSIS basics")).to_be_visible()
+    expect(page.locator("#summary-heading", has_text="Quick summary")).to_be_visible()
+    expect(page.locator("#explanation-heading", has_text="Explanation")).to_be_visible()
+    expect(page.locator(".glossary-index-desktop .glossary-term-link").first).to_have_text("Attenuation")
     expect(page.locator(".glossary-related", has_text="SC-QAM")).to_be_visible()
+    _assert_visible_boxes_do_not_overlap(page, ".glossary-article > .glossary-card, .glossary-meta-grid > .glossary-card")
 
 
-def test_glossary_level_and_related_term_navigation(page, live_server):
+def test_glossary_related_term_navigation(page, live_server):
     page.goto(f"{live_server}/glossary?lang=en&term=sc_qam&level=basic")
     page.wait_for_load_state("networkidle")
 
-    page.locator(".glossary-level", has_text="Technician").click()
-    expect(page).to_have_url(re.compile(r"level=technician"))
-    expect(page.locator("#selected-level-heading", has_text="Technician")).to_be_visible()
-    expect(page.locator(".glossary-level-panel", has_text="gross Layer-1 estimates")).to_be_visible()
+    expect(page.locator("#summary-heading", has_text="Quick summary")).to_be_visible()
+    expect(page.locator(".glossary-explanation-card", has_text="gross Layer-1 capacity")).to_be_visible()
 
     page.locator(".glossary-related a", has_text="Capacity vs. speedtest").click()
     expect(page).to_have_url(re.compile(r"term=capacity_vs_throughput"))
@@ -39,23 +62,36 @@ def test_glossary_mobile_layout_has_no_horizontal_overflow(page, live_server):
     expect(page.locator("#glossary-term-title", has_text="Capacity vs. speedtest")).to_be_visible()
     has_overflow = page.evaluate("document.documentElement.scrollWidth > document.documentElement.clientWidth")
     assert has_overflow is False
+    _assert_visible_boxes_do_not_overlap(page, ".glossary-article > .glossary-card, .glossary-meta-grid > .glossary-card")
 
 
-def test_glossary_search_and_category_filter(page, live_server):
+def test_glossary_search_filters_alphabetical_terms(page, live_server):
     page.goto(f"{live_server}/glossary?lang=en&term=docsis&level=basic")
     page.wait_for_load_state("networkidle")
 
     search = page.locator("#glossary-search")
     search.fill("CMTS")
-    expect(page.locator("[data-glossary-term]", has_text="CMTS")).to_be_visible()
-    expect(page.locator("[data-glossary-term][data-search^='Speedtest ']")).to_be_hidden()
+    expect(page.locator(".glossary-index-desktop [data-glossary-term]", has_text="CMTS")).to_be_visible()
+    expect(page.locator(".glossary-index-desktop [data-search^='Speedtest ']")).to_be_hidden()
     expect(page.locator("#glossary-result-count")).to_contain_text("1 term shown")
 
-    search.fill("")
-    page.locator("[data-category-filter='signal_quality']").click()
-    expect(page.locator("[data-glossary-term]", has_text="Power level")).to_be_visible()
-    expect(page.locator("[data-glossary-term]", has_text="CMTS")).to_be_hidden()
-    expect(page.locator("[data-category-filter='signal_quality']")).to_have_attribute("aria-pressed", "true")
+
+def test_glossary_mobile_uses_picker_instead_of_inline_long_list(page, live_server):
+    page.set_viewport_size({"width": 393, "height": 852})
+    page.goto(f"{live_server}/glossary?lang=en&term=docsis&level=basic")
+    page.wait_for_load_state("networkidle")
+
+    expect(page.locator(".glossary-index-desktop")).to_be_hidden()
+    expect(page.locator(".glossary-mobile-picker-trigger", has_text="Search or change term")).to_be_visible()
+    expect(page.locator("#glossary-term-title", has_text="DOCSIS")).to_be_visible()
+
+    page.locator(".glossary-mobile-picker-trigger").click()
+    expect(page.locator("#glossary-mobile-picker")).to_be_visible()
+    mobile_search = page.locator("#glossary-mobile-search")
+    expect(mobile_search).to_be_focused()
+    mobile_search.fill("CMTS")
+    expect(page.locator("#glossary-mobile-picker [data-glossary-term]", has_text="CMTS")).to_be_visible()
+    expect(page.locator("#glossary-mobile-picker [data-search^='Speedtest ']")).to_be_hidden()
 
 
 def test_dashboard_contextual_help_links_to_matching_glossary_term(page, live_server):

--- a/tests/web/test_glossary_route.py
+++ b/tests/web/test_glossary_route.py
@@ -2,7 +2,7 @@
 
 import re
 
-from app.glossary import GLOSSARY_LEVELS, get_glossary_terms
+from app.glossary import get_glossary_terms
 from app.web import update_state
 
 
@@ -21,17 +21,19 @@ def test_glossary_route_renders_canonical_terms(client, sample_analysis):
     assert "docsis" in html
 
 
-def test_glossary_route_supports_all_explanation_levels(client, sample_analysis):
+def test_glossary_route_renders_simple_summary_and_explanation(client, sample_analysis):
     update_state(analysis=sample_analysis)
 
     resp = client.get("/glossary?lang=en&term=sc_qam&level=technician")
 
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
-    for label in ("ELI5", "Basic", "Advanced", "Technician"):
-        assert label in html
-    assert "aria-current=\"true\"" in html
-    assert "Layer-1 estimates" in html or "gross Layer-1 estimates" in html
+    assert "Quick summary" in html
+    assert "Explanation" in html
+    assert "All explanation levels" not in html
+    assert "Technician" not in html
+    assert "SC-QAM is one kind of cable channel" in html
+    assert "SC-QAM channels are traditional DOCSIS channels" in html
 
 
 def test_glossary_route_falls_back_from_invalid_term_and_level(client, sample_analysis):
@@ -41,8 +43,8 @@ def test_glossary_route_falls_back_from_invalid_term_and_level(client, sample_an
 
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
-    assert "Basic" in html
-    assert any(level in html for level in GLOSSARY_LEVELS)
+    assert "Quick summary" in html
+    assert "Explanation" in html
     assert "No glossary term selected" not in html
 
 
@@ -58,7 +60,7 @@ def test_dashboard_links_to_standalone_glossary(client, sample_analysis):
     assert 'data-glossary-term-id="docsis" data-glossary-term-level="basic"' in html
 
 
-def test_glossary_route_exposes_search_and_category_filter_metadata(client, sample_analysis):
+def test_glossary_route_exposes_simple_search_metadata(client, sample_analysis):
     update_state(analysis=sample_analysis)
 
     resp = client.get("/glossary?lang=en&term=docsis")
@@ -66,10 +68,22 @@ def test_glossary_route_exposes_search_and_category_filter_metadata(client, samp
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     assert 'id="glossary-search"' in html
-    assert 'data-category-filter="signal_quality"' in html
+    assert 'id="glossary-mobile-search"' in html
     assert 'data-glossary-term data-category="capacity_throughput"' in html
+    assert 'data-category-filter=' not in html
     assert 'data-search="CMTS cmts Cable/DOCSIS basics' in html
     assert '/static/js/glossary-page.js?v=' in html
+
+
+def test_glossary_route_lists_terms_alphabetically(client, sample_analysis):
+    update_state(analysis=sample_analysis)
+
+    resp = client.get("/glossary?lang=en&term=docsis")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    desktop_terms = re.findall(r'class="glossary-term-link[^"]*"[^>]*>\s*([^<]+?)\s*</a>', html)
+    assert desktop_terms[:3] == ["Attenuation", "Bootfile/config file", "Cable modem/router"]
 
 
 def test_contextual_glossary_links_target_existing_terms(client, sample_analysis):


### PR DESCRIPTION
## Summary

- replace the standalone glossary layout with a simple desktop split: alphabetical term list with search on the left, selected explanation on the right
- make mobile use a compact selected-term control plus a dedicated search/change picker instead of showing a long inline term list before the article
- reduce visible article content to a short summary and the main explanation, with optional "do not confuse" and related-term chips
- update glossary UI translations, cache version, and regression coverage for mobile picker, alphabetical ordering, no horizontal overflow, and non-overlapping article cards

## Tests

- `node --check app/static/js/glossary-page.js`
- `node --check app/static/sw.js`
- `python3 -m py_compile app/web.py app/glossary.py`
- `python3 scripts/i18n_check.py --validate`
- `git diff --check`
- `uv run --with pytest --with flask --with requests --with beautifulsoup4 --with paho-mqtt --with openpyxl --with waitress --with cryptography pytest tests/web/test_glossary_route.py tests/test_glossary_i18n.py tests/test_glossary_catalog.py -q`
- `uv run --with pytest --with pytest-playwright --with flask --with requests --with beautifulsoup4 --with paho-mqtt --with openpyxl --with waitress --with cryptography --with fpdf pytest tests/e2e/test_glossary_page.py -q`
- `uv run --python 3.13 --with pytest --with flask --with requests --with beautifulsoup4 --with paho-mqtt --with openpyxl --with waitress --with cryptography --with fpdf2 --with pypdf pytest tests -q --ignore=tests/e2e`
- `uv run --python 3.13 --with pytest --with pytest-playwright --with flask --with requests --with beautifulsoup4 --with paho-mqtt --with openpyxl --with waitress --with cryptography --with fpdf2 --with pypdf pytest tests/e2e -q`
