### PR TITLE
Sort glossary terms alphabetically

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -1292,7 +1292,7 @@ def service_worker():
 
 def _build_glossary_context(lang, t, selected_term_id=None):
     """Build static glossary view data for the app shell."""
-    terms = get_glossary_terms(lang)
+    terms = sorted(get_glossary_terms(lang), key=lambda term: term["title"].casefold())
     categories = get_glossary_categories(lang)
     selected_term = get_glossary_term(selected_term_id, lang) if selected_term_id else None
     if not selected_term and terms:

--- a/tests/e2e/test_glossary_page.py
+++ b/tests/e2e/test_glossary_page.py
@@ -43,7 +43,11 @@ def test_glossary_app_view_renders_inside_shell(page, live_server):
     expect(_active_article(page).locator(".glossary-term-header-card h3", has_text="DOCSIS")).to_be_visible()
     expect(_active_article(page).locator(".glossary-summary-card", has_text="Quick summary")).to_be_visible()
     expect(_active_article(page).locator(".glossary-explanation-card", has_text="Explanation")).to_be_visible()
-    expect(page.locator(".glossary-index-desktop .glossary-term-link").first).to_have_text("Channel bonding")
+    expect(page.locator(".glossary-index-desktop .glossary-term-link").first).to_have_text("Before/After Comparison")
+    desktop_terms = page.locator(".glossary-index-desktop .glossary-term-link").evaluate_all(
+        "nodes => nodes.map(node => node.textContent.trim())"
+    )
+    assert desktop_terms == sorted(desktop_terms, key=str.casefold)
     _assert_visible_boxes_do_not_overlap(page, "#view-glossary .glossary-term-article:not([hidden]) > .glossary-card")
 
 

--- a/tests/web/test_glossary_route.py
+++ b/tests/web/test_glossary_route.py
@@ -83,7 +83,8 @@ def test_index_glossary_lists_terms_alphabetically(client, sample_analysis):
     html = resp.get_data(as_text=True)
     desktop = html.split('id="glossary-desktop-terms"', 1)[1].split("</nav>", 1)[0]
     desktop_terms = re.findall(r'class="glossary-term-link[^"]*"[^>]*>\s*([^<]+?)\s*</a>', desktop)
-    assert desktop_terms[:3] == ["Channel bonding", "CMTS", "Correctable errors"]
+    assert desktop_terms == sorted(desktop_terms, key=str.casefold)
+    assert desktop_terms[:3] == ["Before/After Comparison", "BNetzA measurement", "BQM"]
 
 
 def test_contextual_glossary_links_target_existing_terms(client, sample_analysis):


### PR DESCRIPTION
## Summary
- render the in-app glossary term list in global alphabetical order
- add web and browser regressions that assert the visible glossary list is sorted

## Tests
- `git diff --check`
- `uv run --isolated --with-requirements requirements-test.in pytest tests/web/test_glossary_route.py tests/test_glossary_catalog.py -q`
- `uv run --isolated --with-requirements requirements-test.in --with pytest-playwright==0.7.2 --with playwright==1.58.0 pytest tests/e2e/test_glossary_page.py -q`
- `python3 -m compileall -q app/web.py`
