### PR TITLE
Refine glossary dictionary experience

### DIFF
--- a/app/glossary.py
+++ b/app/glossary.py
@@ -42,6 +42,7 @@ class GlossaryTerm:
     tags: tuple[str, ...] = ()
     source_pages: tuple[str, ...] = ()
     ui_contexts: tuple[str, ...] = ()
+    media: tuple[dict[str, Any], ...] = ()
 
     def localized(self, lang: str = "en") -> dict[str, Any]:
         """Return a template-friendly localized term, falling back to English."""
@@ -50,8 +51,17 @@ class GlossaryTerm:
         metadata = _metadata_for_term(self.id)
         aliases = tuple(translation.get("aliases") or self.aliases.get(lang) or self.aliases.get("en", ()))
         aliases = _unique((*aliases, *metadata.get("aliases", ())))
-        levels = translation.get("levels") or self.levels.get(lang) or self.levels["en"]
+        translated_levels = translation.get("levels") if isinstance(translation.get("levels"), dict) else {}
+        native_levels = self.levels.get(lang, {})
+        english_levels = self.levels["en"]
+        levels = {
+            level: (
+                str(translated_levels.get(level) or native_levels.get(level) or english_levels.get(level) or "").strip()
+            )
+            for level in GLOSSARY_LEVELS
+        }
         misconceptions = tuple(translation.get("misconceptions") or self.misconceptions.get(lang) or self.misconceptions.get("en", ()))
+        media = translation.get("media") if isinstance(translation.get("media"), list) else list(self.media)
         return {
             "id": self.id,
             "category": self.category,
@@ -64,6 +74,7 @@ class GlossaryTerm:
             "tags": list(_unique((*self.tags, *metadata.get("tags", ())))),
             "source_pages": list(_unique((*self.source_pages, *metadata.get("source_pages", ())))),
             "ui_contexts": list(_unique((*self.ui_contexts, *metadata.get("ui_contexts", ())))),
+            "media": media,
         }
 
 
@@ -973,13 +984,9 @@ def get_glossary_categories(lang: str = "en") -> list[dict[str, str]]:
 
 
 def get_glossary_terms(lang: str = "en") -> list[dict[str, Any]]:
-    """Return localized glossary terms sorted by category order and title."""
+    """Return localized glossary terms sorted as one global alphabetical dictionary."""
     localized = [term.localized(lang) for term in _TERMS]
-    category_order = {category.id: index for index, category in enumerate(_CATEGORIES)}
-    return sorted(
-        localized,
-        key=lambda item: (category_order.get(item["category"], 999), item["title"].lower()),
-    )
+    return sorted(localized, key=lambda item: item["title"].casefold())
 
 
 def get_glossary_term(term_id: str, lang: str = "en") -> dict[str, Any] | None:

--- a/app/static/css/glossary.css
+++ b/app/static/css/glossary.css
@@ -297,7 +297,8 @@ body > .glossary-popover .glossary-popover-link:focus-visible {
 .glossary-term-link:focus-visible,
 .glossary-mobile-picker-trigger:focus-visible,
 .glossary-mobile-picker-close:focus-visible,
-.glossary-chip-link:focus-visible {
+.glossary-chip-link:focus-visible,
+.glossary-related-link:focus-visible {
   outline: 2px solid var(--amethyst);
   outline-offset: 2px;
 }
@@ -368,17 +369,31 @@ body > .glossary-popover .glossary-popover-link:focus-visible {
 
 .glossary-term-header-card h2,
 .glossary-term-header-card h3 {
-  margin-bottom: 12px;
+  margin-bottom: 0;
   font-size: 2.25rem;
   letter-spacing: 0;
   line-height: 1;
   overflow-wrap: anywhere;
 }
 
+.glossary-aliases {
+  margin: 12px 0 0;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.glossary-aliases span {
+  color: var(--text-secondary);
+  font-weight: 800;
+}
+
 .glossary-term-header-card p:last-child,
 .glossary-summary-card p,
 .glossary-explanation-card p,
-.glossary-callout li {
+.glossary-callout li,
+.glossary-empty-state p {
   margin-bottom: 0;
   color: var(--text-secondary);
   line-height: 1.65;
@@ -395,6 +410,82 @@ body > .glossary-popover .glossary-popover-link:focus-visible {
 
 .glossary-explanation-card p {
   color: var(--text-primary);
+}
+
+.glossary-detail-block {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--glass-border);
+}
+
+.glossary-detail-block summary {
+  color: var(--text-primary);
+  cursor: pointer;
+  font-weight: 800;
+  line-height: 1.4;
+}
+
+.glossary-detail-block summary:focus-visible {
+  outline: 2px solid var(--amethyst);
+  outline-offset: 4px;
+  border-radius: var(--radius-sm);
+}
+
+.glossary-detail-block p {
+  margin-top: 10px;
+}
+
+.glossary-media-card {
+  display: grid;
+  gap: 14px;
+}
+
+.glossary-media-item {
+  margin: 0;
+}
+
+.glossary-media-item img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-sm);
+}
+
+.glossary-media-item figcaption {
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.glossary-related-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.glossary-related-row span {
+  font-weight: 800;
+}
+
+.glossary-related-link {
+  color: var(--text-primary);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--amethyst) 50%, transparent);
+}
+
+.glossary-related-link:hover,
+.glossary-related-link:focus-visible {
+  color: var(--amethyst-light);
+}
+
+.glossary-empty-state[hidden] {
+  display: none !important;
 }
 
 .glossary-callout {

--- a/app/static/js/glossary-page.js
+++ b/app/static/js/glossary-page.js
@@ -8,6 +8,7 @@
   var openButton = document.querySelector('[data-glossary-picker-open]');
   var closeButtons = Array.prototype.slice.call(document.querySelectorAll('[data-glossary-picker-close]'));
   var articles = Array.prototype.slice.call(document.querySelectorAll('[data-glossary-article]'));
+  var missingState = document.querySelector('[data-glossary-missing]');
   var selectedLabel = document.querySelector('[data-glossary-mobile-selected]');
   var focusableSelector = [
     'a[href]',
@@ -20,7 +21,12 @@
   var lastFocused = null;
 
   function normalize(value) {
-    return (value || '').toLocaleLowerCase().trim();
+    return (value || '')
+      .toString()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLocaleLowerCase()
+      .trim();
   }
 
   function parseGlossaryHash() {
@@ -35,8 +41,10 @@
     };
   }
 
-  function glossaryHashForTerm(termId) {
-    return '#glossary?term=' + encodeURIComponent(termId);
+  function glossaryHashForTerm(termId, level) {
+    var hash = '#glossary?term=' + encodeURIComponent(termId);
+    if (level) hash += '&level=' + encodeURIComponent(level);
+    return hash;
   }
 
   function findArticle(termId) {
@@ -46,14 +54,62 @@
     }) || null;
   }
 
+  function resolveTermId(value) {
+    var normalized = normalize(value);
+    if (!normalized) return '';
+    var exact = findArticle(value);
+    if (exact) return exact.getAttribute('data-term-id');
+
+    var links = Array.prototype.slice.call(document.querySelectorAll('[data-glossary-term]'));
+    var match = links.find(function (link) {
+      if (normalize(link.getAttribute('data-term-id')) === normalized) return true;
+      if (normalize(link.getAttribute('data-search-title')) === normalized) return true;
+      var aliases = (link.getAttribute('data-search-alias-values') || '')
+        .split('|||')
+        .map(normalize)
+        .filter(Boolean);
+      return aliases.indexOf(normalized) !== -1;
+    });
+    return match ? match.getAttribute('data-term-id') : value;
+  }
+
+  function setMissingTerm(termId) {
+    articles.forEach(function (item) { item.hidden = true; });
+    document.querySelectorAll('[data-glossary-term]').forEach(function (link) {
+      link.classList.remove('active');
+      link.setAttribute('aria-current', 'false');
+    });
+    if (missingState) missingState.hidden = false;
+    if (selectedLabel) {
+      var prefix = openButton ? openButton.getAttribute('data-glossary-selected-prefix') : '';
+      selectedLabel.textContent = (prefix || 'Selected term') + ': ' + termId;
+    }
+    panels.forEach(function (panel) {
+      var input = panel.querySelector('[data-glossary-search]');
+      if (input && termId) {
+        input.value = termId;
+        filterPanel(panel);
+      }
+    });
+  }
+
   function setActiveTerm(termId, options) {
     options = options || {};
-    var article = findArticle(termId) || articles[0];
-    if (!article) return;
+    var requestedLevel = /^(eli5|basic|advanced|technician)$/.test(options.level || '') ? options.level : '';
+    var resolvedTermId = resolveTermId(termId);
+    var article = findArticle(resolvedTermId) || (!termId ? articles[0] : null);
+    if (!article) {
+      setMissingTerm(termId || resolvedTermId);
+      return;
+    }
+    if (missingState) missingState.hidden = true;
     var activeTermId = article.getAttribute('data-term-id');
 
     articles.forEach(function (item) {
       item.hidden = item !== article;
+      Array.prototype.slice.call(item.querySelectorAll('[data-glossary-detail-level]')).forEach(function (detail) {
+        detail.open = false;
+      });
     });
 
     document.querySelectorAll('[data-glossary-term]').forEach(function (link) {
@@ -63,11 +119,24 @@
     });
 
     if (selectedLabel) {
-      selectedLabel.textContent = selectedLabel.textContent.split(':')[0] + ': ' + (article.getAttribute('data-title') || activeTermId);
+      var selectedPrefix = openButton ? openButton.getAttribute('data-glossary-selected-prefix') : '';
+      selectedLabel.textContent = (selectedPrefix || 'Selected term') + ': ' + (article.getAttribute('data-title') || activeTermId);
     }
 
-    if (options.updateHash && window.location.hash !== glossaryHashForTerm(activeTermId)) {
-      window.location.hash = glossaryHashForTerm(activeTermId);
+    var targetDetail = null;
+    if (requestedLevel === 'advanced' || requestedLevel === 'technician') {
+      targetDetail = article.querySelector('[data-glossary-detail-level="' + requestedLevel + '"]');
+      if (targetDetail) targetDetail.open = true;
+    }
+
+    if (options.updateHash && window.location.hash !== glossaryHashForTerm(activeTermId, requestedLevel)) {
+      window.location.hash = glossaryHashForTerm(activeTermId, requestedLevel);
+    }
+
+    if (options.scroll && targetDetail) {
+      window.requestAnimationFrame(function () {
+        targetDetail.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      });
     }
   }
 
@@ -79,8 +148,23 @@
     resultCount.textContent = (template || '{count} terms shown').replace('{count}', String(visibleCount));
   }
 
+  function searchScore(item, query) {
+    if (!query) return 0;
+    var title = normalize(item.getAttribute('data-search-title'));
+    var aliases = normalize(item.getAttribute('data-search-aliases'));
+    var id = normalize(item.getAttribute('data-search-id'));
+    var metadata = normalize(item.getAttribute('data-search-metadata'));
+    if (title.indexOf(query) === 0) return 100;
+    if (title.indexOf(query) !== -1) return 90;
+    if (aliases.indexOf(query) !== -1) return 80;
+    if (id.indexOf(query) !== -1) return 70;
+    if (metadata.indexOf(query) !== -1) return 50;
+    return -1;
+  }
+
   function filterPanel(panel) {
     var input = panel.querySelector('[data-glossary-search]');
+    var list = panel.querySelector('.glossary-term-list');
     var terms = Array.prototype.slice.call(panel.querySelectorAll('[data-glossary-term]'));
     var resultCount = panel.querySelector('.glossary-result-count');
     var noResults = panel.querySelector('.glossary-no-results');
@@ -88,12 +172,32 @@
 
     var query = normalize(input.value);
     var visibleCount = 0;
-    terms.forEach(function (item) {
-      var haystack = normalize(item.getAttribute('data-search'));
-      var isVisible = !query || haystack.indexOf(query) !== -1;
-      item.hidden = !isVisible;
+    var ranked = terms.map(function (item, index) {
+      var storedIndex = item.getAttribute('data-glossary-original-index');
+      if (storedIndex === null) {
+        storedIndex = String(index);
+        item.setAttribute('data-glossary-original-index', storedIndex);
+      }
+      return {
+        item: item,
+        score: searchScore(item, query),
+        index: Number(storedIndex)
+      };
+    });
+
+    ranked.forEach(function (entry) {
+      var isVisible = !query || entry.score >= 0;
+      entry.item.hidden = !isVisible;
       if (isVisible) visibleCount += 1;
     });
+
+    ranked.sort(function (a, b) {
+      if (!query) return a.index - b.index;
+      if (b.score !== a.score) return b.score - a.score;
+      return a.index - b.index;
+    });
+    if (list) ranked.forEach(function (entry) { list.appendChild(entry.item); });
+
     setCount(resultCount, visibleCount);
     if (noResults) noResults.hidden = visibleCount !== 0;
   }
@@ -150,6 +254,16 @@
     input.addEventListener('input', function () {
       filterPanel(panel);
     });
+    input.addEventListener('keydown', function (event) {
+      if (event.key !== 'Enter') return;
+      var firstVisible = Array.prototype.slice.call(panel.querySelectorAll('[data-glossary-term]')).find(function (term) {
+        return !term.hidden;
+      });
+      if (!firstVisible) return;
+      event.preventDefault();
+      setActiveTerm(firstVisible.getAttribute('data-term-id'), { updateHash: true });
+      closePicker();
+    });
     filterPanel(panel);
   });
 
@@ -180,10 +294,16 @@
   });
 
   document.addEventListener('click', function (event) {
-    var link = event.target.closest('[data-glossary-term]');
+    var relatedLink = event.target.closest('[data-glossary-related-term]');
+    var link = event.target.closest('[data-glossary-term]') || relatedLink;
     if (!link) return;
     var termId = link.getAttribute('data-term-id');
-    if (!findArticle(termId)) return;
+    if (!termId && link.getAttribute('href')) {
+      var href = link.getAttribute('href');
+      var query = href.split('#glossary?', 2)[1] || '';
+      termId = new URLSearchParams(query).get('term') || '';
+    }
+    if (!findArticle(resolveTermId(termId))) return;
     event.preventDefault();
     setActiveTerm(termId, { updateHash: true });
     closePicker();
@@ -191,11 +311,11 @@
 
   window.addEventListener('hashchange', function () {
     var parsed = parseGlossaryHash();
-    if (parsed) setActiveTerm(parsed.term);
+    if (parsed) setActiveTerm(parsed.term, { level: parsed.level, scroll: true });
   });
 
   var parsed = parseGlossaryHash();
-  if (parsed) setActiveTerm(parsed.term);
+  if (parsed) setActiveTerm(parsed.term, { level: parsed.level });
 
   document.addEventListener('keydown', function (event) {
     if (event.key === 'Escape' && picker && !picker.hidden) {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v72';
+var CACHE_VERSION = 'v73';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/partials/glossary_view.html
+++ b/app/templates/partials/glossary_view.html
@@ -11,7 +11,7 @@
         {% for term in glossary_terms %}
         {% set category = glossary_category_by_id[term.category] %}
         {% set search_text = term.title ~ ' ' ~ term.id ~ ' ' ~ category.title ~ ' ' ~ (term.aliases|join(' ')) ~ ' ' ~ (term.tags|join(' ')) ~ ' ' ~ (term.source_pages|join(' ')) ~ ' ' ~ (term.ui_contexts|join(' ')) %}
-        <a data-glossary-term data-term-id="{{ term.id }}" data-category="{{ term.category }}" data-tags="{{ term.tags|join(' ') }}" data-source-pages="{{ term.source_pages|join(' ') }}" data-ui-contexts="{{ term.ui_contexts|join(' ') }}" data-search="{{ search_text|e }}" class="glossary-term-link {{ 'active' if glossary_selected_term and glossary_selected_term.id == term.id else '' }}" href="/?lang={{ lang|urlencode }}#glossary?term={{ term.id|urlencode }}" aria-current="{{ 'page' if glossary_selected_term and glossary_selected_term.id == term.id else 'false' }}">
+        <a data-glossary-term data-term-id="{{ term.id }}" data-category="{{ term.category }}" data-tags="{{ term.tags|join(' ') }}" data-source-pages="{{ term.source_pages|join(' ') }}" data-ui-contexts="{{ term.ui_contexts|join(' ') }}" data-search-title="{{ term.title|e }}" data-search-aliases="{{ term.aliases|join(' ')|e }}" data-search-alias-values="{{ term.aliases|join('|||')|e }}" data-search-id="{{ term.id|e }}" data-search-metadata="{{ (category.title ~ ' ' ~ (term.tags|join(' ')) ~ ' ' ~ (term.source_pages|join(' ')) ~ ' ' ~ (term.ui_contexts|join(' ')))|e }}" data-search="{{ search_text|e }}" class="glossary-term-link {{ 'active' if glossary_selected_term and glossary_selected_term.id == term.id else '' }}" href="/?lang={{ lang|urlencode }}#glossary?term={{ term.id|urlencode }}" aria-current="{{ 'page' if glossary_selected_term and glossary_selected_term.id == term.id else 'false' }}">
             {{ term.title }}
         </a>
         {% endfor %}
@@ -27,7 +27,7 @@
 </div>
 
 {% if glossary_selected_term %}
-<button type="button" class="glossary-mobile-picker-trigger" data-glossary-picker-open aria-controls="glossary-mobile-picker" aria-expanded="false">
+<button type="button" class="glossary-mobile-picker-trigger" data-glossary-picker-open aria-controls="glossary-mobile-picker" aria-expanded="false" data-glossary-selected-prefix="{{ t.get('glossary_selected_term', 'Selected term') }}">
     <span data-glossary-mobile-selected>{{ t.get('glossary_selected_term', 'Selected term') }}: {{ glossary_selected_term.title }}</span>
     <strong>{{ t.get('glossary_change_term', 'Search or change term') }}</strong>
 </button>
@@ -40,12 +40,17 @@
     </aside>
 
     <article class="glossary-article" aria-live="polite">
+        <section class="glossary-card glossary-empty-state" data-glossary-missing hidden>
+            <h3>{{ t.get('glossary_no_term_selected', 'No glossary term selected') }}</h3>
+            <p>{{ t.get('glossary_no_results', 'No matching glossary terms. Try a broader word such as DOCSIS, signal, speed, or errors.') }}</p>
+        </section>
         {% for term in glossary_terms %}
-        {% set category = glossary_category_by_id[term.category] %}
         <section class="glossary-term-article" data-glossary-article data-term-id="{{ term.id }}" data-title="{{ term.title }}" data-category="{{ term.category }}" data-tags="{{ term.tags|join(' ') }}" data-source-pages="{{ term.source_pages|join(' ') }}" data-ui-contexts="{{ term.ui_contexts|join(' ') }}" data-related="{{ term.related|join(' ') }}" {{ 'hidden' if not glossary_selected_term or glossary_selected_term.id != term.id else '' }}>
             <section class="glossary-card glossary-term-header-card">
-                <p class="eyebrow">{{ category.title }}</p>
                 <h3 id="glossary-term-title-{{ term.id }}">{{ term.title }}</h3>
+                {% if term.aliases %}
+                <p class="glossary-aliases"><span>{{ t.get('glossary_aliases_heading', 'Also searched as') }}:</span> {{ term.aliases|join(', ') }}</p>
+                {% endif %}
             </section>
 
             <section class="glossary-card glossary-summary-card" aria-labelledby="summary-heading-{{ term.id }}">
@@ -56,7 +61,42 @@
             <section class="glossary-card glossary-explanation-card" aria-labelledby="explanation-heading-{{ term.id }}">
                 <h4 id="explanation-heading-{{ term.id }}">{{ t.get('glossary_explanation_heading', 'Explanation') }}</h4>
                 <p>{{ term.levels.basic }}</p>
+                {% if term.levels.advanced and term.levels.advanced != term.levels.basic %}
+                <details class="glossary-detail-block" data-glossary-detail-level="advanced">
+                    <summary>{{ t.get('glossary_level_advanced', 'Advanced') }}</summary>
+                    <p>{{ term.levels.advanced }}</p>
+                </details>
+                {% endif %}
+                {% if term.levels.technician and term.levels.technician != term.levels.basic and term.levels.technician != term.levels.advanced %}
+                <details class="glossary-detail-block" data-glossary-detail-level="technician">
+                    <summary>{{ t.get('glossary_level_technician', 'Technician') }}</summary>
+                    <p>{{ term.levels.technician }}</p>
+                </details>
+                {% endif %}
             </section>
+
+            {% if term.media %}
+            <section class="glossary-card glossary-media-card" aria-label="{{ term.title }} media">
+                {% for item in term.media %}
+                <figure class="glossary-media-item">
+                    <img src="{{ item.src }}" alt="{{ item.alt }}" loading="lazy">
+                    {% if item.caption %}<figcaption>{{ item.caption }}</figcaption>{% endif %}
+                </figure>
+                {% endfor %}
+            </section>
+            {% endif %}
+
+            {% if term.related %}
+            <nav class="glossary-related-row" aria-label="{{ t.get('glossary_related_heading', 'Related terms') }}">
+                <span>{{ t.get('glossary_related_heading', 'Related terms') }}:</span>
+                {% for related_id in term.related %}
+                {% set related = glossary_term_by_id.get(related_id) %}
+                {% if related %}
+                <a class="glossary-related-link" data-glossary-related-term href="/?lang={{ lang|urlencode }}#glossary?term={{ related.id|urlencode }}">{{ related.title }}</a>
+                {% endif %}
+                {% endfor %}
+            </nav>
+            {% endif %}
         </section>
         {% endfor %}
         {% if not glossary_terms %}

--- a/app/web.py
+++ b/app/web.py
@@ -1298,10 +1298,12 @@ def _build_glossary_context(lang, t, selected_term_id=None):
     if not selected_term and terms:
         selected_term = terms[0]
     category_by_id = {category["id"]: category for category in categories}
+    term_by_id = {term["id"]: term for term in terms}
     return {
         "glossary_terms": terms,
         "glossary_categories": categories,
         "glossary_category_by_id": category_by_id,
+        "glossary_term_by_id": term_by_id,
         "glossary_selected_term": selected_term,
     }
 

--- a/tests/e2e/test_glossary_page.py
+++ b/tests/e2e/test_glossary_page.py
@@ -62,6 +62,28 @@ def test_glossary_term_list_navigation_updates_hash_and_article(page, live_serve
     expect(_active_article(page).locator(".glossary-term-header-card h3", has_text="Gaming Index")).to_be_visible()
 
 
+def test_glossary_level_deep_link_opens_detail_inside_explanation(page, live_server):
+    page.goto(f"{live_server}/?lang=en#glossary?term=docsis&level=technician")
+    page.wait_for_selector("#view-glossary.active", state="visible")
+
+    article = _active_article(page)
+    expect(article.locator(".glossary-term-header-card h3", has_text="DOCSIS")).to_be_visible()
+    detail = article.locator('[data-glossary-detail-level="technician"]')
+    expect(detail).to_be_visible()
+    assert detail.evaluate("node => node.open") is True
+    expect(article.locator(".glossary-summary-card", has_text="Quick summary")).to_be_visible()
+    expect(article.locator(".glossary-explanation-card", has_text="Explanation")).to_be_visible()
+
+
+def test_glossary_invalid_deep_link_shows_searchable_empty_state(page, live_server):
+    page.goto(f"{live_server}/?lang=en#glossary?term=not_a_real_term")
+    page.wait_for_selector("#view-glossary.active", state="visible")
+
+    expect(page.locator("#view-glossary [data-glossary-missing]")).to_be_visible()
+    expect(page.locator("#glossary-search")).to_have_value("not_a_real_term")
+    expect(page.locator("#view-glossary .glossary-term-article:not([hidden])")).to_have_count(0)
+
+
 def test_glossary_mobile_layout_has_no_horizontal_overflow(page, live_server):
     page.set_viewport_size({"width": 393, "height": 852})
     page.goto(f"{live_server}/?lang=en&term=gaming_index#glossary?term=gaming_index")
@@ -82,6 +104,27 @@ def test_glossary_search_filters_alphabetical_terms(page, live_server):
     expect(page.locator(".glossary-index-desktop [data-term-id='cmts']")).to_be_visible()
     expect(page.locator(".glossary-index-desktop [data-search^='Speedtest ']")).to_be_hidden()
     expect(page.locator("#glossary-result-count")).to_contain_text("1 term shown")
+
+    search.fill("SNR")
+    first_visible = page.locator(".glossary-index-desktop [data-glossary-term]:visible").first
+    expect(first_visible).to_have_attribute("data-term-id", "snr_mer")
+    page.keyboard.press("Enter")
+    expect(page).to_have_url(re.compile(r"#glossary\?term=snr_mer"))
+    expect(_active_article(page).locator(".glossary-term-header-card h3", has_text="SNR/MER")).to_be_visible()
+
+    search.fill("")
+    restored_terms = page.locator(".glossary-index-desktop .glossary-term-link").evaluate_all(
+        "nodes => nodes.slice(0, 3).map(node => node.textContent.trim())"
+    )
+    assert restored_terms == ["Before/After Comparison", "BNetzA measurement", "BQM"]
+
+
+def test_glossary_alias_deep_link_resolves_to_canonical_term(page, live_server):
+    page.goto(f"{live_server}/?lang=en#glossary?term=Signal-to-noise%20ratio")
+    page.wait_for_selector("#view-glossary.active", state="visible")
+
+    expect(_active_article(page).locator(".glossary-term-header-card h3", has_text="SNR/MER")).to_be_visible()
+    expect(page.locator("#view-glossary [data-glossary-missing]")).to_be_hidden()
 
 
 def test_glossary_desktop_click_does_not_refocus_closed_mobile_picker(page, live_server):

--- a/tests/test_glossary_catalog.py
+++ b/tests/test_glossary_catalog.py
@@ -77,6 +77,13 @@ def test_glossary_lookup_falls_back_to_english_for_unsupported_locale():
     assert "DOCSIS is the standard cable modems use" in term["levels"]["eli5"]
 
 
+def test_glossary_terms_use_one_global_alphabetical_order():
+    terms = get_glossary_terms("en")
+    titles = [term["title"] for term in terms]
+    assert titles == sorted(titles, key=str.casefold)
+    assert titles[:3] == ["Before/After Comparison", "BNetzA measurement", "BQM"]
+
+
 def test_speedtest_feature_keeps_throughput_boundary_in_app_terms():
     term = get_glossary_term("speedtest", "en")
     assert term is not None

--- a/tests/web/test_glossary_route.py
+++ b/tests/web/test_glossary_route.py
@@ -54,6 +54,13 @@ def test_index_glossary_renders_simple_summary_and_explanation(client, sample_an
     assert 'data-glossary-level' not in html
     assert "SC-QAM is the classic narrow DOCSIS channel type" in html
     assert "SC-QAM channels are traditional DOCSIS 3.0-style channels" in html
+    active_article = html.split('class="glossary-term-article" data-glossary-article data-term-id="sc_qam"', 1)[1].split('class="glossary-term-article" data-glossary-article', 1)[0]
+    assert '<p class="eyebrow">' not in active_article
+    assert "DOCSIS terms" not in active_article
+    assert "Also searched as" in active_article
+    assert 'data-glossary-detail-level="advanced"' in html
+    assert 'data-glossary-detail-level="technician"' in html
+    assert 'class="glossary-media-card"' not in html
 
 
 def test_index_glossary_exposes_wiki_source_search_metadata(client, sample_analysis):


### PR DESCRIPTION
## Summary
- simplify the glossary article into a dictionary-style title, aliases, quick summary, and explanation flow
- support glossary level deep links with in-article detail sections, alias resolution, and invalid-term empty states
- improve glossary search ranking while preserving alphabetical order after clearing search
- bump the service-worker cache for updated static assets

## Checks
- git diff --check
- uv run --isolated --with-requirements requirements-test.in pytest tests/web/test_glossary_route.py tests/test_glossary_catalog.py tests/test_glossary_i18n.py tests/test_static_contracts.py -q
- uv run --isolated --with-requirements requirements-test.in --with pytest-playwright==0.7.2 --with playwright==1.58.0 pytest tests/e2e/test_glossary.py tests/e2e/test_glossary_page.py tests/e2e/test_glossary_visual.py -q