### PR TITLE
Harden glossary domain semantics

### DIFF
--- a/app/glossary.py
+++ b/app/glossary.py
@@ -220,8 +220,8 @@ _TERMS: tuple[GlossaryTerm, ...] = (
         ('ofdm', 'upstream', 'mixed_mode', 'return_path_interference'),
         'OFDMA is the DOCSIS 3.1 upstream channel type.',
         'OFDMA lets many modems share pieces of a wide upstream block. DOCSight labels it separately from SC-QAM upstream channels.',
-        'OFDMA depends on profile, subcarrier, minislot, return-path noise, and scheduling context. DOCSight should avoid simple SC-QAM-style capacity guesses when the data is incomplete.',
-        'OFDMA depends on profile, subcarrier, minislot, return-path noise, and scheduling context. DOCSight should avoid simple SC-QAM-style capacity guesses when the data is incomplete.',
+        'OFDMA depends on profile, subcarrier, minislot, return-path noise, and scheduling context. Missing or null modem fields mean unsupported or not reported, not measured zero; DOCSight should avoid simple SC-QAM-style capacity guesses when the data is incomplete.',
+        'OFDMA depends on profile, subcarrier, minislot, return-path noise, and scheduling context. Missing, None, or null modem fields mean unsupported or not reported, not measured zero; DOCSight should avoid simple SC-QAM-style capacity guesses when the data is incomplete.',
     ),
     _term(
         'mixed_mode',
@@ -463,8 +463,8 @@ _TERMS: tuple[GlossaryTerm, ...] = (
         ('qam_modulation_order', 'sc_qam', 'ofdm', 'ofdma'),
         "Modulation Performance is a DOCSight feature for understanding the app's diagnostic evidence.",
         'Modulation Performance focuses on QAM/channel-family behavior so degraded modulation and capacity-sensitive signal problems are easier to spot.',
-        'Modulation Performance focuses on QAM/channel-family behavior so degraded modulation and capacity-sensitive signal problems are easier to spot. It should be read as an app feature explanation, not as a new DOCSIS protocol term.',
-        'Modulation Performance focuses on QAM/channel-family behavior so degraded modulation and capacity-sensitive signal problems are easier to spot. Keep the feature evidence boundary explicit: DOCSight can organize and correlate supported data sources, but it should not invent provider-side facts.',
+        'Modulation Performance focuses on QAM/channel-family behavior so degraded modulation and capacity-sensitive signal problems are easier to spot. For DOCSIS 3.1 upstream Low-QAM, DOCSight treats ≤64QAM as the low-QAM boundary.',
+        'Modulation Performance focuses on QAM/channel-family behavior so degraded modulation and capacity-sensitive signal problems are easier to spot. For DOCSIS 3.1 upstream Low-QAM, keep the ≤64QAM boundary separate from DOCSIS 3.0 upstream color semantics.',
     ),
     _term(
         'segment_utilization',
@@ -475,8 +475,8 @@ _TERMS: tuple[GlossaryTerm, ...] = (
         ('shared_medium', 'node_segment', 'speedtest'),
         "Segment Utilization is a DOCSight feature for understanding the app's diagnostic evidence.",
         'Segment Utilization is DOCSight’s view for separating local signal evidence from shared-segment load signals when supported data is available.',
-        'Segment Utilization is DOCSight’s view for separating local signal evidence from shared-segment load signals when supported data is available. It should be read as an app feature explanation, not as a new DOCSIS protocol term.',
-        'Segment Utilization is DOCSight’s view for separating local signal evidence from shared-segment load signals when supported data is available. Keep the feature evidence boundary explicit: DOCSight can organize and correlate supported data sources, but it should not invent provider-side facts.',
+        'Segment Utilization is DOCSight’s view for separating local signal evidence from shared-segment load signals when supported data is available. Unknown remains a visible category and stays in distribution denominators instead of being dropped.',
+        'Segment Utilization is DOCSight’s view for separating local signal evidence from shared-segment load signals when supported data is available. Keep Unknown in denominators so supported samples, unknown buckets, and missing data are not mixed into invented certainty.',
     ),
     _term(
         'correlation_analysis',

--- a/tests/test_glossary_catalog.py
+++ b/tests/test_glossary_catalog.py
@@ -92,6 +92,31 @@ def test_speedtest_feature_keeps_throughput_boundary_in_app_terms():
     assert "latency" in joined
     assert "DOCSIS evidence" in joined
 
+
+def test_glossary_domain_semantics_are_pinned_to_docsight_behavior():
+    """Glossary copy must preserve diagnostic semantics instead of inventing values."""
+    ofdma = get_glossary_term("ofdma", "en")
+    segment = get_glossary_term("segment_utilization", "en")
+    modulation = get_glossary_term("modulation_performance", "en")
+
+    assert ofdma is not None
+    ofdma_joined = " ".join(ofdma["levels"].values())
+    assert "unsupported or not reported" in ofdma_joined
+    assert "not measured zero" in ofdma_joined
+    assert "None" in ofdma_joined
+    assert "null" in ofdma_joined
+
+    assert segment is not None
+    segment_joined = " ".join(segment["levels"].values())
+    assert "Unknown" in segment_joined
+    assert "denominators" in segment_joined
+
+    assert modulation is not None
+    modulation_joined = " ".join(modulation["levels"].values())
+    assert "DOCSIS 3.1 upstream Low-QAM" in modulation_joined
+    assert "≤64QAM" in modulation_joined
+
+
 def test_core_glossary_preserves_required_technical_tokens():
     expected_tokens = {
         "docsis": {"DOCSIS", "DSL"},

--- a/tests/test_glossary_i18n.py
+++ b/tests/test_glossary_i18n.py
@@ -228,3 +228,22 @@ def test_localized_glossary_lookup_normalizes_region_locale():
     assert german is not None and english is not None
     assert german["levels"]["eli5"] != english["levels"]["eli5"]
     assert "DOCSIS" in german["levels"]["eli5"]
+
+
+def test_localized_glossary_preserves_required_literal_tokens():
+    required = {
+        "docsis": {"DOCSIS"},
+        "sc_qam": {"SC-QAM", "QAM"},
+        "ofdm": {"OFDM", "DOCSIS"},
+        "ofdma": {"OFDMA", "DOCSIS"},
+        "snr_mer": {"SNR", "MER"},
+        "modulation_performance": {"DOCSIS", "Low-QAM", "≤64QAM"},
+    }
+
+    for lang in _offered_core_languages():
+        for term_id, tokens in required.items():
+            term = get_glossary_term(term_id, lang)
+            assert term is not None
+            joined = " ".join([term["title"], *term["aliases"], *term["levels"].values(), *term["misconceptions"]])
+            for token in tokens:
+                assert token in joined, f"Missing literal {token} for {term_id} in {lang}"


### PR DESCRIPTION
## Summary
- pin glossary copy for unsupported/null values, Unknown denominator handling, and DOCSIS 3.1 Low-QAM wording
- add glossary catalog and i18n tests for protected technical literals and domain semantics

## Checks
- git diff --check
- python3 -m compileall -q app/glossary.py app/web.py
- uv run --isolated --with-requirements requirements-test.in pytest tests/test_glossary_catalog.py tests/test_glossary_i18n.py tests/web/test_glossary_route.py -q
- uv run --isolated --with-requirements requirements-test.in --with pytest-playwright==0.7.2 --with playwright==1.58.0 pytest tests/e2e/test_glossary_page.py -q

Closes #706