### PR TITLE
Enforce glossary media schema

### DIFF
--- a/app/glossary.py
+++ b/app/glossary.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable
+from urllib.parse import unquote
 
 GLOSSARY_LEVELS: tuple[str, ...] = ("eli5", "basic", "advanced", "technician")
 
@@ -870,6 +871,34 @@ _GLOSSARY_WIKI_INDEX: dict[str, dict[str, tuple[str, ...]]] = {
 def _metadata_for_term(term_id: str) -> dict[str, tuple[str, ...]]:
     return _GLOSSARY_WIKI_INDEX.get(term_id, {})
 
+
+def _validate_media_entries(term_id: str, media: Iterable[dict[str, Any]]) -> list[str]:
+    """Validate optional glossary media stays local, explicit, and accessible."""
+    errors: list[str] = []
+    for index, item in enumerate(media):
+        if not isinstance(item, dict):
+            errors.append(f"{term_id}: media {index} must be an object")
+            continue
+        raw_src = item.get("src", "")
+        raw_alt = item.get("alt", "")
+        src = raw_src.strip() if isinstance(raw_src, str) else ""
+        decoded_src = unquote(src)
+        alt = raw_alt.strip() if isinstance(raw_alt, str) else ""
+        if not src:
+            errors.append(f"{term_id}: media {index} missing src")
+        elif (
+            not src.startswith("/static/")
+            or decoded_src.startswith(("http://", "https://", "//"))
+            or ":" in decoded_src.split("/", 1)[0]
+            or "\\" in decoded_src
+            or ".." in Path(decoded_src).parts
+        ):
+            errors.append(f"{term_id}: media {index} src must be a local static path")
+        if not alt:
+            errors.append(f"{term_id}: media {index} missing alt")
+    return errors
+
+
 _GLOSSARY_I18N_DIR = Path(__file__).with_name("glossary_i18n")
 
 
@@ -958,6 +987,7 @@ def validate_glossary_catalog(terms: Iterable[GlossaryTerm] = _TERMS) -> list[st
         for token in term.protected_terms:
             if not token:
                 errors.append(f"{term.id}: empty protected term")
+        errors.extend(_validate_media_entries(term.id, term.media))
         metadata = _metadata_for_term(term.id)
         for field in ("tags", "source_pages", "ui_contexts"):
             values = metadata.get(field, ())

--- a/tests/test_glossary_catalog.py
+++ b/tests/test_glossary_catalog.py
@@ -2,6 +2,7 @@
 
 from app.glossary import (
     GLOSSARY_LEVELS,
+    GlossaryTerm,
     get_glossary_categories,
     get_glossary_term,
     get_glossary_terms,
@@ -12,6 +13,53 @@ from app.glossary import (
 
 def test_glossary_catalog_schema_is_valid():
     assert validate_glossary_catalog() == []
+
+
+def _media_test_term(media):
+    return GlossaryTerm(
+        id="media_test",
+        category="docsis_terms",
+        title={"en": "Media test"},
+        aliases={"en": ("Media alias",)},
+        levels={"en": {level: f"Valid {level} explanation" for level in GLOSSARY_LEVELS}},
+        misconceptions={},
+        related=(),
+        protected_terms=("DOCSIS",),
+        media=media,
+    )
+
+
+def test_glossary_media_schema_accepts_local_static_media():
+    term = _media_test_term(({"src": "/static/glossary/ofdm.svg", "alt": "OFDM diagram"},))
+
+    assert validate_glossary_catalog((term,)) == []
+
+
+def test_glossary_media_schema_rejects_external_or_unsafe_media():
+    invalid_cases = [
+        ({"src": "https://example.test/ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "//cdn.example.test/ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "javascript:alert(1)", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "data:image/svg+xml,abc", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "/etc/passwd", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "glossary/ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "static/glossary/ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "\\\\cdn.example.test\\ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "/static/glossary\\ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "../private/ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "/static/../private/ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "/static/%2e%2e/private/ofdm.svg", "alt": "OFDM diagram"}, "local static path"),
+        ({"src": "/static/glossary/ofdm.svg", "alt": ""}, "missing alt"),
+        ({"src": "", "alt": "OFDM diagram"}, "missing src"),
+        ({"src": None, "alt": "OFDM diagram"}, "missing src"),
+        ({"src": "/static/glossary/ofdm.svg", "alt": None}, "missing alt"),
+        ("/static/glossary/ofdm.svg", "must be an object"),
+    ]
+
+    for media_item, expected_error in invalid_cases:
+        term = _media_test_term((media_item,))
+        errors = validate_glossary_catalog((term,))
+        assert any(expected_error in error for error in errors), errors
 
 
 def test_core_glossary_contains_only_docsis_terms_and_docsight_features():


### PR DESCRIPTION
## Summary
- validate optional glossary media as local `/static/` assets with non-empty alt text
- reject external, unsafe, traversal, non-string, and malformed media entries
- add catalog tests for accepted and rejected media shapes

## Checks
- git diff --check
- python3 -m compileall -q app/glossary.py app/web.py
- uv run --isolated --with-requirements requirements-test.in pytest tests/test_glossary_catalog.py tests/test_glossary_i18n.py tests/web/test_glossary_route.py -q
- uv run --isolated --with-requirements requirements-test.in --with pytest-playwright==0.7.2 --with playwright==1.58.0 pytest tests/e2e/test_glossary_page.py -q

Closes #708
