### PR TITLE
runtime: support portable web bind configuration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -51,7 +51,32 @@ if os.environ.get("DOCSIGHT_AUDIT_JSON", "").strip() == "1":
 def run_web(port):
     """Run production web server in a separate thread."""
     from waitress import serve
-    serve(web.app, host="0.0.0.0", port=port, threads=4, _quiet=True)
+    host = get_web_host()
+    serve(web.app, host=host, port=port, threads=4, _quiet=True)
+
+
+def get_web_host():
+    """Return the configured web bind address, preserving the server default."""
+    return os.environ.get("WEB_HOST", "0.0.0.0")
+
+
+def _apply_timezone(cfg):
+    """Apply the configured timezone where the platform supports TZ reloads."""
+    tz = cfg.get("timezone")
+    if tz:
+        os.environ["TZ"] = tz
+        if hasattr(time, "tzset"):
+            time.tzset()
+
+
+def _handle_config_changed(config_mgr, storage, start_polling):
+    """Reload config and apply runtime changes after a web UI save."""
+    log.info("Configuration changed, restarting polling loop")
+    config_mgr._load()
+    _apply_timezone(config_mgr)
+    storage.max_days = config_mgr.get("history_days", 7)
+    if config_mgr.is_configured():
+        start_polling()
 
 
 def _get_modem_config_key(config_mgr):
@@ -325,12 +350,6 @@ def polling_loop(config_mgr, storage, stop_event):
 
 
 def main():
-    def _apply_timezone(cfg):
-        tz = cfg.get("timezone")
-        if tz:
-            os.environ["TZ"] = tz
-            time.tzset()
-
     data_dir = os.environ.get("DATA_DIR", "/data")
     config_mgr = ConfigManager(data_dir)
     _apply_timezone(config_mgr)
@@ -366,15 +385,7 @@ def main():
 
     def on_config_changed():
         """Called when config is saved via web UI."""
-        log.info("Configuration changed, restarting polling loop")
-        # Reload config from file
-        config_mgr._load()
-        # Apply timezone change immediately
-        _apply_timezone(config_mgr)
-        # Update storage max_days
-        storage.max_days = config_mgr.get("history_days", 7)
-        if config_mgr.is_configured():
-            start_polling()
+        _handle_config_changed(config_mgr, storage, start_polling)
 
     web.init_config(config_mgr, on_config_changed)
 
@@ -415,9 +426,10 @@ def main():
 
     # Start Flask
     web_port = config_mgr.get("web_port", 8765)
+    web_host = get_web_host()
     web_thread = threading.Thread(target=run_web, args=(web_port,), daemon=True)
     web_thread.start()
-    log.info("Web UI started on port %d", web_port)
+    log.info("Web UI started on %s:%d", web_host, web_port)
 
     # Start polling if already configured
     if config_mgr.is_configured():

--- a/app/modules/backup/backup.py
+++ b/app/modules/backup/backup.py
@@ -310,6 +310,9 @@ def browse_directory(path, allowed_roots=None):
     """
     if allowed_roots is None:
         allowed_roots = ["/backup", "/data"]
+        data_dir = os.environ.get("DATA_DIR")
+        if data_dir:
+            allowed_roots.append(data_dir)
 
     real_path = os.path.realpath(path)
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -368,6 +368,18 @@ class TestBrowseDirectory:
         result = browse_directory(str(root), allowed_roots=[str(root)])
         assert result["parent"] is None
 
+    def test_browse_uses_data_dir_as_default_allowed_root(self, tmp_path, monkeypatch):
+        data_root = tmp_path / "desktop_data"
+        nested = data_root / "exports"
+        nested.mkdir(parents=True)
+
+        monkeypatch.setenv("DATA_DIR", str(data_root))
+
+        result = browse_directory(str(data_root))
+
+        assert "exports" in result["directories"]
+        assert result["path"] == os.path.realpath(data_root)
+
     def test_browse_nonexistent_dir(self, tmp_path):
         with pytest.raises(ValueError, match="Not a directory"):
             browse_directory(str(tmp_path / "nope"), allowed_roots=[str(tmp_path)])

--- a/tests/test_runtime_contract.py
+++ b/tests/test_runtime_contract.py
@@ -1,0 +1,98 @@
+"""Runtime contract tests for portable DOCSight startup."""
+
+import os
+import sys
+import types
+
+from app import main as app_main
+
+
+class _Config:
+    def __init__(self, timezone="Europe/Berlin", history_days=14, configured=True):
+        self.timezone = timezone
+        self.history_days = history_days
+        self.configured = configured
+        self.load_calls = 0
+
+    def get(self, key, default=None):
+        if key == "timezone":
+            return self.timezone
+        if key == "history_days":
+            return self.history_days
+        return default
+
+    def _load(self):
+        self.load_calls += 1
+
+    def is_configured(self):
+        return self.configured
+
+
+class _Storage:
+    def __init__(self):
+        self.max_days = None
+
+
+def test_run_web_defaults_to_public_bind(monkeypatch):
+    calls = []
+
+    def fake_serve(app, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.delenv("WEB_HOST", raising=False)
+    monkeypatch.setitem(sys.modules, "waitress", types.SimpleNamespace(serve=fake_serve))
+
+    app_main.run_web(8765)
+
+    assert calls == [{"host": "0.0.0.0", "port": 8765, "threads": 4, "_quiet": True}]
+
+
+def test_run_web_honors_web_host_env(monkeypatch):
+    calls = []
+
+    def fake_serve(app, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setenv("WEB_HOST", "127.0.0.1")
+    monkeypatch.setitem(sys.modules, "waitress", types.SimpleNamespace(serve=fake_serve))
+
+    app_main.run_web(8770)
+
+    assert calls == [{"host": "127.0.0.1", "port": 8770, "threads": 4, "_quiet": True}]
+
+
+def test_apply_timezone_skips_missing_tzset(monkeypatch):
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.delattr(app_main.time, "tzset", raising=False)
+
+    app_main._apply_timezone(_Config())
+
+    assert os.environ["TZ"] == "Europe/Berlin"
+
+
+def test_apply_timezone_calls_tzset_when_available(monkeypatch):
+    calls = []
+
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.setattr(app_main.time, "tzset", lambda: calls.append("tzset"), raising=False)
+
+    app_main._apply_timezone(_Config("UTC"))
+
+    assert os.environ["TZ"] == "UTC"
+    assert calls == ["tzset"]
+
+
+def test_config_save_handler_uses_guarded_timezone_path(monkeypatch):
+    restart_calls = []
+    cfg = _Config(timezone="Europe/Berlin", history_days=30, configured=True)
+    storage = _Storage()
+
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.delattr(app_main.time, "tzset", raising=False)
+
+    app_main._handle_config_changed(cfg, storage, lambda: restart_calls.append("restart"))
+
+    assert cfg.load_calls == 1
+    assert os.environ["TZ"] == "Europe/Berlin"
+    assert storage.max_days == 30
+    assert restart_calls == ["restart"]


### PR DESCRIPTION
## Summary
- add `WEB_HOST` support while keeping the default web bind address unchanged
- make timezone reloads safe on platforms without `time.tzset()` during startup and config reloads
- allow the backup directory picker to use the active `DATA_DIR` as a default root
- add runtime contract tests for portable startup behavior

## Validation
- `/tmp/docsight-runtime-verify-venv/bin/python -m pytest tests/test_runtime_contract.py tests/test_backup.py -q`
- `/tmp/docsight-runtime-verify-venv/bin/python -m pytest tests/ -q --tb=short --ignore=tests/e2e`
- manual runtime smoke with `WEB_HOST=127.0.0.1 WEB_PORT=8770 DATA_DIR=$(mktemp -d)`: `/health` responded on loopback and the LAN address probe failed as expected
