### PR TITLE
ci: build and smoke-test the portable Windows package

### DIFF
--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -1,0 +1,111 @@
+name: Windows Desktop Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Optional version label for the desktop artifact
+        required: false
+        type: string
+  pull_request:
+    branches: [main]
+    paths:
+      - app/**
+      - packaging/windows/**
+      - requirements.txt
+      - .github/workflows/windows-desktop.yml
+  push:
+    branches: [main]
+    paths:
+      - app/**
+      - packaging/windows/**
+      - requirements.txt
+      - .github/workflows/windows-desktop.yml
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      artifact-name: ${{ steps.artifact.outputs.name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            packaging/windows/requirements-runtime-windows.txt
+            packaging/windows/requirements-build.txt
+
+      - name: Resolve artifact version
+        id: version
+        shell: pwsh
+        run: |
+          $version = ""
+          if ("${{ github.event_name }}" -eq "release") {
+            $version = "${{ github.event.release.tag_name }}"
+          } elseif ("${{ github.event_name }}" -eq "workflow_dispatch" -and -not [string]::IsNullOrWhiteSpace("${{ inputs.version }}")) {
+            $version = "${{ inputs.version }}".Trim()
+          } else {
+            $version = (git describe --tags --always --dirty).Trim()
+          }
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            throw "Unable to resolve artifact version."
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Build portable package
+        shell: pwsh
+        run: powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1 -Version "${{ steps.version.outputs.version }}"
+
+      - name: Smoke-test built package
+        shell: pwsh
+        run: powershell -ExecutionPolicy Bypass -File packaging/windows/smoke_test.ps1 -BundleDir packaging/windows/dist/DOCSight -ExpectedVersion "${{ steps.version.outputs.version }}" -Port 8765
+
+      - name: Resolve artifact name
+        id: artifact
+        shell: pwsh
+        run: |
+          $safeVersion = "${{ steps.version.outputs.version }}" -replace '[^A-Za-z0-9._-]', '-'
+          "name=docsight-desktop-preview-win64-$safeVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          if-no-files-found: error
+          path: |
+            packaging/windows/dist/DOCSight-Desktop-Preview-win64-*.zip
+            packaging/windows/dist/DOCSight-Desktop-Preview-win64-*.zip.sha256
+
+  attach-release-assets:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download desktop artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+          path: release-assets
+
+      - name: Attach assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG_NAME" release-assets/*.zip release-assets/*.sha256 --clobber

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -76,6 +76,27 @@ The build uses a Windows-resolved, hash-pinned runtime install from
 install from `requirements-build.txt`. The generated `VERSION` file is bundled
 next to the packaged `app/` tree so `/health` reports the build version.
 
+## CI automation
+
+The `Windows Desktop Preview` workflow builds the portable package on
+`windows-latest`, smoke-tests the built `DOCSight.exe` against
+`http://127.0.0.1:<port>/health`, and uploads the ZIP plus `.sha256` as workflow
+artifacts. Published releases also receive the ZIP and checksum as release
+assets.
+
+For local Windows smoke testing after a build:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File packaging/windows/smoke_test.ps1 `
+  -BundleDir packaging/windows/dist/DOCSight `
+  -ExpectedVersion v2026-07-09.1
+```
+
+The smoke test launches the packaged executable, uses a temporary
+`LOCALAPPDATA`, skips browser launch via `DOCSIGHT_SKIP_BROWSER=1`, verifies the
+`/health` status and version, checks the listener is bound to `127.0.0.1`, and
+then stops the process.
+
 ## Packaging boundary
 
 The Desktop Preview artifact is a Docker-free tryout build for exploring
@@ -88,7 +109,6 @@ Windows packaging tree out of the Docker build context as well.
 
 ## Non-goals for this slice
 
-- No GitHub Actions automation yet.
 - No tray icon, WebView shell, auto-start, updater, installer, MSI, or MSIX.
 - No native Windows ICMP/traceroute diagnostics.
 - No code signing.

--- a/packaging/windows/docsight_desktop.py
+++ b/packaging/windows/docsight_desktop.py
@@ -206,6 +206,9 @@ def _wait_for_ready(port: int, timeout_seconds: float = HEALTH_TIMEOUT_SECONDS) 
 
 def open_browser(port: int) -> None:
     """Open the desktop preview URL in the default browser."""
+    if os.environ.get("DOCSIGHT_SKIP_BROWSER") == "1":
+        LOG.info("Skipping browser launch because DOCSIGHT_SKIP_BROWSER=1")
+        return
     webbrowser.open(f"http://{DEFAULT_HOST}:{port}/")
 
 

--- a/packaging/windows/smoke_test.ps1
+++ b/packaging/windows/smoke_test.ps1
@@ -1,0 +1,100 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BundleDir,
+    [Parameter(Mandatory = $true)][string]$ExpectedVersion,
+    [int]$Port = 8765,
+    [int]$TimeoutSeconds = 60
+)
+
+$ErrorActionPreference = "Stop"
+
+$BundleDir = [System.IO.Path]::GetFullPath($BundleDir)
+$Executable = Join-Path $BundleDir "DOCSight.exe"
+if (-not (Test-Path $Executable)) {
+    throw "DOCSight executable not found: $Executable"
+}
+
+$SmokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("docsight-desktop-smoke-" + [guid]::NewGuid().ToString("N"))
+$LocalAppData = Join-Path $SmokeRoot "LocalAppData"
+New-Item -ItemType Directory -Force -Path $LocalAppData | Out-Null
+
+$PreviousLocalAppData = $env:LOCALAPPDATA
+$PreviousWebPort = $env:WEB_PORT
+$PreviousSkipBrowser = $env:DOCSIGHT_SKIP_BROWSER
+$Process = $null
+$LogFile = Join-Path $LocalAppData "DOCSight\logs\docsight.log"
+$HealthUrl = "http://127.0.0.1:$Port/health"
+
+function Write-SmokeLog {
+    if (Test-Path $LogFile) {
+        Write-Host "--- DOCSight Desktop log ---"
+        Get-Content -Path $LogFile -Tail 200 | ForEach-Object { Write-Host $_ }
+        Write-Host "--- end DOCSight Desktop log ---"
+    } else {
+        Write-Host "DOCSight Desktop log not found: $LogFile"
+    }
+}
+
+try {
+    $env:LOCALAPPDATA = $LocalAppData
+    $env:WEB_PORT = [string]$Port
+    $env:DOCSIGHT_SKIP_BROWSER = "1"
+
+    $Process = Start-Process -FilePath $Executable -PassThru -WindowStyle Hidden
+    $Deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $Payload = $null
+
+    while ((Get-Date) -lt $Deadline) {
+        if ($Process.HasExited) {
+            Write-SmokeLog
+            throw "DOCSight exited before /health became ready with exit code $($Process.ExitCode)."
+        }
+
+        try {
+            $Payload = Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3
+            if ($Payload.status -eq "ok") {
+                break
+            }
+        } catch {
+            Start-Sleep -Milliseconds 500
+            continue
+        }
+
+        Start-Sleep -Milliseconds 500
+    }
+
+    if ($null -eq $Payload) {
+        Write-SmokeLog
+        throw "DOCSight /health did not respond within $TimeoutSeconds seconds."
+    }
+    if ($Payload.status -ne "ok") {
+        Write-SmokeLog
+        throw "DOCSight /health returned status '$($Payload.status)' instead of 'ok'."
+    }
+    if ($Payload.version -ne $ExpectedVersion) {
+        Write-SmokeLog
+        throw "DOCSight /health returned version '$($Payload.version)' instead of '$ExpectedVersion'."
+    }
+
+    $Connections = @(Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue)
+    if (-not ($Connections | Where-Object { $_.LocalAddress -eq "127.0.0.1" })) {
+        $Addresses = ($Connections | ForEach-Object { $_.LocalAddress } | Sort-Object -Unique) -join ", "
+        Write-SmokeLog
+        throw "DOCSight is not listening on 127.0.0.1:$Port. Observed listener addresses: $Addresses"
+    }
+
+    Write-Host "DOCSight Desktop smoke passed: $HealthUrl returned status=ok version=$($Payload.version), listener=127.0.0.1:$Port"
+} finally {
+    if ($null -ne $Process -and -not $Process.HasExited) {
+        Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+        $Process.WaitForExit(10000) | Out-Null
+    }
+
+    $env:LOCALAPPDATA = $PreviousLocalAppData
+    $env:WEB_PORT = $PreviousWebPort
+    $env:DOCSIGHT_SKIP_BROWSER = $PreviousSkipBrowser
+
+    if (Test-Path $SmokeRoot) {
+        Remove-Item -Recurse -Force $SmokeRoot -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/test_desktop_entrypoint.py
+++ b/tests/test_desktop_entrypoint.py
@@ -112,6 +112,16 @@ def test_select_port_raises_when_range_is_unavailable(monkeypatch):
         desktop.select_port(env, max_port=8766)
 
 
+def test_open_browser_can_be_skipped_for_ci_smoke(monkeypatch):
+    calls = []
+    monkeypatch.setenv("DOCSIGHT_SKIP_BROWSER", "1")
+    monkeypatch.setattr(desktop.webbrowser, "open", lambda url: calls.append(url))
+
+    desktop.open_browser(8765)
+
+    assert calls == []
+
+
 def test_runtime_root_uses_source_checkout_by_default():
     assert desktop.get_runtime_root() == ROOT
 

--- a/tests/test_windows_desktop_ci.py
+++ b/tests/test_windows_desktop_ci.py
@@ -1,0 +1,107 @@
+"""Static checks for the Windows Desktop Preview GitHub Actions workflow."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "windows-desktop.yml"
+SMOKE_SCRIPT = ROOT / "packaging" / "windows" / "smoke_test.ps1"
+
+
+def named_step_block(workflow_text: str, step_name: str) -> str:
+    match = re.search(
+        rf"(?m)^      - name: {re.escape(step_name)}\n(?P<body>(?:        .*\n)*)",
+        workflow_text,
+    )
+    assert match, f"step not found: {step_name}"
+    return match.group("body")
+
+
+def test_windows_desktop_workflow_triggers_and_permissions():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "pull_request:" in workflow
+    assert "push:" in workflow
+    assert "branches: [main]" in workflow
+    assert "release:" in workflow
+    assert "types: [published]" in workflow
+    assert "permissions:\n  contents: read" in workflow
+    assert "attach-release-assets:" in workflow
+    assert "permissions:\n      contents: write" in workflow
+
+
+def test_windows_desktop_workflow_scopes_push_paths():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    for required_path in (
+        "app/**",
+        "packaging/windows/**",
+        "requirements.txt",
+        ".github/workflows/windows-desktop.yml",
+    ):
+        assert required_path in workflow
+
+
+def test_windows_desktop_workflow_uses_sha_pinned_actions():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    for action in (
+        "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+        "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1",
+        "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
+        "actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53",
+    ):
+        assert action in workflow
+
+    assert not re.search(r"uses: actions/[\w-]+@v\d+", workflow)
+
+
+def test_windows_desktop_workflow_builds_smokes_and_uploads_bundle():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    build_block = named_step_block(workflow, "Build portable package")
+    smoke_block = named_step_block(workflow, "Smoke-test built package")
+    upload_block = named_step_block(workflow, "Upload desktop artifact")
+
+    assert "packaging/windows/build.ps1" in build_block
+    assert "-Version \"${{ steps.version.outputs.version }}\"" in build_block
+    assert "packaging/windows/smoke_test.ps1" in smoke_block
+    assert "-BundleDir packaging/windows/dist/DOCSight" in smoke_block
+    assert "-ExpectedVersion \"${{ steps.version.outputs.version }}\"" in smoke_block
+    assert "DOCSight-Desktop-Preview-win64-*.zip" in upload_block
+    assert "DOCSight-Desktop-Preview-win64-*.zip.sha256" in upload_block
+
+
+def test_windows_desktop_workflow_attaches_release_assets():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    release_block = named_step_block(workflow, "Attach assets to release")
+    assert "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in release_block
+    assert "TAG_NAME: ${{ github.event.release.tag_name }}" in release_block
+    assert "gh release upload" in release_block
+    assert "release-assets/*.zip" in release_block
+    assert "release-assets/*.sha256" in release_block
+
+
+def test_smoke_script_launches_built_exe_and_checks_loopback_health():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "DOCSight.exe" in script
+    assert "Start-Process -FilePath $Executable" in script
+    assert "Invoke-RestMethod -Uri $HealthUrl" in script
+    assert "$Payload.status -ne \"ok\"" in script
+    assert "$Payload.version -ne $ExpectedVersion" in script
+    assert "Get-NetTCPConnection -State Listen -LocalPort $Port" in script
+    assert "LocalAddress -eq \"127.0.0.1\"" in script
+    assert "DOCSIGHT_SKIP_BROWSER" in script
+    assert "python -m app.main" not in script
+
+
+def test_step_block_helper_does_not_capture_next_step():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    build_block = named_step_block(workflow, "Build portable package")
+
+    assert "Smoke-test built package" not in build_block

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -16,6 +16,7 @@ def test_windows_packaging_files_exist():
         "requirements-build.in",
         "requirements-build.txt",
         "requirements-runtime-windows.txt",
+        "smoke_test.ps1",
         "README.md",
     ):
         assert (WINDOWS_PACKAGING / relative).is_file()


### PR DESCRIPTION
## Summary
- adds a Windows Desktop Preview workflow that builds the portable package on `windows-latest`
- smoke-tests the packaged `DOCSight.exe` against `/health` on loopback before upload
- uploads ZIP + SHA256 workflow artifacts and attaches them to published releases
- documents the CI smoke flow in the Windows packaging README

## Tests
- `python -m pytest tests/test_desktop_entrypoint.py tests/test_windows_packaging.py tests/test_windows_desktop_ci.py tests/test_runtime_contract.py -q`
- `python -m pytest tests/ -q --tb=short --ignore=tests/e2e`
- `actionlint .github/workflows/windows-desktop.yml`
- workflow permissions mutation check
- local PyInstaller onedir build + `/health` smoke of the packaged executable on loopback
