### PR TITLE
ui/docs: Desktop Preview indicator and capability documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,14 @@
 
 Covers Docker Run, Docker Compose, Portainer, Synology NAS, Unraid, updating, and troubleshooting.
 
-On Windows 10/11, start with the [Windows quick start](docs/windows-quick-start.md). It covers Docker Desktop, WSL 2/Hyper-V, a one-line PowerShell command, and common startup fixes.
+## Windows chooser
+
+| If you want to... | Start here |
+|---|---|
+| Quickly try DOCSight on a Windows PC without Docker | [Desktop Preview for Windows](docs/windows-desktop-preview.md) |
+| Monitor your connection continuously on Windows | [Windows Docker Desktop quick start](docs/windows-quick-start.md) |
+
+On Windows 10/11, the normal 24/7 monitoring path is Docker Desktop. Start with the [Windows quick start](docs/windows-quick-start.md) when you want the supported Docker path. The Desktop Preview is a portable tryout build and is not intended for always-on collection.
 
 If setup or collection does not behave as expected, run the passive local doctor inside the same container before collecting manual environment details:
 

--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Азбучно",
   "glossary_close_picker": "Затваряне на избора на термин",
   "glossary_not_confuse_heading": "Не бъркайте",
-  "glossary_aliases_heading": "Търси се и като"
+  "glossary_aliases_heading": "Търси се и като",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview е пробна версия",
+  "desktop_preview_notice_body": "Използвайте DOCSight Desktop Preview, за да разгледате приложението локално. За надеждно 24/7 наблюдение използвайте Docker; заспиване или хибернация на лаптопа спира събирането на данни.",
+  "desktop_preview_notice_link": "Прочетете възможности и ограничения"
 }

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Abecedně",
   "glossary_close_picker": "Zavřít výběr pojmu",
   "glossary_not_confuse_heading": "Nezaměňovat",
-  "glossary_aliases_heading": "Hledáno také jako"
+  "glossary_aliases_heading": "Hledáno také jako",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview je zkušební sestavení",
+  "desktop_preview_notice_body": "Použijte DOCSight Desktop Preview k místnímu vyzkoušení aplikace. Pro spolehlivý monitoring 24/7 použijte Docker; spánek nebo hibernace notebooku pozastaví sběr dat.",
+  "desktop_preview_notice_link": "Přečíst možnosti a omezení"
 }

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabetisk",
   "glossary_close_picker": "Luk begrebsvælger",
   "glossary_not_confuse_heading": "Må ikke forveksles",
-  "glossary_aliases_heading": "Søges også som"
+  "glossary_aliases_heading": "Søges også som",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview er en prøveversion",
+  "desktop_preview_notice_body": "Brug DOCSight Desktop Preview til at udforske appen lokalt. Til pålidelig 24/7-overvågning skal du bruge Docker; slumre- eller dvaletilstand pauser dataindsamlingen.",
+  "desktop_preview_notice_link": "Læs funktioner og begrænsninger"
 }

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alphabetisch",
   "glossary_close_picker": "Begriffsauswahl schließen",
   "glossary_not_confuse_heading": "Nicht verwechseln",
-  "glossary_aliases_heading": "Auch gesucht als"
+  "glossary_aliases_heading": "Auch gesucht als",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview ist eine Testversion",
+  "desktop_preview_notice_body": "Nutze DOCSight Desktop Preview, um die App lokal auszuprobieren. Für zuverlässiges 24/7-Monitoring verwende Docker; Energiesparen oder Ruhezustand pausiert die Datenerfassung.",
+  "desktop_preview_notice_link": "Funktionen und Grenzen lesen"
 }

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Αλφαβητικά",
   "glossary_close_picker": "Κλείσιμο επιλογέα όρων",
   "glossary_not_confuse_heading": "Να μη συγχέεται",
-  "glossary_aliases_heading": "Αναζητείται και ως"
+  "glossary_aliases_heading": "Αναζητείται και ως",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Το Desktop Preview είναι δοκιμαστική έκδοση",
+  "desktop_preview_notice_body": "Χρησιμοποιήστε το DOCSight Desktop Preview για τοπική δοκιμή της εφαρμογής. Για αξιόπιστη παρακολούθηση 24/7, χρησιμοποιήστε Docker· η αναστολή ή αδρανοποίηση του φορητού διακόπτει τη συλλογή δεδομένων.",
+  "desktop_preview_notice_link": "Διαβάστε δυνατότητες και όρια"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alphabetical",
   "glossary_close_picker": "Close term picker",
   "glossary_not_confuse_heading": "Do not confuse",
-  "glossary_aliases_heading": "Also searched as"
+  "glossary_aliases_heading": "Also searched as",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview is a tryout build",
+  "desktop_preview_notice_body": "Use DOCSight Desktop Preview to explore the app locally. For reliable 24/7 monitoring, use Docker; laptop sleep or hibernate pauses data collection.",
+  "desktop_preview_notice_link": "Read capabilities and limits"
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1107,5 +1107,9 @@
   "glossary_alphabetical_terms": "Alfabético",
   "glossary_close_picker": "Cerrar selector de términos",
   "glossary_not_confuse_heading": "No confundir",
-  "glossary_aliases_heading": "También buscado como"
+  "glossary_aliases_heading": "También buscado como",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview es una versión de prueba",
+  "desktop_preview_notice_body": "Use DOCSight Desktop Preview para explorar la app localmente. Para monitorización fiable 24/7, use Docker; la suspensión o hibernación del equipo pausa la recopilación de datos.",
+  "desktop_preview_notice_link": "Ver capacidades y límites"
 }

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Tähestikuliselt",
   "glossary_close_picker": "Sulge terminivalik",
   "glossary_not_confuse_heading": "Ära aja segi",
-  "glossary_aliases_heading": "Otsitakse ka kui"
+  "glossary_aliases_heading": "Otsitakse ka kui",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview on prooviversioon",
+  "desktop_preview_notice_body": "Kasuta DOCSight Desktop Preview’d rakenduse kohalikuks proovimiseks. Usaldusväärseks 24/7 jälgimiseks kasuta Dockerit; sülearvuti unerežiim või talveuni peatab andmete kogumise.",
+  "desktop_preview_notice_link": "Loe võimalusi ja piiranguid"
 }

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Aakkosjärjestys",
   "glossary_close_picker": "Sulje termivalitsin",
   "glossary_not_confuse_heading": "Älä sekoita",
-  "glossary_aliases_heading": "Haetaan myös nimellä"
+  "glossary_aliases_heading": "Haetaan myös nimellä",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview on kokeiluversio",
+  "desktop_preview_notice_body": "Käytä DOCSight Desktop Previewiä sovelluksen paikalliseen kokeiluun. Luotettavaan 24/7-valvontaan käytä Dockeria; lepotila tai horrostila keskeyttää datan keruun.",
+  "desktop_preview_notice_link": "Lue ominaisuudet ja rajoitukset"
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -1104,5 +1104,9 @@
   "glossary_alphabetical_terms": "Alphabétique",
   "glossary_close_picker": "Fermer le sélecteur de termes",
   "glossary_not_confuse_heading": "Ne pas confondre",
-  "glossary_aliases_heading": "Aussi recherché comme"
+  "glossary_aliases_heading": "Aussi recherché comme",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview est une version d’essai",
+  "desktop_preview_notice_body": "Utilisez DOCSight Desktop Preview pour découvrir l’app localement. Pour une surveillance fiable 24/7, utilisez Docker; la veille ou l’hibernation de l’ordinateur interrompt la collecte.",
+  "desktop_preview_notice_link": "Lire les capacités et limites"
 }

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "In ord aibítre",
   "glossary_close_picker": "Dún roghnóir téarmaí",
   "glossary_not_confuse_heading": "Ná measctar le",
-  "glossary_aliases_heading": "Cuardaítear freisin mar"
+  "glossary_aliases_heading": "Cuardaítear freisin mar",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Is leagan trialach é Desktop Preview",
+  "desktop_preview_notice_body": "Úsáid DOCSight Desktop Preview chun an aip a thriail go háitiúil. Le haghaidh monatóireacht iontaofa 24/7, úsáid Docker; cuireann codladh nó geimhriú ríomhaire glúine bailiú sonraí ar sos.",
+  "desktop_preview_notice_link": "Léigh cumais agus teorainneacha"
 }

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Abecedno",
   "glossary_close_picker": "Zatvori odabir pojma",
   "glossary_not_confuse_heading": "Ne miješati s",
-  "glossary_aliases_heading": "Traži se i kao"
+  "glossary_aliases_heading": "Traži se i kao",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview je probna verzija",
+  "desktop_preview_notice_body": "Koristite DOCSight Desktop Preview za lokalno upoznavanje aplikacije. Za pouzdano 24/7 praćenje koristite Docker; mirovanje ili hibernacija prijenosnika pauzira prikupljanje podataka.",
+  "desktop_preview_notice_link": "Pročitaj mogućnosti i ograničenja"
 }

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Ábécé szerint",
   "glossary_close_picker": "Fogalomválasztó bezárása",
   "glossary_not_confuse_heading": "Nem összetévesztendő",
-  "glossary_aliases_heading": "Így is keresik"
+  "glossary_aliases_heading": "Így is keresik",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "A Desktop Preview próba build",
+  "desktop_preview_notice_body": "A DOCSight Desktop Preview helyi kipróbálásra való. Megbízható 24/7 monitorozáshoz használj Dockert; a laptop alvó vagy hibernált állapota szünetelteti az adatgyűjtést.",
+  "desktop_preview_notice_link": "Képességek és korlátok"
 }

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabetico",
   "glossary_close_picker": "Chiudi selettore dei termini",
   "glossary_not_confuse_heading": "Non confondere",
-  "glossary_aliases_heading": "Cercato anche come"
+  "glossary_aliases_heading": "Cercato anche come",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview è una versione di prova",
+  "desktop_preview_notice_body": "Usa DOCSight Desktop Preview per esplorare l’app localmente. Per monitoraggio affidabile 24/7, usa Docker; sospensione o ibernazione del PC interrompono la raccolta dati.",
+  "desktop_preview_notice_link": "Leggi funzionalità e limiti"
 }

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Abėcėlės tvarka",
   "glossary_close_picker": "Uždaryti terminų parinkiklį",
   "glossary_not_confuse_heading": "Nepainioti",
-  "glossary_aliases_heading": "Taip pat ieškoma kaip"
+  "glossary_aliases_heading": "Taip pat ieškoma kaip",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview yra bandomoji versija",
+  "desktop_preview_notice_body": "Naudokite DOCSight Desktop Preview programai vietoje išbandyti. Patikimam 24/7 stebėjimui naudokite Docker; kompiuterio miegas ar hibernacija sustabdo duomenų rinkimą.",
+  "desktop_preview_notice_link": "Skaityti galimybes ir ribas"
 }

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabētiski",
   "glossary_close_picker": "Aizvērt terminu izvēli",
   "glossary_not_confuse_heading": "Nejaukt ar",
-  "glossary_aliases_heading": "Meklē arī kā"
+  "glossary_aliases_heading": "Meklē arī kā",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview ir izmēģinājuma versija",
+  "desktop_preview_notice_body": "Izmantojiet DOCSight Desktop Preview, lai lokāli iepazītu lietotni. Uzticamai 24/7 uzraudzībai izmantojiet Docker; klēpjdatora miegs vai hibernācija aptur datu vākšanu.",
+  "desktop_preview_notice_link": "Lasīt iespējas un ierobežojumus"
 }

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabetisk",
   "glossary_close_picker": "Lukk begrepsvelger",
   "glossary_not_confuse_heading": "Ikke forveksle",
-  "glossary_aliases_heading": "Søkes også som"
+  "glossary_aliases_heading": "Søkes også som",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview er en prøveversjon",
+  "desktop_preview_notice_body": "Bruk DOCSight Desktop Preview for å utforske appen lokalt. For pålitelig 24/7-overvåking, bruk Docker; hvilemodus eller dvalemodus pauser datainnsamlingen.",
+  "desktop_preview_notice_link": "Les funksjoner og begrensninger"
 }

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabetisch",
   "glossary_close_picker": "Termkiezer sluiten",
   "glossary_not_confuse_heading": "Niet verwarren met",
-  "glossary_aliases_heading": "Ook gezocht als"
+  "glossary_aliases_heading": "Ook gezocht als",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview is een proefversie",
+  "desktop_preview_notice_body": "Gebruik DOCSight Desktop Preview om de app lokaal te verkennen. Gebruik Docker voor betrouwbare 24/7-monitoring; slaapstand of sluimerstand pauzeert de gegevensverzameling.",
+  "desktop_preview_notice_link": "Lees mogelijkheden en beperkingen"
 }

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabetycznie",
   "glossary_close_picker": "Zamknij wybór terminu",
   "glossary_not_confuse_heading": "Nie mylić z",
-  "glossary_aliases_heading": "Wyszukiwane także jako"
+  "glossary_aliases_heading": "Wyszukiwane także jako",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview to wersja próbna",
+  "desktop_preview_notice_body": "Użyj DOCSight Desktop Preview, aby lokalnie poznać aplikację. Do niezawodnego monitoringu 24/7 użyj Dockera; uśpienie lub hibernacja laptopa wstrzymuje zbieranie danych.",
+  "desktop_preview_notice_link": "Zobacz możliwości i ograniczenia"
 }

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabético",
   "glossary_close_picker": "Fechar seletor de termos",
   "glossary_not_confuse_heading": "Não confundir",
-  "glossary_aliases_heading": "Também pesquisado como"
+  "glossary_aliases_heading": "Também pesquisado como",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview é uma versão de teste",
+  "desktop_preview_notice_body": "Use o DOCSight Desktop Preview para explorar a app localmente. Para monitorização fiável 24/7, use Docker; suspensão ou hibernação do portátil pausa a recolha de dados.",
+  "desktop_preview_notice_link": "Ler capacidades e limites"
 }

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabetic",
   "glossary_close_picker": "Închide selectorul de termeni",
   "glossary_not_confuse_heading": "A nu se confunda",
-  "glossary_aliases_heading": "Căutat și ca"
+  "glossary_aliases_heading": "Căutat și ca",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview este o versiune de probă",
+  "desktop_preview_notice_body": "Folosiți DOCSight Desktop Preview pentru a explora aplicația local. Pentru monitorizare fiabilă 24/7, folosiți Docker; somnul sau hibernarea laptopului oprește temporar colectarea datelor.",
+  "desktop_preview_notice_link": "Citiți capabilitățile și limitele"
 }

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Abecedne",
   "glossary_close_picker": "Zavrieť výber pojmu",
   "glossary_not_confuse_heading": "Nezamieňať",
-  "glossary_aliases_heading": "Hľadané aj ako"
+  "glossary_aliases_heading": "Hľadané aj ako",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview je skúšobné zostavenie",
+  "desktop_preview_notice_body": "Použite DOCSight Desktop Preview na lokálne vyskúšanie aplikácie. Na spoľahlivé monitorovanie 24/7 použite Docker; spánok alebo hibernácia notebooku pozastaví zber dát.",
+  "desktop_preview_notice_link": "Prečítať možnosti a obmedzenia"
 }

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Abecedno",
   "glossary_close_picker": "Zapri izbiro izraza",
   "glossary_not_confuse_heading": "Ne zamenjuj",
-  "glossary_aliases_heading": "Išče se tudi kot"
+  "glossary_aliases_heading": "Išče se tudi kot",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview je preizkusna različica",
+  "desktop_preview_notice_body": "Uporabite DOCSight Desktop Preview za lokalno spoznavanje aplikacije. Za zanesljiv nadzor 24/7 uporabite Docker; spanje ali hibernacija prenosnika začasno ustavi zbiranje podatkov.",
+  "desktop_preview_notice_link": "Preberi zmožnosti in omejitve"
 }

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -1112,5 +1112,9 @@
   "glossary_alphabetical_terms": "Alfabetiskt",
   "glossary_close_picker": "Stäng termväljaren",
   "glossary_not_confuse_heading": "Förväxla inte",
-  "glossary_aliases_heading": "Söks även som"
+  "glossary_aliases_heading": "Söks även som",
+  "desktop_preview_badge": "Desktop Preview",
+  "desktop_preview_notice_title": "Desktop Preview är en testversion",
+  "desktop_preview_notice_body": "Använd DOCSight Desktop Preview för att utforska appen lokalt. För tillförlitlig övervakning dygnet runt, använd Docker; viloläge eller strömsparläge pausar datainsamlingen.",
+  "desktop_preview_notice_link": "Läs funktioner och begränsningar"
 }

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -89,6 +89,42 @@ body {
   background: rgba(120,130,180,0.1);
   color: var(--text-muted);
 }
+.desktop-preview-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  max-width: 100%;
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--info) 32%, transparent);
+  background: color-mix(in srgb, var(--info) 14%, transparent);
+  color: var(--info);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.desktop-preview-badge:hover,
+.desktop-preview-badge:focus-visible {
+  border-color: var(--info);
+  color: var(--info);
+  text-decoration: none;
+}
+.desktop-preview-badge-sidebar { margin-top: var(--space-sm); min-height: auto !important; }
+.desktop-preview-badge-settings { margin-top: 4px; }
+.sidebar > .desktop-preview-badge-settings {
+  margin: 0 var(--space-sm) var(--space-sm);
+}
+.desktop-preview-badge-mobile {
+  flex-shrink: 0;
+  margin-left: var(--space-xs);
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+}
 
 /* ── Status Dots ── */
 .status-dot {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v73';
+var CACHE_VERSION = 'v74';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -55,6 +55,9 @@
         <i data-lucide="menu"></i>
     </button>
     <span class="mobile-header-title">DOCSight</span>
+    {% if desktop_mode %}
+    <a class="desktop-preview-badge desktop-preview-badge-mobile" href="{{ desktop_preview_doc_url }}" target="_blank" rel="noopener noreferrer">{{ t.get('desktop_preview_badge', 'Desktop Preview') }}</a>
+    {% endif %}
     <div class="mobile-header-status">
         <span id="topbar-countdown"></span>
         <button class="hamburger" id="refresh-btn" title="{{ t.refresh }}" style="min-width:36px;min-height:36px;padding:4px;">
@@ -70,6 +73,9 @@
         <div class="sidebar-brand-text">
             <div class="sidebar-title">DOCSight</div>
             <div class="sidebar-subtitle">{{ t.sidebar_monitoring }}</div>
+            {% if desktop_mode %}
+            <a class="desktop-preview-badge desktop-preview-badge-settings" href="{{ desktop_preview_doc_url }}" target="_blank" rel="noopener noreferrer">{{ t.get('desktop_preview_badge', 'Desktop Preview') }}</a>
+            {% endif %}
         </div>
         <button type="button" class="sidebar-close" onclick="closeSidebar()" aria-label="{{ t.get('close_menu', 'Close menu') }}">
             <i data-lucide="x"></i>
@@ -267,6 +273,9 @@
                 </a>
             </div>
         </div>
+        {% if desktop_mode %}
+        <a class="desktop-preview-badge desktop-preview-badge-sidebar" href="{{ desktop_preview_doc_url }}" target="_blank" rel="noopener noreferrer">{{ t.get('desktop_preview_badge', 'Desktop Preview') }}</a>
+        {% endif %}
     </div>
 </nav>
 <div class="backdrop" id="sidebar-backdrop" onclick="closeSidebar()"></div>
@@ -278,6 +287,25 @@
 <div class="main-content">
 <div id="view-dashboard" class="view active dashboard-view">
 
+
+{% if desktop_mode and not desktop_preview_notice_dismissed %}
+<div class="notice-stack dashboard-notice-stack desktop-preview-notice-stack">
+    <article class="maintainer-notice notice-info desktop-preview-notice" data-notice-id="{{ desktop_preview_notice_id }}">
+        <div class="notice-icon"><i data-lucide="info"></i></div>
+        <div class="notice-content">
+            <div class="notice-title-row">
+                <h2>{{ t.get('desktop_preview_notice_title', 'Desktop Preview is a tryout build') }}</h2>
+                <span class="badge badge-info">{{ t.get('desktop_preview_badge', 'Desktop Preview') }}</span>
+            </div>
+            <p>{{ t.get('desktop_preview_notice_body', 'Use DOCSight Desktop Preview to explore the app locally. For reliable 24/7 monitoring, use Docker; laptop sleep or hibernate pauses data collection.') }}</p>
+            <a class="notice-link" href="{{ desktop_preview_doc_url }}" target="_blank" rel="noopener noreferrer">{{ t.get('desktop_preview_notice_link', 'Read capabilities and limits') }}</a>
+        </div>
+        <button type="button" class="notice-dismiss" onclick="dismissMaintainerNotice('{{ desktop_preview_notice_id }}')" aria-label="{{ t.get('notice_dismiss', 'Dismiss') }}">
+            <i data-lucide="x"></i>
+        </button>
+    </article>
+</div>
+{% endif %}
 
 {% if dashboard_notices %}
 <div class="notice-stack dashboard-notice-stack">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -51,6 +51,9 @@
                 <div class="sidebar-subtitle">{{ t.settings }}</div>
             </div>
         </a>
+        {% if desktop_mode %}
+        <a class="desktop-preview-badge desktop-preview-badge-settings" href="{{ desktop_preview_doc_url }}" target="_blank" rel="noopener noreferrer">{{ t.get('desktop_preview_badge', 'Desktop Preview') }}</a>
+        {% endif %}
 
         <!-- Settings Navigation -->
         <div class="sidebar-nav">
@@ -128,9 +131,31 @@
                 <i data-lucide="menu" aria-hidden="true"></i>
             </button>
             <span class="page-title" style="font-size: 1.1rem;" id="mobile-title">{{ t.step_modem }}</span>
+            {% if desktop_mode %}
+            <a class="desktop-preview-badge desktop-preview-badge-mobile" href="{{ desktop_preview_doc_url }}" target="_blank" rel="noopener noreferrer">{{ t.get('desktop_preview_badge', 'Desktop Preview') }}</a>
+            {% endif %}
         </div>
 
         <form id="settings-form" autocomplete="off">
+            {% if desktop_mode and not desktop_preview_notice_dismissed %}
+            <div class="notice-stack settings-notice-stack desktop-preview-notice-stack">
+                <article class="maintainer-notice notice-info desktop-preview-notice" data-notice-id="{{ desktop_preview_notice_id }}">
+                    <div class="notice-icon"><i data-lucide="info"></i></div>
+                    <div class="notice-content">
+                        <div class="notice-title-row">
+                            <h2>{{ t.get('desktop_preview_notice_title', 'Desktop Preview is a tryout build') }}</h2>
+                            <span class="badge badge-info">{{ t.get('desktop_preview_badge', 'Desktop Preview') }}</span>
+                        </div>
+                        <p>{{ t.get('desktop_preview_notice_body', 'Use DOCSight Desktop Preview to explore the app locally. For reliable 24/7 monitoring, use Docker; laptop sleep or hibernate pauses data collection.') }}</p>
+                        <a class="notice-link" href="{{ desktop_preview_doc_url }}" target="_blank" rel="noopener noreferrer">{{ t.get('desktop_preview_notice_link', 'Read capabilities and limits') }}</a>
+                    </div>
+                    <button type="button" class="notice-dismiss" onclick="dismissMaintainerNotice('{{ desktop_preview_notice_id }}')" aria-label="{{ t.get('notice_dismiss', 'Dismiss') }}">
+                        <i data-lucide="x"></i>
+                    </button>
+                </article>
+            </div>
+            {% endif %}
+
             {% if demo_mode %}
             <!-- ═══ Demo Mode Migration Banner ═══ -->
             <div class="settings-card glass" style="border-color: rgba(245,158,11,0.3);" id="demo-migrate-banner">

--- a/app/web.py
+++ b/app/web.py
@@ -54,6 +54,15 @@ def _server_tz_info():
 log = logging.getLogger("docsis.web")
 audit_log = logging.getLogger("docsis.audit")
 
+DESKTOP_PREVIEW_NOTICE_ID = "docsight-desktop-preview-v0"
+DESKTOP_PREVIEW_DOC_URL = "https://github.com/itsDNNS/docsight/blob/main/docs/windows-desktop-preview.md"
+
+
+def is_desktop_preview_mode() -> bool:
+    """Return True when DOCSight runs as the local Desktop Preview build."""
+    return os.environ.get("DOCSIGHT_DESKTOP_MODE") == "1"
+
+
 _THEME_COLLECTIONS = [
     {
         "key": "signature",
@@ -727,6 +736,7 @@ def inject_auth():
     ]
     theme_collections = _build_theme_collections(all_theme_modules)
 
+    desktop_mode = is_desktop_preview_mode()
     return {
         "auth_enabled": auth_enabled,
         "version": APP_VERSION,
@@ -736,6 +746,10 @@ def inject_auth():
         "theme_collections": theme_collections,
         "active_theme_data": active_theme_data,
         "active_theme_id": active_theme_id,
+        "desktop_mode": desktop_mode,
+        "desktop_preview_doc_url": DESKTOP_PREVIEW_DOC_URL,
+        "desktop_preview_notice_id": DESKTOP_PREVIEW_NOTICE_ID,
+        "desktop_preview_notice_dismissed": desktop_mode and DESKTOP_PREVIEW_NOTICE_ID in _get_dismissed_notice_ids(),
     }
 
 

--- a/docs/windows-desktop-preview.md
+++ b/docs/windows-desktop-preview.md
@@ -1,0 +1,116 @@
+# DOCSight Desktop Preview for Windows
+
+DOCSight Desktop Preview is a portable Windows build for trying DOCSight without Docker, WSL, PowerShell setup, or a server. It starts DOCSight locally and opens it in your browser.
+
+Use it for first contact, demos, and short local tests. For reliable 24/7 monitoring, use the normal Docker deployment.
+
+## Choose the right Windows path
+
+| Goal | Recommended path |
+|---|---|
+| Try DOCSight quickly on a Windows PC | Desktop Preview ZIP |
+| Explore Demo Mode, the setup wizard, dashboard, glossary, or evidence workflow | Desktop Preview ZIP |
+| Monitor your line continuously on a machine that stays awake, or after host restarts | Docker Desktop on an always-awake Windows PC, or another always-on Docker host |
+| Run DOCSight on a NAS, mini-PC, server, or homelab | Docker |
+
+## Download and verify
+
+1. Open the DOCSight [GitHub releases](https://github.com/itsDNNS/docsight/releases).
+2. Download the Windows Desktop Preview ZIP when a release provides one. The asset name uses this shape:
+
+   ```text
+   DOCSight-Desktop-Preview-win64-<version>.zip
+   ```
+
+3. Download the matching `.sha256` file.
+4. In PowerShell, verify the checksum from the folder where you saved the files:
+
+   ```powershell
+   Get-FileHash .\DOCSight-Desktop-Preview-win64-<version>.zip -Algorithm SHA256
+   Get-Content .\DOCSight-Desktop-Preview-win64-<version>.zip.sha256
+   ```
+
+   The hash values must match.
+5. Extract the ZIP to a folder such as `Downloads\DOCSight` or `C:\Tools\DOCSight`.
+6. Start `DOCSight.exe`.
+
+## First start and SmartScreen
+
+The preview is a portable app. Early builds may be unsigned. Windows SmartScreen can therefore show an "unrecognized app" warning even when the checksum matches the release checksum.
+
+If you downloaded DOCSight from the official GitHub release and the SHA256 checksum matches, choose **More info** and then **Run anyway**.
+
+DOCSight starts a local web app and opens your default browser. The address is local to your PC, normally similar to:
+
+```text
+http://127.0.0.1:8765
+```
+
+## What works in the Desktop Preview
+
+The preview uses the same DOCSight web app and is useful for exploring the product:
+
+- Demo Mode.
+- Initial setup wizard.
+- Dashboard and signal cards.
+- Glossary and beginner help.
+- Evidence Journey and local diagnostic exports.
+- Basic supported-modem polling from your Windows PC.
+- Connection Monitor with TCP-based checks.
+- Local settings stored on your Windows user profile.
+
+## Known v0 limitations
+
+Desktop Preview is intentionally not full Windows service support yet:
+
+- **Not an always-on monitor.** It runs only while your Windows user session and the DOCSight process are running.
+- **Sleep and hibernate pause collection.** If the laptop or PC sleeps, DOCSight cannot poll the modem or record connection samples during that time.
+- **No native ICMP probing in v0.** Connection Monitor falls back to TCP probing on Windows. That still shows reachability signals, but it is not the same as raw ICMP ping.
+- **No Windows service or autostart setup.** It does not install a background service that starts before login.
+- **No auto-update channel.** Download a newer ZIP from GitHub releases when you want to update.
+- **No installer, MSIX, or Store package.** The preview is a portable ZIP.
+- **Local-only browser app.** It binds to loopback for tryout use, not to your LAN.
+
+For continuous monitoring, use Docker on an always-on machine instead.
+
+## Where data lives
+
+Desktop Preview stores its data under your Windows user profile:
+
+```text
+%LOCALAPPDATA%\DOCSight
+```
+
+Typical subfolders:
+
+| Folder | Purpose |
+|---|---|
+| `%LOCALAPPDATA%\DOCSight\data` | Configuration and local monitoring database |
+| `%LOCALAPPDATA%\DOCSight\modules` | Community modules and themes |
+| `%LOCALAPPDATA%\DOCSight\logs` | Desktop launcher and runtime logs |
+
+## Remove the Desktop Preview
+
+1. Close DOCSight.
+2. Delete the extracted Desktop Preview folder.
+3. If you also want to remove local data, delete:
+
+   ```text
+   %LOCALAPPDATA%\DOCSight
+   ```
+
+Deleting the data folder removes configuration and history for the Desktop Preview.
+
+## Move from Desktop Preview to Docker
+
+When you want DOCSight to monitor continuously:
+
+1. Install Docker Desktop or use an always-on Docker host.
+2. Follow the [Windows quick start](windows-quick-start.md) or the full [Installation guide](../INSTALL.md).
+3. Start DOCSight with a persistent Docker volume:
+
+   ```powershell
+   docker run -d --name docsight --restart unless-stopped -p 8765:8765 -v docsight_data:/data ghcr.io/itsdnns/docsight:latest
+   ```
+
+Docker remains the recommended path for 24/7 monitoring because it can restart with the host and is easier to run on a machine that stays online.

--- a/docs/windows-quick-start.md
+++ b/docs/windows-quick-start.md
@@ -1,6 +1,15 @@
 # Windows 10/11 Quick Start
 
-DOCSight runs on Windows through Docker Desktop. This is still the normal Docker deployment path: Docker Desktop provides the Linux container runtime and DOCSight keeps its data in a Docker volume.
+DOCSight has two Windows paths:
+
+| If you want to... | Start here |
+|---|---|
+| Try DOCSight without Docker | [Desktop Preview for Windows](windows-desktop-preview.md) |
+| Monitor your connection continuously | Docker Desktop quick start below |
+
+The Desktop Preview is a portable ZIP for demos and short local tryouts. For 24/7 monitoring, use Docker Desktop or another always-on Docker host.
+
+DOCSight runs on Windows through Docker Desktop for continuous monitoring. Docker Desktop provides the Linux container runtime and DOCSight keeps its data in a Docker volume.
 
 ## 1. Install and verify Docker Desktop
 

--- a/packaging/windows/requirements-runtime-windows.txt
+++ b/packaging/windows/requirements-runtime-windows.txt
@@ -1174,9 +1174,9 @@ requests==2.34.2 \
     # via
     #   -r requirements.txt
     #   pywebpush
-soupsieve==2.8.3 \
-    --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
-    --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
+soupsieve==2.8.4 \
+    --hash=sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e \
+    --hash=sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65
     # via
     #   -r requirements.txt
     #   beautifulsoup4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1155,9 +1155,9 @@ requests==2.34.2 \
     # via
     #   -r requirements.in
     #   pywebpush
-soupsieve==2.8.3 \
-    --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
-    --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
+soupsieve==2.8.4 \
+    --hash=sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e \
+    --hash=sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65
     # via beautifulsoup4
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1135,9 +1135,9 @@ requests==2.34.2 \
     # via
     #   -r requirements.in
     #   pywebpush
-soupsieve==2.8.3 \
-    --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
-    --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
+soupsieve==2.8.4 \
+    --hash=sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e \
+    --hash=sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65
     # via beautifulsoup4
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \

--- a/tests/test_desktop_preview_boundary.py
+++ b/tests/test_desktop_preview_boundary.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app import web
+
+ROOT = Path(__file__).resolve().parents[1]
+I18N_DIR = ROOT / "app" / "i18n"
+INDEX_TEMPLATE = ROOT / "app" / "templates" / "index.html"
+SETTINGS_TEMPLATE = ROOT / "app" / "templates" / "settings.html"
+DESKTOP_DOC = ROOT / "docs" / "windows-desktop-preview.md"
+INSTALL_DOC = ROOT / "INSTALL.md"
+WINDOWS_QUICK_START = ROOT / "docs" / "windows-quick-start.md"
+
+DESKTOP_KEYS = {
+    "desktop_preview_badge",
+    "desktop_preview_notice_title",
+    "desktop_preview_notice_body",
+    "desktop_preview_notice_link",
+}
+
+
+def test_desktop_preview_mode_requires_explicit_env_flag(monkeypatch):
+    monkeypatch.delenv("DOCSIGHT_DESKTOP_MODE", raising=False)
+    assert web.is_desktop_preview_mode() is False
+
+    monkeypatch.setenv("DOCSIGHT_DESKTOP_MODE", "0")
+    assert web.is_desktop_preview_mode() is False
+
+    monkeypatch.setenv("DOCSIGHT_DESKTOP_MODE", "1")
+    assert web.is_desktop_preview_mode() is True
+
+
+def test_desktop_preview_badge_and_notice_are_template_gated():
+    for template_path in (INDEX_TEMPLATE, SETTINGS_TEMPLATE):
+        template = template_path.read_text(encoding="utf-8")
+        assert "{% if desktop_mode" in template
+        assert "desktop_preview_badge" in template
+        assert "desktop_preview_notice_dismissed" in template
+        assert "dismissMaintainerNotice('{{ desktop_preview_notice_id }}')" in template
+        assert "desktop_preview_doc_url" in template
+
+
+def test_desktop_preview_i18n_keys_exist_in_every_core_locale():
+    missing: dict[str, set[str]] = {}
+    for path in I18N_DIR.glob("*.json"):
+        if path.name == "template.json":
+            continue
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+        absent = {key for key in DESKTOP_KEYS if not data.get(key)}
+        if absent:
+            missing[path.name] = absent
+
+    assert missing == {}
+
+
+def test_desktop_preview_docs_cover_plain_language_capabilities_and_limits():
+    doc = DESKTOP_DOC.read_text(encoding="utf-8")
+    lower = doc.lower()
+
+    assert "sha256" in lower
+    assert "smartscreen" in lower
+    assert "demo mode" in lower
+    assert "tcp" in lower
+    assert "icmp" in lower
+    assert "sleep" in lower
+    assert "hibernate" in lower or "hibernation" in lower
+    assert "%localappdata%\\docsight" in lower
+    assert "docker" in lower
+
+
+def test_windows_install_docs_link_tryout_to_preview_and_monitoring_to_docker():
+    install = INSTALL_DOC.read_text(encoding="utf-8")
+    quick_start = WINDOWS_QUICK_START.read_text(encoding="utf-8")
+
+    assert "docs/windows-desktop-preview.md" in install
+    assert "docs/windows-quick-start.md" in install
+    assert "windows-desktop-preview.md" in quick_start
+    assert "24/7" in install
+    assert "24/7" in quick_start
+    assert "Docker" in install
+    assert "Docker" in quick_start


### PR DESCRIPTION
## Summary
- Show a Desktop Preview badge and first-run notice when the desktop build is active.
- Add capability documentation for the Windows Desktop Preview, including monitoring limits and the Docker path for continuous monitoring.
- Add Windows chooser links and translated Desktop Preview notice copy.

## Validation
- `python3 scripts/i18n_check.py --validate`
- `git diff --check`
- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest -q tests/test_desktop_preview_boundary.py tests/test_maintainer_notices.py tests/test_static_contracts.py tests/test_pwa_contract.py tests/test_public_launch_surface.py::test_windows_quick_start_is_discoverable_and_powershell_safe --tb=short`
- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest tests/ -q --tb=short --ignore=tests/e2e`
- `TZ=UTC uv run --with pytest-playwright==0.7.2 --with playwright==1.58.0 --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest -q tests/e2e/test_mobile_quality_gate.py --tb=short`
- Desktop-mode and normal-mode browser smokes