### PR TITLE
drivers: add Arris SB6183 support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -409,6 +409,7 @@ class ModemDriver(ABC):
 | `vodafone_station` | `vodafone_station.py` | CGA6444VF, CGA4322DE, TG3442DE | Auto-detected (see below) |
 | `cm3000` | `cm3000.py` | Netgear CM3000 | HTTP Basic Auth |
 | `surfboard` | `surfboard.py` | Arris SURFboard S33/S34/SB8200 | HNAP1 HMAC-SHA256 |
+| `sb6183` | `sb6183.py` | Arris SB6183 | None (HTTP status pages) |
 | `cm8200` | `cm8200.py` | Arris Touchstone CM8200A | Base64 query string |
 | `hitron_coda_4680` | `hitron_coda_4680.py` | Hitron CODA-4680 | Form POST (`/1/Device/Users/Login`) |
 | `generic` | `generic.py` | Generic Router (no DOCSIS) | None |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  <strong>Self-hosted</strong> • <strong>Local data</strong> • <strong>Demo</strong> • <strong>Reports</strong> • <strong>17 modem families</strong> • <strong>MIT</strong>
+  <strong>Self-hosted</strong> • <strong>Local data</strong> • <strong>Demo</strong> • <strong>Reports</strong> • <strong>18 modem families</strong> • <strong>MIT</strong>
 </p>
 
 <p align="center">
@@ -279,7 +279,7 @@ More views from the product:
 
 ## Supported Hardware
 
-DOCSight supports **17 modem families** out of the box and also offers **Generic Router mode** for fiber, DSL, and satellite connections.
+DOCSight supports **18 modem families** out of the box and also offers **Generic Router mode** for fiber, DSL, and satellite connections.
 
 ### Common setups
 
@@ -290,6 +290,7 @@ DOCSight supports **17 modem families** out of the box and also offers **Generic
 - **Sagemcom F@st 3896:** JSON-RPC API
 - **Technicolor TC4400**
 - **Arris SURFboard** (S33, S34, SB8200): HNAP1 API
+- **Arris SB6183:** HTTP status pages, no authentication required
 - **Hitron CODA-56 and CODA-4680**
 - **Netgear CM3000**
 - **Generic Router mode:** no DOCSIS signal pages, but still supports speed tracking, latency monitoring, incident logging, reports, and modules

--- a/app/drivers/__init__.py
+++ b/app/drivers/__init__.py
@@ -28,6 +28,9 @@ driver_registry.register_builtin("surfboard", "app.drivers.surfboard.SurfboardDr
 driver_registry.register_builtin("sb6141", "app.drivers.sb6141.SB6141Driver",
                                  "Arris/Motorola SB6141",
                                  hints={"default_url": "http://192.168.100.1", "credentials_required": False})
+driver_registry.register_builtin("sb6183", "app.drivers.sb6183.SB6183Driver",
+                                 "Arris SB6183",
+                                 hints={"default_url": "http://192.168.100.1", "credentials_required": False})
 driver_registry.register_builtin("sb6190", "app.drivers.sb6190.SB6190Driver",
                                  "Arris SB6190",
                                  hints={"default_url": "https://192.168.100.1", "default_user": "admin"})

--- a/app/drivers/sb6141.py
+++ b/app/drivers/sb6141.py
@@ -7,8 +7,8 @@ authentication. Channel data is on /cmSignalData.htm in transposed tables
 
 Device info is on /cmHelpData.htm as plain text with <BR> separators.
 
-This driver may also work with other Motorola/Arris SB6xxx modems
-(SB6121, SB6183) that share the same web UI format.
+This driver may also work with Motorola/Arris SB6xxx modems that share
+the same transposed table web UI format.
 """
 
 from __future__ import annotations

--- a/app/drivers/sb6183.py
+++ b/app/drivers/sb6183.py
@@ -1,0 +1,169 @@
+"""Arris SB6183 driver for DOCSight.
+
+The SB6183 is a DOCSIS 3.0 cable modem with a no-auth HTTP web UI.
+Channel data is exposed on ``/RgConnect.asp`` as row-oriented downstream
+and upstream bonded-channel tables. Device information is exposed on
+``/RgSwInfo.asp``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+from bs4 import BeautifulSoup
+
+from .base import ModemDriver
+from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
+
+log = logging.getLogger("docsis.driver.sb6183")
+
+
+class SB6183Driver(ModemDriver):
+    """Driver for Arris SB6183 DOCSIS 3.0 cable modem.
+
+    No authentication is required. DOCSIS channel data is scraped from
+    ``/RgConnect.asp`` and product information from ``/RgSwInfo.asp``.
+    """
+
+    def __init__(self, url: str, user: str, password: str):
+        super().__init__(url.rstrip("/"), user, password)
+        self._session = requests.Session()
+
+    def login(self) -> None:
+        """Verify modem is reachable (no auth required)."""
+        try:
+            r = self._session.get(f"{self._url}/RgConnect.asp", timeout=15)
+            r.raise_for_status()
+        except requests.RequestException as e:
+            raise RuntimeError(f"SB6183 connection failed: {e}")
+        if not self._is_status_page(r.text):
+            raise RuntimeError("SB6183 connection failed: status page not returned")
+        log.info("SB6183 reachable (no auth required)")
+
+    def get_docsis_data(self) -> DocsisData:
+        """Retrieve DOCSIS channel data from the status page."""
+        try:
+            r = self._session.get(f"{self._url}/RgConnect.asp", timeout=15)
+            r.raise_for_status()
+        except requests.RequestException as e:
+            raise RuntimeError(f"SB6183 DOCSIS data retrieval failed: {e}")
+
+        soup = BeautifulSoup(r.text, "html.parser")
+        ds_table = us_table = None
+        for table in soup.find_all("table"):
+            th = table.find("th")
+            if not th:
+                continue
+            text = th.get_text(" ", strip=True).lower()
+            if "downstream bonded" in text:
+                ds_table = table
+            elif "upstream bonded" in text:
+                us_table = table
+
+        return {
+            "channelDs": {"docsis30": self._parse_downstream(ds_table), "docsis31": []},
+            "channelUs": {"docsis30": self._parse_upstream(us_table), "docsis31": []},
+        }
+
+    def get_device_info(self) -> DeviceInfo:
+        """Retrieve device info from ``/RgSwInfo.asp``."""
+        try:
+            r = self._session.get(f"{self._url}/RgSwInfo.asp", timeout=15)
+            r.raise_for_status()
+        except requests.RequestException:
+            return {"manufacturer": "Arris", "model": "SB6183", "sw_version": ""}
+
+        soup = BeautifulSoup(r.text, "html.parser")
+        info: dict[str, str] = {}
+        model_tag = soup.find(id="thisModelNumberIs")
+        model = model_tag.get_text(strip=True) if model_tag else ""
+
+        for row in soup.find_all("tr"):
+            cells = row.find_all("td")
+            if len(cells) < 2:
+                continue
+            label = cells[0].get_text(" ", strip=True).lower()
+            value = cells[1].get_text(" ", strip=True)
+            if "software version" in label:
+                info["sw_version"] = value
+            elif "hardware version" in label:
+                info["hw_version"] = value
+            elif "standard specification" in label:
+                info["docsis_status"] = value
+
+        result: DeviceInfo = {
+            "manufacturer": "Arris",
+            "model": model or "SB6183",
+            "sw_version": info.get("sw_version", ""),
+        }
+        if info.get("hw_version"):
+            result["hw_version"] = info["hw_version"]
+        if info.get("docsis_status"):
+            result["docsis_status"] = info["docsis_status"]
+        return result
+
+    def get_connection_info(self) -> ConnectionInfo:
+        """Standalone modem, no connection info."""
+        return {}
+
+    def _parse_downstream(self, table) -> list[RawChannel]:
+        """Parse downstream table where each row is one channel."""
+        if not table:
+            return []
+        result: list[RawChannel] = []
+        for tr in table.find_all("tr"):
+            cells = [td.get_text(" ", strip=True) for td in tr.find_all("td")]
+            if len(cells) < 9 or not cells[3].isdigit() or cells[1].strip().lower() != "locked":
+                continue
+            try:
+                snr = self._parse_number(cells[6])
+                result.append({
+                    "channelID": int(cells[3]),
+                    "frequency": self._normalize_mhz(cells[4]),
+                    "powerLevel": self._parse_number(cells[5]),
+                    "mer": snr,
+                    "mse": -snr if snr else None,
+                    "modulation": cells[2],
+                    "corrErrors": int(self._parse_number(cells[7])),
+                    "nonCorrErrors": int(self._parse_number(cells[8])),
+                })
+            except (ValueError, TypeError, IndexError) as e:
+                log.warning("Failed to parse SB6183 DS channel: %s", e)
+        return result
+
+    def _parse_upstream(self, table) -> list[RawChannel]:
+        """Parse upstream table where each row is one channel."""
+        if not table:
+            return []
+        result: list[RawChannel] = []
+        for tr in table.find_all("tr"):
+            cells = [td.get_text(" ", strip=True) for td in tr.find_all("td")]
+            if len(cells) < 7 or not cells[3].isdigit() or cells[1].strip().lower() != "locked":
+                continue
+            try:
+                result.append({
+                    "channelID": int(cells[3]),
+                    "frequency": self._normalize_mhz(cells[5]),
+                    "powerLevel": self._parse_number(cells[6]),
+                    "modulation": cells[2],
+                    "multiplex": cells[2],
+                })
+            except (ValueError, TypeError, IndexError) as e:
+                log.warning("Failed to parse SB6183 US channel: %s", e)
+        return result
+
+    @staticmethod
+    def _normalize_mhz(freq_str: str) -> str:
+        from .utils import hz_to_mhz
+        return hz_to_mhz(freq_str)
+
+    @staticmethod
+    def _parse_number(val_str: str) -> float:
+        from .utils import parse_number
+        return parse_number(val_str)
+
+    @staticmethod
+    def _is_status_page(html: str) -> bool:
+        text = (html or "").lower()
+        return "downstream bonded" in text and "upstream bonded" in text

--- a/tests/fixtures/sb6183/RgConnect.asp.html
+++ b/tests/fixtures/sb6183/RgConnect.asp.html
@@ -1,0 +1,688 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Status</title>
+<meta charset="utf-8">
+<!-- Temp disable <meta name="viewport" content="width=device-width"> -->
+<script src="jquery-1.7.1.min.js"></script>
+<script src="json2.js"></script>
+<script src="main.js"></script>
+
+
+<!-- START HTMLHEADER.HTML ADDITIONS -->
+
+	<!-- typography -->
+	<link href="css/styles.css" rel="stylesheet">
+	<!-- layout -->
+	<link href="css/styles_layout.css" rel="stylesheet">
+	<!-- images and colors -->
+	<link id="pictures_css" href="css/styles_images.css" rel="stylesheet">
+
+ <!-- END HTMLHEADER ADDITIONS -->
+<script type="text/javascript">
+         var cusID = 1;
+         var platformType = 0;
+
+	   if (cusID == 14 || (cusID == 1 && platformType == 17))
+           {
+               document.getElementById('pictures_css').href ="css/styles_images_arris.css";
+	   }
+</script>
+
+</head>
+<body onload="load()">
+
+          <!-- Header Area Begin -->
+<div class="header">
+<!-- START pageheaderA.htm -->
+
+    <!-- modal overlay semi-opaque background, black -->
+    <div id="modalUnderlayBlack" class="modalUnderlayBlack modalDisplayBlack" style="display:none;"></div>
+
+     <!-- modal overlay semi-opaque background, white -->
+    <div id="modalUnderlayWhite" class="modalUnderlayWhite modalDisplayWhite" style="display:none;"></div>
+
+
+    <!-- MESSAGE MODAL -->
+    <!-- floater w/shadow background -->
+    <div id="modalFloaterMessage" class="modalDisplayBlack modalDisplayWhite" style="display:none;"></div>
+
+    <!-- floater inset container -->
+    <div id="modalContainerMessage" class="modalDisplayBlack modalDisplayWhite" style="display:none;">
+        <div id="modalContainerMessageTitle">
+                        <span class="modalContainerMessageTitleText" id="modalContainerMessageTitleText">Confirm Settings</span>
+                </div>
+        <div id="modalContainerMessageAlert" class="vertCenterWrap1">
+                        <div class="vertCenterWrap2">
+                                <div class="vertCenterWrap3">
+                            <div class="modalContainerMessageAlertText" id="modalContainerMessageAlertText"></div>
+                            <div class="modalContainerMessageAlertText" id="modalContainerMessageAlertTextPrompt"><strong>Do you want to continue?</strong></div>
+                            <div class="modalContainerMessageAlertButtons">
+                                                <input type="button"
+                                                                class="modalButton"
+                                                                id="modalButtonYes"
+                                                                value="Disable WPS and Continue">
+                                                <input type="button"
+                                                                class="modalButton"
+                                                                id="modalButtonNo"
+                                                                value="Cancel">
+                                        </div>
+                        </div>
+                        </div>
+                </div>
+        <div id="modalContainerMessageAlertImage"><img src="images/px1_Ux.png" alt="" class="wizardFrameSpriteImage_12"></div>
+        </div>
+    <!-- END MESSAGE MODAL -->
+
+    <div id="pw1"><div id="pw2"><div id="pw3"><div id="pw4">
+
+                <div id="hg1"><div id="hg2"><div id="hg3"><div id="hg4"><div id="hg5"><div id="hg6"><div id="hg7">
+
+            <div id="logo"><a href="http://www.arris.com"><img src="images/px1_Ux.png" alt="ARRIS Logo" title="ARRIS Logo" class="logo"></a></div>
+
+                        <div id="binnacleWrapper1" class="binnacleItems_hide" style="display:none;">
+                <div id="binnacleWrapper2" class="binnacleItems_hide" style="display:none;">
+                    <div id="binnacleWrapperLeft"><img src="images/px1_Ux.png" alt="" class="binnacleWrapperShim"></div>
+                    <div id="binnacleWrapperRight"><img src="images/px1_Ux.png" alt="" class="binnacleWrapperShim"></div>
+                    <div id="binnacleWrapperMiddle">
+                        <div id="binnacleInnards">
+
+                                                        <div id="binnacleIndicatorWrap"></div>
+                            <div id="binnacleModelName"><span id="thisModelNumberIs">SB6183</span></div>
+                        </div>
+                    </div>
+                <!-- end binnacleWrapper1/2 -->
+                                </div>
+                        </div>
+
+                <!-- end divs for hg -->
+                </div></div></div></div></div></div></div>
+
+                <!--gap--><div id="tmtg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+                <div id="tmg1"><div id="tmg2"><div id="tmg3"><div id="tmg4"><div id="tmg5"><div id="tmg6">
+<!-- END pageheaderA.htm ADDITIONS -->
+                <script>
+                        $(document).ready(function(){
+
+                        // Strip the default values.
+                        $("#binnacleWrapper1").removeClass("binnacleItems_0");
+                        $("#binnacleWrapper2").removeClass("binnacleItems_0");
+                        // Set number of items in binnacle (0 to 8)
+                        $("#binnacleWrapper1").addClass("binnacleItems_0");
+                        $("#binnacleWrapper2").addClass("binnacleItems_0");
+                        // Show the binnacle.
+                        $("#binnacleWrapper1").show();
+                        $("#binnacleWrapper2").show();
+
+                        });
+                        // End READY functon
+                </script>
+
+<!-- END pageheaderA.htm -->
+
+<script language="javascript" type="text/javascript">
+var hiddenMenuList = '';
+</script>
+<div id="topMenu">
+</div>
+
+<script type='text/javascript'>
+
+        var menuCM = [
+                {name:'STATUS', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgConnect.asp',
+                         menuID:'menu3e'}
+                ]},
+                {name:'PRODUCT INFORMATION', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgSwInfo.asp',
+                         menuID:'menu21'}
+                ]},
+                {name:'EVENT LOG', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgEventLog.asp',
+                         menuID:'menu43'}
+                ]},
+                {name:'ADDRESSES', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgAddress.asp',
+                         menuID:'menuff'}
+                ]},
+                {name:'CONFIGURATION', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgConfiguration.asp',
+                         menuID:'menu39'}
+                ]},
+                {name:'HELP', subMenu: [
+                        {name:'null',
+                         linkUrl:'StatusHelp.asp',
+                         menuID:'menu9d'}
+                ]}
+        ];
+        var menuGW = [
+                {name:'HOME', subMenu: [
+                        {name:'null',
+                         linkUrl:'home.asp',
+                         menuID:'menua6'}
+                ]},
+
+                {name:'STATUS', subMenu: [
+                        {name:'Product Information',
+                         linkUrl:'RgSwInfo.asp',
+                         menuID:'menu21'},
+
+                        {name:'Connection',
+                         linkUrl:'RgConnect.asp',
+                         menuID:'menu3e'},
+
+                        {name:'Security',
+                         linkUrl:'RgSecurity.asp',
+                         menuID:'menua'},
+
+                        {name:'Diagnostics',
+                         linkUrl:'RgDiagnostics.asp',
+                         menuID:'menu53'},
+
+                        {name:'Event Log',
+                         linkUrl:'RgEventLog.asp',
+                         menuID:'menu43'},
+
+                        {name:'Configuration',
+                         linkUrl:'RgConfiguration.asp',
+                         menuID:'menu39'}
+                ]},
+
+                {name:'BASIC', subMenu: [
+                        {name:'Setup',
+                         linkUrl:'RgSetup.asp',
+                         menuID:'menu41'},
+
+                        {name:'DHCP',
+                         linkUrl:'RgDhcp.asp',
+                         menuID:'menu13'},
+
+                        {name:'DHCPv6',
+                         linkUrl:'RgDhcpV6.asp',
+                         menuID:'menu9f'},
+
+                        {name:'IPv6 Clients',
+                         linkUrl:'RgIPv6Clients.asp',
+                         menuID:'menu84'},
+
+                        {name:'DDNS',
+                         linkUrl:'RgDdns.asp',
+                         menuID:'menu6b'},
+
+                        {name:'Backup and Restore',
+                         linkUrl:'RgBackup.asp',
+                         menuID:'menu3a'},
+
+                        {name:'MoCA',
+                         linkUrl:'MoCA.asp',
+                         menuID:'menu93'},
+
+                        {name:'USB Connect',
+                         linkUrl:'USB.asp',
+                         menuID:'menu96'},
+
+                        {name:'Ethernet Ports',
+                         linkUrl:'RgEthPort.asp',
+                         menuID:'menu95'},
+
+                        {name:'LED Control',
+                         linkUrl:'LedControl.asp',
+                         menuID:'menuab'}
+                ]},
+
+                {name:'ADVANCED', subMenu: [
+                        {name:'Options',
+                         linkUrl:'RgOptions.asp',
+                         menuID:'menu50'},
+
+                        {name:'IP Filtering',
+                         linkUrl:'RgIpFiltering.asp',
+                         menuID:'menu2b'},
+
+                        {name:'MAC Filtering',
+                         linkUrl:'RgMacFiltering.asp',
+                         menuID:'menu2f'},
+
+                        {name:'Port Filtering',
+                         linkUrl:'RgPortFiltering.asp',
+                         menuID:'menu29'},
+
+                        {name:'Port Triggers',
+                         linkUrl:'RgPortTriggering.asp',
+                         menuID:'menu1e'},
+
+                        {name:'Port Forwarding',
+                         linkUrl:'RgForwarding.asp',
+                         menuID:'menu63'},
+
+                        {name:'DMZ Host',
+                         linkUrl:'RgDmzHost.asp',
+                         menuID:'menu6'},
+
+                        {name:'RIP',
+                         linkUrl:'RgRipSetup.asp',
+                         menuID:'menu8'},
+
+                        {name:'Linux Apps',
+                         linkUrl:'NASWebInterface/admin/index.php?user=admin',
+                         menuID:'menu9e'}
+                ]},
+
+                {name:'WIRELESS', subMenu: [
+                        {name:'802.11 Radio',
+                         linkUrl:'wlanRadio.asp',
+                         menuID:'menu20'},
+
+                        {name:'Primary Network Settings',
+                         linkUrl:'wlanPrimaryNetwork.asp',
+                         menuID:'menu68'},
+
+                        {name:'Guest Network Settings',
+                         linkUrl:'wlanGuestNetwork.asp',
+                         menuID:'menu10'},
+
+                        {name:'Access Control',
+                         linkUrl:'wlanAccess.asp',
+                         menuID:'menu32'},
+
+                        {name:'Extend Network Range',
+                         linkUrl:'wlanBridging.asp',
+                         menuID:'menuc'},
+
+                        {name:'WMM Quality of Service',
+                         linkUrl:'wlanWmm.asp',
+                         menuID:'menu42'},
+
+                        {name:'Performance Enhancements',
+                         linkUrl:'wlanMedia.asp',
+                         menuID:'menua8'},
+
+                        {name:'Advanced',
+                         linkUrl:'wlanAdvanced.asp',
+                         menuID:'menu33'}
+                ]},
+
+                {name:'FIREWALL', subMenu: [
+                        {name:'Protection Level',
+                         linkUrl:'RgContentFilter.asp',
+                         menuID:'menu52'},
+
+                        {name:'Parental Control',
+                         linkUrl:'RgFiltering.asp',
+                         menuID:'menu8e'},
+
+                        {name:'Local Log',
+                         linkUrl:'RgFirewallEL.asp',
+                         menuID:'menu4d'},
+
+                        {name:'Remote Log',
+                         linkUrl:'RgFirewallRL.asp',
+                         menuID:'menu46'}
+                ]},
+
+                {name:'VPN', subMenu: [
+                        {name:'L2TPv3',
+                         linkUrl:'RgVpnL2tpV3.asp',
+                         menuID:'menu7d'},
+
+                        {name:'Event Log',
+                         linkUrl:'RgVpnEventLog.asp',
+                         menuID:'menu58'}
+                ]},
+
+                {name:'TELEPHONY', subMenu: [
+                        {name:'Status',
+                         linkUrl:'MtaStatus.asp',
+                         menuID:'menu3d'},
+
+                        {name:'MTA DHCP',
+                         linkUrl:'MtaDhcp.asp',
+                         menuID:'menu6a'},
+
+                        {name:'Provisioning Details',
+                         linkUrl:'MtaProvisioning.asp',
+                         menuID:'menu45'},
+
+                        {name:'QoS Parameters',
+                         linkUrl:'MtaQos.asp',
+                         menuID:'menu44'},
+
+                        {name:'Event Log',
+                         linkUrl:'MtaEventLog.asp',
+                         menuID:'menu26'},
+
+                        {name:'Battery Charger',
+                         linkUrl:'BatController.asp',
+                         menuID:'menu30'},
+
+                        {name:'Power Management',
+                         linkUrl:'BatInterfaceDelay.asp',
+                         menuID:'menu3f'},
+
+                        {name:'Battery Pack Information',
+                         linkUrl:'BatUps.asp',
+                         menuID:'menu5c'}
+                ]},
+
+                {name:'HELP', subMenu: [
+                        {name:'Overview',
+                         linkUrl:'help.asp',
+                         menuID:'menu9d'},
+
+                        {name:'About',
+                         linkUrl:'About.asp',
+                         menuID:'menua7'}
+                ]}
+        ];
+        var menuItem = menuCM;
+</script>
+
+<!-- START pageheaderB.htm -->
+
+<!-- START pageheaderB.htm ADDITIONS -->
+		<!-- end divs for tmg -->
+		</div></div></div></div></div></div>
+
+		<!--gap--><div id="tmbg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+		<div id="bg1"><div id="bg2"><div id="bg3"><div id="bg4">
+<!-- END pageheaderB.htm ADDITIONS -->
+
+<!-- END pageheaderB.htm -->
+</div>
+        <!-- End Header -->
+
+        <div class="container">
+                <div class="subHeader">
+                        <div class="subHeadcontent">Status</div>
+                </div>
+        <div class="breadcrumbs">
+        <a href="home.asp"> Home</a> > <a href="RgSwInfo.asp">Status</a> > Connection </div>
+
+        <div class="content">
+        <div class="introText">
+                <p>The statuses listed show the connection state of the cable modem. They are used by your service provider to evaluate the operation of the cable modem.</p>
+        </div>
+
+
+                <form action=/goform/RgConnect method="post" name="RgConnect"><table><tr><td><input type="hidden" name="GetNonce" size=31 value=> </td></tr></table>
+
+
+
+<!--
+                        <center>
+                        <table class="simpleTable">
+
+                        <tr>
+                <th colspan="3">Startup Procedure</strong></th>
+            </tr>
+
+                        <tr >
+                <td width="44%" ><strong><u>Procedure</u></strong></td>
+                        <td width="31%" ><strong><u>Status</u></strong></td>
+                <td width="25%" ><strong><u>Comment</u></strong></td>
+                        </tr>
+
+                        <tr>
+                <td>Acquire Downstream Channel</td>
+                        <td></td>
+                        <td></td>
+                        </tr>
+
+                        <tr>
+                <td>Connectivity State</td>
+                        <td></td>
+                        <td></td>
+                        </tr>
+
+                        <tr>
+                <td>Boot State</td>
+                                <td></td>
+                        <td></td>
+                        </tr>
+
+
+
+                        <tr>
+                <td >Security</td>
+                                <td></td>
+                        <td></td>
+                        </tr>
+
+                        <tr>
+                <td >DOCSIS Network Access Enabled</td>
+                                <td>Allowed
+</td>
+                        </tr>
+                </table>
+        </center>
+
+        <br clear="all" class="clearfloat">
+                <div class="spacer30"></div>
+-->
+<table class="simpleTable">
+<tr><th colspan=3>Startup Procedure
+</th></tr>
+<tr><td width="44%"><strong>Procedure
+</strong></td><td width="31%"><strong>Status
+</strong></td><td width="25%"><strong>Comment
+</strong></td></tr>
+<tr><td>Acquire Downstream Channel
+</td><td>&nbsp;</td><td>Locked
+</td></tr>
+<tr><td>Connectivity State
+</td><td>OK
+</td><td>Operational
+</td></tr>
+<tr><td>Boot State
+</td><td>OK
+</td><td>Operational
+</td></tr>
+<tr><td>Configuration File
+</td><td>OK
+</td><td></td></tr>
+<tr><td>Security
+</td><td>Enabled
+</td><td>BPI+
+</td></tr>
+<tr><td>DOCSIS Network Access Enabled
+</td><td>Allowed
+</td><td></td></tr></table>
+
+
+    <br clear="all" class="clearfloat">
+        <div class="spacer30"></div>
+
+        <center>
+        <table class="simpleTable">
+                        <tr>
+                                <th colspan="9"><strong>Downstream Bonded Channels</strong></th>
+                        </tr>
+                        <tr>
+                                <td ><strong>Channel</strong></td>
+                                <td ><strong>Lock Status</strong></td>
+                                <td ><strong>Modulation</strong></td>
+                                <td ><strong>Channel ID</strong></td>
+                                <td ><strong>Frequency</strong></td>
+                                <td ><strong>Power</strong></td>
+                                <td ><strong>SNR</strong></td>
+                                <td ><strong>Corrected</strong></td>
+                                <td ><strong>Uncorrectables</strong></td>
+                        </tr>
+<tr><td>1</td><td>Locked
+</td><td>QAM256</td><td>6</td><td>315000000 Hz
+</td><td> 0.7 dBmV</td><td>40.2 dB</td><td>29</td><td>0</td></tr>
+<tr><td>2</td><td>Locked
+</td><td>QAM256</td><td>1</td><td>285000000 Hz
+</td><td> 0.4 dBmV</td><td>40.0 dB</td><td>1</td><td>0</td></tr>
+<tr><td>3</td><td>Locked
+</td><td>QAM256</td><td>2</td><td>291000000 Hz
+</td><td> 0.3 dBmV</td><td>40.1 dB</td><td>1</td><td>0</td></tr>
+<tr><td>4</td><td>Locked
+</td><td>QAM256</td><td>3</td><td>297000000 Hz
+</td><td> 0.3 dBmV</td><td>40.1 dB</td><td>9</td><td>0</td></tr>
+<tr><td>5</td><td>Locked
+</td><td>QAM256</td><td>4</td><td>303000000 Hz
+</td><td> 0.7 dBmV</td><td>40.2 dB</td><td>20</td><td>0</td></tr>
+<tr><td>6</td><td>Locked
+</td><td>QAM256</td><td>5</td><td>309000000 Hz
+</td><td> 0.8 dBmV</td><td>40.2 dB</td><td>2</td><td>0</td></tr>
+<tr><td>7</td><td>Locked
+</td><td>QAM256</td><td>7</td><td>321000000 Hz
+</td><td> 0.3 dBmV</td><td>40.1 dB</td><td>3</td><td>0</td></tr>
+<tr><td>8</td><td>Locked
+</td><td>QAM256</td><td>8</td><td>327000000 Hz
+</td><td> 0.7 dBmV</td><td>40.2 dB</td><td>24</td><td>0</td></tr>
+<tr><td>9</td><td>Locked
+</td><td>QAM256</td><td>9</td><td>333000000 Hz
+</td><td> 1.1 dBmV</td><td>40.2 dB</td><td>21</td><td>0</td></tr>
+<tr><td>10</td><td>Locked
+</td><td>QAM256</td><td>10</td><td>339000000 Hz
+</td><td> 1.3 dBmV</td><td>40.2 dB</td><td>7</td><td>0</td></tr>
+<tr><td>11</td><td>Locked
+</td><td>QAM256</td><td>11</td><td>345000000 Hz
+</td><td> 0.9 dBmV</td><td>40.2 dB</td><td>16</td><td>0</td></tr>
+<tr><td>12</td><td>Locked
+</td><td>QAM256</td><td>12</td><td>351000000 Hz
+</td><td> 0.7 dBmV</td><td>40.2 dB</td><td>27</td><td>0</td></tr>
+<tr><td>13</td><td>Locked
+</td><td>QAM256</td><td>14</td><td>363000000 Hz
+</td><td> 1.1 dBmV</td><td>40.3 dB</td><td>15</td><td>0</td></tr>
+<tr><td>14</td><td>Locked
+</td><td>QAM256</td><td>16</td><td>375000000 Hz
+</td><td> 0.5 dBmV</td><td>40.1 dB</td><td>43</td><td>0</td></tr>
+<tr><td>15</td><td>Locked
+</td><td>QAM256</td><td>31</td><td>483000000 Hz
+</td><td> 0.9 dBmV</td><td>40.2 dB</td><td>40</td><td>0</td></tr>
+<tr><td>16</td><td>Locked
+</td><td>QAM256</td><td>33</td><td>495000000 Hz
+</td><td> 0.5 dBmV</td><td>40.1 dB</td><td>55</td><td>0</td></tr>
+
+
+</table>
+        </center>
+
+<br clear="all" class="clearfloat">
+<div class="spacer30"></div>
+
+<center>
+                <table class="simpleTable">
+                        <tr>
+                                <th colspan="7" ><strong>Upstream Bonded Channels</strong></th>
+                        </tr>
+                        <tr>
+                                <td><strong>Channel</strong></td>
+                                <td><strong>Lock Status</strong></td>
+                <td><strong>US Channel Type</strong></td>
+                <td><strong>Channel ID</strong></td>
+                <td><strong>Symbol Rate</strong></td>
+                <td><strong>Frequency</strong></td>
+                <td><strong>Power</strong></td>
+                        </tr>
+<tr><td>1</td><td>Locked
+</td><td>ATDMA</td><td>67</td><td>5120 Ksym/sec</td><td>30400000 Hz
+</td><td>48.3 dBmV</td></tr>
+<tr><td>2</td><td>Locked
+</td><td>ATDMA</td><td>65</td><td>5120 Ksym/sec</td><td>17600000 Hz
+</td><td>47.5 dBmV</td></tr>
+<tr><td>3</td><td>Locked
+</td><td>ATDMA</td><td>66</td><td>5120 Ksym/sec</td><td>24000000 Hz
+</td><td>48.5 dBmV</td></tr>
+<tr><td>4</td><td>Locked
+</td><td>ATDMA</td><td>68</td><td>5120 Ksym/sec</td><td>36800000 Hz
+</td><td>48.5 dBmV</td></tr>
+
+                </table>
+        </center>
+
+<br />
+<!-- w20122: JKU 07-09-09: CR16167 - Hide menu when logged on as an admin -->
+
+
+
+
+<!-- end of CR16167 - Hide menu when logged on as an admin -->
+
+<br clear="all" class="clearfloat">
+<div class="spacer30"></div>
+
+<p id="systime" align="center"><strong>Current System Time:</strong> Thu Jul 09 10:14:49 2026
+</p>
+
+</div>
+
+
+</form>
+
+
+<br clear="all" class="clearfloat">
+<div class="spacer40"></div>
+
+<!-- end .container --></div>
+
+<!-- START footer.htm ADDITIONS -->
+		<!-- end divs for bc -->
+		</div></div></div></div>
+
+		<!--gap--><div id="bmtg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+
+		<div id="bmg1"><div id="bmg2"><div id="bmg3"><div id="bmg4"><div id="bmg5"><div id="bmg6">
+
+	    <div id="siteMapBottom"></div>
+        <br clear="all" class="clearfloat">
+
+		</div></div></div></div></div></div>
+
+
+		<!--gap--><div id="bmbg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+
+		<div id="fg1"><div id="fg2"><div id="fg3"><div id="fg4"><div id="fg5"><div id="fg6"><div id="fg7">
+
+			<div id="logo_bottom"><a href="http://www.arris.com"><img src="images/px1_Ux.png" alt="ARRIS" title="ARRIS" class="logo_bottom"></a></div>
+
+			<div id="copyright">
+			<a href="http://www.arris.com">&copy;2022 ARRIS Group, Inc. ALL RIGHTS RESERVED.</a>
+			</div>
+
+		</div></div></div></div></div></div></div>
+
+
+		<div id="fgbl1"><div id="fgbl2"><div id="fgbl3"><div id="fgbl4"><img src="images/px1_Ux.png" alt="" title="" class="fgbl3"></div></div></div></div>
+
+
+    <!-- end divs for pw -->
+    </div></div></div></div>
+
+<!-- END footer.htm ADDITIONS -->
+
+
+<script>
+
+function ShowNewWindow1()
+{
+        window.open("RgCmConfiguration.asp#connection","_blank", "toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=no, copyhistory=no, width=500, height=500");
+}
+
+function load()
+{
+        var customerID = 1;
+        var userLoginAccess = "???";
+
+        if (userLoginAccess == "User")
+        {
+                $("#systime").hide();
+        }
+}
+
+</script>
+
+</body>
+</html>

--- a/tests/fixtures/sb6183/RgSwInfo.asp.html
+++ b/tests/fixtures/sb6183/RgSwInfo.asp.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Product Information</title>
+<meta charset="utf-8">
+<!-- Temp disable <meta name="viewport" content="width=device-width"> -->
+<script src="jquery-1.7.1.min.js"></script>
+<script src="json2.js"></script>
+<script src="main.js"></script>
+
+
+<!-- START HTMLHEADER.HTML ADDITIONS -->
+
+	<!-- typography -->
+	<link href="css/styles.css" rel="stylesheet">
+	<!-- layout -->
+	<link href="css/styles_layout.css" rel="stylesheet">
+	<!-- images and colors -->
+	<link id="pictures_css" href="css/styles_images.css" rel="stylesheet">
+
+ <!-- END HTMLHEADER ADDITIONS -->
+<script type="text/javascript">
+         var cusID = 1;
+         var platformType = 0;
+
+	   if (cusID == 14 || (cusID == 1 && platformType == 17))
+           {
+               document.getElementById('pictures_css').href ="css/styles_images_arris.css";
+	   }
+</script>
+
+</head>
+<body>
+
+        <!-- Header Area Begin -->
+<div class="header">
+<!-- START pageheaderA.htm -->
+
+    <!-- modal overlay semi-opaque background, black -->
+    <div id="modalUnderlayBlack" class="modalUnderlayBlack modalDisplayBlack" style="display:none;"></div>
+
+     <!-- modal overlay semi-opaque background, white -->
+    <div id="modalUnderlayWhite" class="modalUnderlayWhite modalDisplayWhite" style="display:none;"></div>
+
+
+    <!-- MESSAGE MODAL -->
+    <!-- floater w/shadow background -->
+    <div id="modalFloaterMessage" class="modalDisplayBlack modalDisplayWhite" style="display:none;"></div>
+
+    <!-- floater inset container -->
+    <div id="modalContainerMessage" class="modalDisplayBlack modalDisplayWhite" style="display:none;">
+        <div id="modalContainerMessageTitle">
+                        <span class="modalContainerMessageTitleText" id="modalContainerMessageTitleText">Confirm Settings</span>
+                </div>
+        <div id="modalContainerMessageAlert" class="vertCenterWrap1">
+                        <div class="vertCenterWrap2">
+                                <div class="vertCenterWrap3">
+                            <div class="modalContainerMessageAlertText" id="modalContainerMessageAlertText"></div>
+                            <div class="modalContainerMessageAlertText" id="modalContainerMessageAlertTextPrompt"><strong>Do you want to continue?</strong></div>
+                            <div class="modalContainerMessageAlertButtons">
+                                                <input type="button"
+                                                                class="modalButton"
+                                                                id="modalButtonYes"
+                                                                value="Disable WPS and Continue">
+                                                <input type="button"
+                                                                class="modalButton"
+                                                                id="modalButtonNo"
+                                                                value="Cancel">
+                                        </div>
+                        </div>
+                        </div>
+                </div>
+        <div id="modalContainerMessageAlertImage"><img src="images/px1_Ux.png" alt="" class="wizardFrameSpriteImage_12"></div>
+        </div>
+    <!-- END MESSAGE MODAL -->
+
+    <div id="pw1"><div id="pw2"><div id="pw3"><div id="pw4">
+
+                <div id="hg1"><div id="hg2"><div id="hg3"><div id="hg4"><div id="hg5"><div id="hg6"><div id="hg7">
+
+            <div id="logo"><a href="http://www.arris.com"><img src="images/px1_Ux.png" alt="ARRIS Logo" title="ARRIS Logo" class="logo"></a></div>
+
+                        <div id="binnacleWrapper1" class="binnacleItems_hide" style="display:none;">
+                <div id="binnacleWrapper2" class="binnacleItems_hide" style="display:none;">
+                    <div id="binnacleWrapperLeft"><img src="images/px1_Ux.png" alt="" class="binnacleWrapperShim"></div>
+                    <div id="binnacleWrapperRight"><img src="images/px1_Ux.png" alt="" class="binnacleWrapperShim"></div>
+                    <div id="binnacleWrapperMiddle">
+                        <div id="binnacleInnards">
+
+                                                        <div id="binnacleIndicatorWrap"></div>
+                            <div id="binnacleModelName"><span id="thisModelNumberIs">SB6183</span></div>
+                        </div>
+                    </div>
+                <!-- end binnacleWrapper1/2 -->
+                                </div>
+                        </div>
+
+                <!-- end divs for hg -->
+                </div></div></div></div></div></div></div>
+
+                <!--gap--><div id="tmtg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+                <div id="tmg1"><div id="tmg2"><div id="tmg3"><div id="tmg4"><div id="tmg5"><div id="tmg6">
+<!-- END pageheaderA.htm ADDITIONS -->
+                <script>
+                        $(document).ready(function(){
+
+                        // Strip the default values.
+                        $("#binnacleWrapper1").removeClass("binnacleItems_0");
+                        $("#binnacleWrapper2").removeClass("binnacleItems_0");
+                        // Set number of items in binnacle (0 to 8)
+                        $("#binnacleWrapper1").addClass("binnacleItems_0");
+                        $("#binnacleWrapper2").addClass("binnacleItems_0");
+                        // Show the binnacle.
+                        $("#binnacleWrapper1").show();
+                        $("#binnacleWrapper2").show();
+
+                        });
+                        // End READY functon
+                </script>
+
+<!-- END pageheaderA.htm -->
+
+<script language="javascript" type="text/javascript">
+var hiddenMenuList = '';
+</script>
+<div id="topMenu">
+</div>
+
+<script type='text/javascript'>
+
+        var menuCM = [
+                {name:'STATUS', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgConnect.asp',
+                         menuID:'menu3e'}
+                ]},
+                {name:'PRODUCT INFORMATION', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgSwInfo.asp',
+                         menuID:'menu21'}
+                ]},
+                {name:'EVENT LOG', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgEventLog.asp',
+                         menuID:'menu43'}
+                ]},
+                {name:'ADDRESSES', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgAddress.asp',
+                         menuID:'menuff'}
+                ]},
+                {name:'CONFIGURATION', subMenu: [
+                        {name:'null',
+                         linkUrl:'RgConfiguration.asp',
+                         menuID:'menu39'}
+                ]},
+                {name:'HELP', subMenu: [
+                        {name:'null',
+                         linkUrl:'StatusHelp.asp',
+                         menuID:'menu9d'}
+                ]}
+        ];
+        var menuGW = [
+                {name:'HOME', subMenu: [
+                        {name:'null',
+                         linkUrl:'home.asp',
+                         menuID:'menua6'}
+                ]},
+
+                {name:'STATUS', subMenu: [
+                        {name:'Product Information',
+                         linkUrl:'RgSwInfo.asp',
+                         menuID:'menu21'},
+
+                        {name:'Connection',
+                         linkUrl:'RgConnect.asp',
+                         menuID:'menu3e'},
+
+                        {name:'Security',
+                         linkUrl:'RgSecurity.asp',
+                         menuID:'menua'},
+
+                        {name:'Diagnostics',
+                         linkUrl:'RgDiagnostics.asp',
+                         menuID:'menu53'},
+
+                        {name:'Event Log',
+                         linkUrl:'RgEventLog.asp',
+                         menuID:'menu43'},
+
+                        {name:'Configuration',
+                         linkUrl:'RgConfiguration.asp',
+                         menuID:'menu39'}
+                ]},
+
+                {name:'BASIC', subMenu: [
+                        {name:'Setup',
+                         linkUrl:'RgSetup.asp',
+                         menuID:'menu41'},
+
+                        {name:'DHCP',
+                         linkUrl:'RgDhcp.asp',
+                         menuID:'menu13'},
+
+                        {name:'DHCPv6',
+                         linkUrl:'RgDhcpV6.asp',
+                         menuID:'menu9f'},
+
+                        {name:'IPv6 Clients',
+                         linkUrl:'RgIPv6Clients.asp',
+                         menuID:'menu84'},
+
+                        {name:'DDNS',
+                         linkUrl:'RgDdns.asp',
+                         menuID:'menu6b'},
+
+                        {name:'Backup and Restore',
+                         linkUrl:'RgBackup.asp',
+                         menuID:'menu3a'},
+
+                        {name:'MoCA',
+                         linkUrl:'MoCA.asp',
+                         menuID:'menu93'},
+
+                        {name:'USB Connect',
+                         linkUrl:'USB.asp',
+                         menuID:'menu96'},
+
+                        {name:'Ethernet Ports',
+                         linkUrl:'RgEthPort.asp',
+                         menuID:'menu95'},
+
+                        {name:'LED Control',
+                         linkUrl:'LedControl.asp',
+                         menuID:'menuab'}
+                ]},
+
+                {name:'ADVANCED', subMenu: [
+                        {name:'Options',
+                         linkUrl:'RgOptions.asp',
+                         menuID:'menu50'},
+
+                        {name:'IP Filtering',
+                         linkUrl:'RgIpFiltering.asp',
+                         menuID:'menu2b'},
+
+                        {name:'MAC Filtering',
+                         linkUrl:'RgMacFiltering.asp',
+                         menuID:'menu2f'},
+
+                        {name:'Port Filtering',
+                         linkUrl:'RgPortFiltering.asp',
+                         menuID:'menu29'},
+
+                        {name:'Port Triggers',
+                         linkUrl:'RgPortTriggering.asp',
+                         menuID:'menu1e'},
+
+                        {name:'Port Forwarding',
+                         linkUrl:'RgForwarding.asp',
+                         menuID:'menu63'},
+
+                        {name:'DMZ Host',
+                         linkUrl:'RgDmzHost.asp',
+                         menuID:'menu6'},
+
+                        {name:'RIP',
+                         linkUrl:'RgRipSetup.asp',
+                         menuID:'menu8'},
+
+                        {name:'Linux Apps',
+                         linkUrl:'NASWebInterface/admin/index.php?user=admin',
+                         menuID:'menu9e'}
+                ]},
+
+                {name:'WIRELESS', subMenu: [
+                        {name:'802.11 Radio',
+                         linkUrl:'wlanRadio.asp',
+                         menuID:'menu20'},
+
+                        {name:'Primary Network Settings',
+                         linkUrl:'wlanPrimaryNetwork.asp',
+                         menuID:'menu68'},
+
+                        {name:'Guest Network Settings',
+                         linkUrl:'wlanGuestNetwork.asp',
+                         menuID:'menu10'},
+
+                        {name:'Access Control',
+                         linkUrl:'wlanAccess.asp',
+                         menuID:'menu32'},
+
+                        {name:'Extend Network Range',
+                         linkUrl:'wlanBridging.asp',
+                         menuID:'menuc'},
+
+                        {name:'WMM Quality of Service',
+                         linkUrl:'wlanWmm.asp',
+                         menuID:'menu42'},
+
+                        {name:'Performance Enhancements',
+                         linkUrl:'wlanMedia.asp',
+                         menuID:'menua8'},
+
+                        {name:'Advanced',
+                         linkUrl:'wlanAdvanced.asp',
+                         menuID:'menu33'}
+                ]},
+
+                {name:'FIREWALL', subMenu: [
+                        {name:'Protection Level',
+                         linkUrl:'RgContentFilter.asp',
+                         menuID:'menu52'},
+
+                        {name:'Parental Control',
+                         linkUrl:'RgFiltering.asp',
+                         menuID:'menu8e'},
+
+                        {name:'Local Log',
+                         linkUrl:'RgFirewallEL.asp',
+                         menuID:'menu4d'},
+
+                        {name:'Remote Log',
+                         linkUrl:'RgFirewallRL.asp',
+                         menuID:'menu46'}
+                ]},
+
+                {name:'VPN', subMenu: [
+                        {name:'L2TPv3',
+                         linkUrl:'RgVpnL2tpV3.asp',
+                         menuID:'menu7d'},
+
+                        {name:'Event Log',
+                         linkUrl:'RgVpnEventLog.asp',
+                         menuID:'menu58'}
+                ]},
+
+                {name:'TELEPHONY', subMenu: [
+                        {name:'Status',
+                         linkUrl:'MtaStatus.asp',
+                         menuID:'menu3d'},
+
+                        {name:'MTA DHCP',
+                         linkUrl:'MtaDhcp.asp',
+                         menuID:'menu6a'},
+
+                        {name:'Provisioning Details',
+                         linkUrl:'MtaProvisioning.asp',
+                         menuID:'menu45'},
+
+                        {name:'QoS Parameters',
+                         linkUrl:'MtaQos.asp',
+                         menuID:'menu44'},
+
+                        {name:'Event Log',
+                         linkUrl:'MtaEventLog.asp',
+                         menuID:'menu26'},
+
+                        {name:'Battery Charger',
+                         linkUrl:'BatController.asp',
+                         menuID:'menu30'},
+
+                        {name:'Power Management',
+                         linkUrl:'BatInterfaceDelay.asp',
+                         menuID:'menu3f'},
+
+                        {name:'Battery Pack Information',
+                         linkUrl:'BatUps.asp',
+                         menuID:'menu5c'}
+                ]},
+
+                {name:'HELP', subMenu: [
+                        {name:'Overview',
+                         linkUrl:'help.asp',
+                         menuID:'menu9d'},
+
+                        {name:'About',
+                         linkUrl:'About.asp',
+                         menuID:'menua7'}
+                ]}
+        ];
+        var menuItem = menuCM;
+</script>
+
+<!-- START pageheaderB.htm -->
+
+<!-- START pageheaderB.htm ADDITIONS -->
+		<!-- end divs for tmg -->
+		</div></div></div></div></div></div>
+
+		<!--gap--><div id="tmbg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+		<div id="bg1"><div id="bg2"><div id="bg3"><div id="bg4">
+<!-- END pageheaderB.htm ADDITIONS -->
+
+<!-- END pageheaderB.htm -->
+</div> <!-- End Header -->
+
+<div class="container">
+        <div class="subHeader">
+                <div class="subHeadcontent">Product Information</div>
+        </div>
+<div class="breadcrumbs"> <a href="home.asp"> Home</a> > <a href="RgSwInfo.asp">Status</a> > Product Info </div>
+
+        <div class="content">
+                <div class="introText">
+                        <p>The information below describes the current state and status of different cable modem elements.</p>
+        </div>
+
+        <table class="simpleTable">
+                <tr>
+                <th colspan="2" >Information</th>
+                </tr>
+                <tr colspan="2">
+                <td width="60%"><strong>Standard Specification Compliant</strong></td>
+                <td width="40%">DOCSIS 3.0</td>
+                </tr>
+                <tr colspan="2">
+                <td><strong>Hardware Version</strong></td>
+                <td >1</td>
+                </tr>
+                <tr>
+                <td><strong>Software Version</strong></td>
+                <td >D30CM-OSPREY-2.4.0.3-GA-00-NOSH</td>
+                </tr>
+                <tr>
+                <td ><strong>Cable Modem MAC Address</strong></td>
+                <td>[REDACTED MAC]</td>
+                </tr>
+                <tr>
+                <td><strong>Serial Number</strong></td>
+                <td>REDACTED</td>
+                </tr>
+
+                <!--<tr>
+                <td width="192" > <strong>CM Certificate</strong></td>
+                <td >Not Installed
+</td>
+                </tr>-->
+        </table>
+
+    <br clear="all" class="clearfloat">
+        <div class="spacer30"></div>
+
+        <table class="simpleTable">
+                <tr>
+                <th colspan="2">Status</th>
+                </tr>
+
+                <tr>
+                <td width="60%"><strong>Up Time</strong></td>
+                <td width="40%">4 days 23h:19m:44s</td>
+
+                </tr>
+
+
+        </table>
+</div>
+
+<br clear="all" class="clearfloat">
+<div class="spacer40"></div>
+
+</div><!-- end container -->
+
+<!-- Footer and Sitemap -->
+
+<!-- START footer.htm ADDITIONS -->
+		<!-- end divs for bc -->
+		</div></div></div></div>
+
+		<!--gap--><div id="bmtg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+
+		<div id="bmg1"><div id="bmg2"><div id="bmg3"><div id="bmg4"><div id="bmg5"><div id="bmg6">
+
+	    <div id="siteMapBottom"></div>
+        <br clear="all" class="clearfloat">
+
+		</div></div></div></div></div></div>
+
+
+		<!--gap--><div id="bmbg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+
+		<div id="fg1"><div id="fg2"><div id="fg3"><div id="fg4"><div id="fg5"><div id="fg6"><div id="fg7">
+
+			<div id="logo_bottom"><a href="http://www.arris.com"><img src="images/px1_Ux.png" alt="ARRIS" title="ARRIS" class="logo_bottom"></a></div>
+
+			<div id="copyright">
+			<a href="http://www.arris.com">&copy;2022 ARRIS Group, Inc. ALL RIGHTS RESERVED.</a>
+			</div>
+
+		</div></div></div></div></div></div></div>
+
+
+		<div id="fgbl1"><div id="fgbl2"><div id="fgbl3"><div id="fgbl4"><img src="images/px1_Ux.png" alt="" title="" class="fgbl3"></div></div></div></div>
+
+
+    <!-- end divs for pw -->
+    </div></div></div></div>
+
+<!-- END footer.htm ADDITIONS -->
+
+
+<!-- Insert Scripts Here -->
+
+<!-- End Scripts -->
+
+</body>
+</html>

--- a/tests/test_sb6183_driver.py
+++ b/tests/test_sb6183_driver.py
@@ -1,0 +1,189 @@
+"""Tests for Arris SB6183 modem driver."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from app.drivers.sb6183 import SB6183Driver
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "sb6183"
+SAMPLE_STATUS_HTML = (FIXTURE_DIR / "RgConnect.asp.html").read_text(encoding="utf-8")
+SAMPLE_SWINFO_HTML = (FIXTURE_DIR / "RgSwInfo.asp.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def driver():
+    return SB6183Driver("http://192.168.100.1/", "", "")
+
+
+@pytest.fixture
+def mock_status(driver):
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.text = SAMPLE_STATUS_HTML
+    with patch.object(driver._session, "get", return_value=mock_response):
+        yield driver
+
+
+class TestDriverInit:
+    def test_strips_trailing_slash(self):
+        d = SB6183Driver("http://192.168.100.1/", "", "")
+        assert d._url == "http://192.168.100.1"
+
+    def test_load_via_registry(self):
+        from app.drivers import load_driver
+        d = load_driver("sb6183", "http://192.168.100.1", "", "")
+        assert isinstance(d, SB6183Driver)
+
+    def test_registry_hints_mark_credentials_optional(self):
+        from app.drivers import driver_registry
+        hints = driver_registry.get_driver_hints()["sb6183"]
+        assert hints["default_url"] == "http://192.168.100.1"
+        assert hints["credentials_required"] is False
+
+
+class TestLogin:
+    def test_login_verifies_rgconnect(self, driver):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = SAMPLE_STATUS_HTML
+        with patch.object(driver._session, "get", return_value=mock_resp) as mock_get:
+            driver.login()
+            assert mock_get.call_args[0][0].endswith("/RgConnect.asp")
+
+    def test_login_rejects_non_status_page(self, driver):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = "<html><body>Product Information</body></html>"
+        with patch.object(driver._session, "get", return_value=mock_resp):
+            with pytest.raises(RuntimeError, match="status page not returned"):
+                driver.login()
+
+    def test_login_raises_on_connection_error(self, driver):
+        with patch.object(driver._session, "get", side_effect=requests.ConnectionError("refused")):
+            with pytest.raises(RuntimeError, match="SB6183 connection failed"):
+                driver.login()
+
+
+class TestDownstream:
+    def test_channel_count(self, mock_status):
+        data = mock_status.get_docsis_data()
+        assert len(data["channelDs"]["docsis30"]) == 16
+        assert data["channelDs"]["docsis31"] == []
+
+    def test_first_channel_fields(self, mock_status):
+        data = mock_status.get_docsis_data()
+        ch = data["channelDs"]["docsis30"][0]
+        assert ch["channelID"] == 6
+        assert ch["frequency"] == "315 MHz"
+        assert ch["powerLevel"] == pytest.approx(0.7)
+        assert ch["mer"] == pytest.approx(40.2)
+        assert ch["mse"] == pytest.approx(-40.2)
+        assert ch["modulation"] == "QAM256"
+        assert ch["corrErrors"] == 29
+        assert ch["nonCorrErrors"] == 0
+
+    def test_last_channel_fields(self, mock_status):
+        data = mock_status.get_docsis_data()
+        ch = data["channelDs"]["docsis30"][-1]
+        assert ch["channelID"] == 33
+        assert ch["frequency"] == "495 MHz"
+        assert ch["powerLevel"] == pytest.approx(0.5)
+        assert ch["corrErrors"] == 55
+        assert ch["nonCorrErrors"] == 0
+
+
+class TestUpstream:
+    def test_channel_count(self, mock_status):
+        data = mock_status.get_docsis_data()
+        assert len(data["channelUs"]["docsis30"]) == 4
+        assert data["channelUs"]["docsis31"] == []
+
+    def test_first_channel_fields(self, mock_status):
+        data = mock_status.get_docsis_data()
+        ch = data["channelUs"]["docsis30"][0]
+        assert ch["channelID"] == 67
+        assert ch["frequency"] == "30.4 MHz"
+        assert ch["powerLevel"] == pytest.approx(48.3)
+        assert ch["modulation"] == "ATDMA"
+        assert ch["multiplex"] == "ATDMA"
+
+    def test_last_channel_fields(self, mock_status):
+        data = mock_status.get_docsis_data()
+        ch = data["channelUs"]["docsis30"][-1]
+        assert ch["channelID"] == 68
+        assert ch["frequency"] == "36.8 MHz"
+        assert ch["powerLevel"] == pytest.approx(48.5)
+
+
+class TestDeviceInfo:
+    def test_parses_swinfo_page(self, driver):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = SAMPLE_SWINFO_HTML
+        with patch.object(driver._session, "get", return_value=mock_resp) as mock_get:
+            info = driver.get_device_info()
+        assert mock_get.call_args[0][0].endswith("/RgSwInfo.asp")
+        assert info["manufacturer"] == "Arris"
+        assert info["model"] == "SB6183"
+        assert info["sw_version"] == "D30CM-OSPREY-2.4.0.3-GA-00-NOSH"
+        assert info["hw_version"] == "1"
+        assert info["docsis_status"] == "DOCSIS 3.0"
+
+    def test_fallback_on_connection_error(self, driver):
+        with patch.object(driver._session, "get", side_effect=requests.ConnectionError()):
+            info = driver.get_device_info()
+            assert info == {"manufacturer": "Arris", "model": "SB6183", "sw_version": ""}
+
+    def test_connection_info_empty(self, driver):
+        assert driver.get_connection_info() == {}
+
+
+class TestEdgeCases:
+    def test_no_tables(self, driver):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = "<html><body></body></html>"
+        with patch.object(driver._session, "get", return_value=mock_resp):
+            data = driver.get_docsis_data()
+        assert data["channelDs"]["docsis30"] == []
+        assert data["channelUs"]["docsis30"] == []
+
+    def test_get_docsis_data_raises_on_connection_error(self, driver):
+        with patch.object(driver._session, "get", side_effect=requests.ConnectionError("refused")):
+            with pytest.raises(RuntimeError, match="SB6183 DOCSIS data retrieval failed"):
+                driver.get_docsis_data()
+
+    def test_unlocked_channels_are_skipped(self, driver):
+        html = """<html><body>
+        <table><tr><th>Downstream Bonded Channels</th></tr>
+        <tr><td>1</td><td>Locked</td><td>QAM256</td><td>6</td><td>315000000 Hz</td><td>0.7 dBmV</td><td>40.2 dB</td><td>29</td><td>0</td></tr>
+        <tr><td>2</td><td>Not Locked</td><td>QAM256</td><td>1</td><td>285000000 Hz</td><td>0.4 dBmV</td><td>40.0 dB</td><td>1</td><td>0</td></tr>
+        </table>
+        <table><tr><th>Upstream Bonded Channels</th></tr>
+        <tr><td>1</td><td>Locked</td><td>ATDMA</td><td>67</td><td>5120 Ksym/sec</td><td>30400000 Hz</td><td>48.3 dBmV</td></tr>
+        <tr><td>2</td><td>Not Locked</td><td>ATDMA</td><td>65</td><td>5120 Ksym/sec</td><td>17600000 Hz</td><td>47.5 dBmV</td></tr>
+        </table></body></html>"""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.text = html
+        with patch.object(driver._session, "get", return_value=mock_resp):
+            data = driver.get_docsis_data()
+        assert [ch["channelID"] for ch in data["channelDs"]["docsis30"]] == [6]
+        assert [ch["channelID"] for ch in data["channelUs"]["docsis30"]] == [67]
+
+
+class TestAnalyzerIntegration:
+    def test_full_pipeline(self, mock_status):
+        from app.analyzer import analyze
+        data = mock_status.get_docsis_data()
+        result = analyze(data)
+        assert result["summary"]["ds_total"] == 16
+        assert result["summary"]["us_total"] == 4
+        assert result["summary"]["health"] in ("good", "tolerated", "marginal", "poor", "critical")
+        assert len(result["ds_channels"]) == 16
+        assert len(result["us_channels"]) == 4
+        assert {ch["docsis_version"] for ch in result["ds_channels"]} == {"3.0"}
+        assert {ch["docsis_version"] for ch in result["us_channels"]} == {"3.0"}


### PR DESCRIPTION
## Summary
- add a dedicated Arris SB6183 driver for the no-auth HTTP status pages
- cover the provided redacted SB6183 captures with regression tests for channel and device-info parsing
- update supported-hardware documentation and narrow the SB6141 compatibility note

Closes #720

## Checks
- `pytest tests/ -q --tb=short --ignore=tests/e2e`
- `pytest tests/ -q --tb=short --ignore=tests/e2e -m "not linux_only"`
- `pytest -q tests/test_sb6183_driver.py tests/test_sb6141_driver.py tests/test_sb6190_driver.py tests/test_driver_registry.py tests/collectors/test_builtin_drivers.py tests/test_public_launch_surface.py --tb=short`
- `python3 scripts/i18n_check.py --validate`
- `git diff --check`
