### PR TITLE
Fix CODA-56 OFDMA report power

### DIFF
--- a/app/drivers/hitron.py
+++ b/app/drivers/hitron.py
@@ -21,7 +21,7 @@ import requests
 
 from .base import ModemDriver
 from ..types import DocsisData, DeviceInfo, ConnectionInfo, RawChannel
-from .utils import make_legacy_tls_adapter
+from .utils import make_legacy_tls_adapter, parse_optional_finite_float
 
 log = logging.getLogger("docsis.driver.hitron")
 
@@ -177,13 +177,20 @@ class HitronDriver(ModemDriver):
                     "channelID": int(ch["uschindex"]),
                     "type": "OFDMA",
                     "frequency": self._hz_to_mhz(ch.get("frequency", "0")),
-                    "powerLevel": float(ch["repPower"]),
+                    "powerLevel": self._ofdma_power_1_6(ch),
                     "modulation": "OFDMA",
                     "multiplex": "",
                 })
             except (ValueError, KeyError, TypeError) as e:
                 log.warning("Failed to parse Hitron US OFDMA row: %s", e)
         return channels
+
+    @staticmethod
+    def _ofdma_power_1_6(row: dict[str, str]) -> float | None:
+        if "repPower1_6" not in row:
+            log.warning("Hitron CODA-56 OFDMA row missing repPower1_6; leaving power unsupported")
+            return None
+        return parse_optional_finite_float(row.get("repPower1_6"))
 
     # -- Helpers --
 

--- a/app/drivers/hitron_coda_4680.py
+++ b/app/drivers/hitron_coda_4680.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import time
 from typing import Any
 
@@ -22,7 +21,7 @@ import requests
 
 from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
 from .base import ModemDriver
-from .utils import hz_to_mhz, make_legacy_tls_adapter, normalize_modulation
+from .utils import hz_to_mhz, make_legacy_tls_adapter, normalize_modulation, parse_optional_finite_float
 
 log = logging.getLogger("docsis.driver.hitron_coda_4680")
 
@@ -284,11 +283,7 @@ class HitronCoda4680Driver(ModemDriver):
         if "repPower1_6" not in row:
             log.warning("Hitron CODA-4680 OFDMA row missing repPower1_6; leaving power unsupported")
             return None
-        try:
-            power = float(str(row.get("repPower1_6")).strip())
-        except (TypeError, ValueError):
-            return None
-        return power if math.isfinite(power) else None
+        return parse_optional_finite_float(row.get("repPower1_6"))
 
     @staticmethod
     def _parse_rate_kbps(value: Any) -> int:

--- a/app/drivers/utils.py
+++ b/app/drivers/utils.py
@@ -7,6 +7,7 @@ automatically.
 
 import hashlib
 import logging
+import math
 import re
 import ssl
 
@@ -53,6 +54,15 @@ def parse_number(value: str) -> float:
         return float(parts[0])
     except (ValueError, IndexError):
         return 0.0
+
+
+def parse_optional_finite_float(value) -> float | None:
+    """Parse a finite float while preserving missing or invalid values as unsupported."""
+    try:
+        number = float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
 
 
 def hz_to_mhz(freq) -> str:

--- a/tests/test_hitron_driver.py
+++ b/tests/test_hitron_driver.py
@@ -162,7 +162,30 @@ class TestUpstreamOFDMA:
         assert ch["channelID"] == 0
         assert ch["type"] == "OFDMA"
         assert ch["frequency"] == "42 MHz"
-        assert ch["powerLevel"] == pytest.approx(51.6417)
+        assert ch["powerLevel"] == pytest.approx(37.75)
+
+    def test_missing_1_6_mhz_report_power_stays_unsupported(self, driver, caplog):
+        operating = [dict(US_OFDMA_DATA[0])]
+        del operating[0]["repPower1_6"]
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = operating
+
+        with patch.object(driver._session, "get", return_value=resp):
+            channels = driver._fetch_us_ofdma()
+
+        assert channels[0]["powerLevel"] is None
+        assert "missing repPower1_6" in caplog.text
+
+    @pytest.mark.parametrize("value", [None, "", "N/A", "nan", "inf", "-inf", []])
+    def test_invalid_1_6_mhz_report_power_stays_unsupported(self, driver, value):
+        operating = [dict(US_OFDMA_DATA[0], repPower1_6=value)]
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = operating
+
+        with patch.object(driver._session, "get", return_value=resp):
+            channels = driver._fetch_us_ofdma()
+
+        assert channels[0]["powerLevel"] is None
 
     def test_skip_disabled_ofdma(self, driver):
         disabled = [dict(US_OFDMA_DATA[1])]


### PR DESCRIPTION
## Summary
- Read CODA-56 upstream OFDMA power from the per-1.6 MHz `repPower1_6` field instead of aggregate `repPower`.
- Preserve missing, invalid, and non-finite report power as unsupported rather than falling back to aggregate power.
- Share finite optional-number parsing with the CODA-4680 driver and add regression coverage for the CODA-56 payload.

## Validation
- `pytest tests/test_hitron_driver.py tests/test_hitron_coda_4680_driver.py -q`
- `pytest tests/test_hitron_driver.py tests/test_hitron_coda_4680_driver.py tests/collectors/test_builtin_drivers.py tests/collectors/test_modem_collector.py tests/web/test_index.py -q`
- `pytest tests/ -q --ignore=tests/e2e`
- `python -m compileall -q app tests/test_hitron_driver.py`
- `git diff --check`

## Documentation
Documentation is unchanged because this corrects one modem parser field without changing setup or operator workflows.

Closes #726
