### PR TITLE
Restrict speedtest connection test destinations

### DIFF
--- a/app/blueprints/polling_bp.py
+++ b/app/blueprints/polling_bp.py
@@ -175,17 +175,24 @@ def api_test_speedtest():
     """Test Speedtest Tracker connection."""
     _config_manager = get_config_manager()
     try:
-        data = request.get_json()
-        url = data.get("speedtest_tracker_url", "")
-        token = data.get("speedtest_tracker_token", "")
+        data = request.get_json(silent=True) or {}
+        submitted_url = data.get("speedtest_tracker_url", "")
         tls_insecure = _as_bool(data.get("speedtest_tls_insecure", False))
-        # Resolve masked token to real value
-        if token == PASSWORD_MASK and _config_manager:
-            token = _config_manager.get("speedtest_tracker_token", "")
-        if not url or not token:
+        if not submitted_url:
             return jsonify({"success": False, "error": "URL and token are required"})
+
+        saved_url = _config_manager.get("speedtest_tracker_url", "") if _config_manager else ""
+        token = _config_manager.get("speedtest_tracker_token", "") if _config_manager else ""
+        if not saved_url or submitted_url.rstrip("/") != saved_url.rstrip("/"):
+            return jsonify({
+                "success": False,
+                "error": "Save Speedtest Tracker settings before testing.",
+            })
+        if not token:
+            return jsonify({"success": False, "error": "URL and token are required"})
+
         from app.modules.speedtest.client import SpeedtestClient
-        client = SpeedtestClient(url, token, tls_insecure=tls_insecure)
+        client = SpeedtestClient(saved_url, token, tls_insecure=tls_insecure)
         results, error = client.get_latest_with_error(1)
         if error:
             return jsonify({"success": False, "error": error})

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 from app.modules.speedtest.client import SpeedtestClient
 from app.web import app, init_config, init_storage
-from app.config import ConfigManager
+from app.config import ConfigManager, PASSWORD_MASK
 
 
 # ── Sample API responses ──
@@ -311,17 +311,71 @@ class TestSpeedtestAPI:
 
         resp = speedtest_client.post("/api/test-speedtest", json={
             "speedtest_tracker_url": "http://speedtest.local:8999",
-            "speedtest_tracker_token": "[REDACTED]",
+            "speedtest_tracker_token": PASSWORD_MASK,
         })
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["success"] is True
         assert data["results"] == 1
         assert "download" in data["latest"]
+        assert mock_get.call_args.args[0] == "http://speedtest.local:8999/api/v1/results"
         assert mock_get.call_args.kwargs["verify"] is True
+
+    @patch("app.modules.speedtest.client.SpeedtestClient")
+    def test_api_test_speedtest_rejects_unsaved_destination_without_requesting_it(
+        self, mock_client, speedtest_client
+    ):
+        resp = speedtest_client.post("/api/test-speedtest", json={
+            "speedtest_tracker_url": "http://attacker.example",
+            "speedtest_tracker_token": PASSWORD_MASK,
+        })
+
+        assert resp.status_code == 200
+        assert resp.get_json() == {
+            "success": False,
+            "error": "Save Speedtest Tracker settings before testing.",
+        }
+        mock_client.assert_not_called()
+
+    @patch("app.modules.speedtest.client.SpeedtestClient")
+    def test_api_test_speedtest_uses_saved_credentials(self, mock_client, speedtest_client):
+        mock_client.return_value.get_latest_with_error.return_value = ([], None)
+
+        resp = speedtest_client.post("/api/test-speedtest", json={
+            "speedtest_tracker_url": "http://speedtest.local:8999",
+            "speedtest_tracker_token": "attacker-controlled-token",
+        })
+
+        assert resp.status_code == 200
+        assert resp.get_json() == {"success": True, "results": 0}
+        mock_client.assert_called_once_with(
+            "http://speedtest.local:8999", "test-token", tls_insecure=False
+        )
+
+    @patch("app.modules.speedtest.client.requests.Session.get")
+    def test_api_test_speedtest_allows_saved_destination_trailing_slash(
+        self, mock_get, speedtest_client
+    ):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        resp = speedtest_client.post("/api/test-speedtest", json={
+            "speedtest_tracker_url": "http://speedtest.local:8999/",
+            "speedtest_tracker_token": PASSWORD_MASK,
+        })
+
+        assert resp.status_code == 200
+        assert resp.get_json() == {"success": True, "results": 0}
+        assert mock_get.call_args.args[0] == "http://speedtest.local:8999/api/v1/results"
 
     @patch("app.modules.speedtest.client.requests.Session.get")
     def test_api_test_speedtest_passes_insecure_tls_flag(self, mock_get, speedtest_client):
+        from app.web import get_config_manager
+
+        get_config_manager().save({"speedtest_tracker_url": "https://speedtest.local:8443"})
+
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"data": [SAMPLE_RESULT]}
         mock_resp.raise_for_status = MagicMock()
@@ -335,6 +389,7 @@ class TestSpeedtestAPI:
 
         assert resp.status_code == 200
         assert resp.get_json()["success"] is True
+        assert mock_get.call_args.args[0] == "https://speedtest.local:8443/api/v1/results"
         assert mock_get.call_args.kwargs["verify"] is False
 
     def test_api_test_speedtest_missing_fields(self, speedtest_client):


### PR DESCRIPTION
## Summary
- use persisted Speedtest Tracker destinations and credentials for connection tests
- reject unsaved destination changes before constructing the HTTP client
- preserve private-network endpoints, trailing-slash handling, and the TLS verification option
- add regression coverage for destination and credential isolation

## Checks
- `python -m pytest tests/test_speedtest.py -q` — 37 passed
- `python -m pytest tests/ -q --tb=short --ignore=tests/e2e` — 2866 passed, 11 skipped
- regression mutation check against the previous implementation

Addresses [Code scanning alert 94](https://github.com/itsDNNS/docsight/security/code-scanning/94).
