### PR TITLE
Sanitize connection probe fallback details

### DIFF
--- a/app/modules/connection_monitor/probe.py
+++ b/app/modules/connection_monitor/probe.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 logger = logging.getLogger(__name__)
 
 PROBE_TIMEOUT_S = 2.0
+ICMP_UNAVAILABLE_REASON = "ICMP probing is unavailable"
 ICMP_HELPER_PATH = os.environ.get(
     "DOCSIGHT_ICMP_HELPER", "/usr/local/bin/docsight-icmp-helper"
 )
@@ -63,9 +64,8 @@ class ProbeEngine:
         self._seq = 0
 
     def _detect_method(self) -> str:
-        """Try ICMP raw socket; fall back to TCP if not permitted."""
-        helper_reason = self._helper_check()
-        if helper_reason is None:
+        """Try the ICMP helper and raw socket before falling back to TCP."""
+        if self._helper_check():
             logger.info("ICMP helper available - using ICMP probing")
             return "icmp"
         try:
@@ -75,12 +75,9 @@ class ProbeEngine:
                 pass
             logger.info("ICMP raw socket available - using ICMP probing")
             return "icmp"
-        except (PermissionError, OSError) as exc:
-            self._fallback_reason = helper_reason or str(exc)
-            logger.warning(
-                "ICMP raw socket not available (%s) - falling back to TCP",
-                self._fallback_reason,
-            )
+        except (PermissionError, OSError):
+            self._fallback_reason = ICMP_UNAVAILABLE_REASON
+            logger.warning("ICMP probing is unavailable - falling back to TCP")
             return "tcp"
 
     def capability_info(self) -> dict[str, str]:
@@ -239,8 +236,8 @@ class ProbeEngine:
         finally:
             sock.close()
 
-    def _helper_check(self) -> str | None | bool:
-        """Return None when helper is usable, otherwise reason/False."""
+    def _helper_check(self) -> bool:
+        """Return whether the configured helper is usable."""
         if not self._helper_available:
             return False
         try:
@@ -251,11 +248,9 @@ class ProbeEngine:
                 timeout=PROBE_TIMEOUT_S + 1,
                 check=False,
             )
-        except (OSError, subprocess.SubprocessError) as exc:
-            return str(exc)
-        if proc.returncode == 0:
-            return None
-        return (proc.stderr or proc.stdout or "helper check failed").strip()
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return proc.returncode == 0
 
     def _icmp_probe_with_helper(self, host: str) -> ProbeResult | None:
         """Run a single ICMP probe via the dedicated helper when present."""
@@ -269,8 +264,8 @@ class ProbeEngine:
                 timeout=PROBE_TIMEOUT_S + 1,
                 check=False,
             )
-        except (OSError, subprocess.SubprocessError) as exc:
-            logger.debug("ICMP helper execution failed for %s: %s", host, exc)
+        except (OSError, subprocess.SubprocessError):
+            logger.debug("ICMP helper execution failed")
             return None
 
         output = (proc.stdout or "").strip()
@@ -282,16 +277,12 @@ class ProbeEngine:
                     method="icmp",
                 )
             except ValueError:
-                logger.debug("ICMP helper returned invalid latency for %s: %r", host, output)
+                logger.debug("ICMP helper returned invalid latency")
                 return None
         if proc.returncode == 1:
             return ProbeResult(latency_ms=None, timeout=True, method="icmp")
 
-        logger.debug(
-            "ICMP helper failed for %s: %s",
-            host,
-            (proc.stderr or output or f"exit {proc.returncode}").strip(),
-        )
+        logger.debug("ICMP helper probe failed")
         return None
 
     @staticmethod

--- a/tests/modules/connection_monitor/test_probe.py
+++ b/tests/modules/connection_monitor/test_probe.py
@@ -1,5 +1,6 @@
 """Tests for the Connection Monitor probe engine."""
 
+import logging
 import socket
 import subprocess
 import sys
@@ -77,6 +78,98 @@ class TestProbeEngineAutoDetection:
             info = engine.capability_info()
             assert info["method"] == "tcp"
             assert "reason" in info
+
+    @pytest.mark.parametrize(
+        ("helper_error", "helper_marker"),
+        [
+            (
+                OSError("HELPER_OSERROR_INTERNAL_MARKER at /private/helper"),
+                "HELPER_OSERROR_INTERNAL_MARKER",
+            ),
+            (
+                subprocess.TimeoutExpired(
+                    cmd=["/private/HELPER_TIMEOUT_INTERNAL_MARKER", "--check"],
+                    timeout=3,
+                ),
+                "HELPER_TIMEOUT_INTERNAL_MARKER",
+            ),
+        ],
+        ids=["os-error", "subprocess-timeout"],
+    )
+    def test_capability_hides_helper_check_exceptions(
+        self, caplog, helper_error, helper_marker
+    ):
+        raw_marker = "RAW_SOCKET_PERMISSION_INTERNAL_MARKER"
+        caplog.set_level(
+            logging.DEBUG, logger="app.modules.connection_monitor.probe"
+        )
+
+        with patch(
+            "app.modules.connection_monitor.probe.os.path.isfile", return_value=True
+        ), patch(
+            "app.modules.connection_monitor.probe.os.access", return_value=True
+        ), patch(
+            "app.modules.connection_monitor.probe.subprocess.run",
+            side_effect=helper_error,
+        ), patch(
+            "app.modules.connection_monitor.probe.socket.socket",
+            side_effect=PermissionError(
+                f"{raw_marker}: operation denied for /private/raw-socket"
+            ),
+        ):
+            info = ProbeEngine(method="auto").capability_info()
+
+        assert info["method"] == "tcp"
+        assert info["reason"] == "ICMP probing is unavailable"
+        assert info["hint"] == (
+            "Add cap_add: [NET_RAW] to your Docker Compose file "
+            "for ICMP probing (more accurate)."
+        )
+        exposed_text = f"{info!r}\n{caplog.text}"
+        assert "ICMP probing is unavailable - falling back to TCP" in caplog.text
+        assert helper_marker not in exposed_text
+        assert raw_marker not in exposed_text
+        assert "/private/" not in exposed_text
+
+    def test_capability_hides_nonzero_helper_output(self, caplog):
+        stdout_marker = "HELPER_STDOUT_INTERNAL_MARKER"
+        stderr_marker = "HELPER_STDERR_INTERNAL_MARKER"
+        raw_marker = "RAW_SOCKET_OSERROR_INTERNAL_MARKER"
+        helper_failure = subprocess.CompletedProcess(
+            args=["/private/docsight-icmp-helper", "--check"],
+            returncode=2,
+            stdout=f"{stdout_marker}: kernel detail\n",
+            stderr=f"{stderr_marker}: command failed\n",
+        )
+        caplog.set_level(
+            logging.DEBUG, logger="app.modules.connection_monitor.probe"
+        )
+
+        with patch(
+            "app.modules.connection_monitor.probe.os.path.isfile", return_value=True
+        ), patch(
+            "app.modules.connection_monitor.probe.os.access", return_value=True
+        ), patch(
+            "app.modules.connection_monitor.probe.subprocess.run",
+            return_value=helper_failure,
+        ), patch(
+            "app.modules.connection_monitor.probe.socket.socket",
+            side_effect=OSError(f"{raw_marker}: unsupported protocol"),
+        ):
+            info = ProbeEngine(method="auto").capability_info()
+
+        assert info["method"] == "tcp"
+        assert info["reason"] == "ICMP probing is unavailable"
+        assert info["hint"] == (
+            "Add cap_add: [NET_RAW] to your Docker Compose file "
+            "for ICMP probing (more accurate)."
+        )
+        exposed_text = f"{info!r}\n{caplog.text}"
+        assert "ICMP probing is unavailable - falling back to TCP" in caplog.text
+        assert stdout_marker not in exposed_text
+        assert stderr_marker not in exposed_text
+        assert raw_marker not in exposed_text
+        assert "/private/" not in exposed_text
 
 
 class TestTCPProbe:

--- a/tests/modules/connection_monitor/test_routes.py
+++ b/tests/modules/connection_monitor/test_routes.py
@@ -2,12 +2,14 @@
 
 import csv
 import io
+import subprocess
 import time
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 import pytest
 
 from app.modules.connection_monitor.routes import bp
+from app.modules.connection_monitor.probe import ProbeEngine
 from app.modules.connection_monitor.storage import ConnectionMonitorStorage
 
 
@@ -739,6 +741,51 @@ class TestAuthProtection:
     def test_capability_requires_auth(self, auth_client):
         c, _ = auth_client
         assert c.get("/api/connection-monitor/capability").status_code == 401
+
+    def test_authenticated_capability_hides_probe_detection_details(
+        self, auth_client
+    ):
+        c, _ = auth_client
+        _auth_session(c)
+        helper_marker = "ROUTE_HELPER_STDERR_INTERNAL_MARKER"
+        raw_marker = "ROUTE_RAW_SOCKET_INTERNAL_MARKER"
+        helper_failure = subprocess.CompletedProcess(
+            args=["/private/docsight-icmp-helper", "--check"],
+            returncode=2,
+            stdout="",
+            stderr=f"{helper_marker}: /private/helper/config\n",
+        )
+
+        with patch(
+            "app.modules.connection_monitor.probe.os.path.isfile", return_value=True
+        ), patch(
+            "app.modules.connection_monitor.probe.os.access", return_value=True
+        ), patch(
+            "app.modules.connection_monitor.probe.subprocess.run",
+            return_value=helper_failure,
+        ), patch(
+            "app.modules.connection_monitor.probe.socket.socket",
+            side_effect=PermissionError(
+                f"{raw_marker}: permission denied for raw protocol"
+            ),
+        ), patch(
+            "app.modules.connection_monitor.routes._get_probe_engine",
+            side_effect=lambda: ProbeEngine(method="auto"),
+        ):
+            resp = c.get("/api/connection-monitor/capability")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["method"] == "tcp"
+        assert data["reason"] == "ICMP probing is unavailable"
+        assert data["hint"] == (
+            "Add cap_add: [NET_RAW] to your Docker Compose file "
+            "for ICMP probing (more accurate)."
+        )
+        response_text = resp.get_data(as_text=True)
+        assert helper_marker not in response_text
+        assert raw_marker not in response_text
+        assert "/private/" not in response_text
 
     def test_pinned_days_get_requires_auth(self, auth_client):
         c, _ = auth_client


### PR DESCRIPTION
## Summary
- replace raw ICMP helper and socket errors with a stable capability reason
- preserve helper, raw-socket, and TCP fallback detection behavior
- avoid logging helper output, internal paths, and operating-system error details
- retain the authenticated capability response schema and existing remediation hint
- add probe and API regression coverage for exception, stdout, and stderr paths

## Checks
- `python -m pytest tests/modules/connection_monitor/test_probe.py tests/modules/connection_monitor/test_routes.py -q` — 89 passed
- `python -m pytest tests/ -q --tb=short --ignore=tests/e2e` — 2873 passed, 11 skipped
- regression mutation checks against the previous implementation

Addresses [Code scanning alert 95](https://github.com/itsDNNS/docsight/security/code-scanning/95).
