### PR TITLE
Persist admin sessions across browser restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ HISTORY_DAYS=0                 # Snapshot retention in days (0 = unlimited)
 # SNAPSHOT_TIME=06:00          # Daily snapshot time (HH:MM) -- UI only, no env var
 WEB_PORT=8765
 # ADMIN_PASSWORD=              # Web UI password (hashed with scrypt)
+# SESSION_LIFETIME_DAYS=30     # Rolling login lifetime in days (bounded to 1-365)
+# REVERSE_PROXY=1              # Trusted proxy hops; enables Secure HTTPS-only session cookies
 # LANGUAGE=en                  # UI language (en, de, fr, es) -- UI only, no env var
 # THEME=dark                   # UI theme (dark, light) -- UI only, no env var
 # DEMO_MODE=false              # Enable demo mode with synthetic data

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -822,8 +822,11 @@ def test_my_collector_success():
 
 **Session Management:**
 - Flask sessions with HTTPOnly cookies
-- SameSite=Strict policy
+- Rolling 30-day lifetime by default (`SESSION_LIFETIME_DAYS`, bounded to 1–365 days)
+- SameSite=Lax policy; reverse-proxy deployments retain Secure HTTPS-only cookies
+- Password-bound session markers invalidate existing logins when the effective admin password changes
 - Persistent session key in `/data/.session_key`
+- Keyed effective-auth state in `/data/.auth_state` detects changes across restarts
 
 **Rate Limiting:**
 - Login: 5 attempts per 15 minutes per IP

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,10 +89,16 @@ Modal or blocking notices are not allowed for normal release notes, feature anno
 DOCSight includes built-in authentication protecting all routes:
 
 - **Admin password** — hashed with Werkzeug (`scrypt` or `pbkdf2`). Plaintext passwords from older versions are auto-upgraded to hashes on first login.
-- **Session-based login** — browser sessions via Flask's signed cookies.
+- **Session-based login** — browser sessions use Flask's signed cookies and are valid for a rolling 30 days by default. Operators can set `SESSION_LIFETIME_DAYS`; values are bounded to 1–365 days, and malformed values safely use the 30-day default.
 - **API tokens** — Bearer token authentication for programmatic access (see [API Token Security](#api-token-security) below).
 
 All routes are protected by the `require_auth` decorator. Sensitive management endpoints (token creation/revocation, settings) require a session login and cannot be accessed with API tokens alone.
+
+Session cookies remain `HttpOnly` and use `SameSite=Lax`, allowing navigation from external top-level links without allowing normal cross-site subrequests to carry the cookie. Browser sessions are bound to the currently effective admin-password representation with a keyed, non-reversible marker. Changing or removing the password in Settings rotates the persistent signing key and logs out all browsers; environment-backed password changes also invalidate prior sessions when they are next used. Unchanged saved-secret masks, omitted password fields, unrelated settings saves, and safely detected re-entry of the same password do not invalidate sessions.
+
+The session key is stored in `DATA_DIR/.session_key`, so normal restarts with the same data directory preserve valid logins. `DATA_DIR/.auth_state` stores only a keyed fingerprint of the effective authentication state so that observed password removal and later same-value re-enablement cannot revive an old cookie. Both files are atomically written with mode `0600`. Cookies created before password binding was introduced do not contain the required marker and require a one-time login after upgrade. DOCSight does not store the admin password, its hash, or a reusable unkeyed password-derived value in either the cookie or auth-state file.
+
+For HTTPS deployments, enable trusted reverse-proxy mode with `REVERSE_PROXY`; DOCSight then keeps the session cookie `Secure`, so it is sent only over HTTPS. Do not expose an authenticated instance over unencrypted remote HTTP.
 
 ### Login Rate Limiting
 
@@ -184,6 +190,7 @@ Security-relevant events are logged to the `docsis.audit` logger:
 3. **Use strong modem passwords:** DOCSight inherits your modem's security
 4. **Review audit logs:** Check `docker logs docsight` or enable JSON audit logging for structured analysis
 5. **Backup your data:** `data/` directory contains all configuration and history
+6. **Protect backup archives:** Backups contain session-signing and encryption key material; store and transfer them like credentials
 
 ## Defensive Review Checklist
 

--- a/app/blueprints/config_bp.py
+++ b/app/blueprints/config_bp.py
@@ -8,11 +8,12 @@ from zoneinfo import ZoneInfo
 from flask import Blueprint, request, jsonify
 
 from app.web import (
-    require_auth, _require_session_auth,
+    require_auth, _require_session_auth, _admin_password_matches,
+    _invalidate_admin_sessions, _secret_values_match,
     get_config_manager, get_storage, get_on_config_changed,
     _get_client_ip, _localize_timestamps,
 )
-from app.config import POLL_MIN, POLL_MAX, SECRET_KEYS, HASH_KEYS
+from app.config import POLL_MIN, POLL_MAX, SECRET_KEYS, HASH_KEYS, PASSWORD_MASK
 
 audit_log = logging.getLogger("docsis.audit")
 log = logging.getLogger("docsis.web")
@@ -44,7 +45,7 @@ def run_bqm_initial_fetch(config_manager=None, storage=None):
 
 
 @config_bp.route("/api/config", methods=["POST"])
-@require_auth
+@_require_session_auth
 def api_config():
     """Save configuration."""
     _config_manager = get_config_manager()
@@ -54,6 +55,14 @@ def api_config():
         data = request.get_json()
         if not data:
             return jsonify({"success": False, "error": "No data"}), 400
+        data = dict(data)
+        previous_admin_password = _config_manager.get("admin_password", "")
+        admin_password_requested = "admin_password" in data
+        if admin_password_requested and (
+            data["admin_password"] == PASSWORD_MASK
+            or _admin_password_matches(previous_admin_password, data["admin_password"])
+        ):
+            del data["admin_password"]
         # Validate timezone if provided
         if "timezone" in data and data["timezone"]:
             try:
@@ -67,8 +76,6 @@ def api_config():
                 data["poll_interval"] = max(POLL_MIN, min(POLL_MAX, pi))
             except (ValueError, TypeError):
                 pass
-        changed_keys = [k for k in data if k not in SECRET_KEYS and k not in HASH_KEYS]
-        secret_changed = [k for k in data if k in SECRET_KEYS or k in HASH_KEYS]
         previous_bqm_url = (_config_manager.get("bqm_url") or "").strip()
         requested_bqm_url = (data.get("bqm_url") or "").strip() if "bqm_url" in data else previous_bqm_url
         should_fetch_bqm = (
@@ -77,6 +84,15 @@ def api_config():
             and _should_run_bqm_initial_fetch(requested_bqm_url)
         )
         _config_manager.save(data)
+        effective_admin_password = _config_manager.get("admin_password", "")
+        admin_password_changed = (
+            admin_password_requested
+            and not _secret_values_match(previous_admin_password, effective_admin_password)
+        )
+        if admin_password_changed:
+            _invalidate_admin_sessions()
+        changed_keys = [k for k in data if k not in SECRET_KEYS and k not in HASH_KEYS]
+        secret_changed = [k for k in data if k in SECRET_KEYS or k in HASH_KEYS]
         audit_log.info(
             "Config changed: ip=%s keys=%s secrets_changed=%s",
             _get_client_ip(), changed_keys, secret_changed,

--- a/app/doctor.py
+++ b/app/doctor.py
@@ -356,7 +356,7 @@ def _check_database(data_dir: Path) -> CheckResult:
 def _check_secret_files(data_dir: Path, raw_config: Mapping[str, Any]) -> CheckResult:
     details: dict[str, Any] = {}
     statuses: list[str] = []
-    for filename in (".config_key", ".session_key"):
+    for filename in (".config_key", ".session_key", ".auth_state"):
         path = data_dir / filename
         if not path.exists():
             statuses.append("warn")

--- a/app/modules/backup/backup.py
+++ b/app/modules/backup/backup.py
@@ -21,7 +21,7 @@ log = logging.getLogger("docsis.backup")
 # Files under data_dir to include in backups
 DATA_FILES = [
     "docsis_history.db", "connection_monitor.db",
-    "config.json", ".config_key", ".session_key",
+    "config.json", ".config_key", ".session_key", ".auth_state",
 ]
 
 BACKUP_META_FILE = "backup_meta.json"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -247,9 +247,11 @@
             <i data-lucide="heart-handshake"></i> {{ t.get('support_nav', 'Support') }}
         </a>
         {% if auth_enabled %}
-        <a class="nav-item" href="/logout">
-            <i data-lucide="log-out"></i> {{ t.logout }}
-        </a>
+        <form action="/logout" method="post">
+            <button type="submit" class="nav-item">
+                <i data-lucide="log-out"></i> {{ t.logout }}
+            </button>
+        </form>
         {% endif %}
     </div>
     <div class="sidebar-footer">

--- a/app/web.py
+++ b/app/web.py
@@ -1,6 +1,7 @@
 """Flask web UI for DOCSight – DOCSIS channel monitoring."""
 
 import functools
+import hmac
 import logging
 import math
 import os
@@ -146,6 +147,13 @@ _LOGIN_WINDOW = 900  # 15 min
 _LOGIN_LOCKOUT_BASE = 30  # seconds, doubles each excess attempt
 _LOGIN_MAX_TRACKED_IPS = 2048
 _LOGIN_CSRF_SESSION_KEY = "login_csrf_token"
+_AUTH_MARKER_SESSION_KEY = "auth_marker"
+_AUTH_MARKER_CONTEXT = b"docsight-admin-session-v1\0"
+_AUTH_STATE_CONTEXT = b"docsight-admin-auth-state-v1\0"
+_AUTH_STATE_FILENAME = ".auth_state"
+_SESSION_LIFETIME_DEFAULT_DAYS = 30
+_SESSION_LIFETIME_MIN_DAYS = 1
+_SESSION_LIFETIME_MAX_DAYS = 365
 
 
 def _get_client_ip():
@@ -287,8 +295,9 @@ app = Flask(__name__, template_folder="templates")
 app.secret_key = os.urandom(32)  # overwritten by _init_session_key
 app.config.update(
     SESSION_COOKIE_HTTPONLY=True,
-    SESSION_COOKIE_SAMESITE="Strict",
-    PERMANENT_SESSION_LIFETIME=timedelta(hours=24),
+    SESSION_COOKIE_SAMESITE="Lax",
+    PERMANENT_SESSION_LIFETIME=timedelta(days=_SESSION_LIFETIME_DEFAULT_DAYS),
+    SESSION_REFRESH_EACH_REQUEST=True,
 )
 
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -570,22 +579,79 @@ def setup_module_templates(module_loader):
         app.jinja_loader = ChoiceLoader(loaders)
 
 
+def _write_private_file(path, value):
+    """Atomically replace a private state file with mode 0600."""
+    data_dir = os.path.dirname(path)
+    os.makedirs(data_dir, exist_ok=True)
+    temp_path = f"{path}.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+    fd = None
+    try:
+        fd = os.open(
+            temp_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "wb") as f:
+            fd = None
+            f.write(value)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp_path, path)
+        try:
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+            directory_fd = os.open(data_dir, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            pass
+    finally:
+        if fd is not None:
+            os.close(fd)
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
+
+
 def _init_session_key(data_dir):
     """Load or generate a persistent session secret key."""
     key_path = os.path.join(data_dir, ".session_key")
     if os.path.exists(key_path):
         with open(key_path, "rb") as f:
-            app.secret_key = f.read()
+            key = f.read()
     else:
         key = os.urandom(32)
-        os.makedirs(data_dir, exist_ok=True)
-        with open(key_path, "wb") as f:
-            f.write(key)
-        try:
-            os.chmod(key_path, stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
-        app.secret_key = key
+        _write_private_file(key_path, key)
+    app.secret_key = key
+
+
+def _rotate_session_key():
+    """Persist and activate a new signing key, invalidating all old cookies."""
+    if not _config_manager:
+        raise RuntimeError("Config not initialized")
+    key = os.urandom(32)
+    _write_private_file(os.path.join(_config_manager.data_dir, ".session_key"), key)
+    # In-memory activation assumes today's single-process waitress deployment;
+    # a future multi-worker server must coordinate shared signing-key rotation.
+    app.secret_key = key
+
+
+def _session_lifetime_days():
+    """Return the safe, bounded operator-configured session lifetime."""
+    configured = os.environ.get("SESSION_LIFETIME_DAYS", "").strip()
+    if not configured:
+        return _SESSION_LIFETIME_DEFAULT_DAYS
+    try:
+        days = int(configured)
+    except (TypeError, ValueError):
+        log.warning(
+            "Invalid SESSION_LIFETIME_DAYS; using %d days",
+            _SESSION_LIFETIME_DEFAULT_DAYS,
+        )
+        return _SESSION_LIFETIME_DEFAULT_DAYS
+    return max(_SESSION_LIFETIME_MIN_DAYS, min(_SESSION_LIFETIME_MAX_DAYS, days))
 
 
 def init_config(config_manager, on_config_changed=None):
@@ -594,6 +660,113 @@ def init_config(config_manager, on_config_changed=None):
     _config_manager = config_manager
     _on_config_changed = on_config_changed
     _init_session_key(config_manager.data_dir)
+    _init_auth_state()
+    app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=_session_lifetime_days())
+
+
+def _secret_values_match(left, right):
+    """Compare secret representations without timing-sensitive equality."""
+    return hmac.compare_digest(str(left or "").encode(), str(right or "").encode())
+
+
+def _admin_password_matches(effective_password, candidate):
+    """Safely check whether candidate represents the current admin password."""
+    effective_password = str(effective_password or "")
+    candidate = str(candidate or "")
+    if effective_password.startswith(("scrypt:", "pbkdf2:")):
+        try:
+            return check_password_hash(effective_password, candidate)
+        except (TypeError, ValueError):
+            return False
+    return _secret_values_match(effective_password, candidate)
+
+
+def _auth_state_fingerprint(password_representation=None):
+    """Return a keyed fingerprint of the effective admin-password state."""
+    if password_representation is None:
+        password_representation = (
+            _config_manager.get("admin_password", "") if _config_manager else ""
+        )
+    key = app.secret_key.encode() if isinstance(app.secret_key, str) else app.secret_key
+    value = _AUTH_STATE_CONTEXT + str(password_representation or "").encode("utf-8")
+    return hmac.new(key, value, "sha256").hexdigest()
+
+
+def _auth_state_path():
+    return os.path.join(_config_manager.data_dir, _AUTH_STATE_FILENAME)
+
+
+def _read_auth_state():
+    try:
+        with open(_auth_state_path(), "r", encoding="ascii") as state_file:
+            value = state_file.read().strip()
+    except (FileNotFoundError, OSError, UnicodeError):
+        return None
+    if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+        return None
+    return value
+
+
+def _write_auth_state():
+    fingerprint = _auth_state_fingerprint()
+    _write_private_file(_auth_state_path(), fingerprint.encode("ascii"))
+
+
+def _init_auth_state():
+    """Create auth state or invalidate cookies after an offline state change."""
+    stored = _read_auth_state()
+    current = _auth_state_fingerprint()
+    if stored is None:
+        _write_auth_state()
+    elif not _secret_values_match(stored, current):
+        _rotate_session_key()
+        _write_auth_state()
+
+
+def _sync_auth_state():
+    """Observe runtime auth changes and durably invalidate existing cookies."""
+    if not _config_manager:
+        return
+    stored = _read_auth_state()
+    current = _auth_state_fingerprint()
+    if stored is not None and _secret_values_match(stored, current):
+        return
+    _rotate_session_key()
+    _write_auth_state()
+
+
+def _admin_session_marker(password_representation=None):
+    """Create a keyed, non-reversible marker for the effective password state."""
+    if password_representation is None:
+        if not _config_manager:
+            return ""
+        password_representation = _config_manager.get("admin_password", "")
+    if not password_representation:
+        return ""
+    key = app.secret_key.encode() if isinstance(app.secret_key, str) else app.secret_key
+    value = _AUTH_MARKER_CONTEXT + str(password_representation).encode("utf-8")
+    return hmac.new(key, value, "sha256").hexdigest()
+
+
+def _authenticated_session_is_valid():
+    """Return True only for a password-bound authenticated browser session."""
+    if not session.get("authenticated"):
+        return False
+    actual = session.get(_AUTH_MARKER_SESSION_KEY, "")
+    expected = _admin_session_marker()
+    if actual and expected and _secret_values_match(actual, expected):
+        return True
+    session.clear()
+    return False
+
+
+def _invalidate_admin_sessions():
+    """Globally invalidate signed cookies and clear the current request session."""
+    _rotate_session_key()
+    _write_auth_state()
+    # The request cookie was loaded with the prior key. Clearing after rotation
+    # makes Flask write the logged-out session using the new key on this response.
+    session.clear()
 
 
 def _auth_required():
@@ -604,10 +777,11 @@ def _auth_required():
     """
     if not _config_manager:
         return False
+    _sync_auth_state()
     admin_pw = _config_manager.get("admin_password", "")
     if not admin_pw:
         return False
-    if session.get("authenticated"):
+    if _authenticated_session_is_valid():
         return False
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer ") and _storage:
@@ -635,9 +809,10 @@ def _require_session_auth(f):
     """Decorator: only allow session-based login, no API tokens."""
     @functools.wraps(f)
     def decorated(*args, **kwargs):
+        _sync_auth_state()
         if not _config_manager or not _config_manager.get("admin_password", ""):
             return f(*args, **kwargs)
-        if not session.get("authenticated"):
+        if not _authenticated_session_is_valid():
             # Token auth is not sufficient for this endpoint
             if getattr(request, "_api_token", None) or request.headers.get("Authorization", "").startswith("Bearer "):
                 return jsonify({"error": "Session authentication required"}), 403
@@ -650,6 +825,7 @@ def _require_session_auth(f):
 
 @app.route("/login", methods=["GET", "POST"])
 def login():
+    _sync_auth_state()
     if not _config_manager or not _config_manager.get("admin_password", ""):
         return redirect("/")
     lang = _get_lang()
@@ -674,15 +850,20 @@ def login():
         if stored.startswith(("scrypt:", "pbkdf2:")):
             success = check_password_hash(stored, pw)
         else:
-            success = (pw == stored)
-            if success:
+            success = _secret_values_match(pw, stored)
+            if success and not os.environ.get("ADMIN_PASSWORD"):
                 # Auto-upgrade plaintext password to hash
                 _config_manager.save({"admin_password": pw})
+                stored = _config_manager.get("admin_password", "")
+                # This is the same credential in a safer representation, so
+                # preserve the signing key while rebinding durable auth state.
+                _write_auth_state()
                 audit_log.info("Auto-upgraded plaintext password to hash for ip=%s", ip)
         if success:
             _login_attempts.pop(ip, None)
             session.permanent = True
             session["authenticated"] = True
+            session[_AUTH_MARKER_SESSION_KEY] = _admin_session_marker(stored)
             session.pop(_LOGIN_CSRF_SESSION_KEY, None)
             audit_log.info("Login successful: ip=%s", ip)
             return redirect("/")
@@ -692,9 +873,9 @@ def login():
     return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token)
 
 
-@app.route("/logout")
+@app.route("/logout", methods=["POST"])
 def logout():
-    session.pop("authenticated", None)
+    session.clear()
     return redirect("/login")
 
 

--- a/app/web.py
+++ b/app/web.py
@@ -1,7 +1,6 @@
 """Flask web UI for DOCSight – DOCSIS channel monitoring."""
 
 import functools
-import hmac
 import logging
 import math
 import os
@@ -15,6 +14,7 @@ from urllib.parse import urlencode
 
 import requests as _requests
 
+from cryptography.hazmat.primitives import hashes, hmac
 from flask import Flask, render_template, request, jsonify, redirect, session, send_from_directory
 from jinja2 import FileSystemLoader, ChoiceLoader
 from markupsafe import Markup
@@ -664,9 +664,18 @@ def init_config(config_manager, on_config_changed=None):
     app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=_session_lifetime_days())
 
 
+def _keyed_sha256_hexdigest(key: bytes, message: bytes) -> str:
+    """Return the HMAC-SHA256 of message as lowercase hexadecimal."""
+    mac = hmac.HMAC(key, hashes.SHA256())
+    mac.update(message)
+    return mac.finalize().hex()
+
+
 def _secret_values_match(left, right):
     """Compare secret representations without timing-sensitive equality."""
-    return hmac.compare_digest(str(left or "").encode(), str(right or "").encode())
+    return secrets.compare_digest(
+        str(left or "").encode(), str(right or "").encode()
+    )
 
 
 def _admin_password_matches(effective_password, candidate):
@@ -689,7 +698,7 @@ def _auth_state_fingerprint(password_representation=None):
         )
     key = app.secret_key.encode() if isinstance(app.secret_key, str) else app.secret_key
     value = _AUTH_STATE_CONTEXT + str(password_representation or "").encode("utf-8")
-    return hmac.new(key, value, "sha256").hexdigest()
+    return _keyed_sha256_hexdigest(key, value)
 
 
 def _auth_state_path():
@@ -745,7 +754,7 @@ def _admin_session_marker(password_representation=None):
         return ""
     key = app.secret_key.encode() if isinstance(app.secret_key, str) else app.secret_key
     value = _AUTH_MARKER_CONTEXT + str(password_representation).encode("utf-8")
-    return hmac.new(key, value, "sha256").hexdigest()
+    return _keyed_sha256_hexdigest(key, value)
 
 
 def _authenticated_session_is_valid():

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -52,6 +52,36 @@ class TestLoginFlow:
         auth_page.goto(f"{auth_server}/settings")
         assert "settings" in auth_page.url.lower() or "Settings" in auth_page.title()
 
+    def test_sidebar_logout_button_logs_out_and_protects_dashboard(self, auth_page, auth_server):
+        auth_page.goto(f"{auth_server}/login")
+        auth_page.fill('input[name="password"]', "e2e-test-password")
+        auth_page.click('button[type="submit"]')
+        auth_page.wait_for_load_state("networkidle")
+
+        logout_button = auth_page.locator('form[action="/logout"] button[type="submit"]')
+        assert logout_button.is_visible()
+        logout_button.click()
+        auth_page.wait_for_url("**/login")
+
+        auth_page.goto(auth_server)
+        assert "/login" in auth_page.url
+
+    def test_storage_state_restores_dashboard_session(self, auth_page, auth_server, browser):
+        auth_page.goto(f"{auth_server}/login")
+        auth_page.fill('input[name="password"]', "e2e-test-password")
+        auth_page.click('button[type="submit"]')
+        auth_page.wait_for_load_state("networkidle")
+        storage_state = auth_page.context.storage_state()
+
+        restored_context = browser.new_context(storage_state=storage_state)
+        try:
+            restored_page = restored_context.new_page()
+            restored_page.goto(auth_server)
+            restored_page.wait_for_load_state("networkidle")
+            assert "/login" not in restored_page.url
+        finally:
+            restored_context.close()
+
 
 class TestProtectedRoutes:
     """Unauthenticated access is blocked."""

--- a/tests/modules/connection_monitor/test_routes.py
+++ b/tests/modules/connection_monitor/test_routes.py
@@ -2,6 +2,7 @@
 
 import csv
 import io
+import os
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -31,7 +32,8 @@ def app(tmp_path):
     import app.modules.connection_monitor.routes as routes_mod
     routes_mod._storage = storage
 
-    with patch("app.modules.connection_monitor.routes._get_probe_engine", return_value=mock_probe), \
+    with patch("app.web._config_manager", None), \
+         patch("app.modules.connection_monitor.routes._get_probe_engine", return_value=mock_probe), \
          patch("app.modules.connection_monitor.routes._get_tz", return_value="UTC"):
         yield app, storage
 
@@ -45,10 +47,13 @@ def client(app):
     return flask_app.test_client(), storage
 
 
-def _auth_session(c):
+def _auth_session(c, marker_source=None):
     """Set authenticated session for protected routes."""
     with c.session_transaction() as sess:
         sess["authenticated"] = True
+        if marker_source:
+            from app.web import _admin_session_marker
+            sess["auth_marker"] = _admin_session_marker(marker_source)
 
 
 class TestTargetsAPI:
@@ -710,7 +715,10 @@ class TestAuthProtection:
         mock_cfg.get.side_effect = lambda key, default=None: {
             "admin_password": "hashed_pw",
         }.get(key, default)
+        mock_cfg.data_dir = os.path.dirname(storage.db_path)
         with patch("app.web._config_manager", mock_cfg):
+            from app.web import _init_auth_state
+            _init_auth_state()
             yield flask_app.test_client(), storage
 
     def test_targets_get_requires_auth(self, auth_client):
@@ -746,7 +754,7 @@ class TestAuthProtection:
         self, auth_client
     ):
         c, _ = auth_client
-        _auth_session(c)
+        _auth_session(c, "hashed_pw")
         helper_marker = "ROUTE_HELPER_STDERR_INTERNAL_MARKER"
         raw_marker = "ROUTE_RAW_SOCKET_INTERNAL_MARKER"
         helper_failure = subprocess.CompletedProcess(
@@ -802,5 +810,5 @@ class TestAuthProtection:
 
     def test_authenticated_request_passes(self, auth_client):
         c, _ = auth_client
-        _auth_session(c)
+        _auth_session(c, "hashed_pw")
         assert c.get("/api/connection-monitor/targets").status_code == 200

--- a/tests/modules/connection_monitor/test_traceroute_routes.py
+++ b/tests/modules/connection_monitor/test_traceroute_routes.py
@@ -1,5 +1,6 @@
 """Tests for Connection Monitor traceroute API routes."""
 
+import os
 import time
 from unittest.mock import MagicMock, patch
 
@@ -41,7 +42,8 @@ def app(tmp_path):
     routes_mod._storage = storage
     routes_mod._traceroute_probe = mock_tr_probe
 
-    with patch("app.modules.connection_monitor.routes._get_probe_engine", return_value=mock_probe), \
+    with patch("app.web._config_manager", None), \
+         patch("app.modules.connection_monitor.routes._get_probe_engine", return_value=mock_probe), \
          patch("app.modules.connection_monitor.routes._get_tz", return_value="UTC"):
         yield app, storage, mock_tr_probe
 
@@ -97,7 +99,10 @@ class TestManualTraceroute:
         mock_cfg.get.side_effect = lambda key, default=None: {
             "admin_password": "hashed_pw",
         }.get(key, default)
+        mock_cfg.data_dir = os.path.dirname(storage.db_path)
         with patch("app.web._config_manager", mock_cfg):
+            from app.web import _init_auth_state
+            _init_auth_state()
             c = flask_app.test_client()
             resp = c.post(f"/api/connection-monitor/traceroute/{tid}")
             assert resp.status_code == 401

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -281,7 +281,9 @@ class TestAuthEnabled:
         assert resp.status_code == 302
         assert "/login" in resp.headers["Location"]
         auth_state_path = os.path.join(manager.data_dir, ".auth_state")
-        assert os.stat(auth_state_path).st_mode & 0o777 == 0o600
+        assert os.path.isfile(auth_state_path)
+        if os.name != "nt":
+            assert os.stat(auth_state_path).st_mode & 0o777 == 0o600
 
     def test_password_change_invalidates_current_and_other_sessions(self, auth_config):
         init_config(auth_config)
@@ -297,8 +299,10 @@ class TestAuthEnabled:
 
         assert response.status_code == 200
         assert app.secret_key != old_key
-        key_mode = os.stat(os.path.join(auth_config.data_dir, ".session_key")).st_mode & 0o777
-        assert key_mode == 0o600
+        session_key_path = os.path.join(auth_config.data_dir, ".session_key")
+        assert os.path.isfile(session_key_path)
+        if os.name != "nt":
+            assert os.stat(session_key_path).st_mode & 0o777 == 0o600
         assert current.get("/").status_code == 302
         assert other.get("/").status_code == 302
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,16 @@ from email.utils import parsedate_to_datetime
 
 import pytest
 from werkzeug.security import generate_password_hash
-from app.web import app, update_state, init_config, init_storage, _login_attempts, _LOGIN_MAX_TRACKED_IPS
+from app.web import (
+    _AUTH_STATE_CONTEXT,
+    _LOGIN_MAX_TRACKED_IPS,
+    _keyed_sha256_hexdigest,
+    _login_attempts,
+    app,
+    init_config,
+    init_storage,
+    update_state,
+)
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 
@@ -29,6 +38,19 @@ def _login(client, credential=None):
         data={"password": credential, "csrf_token": _login_csrf(client)},
         follow_redirects=False,
     )
+
+
+def test_keyed_sha256_digest_is_compatible_with_existing_auth_state_format():
+    key = bytes(range(32))
+    password_representation = (
+        b"scrypt:32768:8:1$fixed-salt$fixed-password-hash"
+    )
+
+    digest = _keyed_sha256_hexdigest(
+        key, _AUTH_STATE_CONTEXT + password_representation
+    )
+
+    assert digest == "d9657a5a0e8823e7c611426f9e40f0ac2fd3af7c2df8479e90410f238bd89f31"
 
 
 @pytest.fixture

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,8 +1,12 @@
 """Tests for web UI authentication."""
 
 import json
+import os
 import re
 import sqlite3
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
 import pytest
 from werkzeug.security import generate_password_hash
 from app.web import app, update_state, init_config, init_storage, _login_attempts, _LOGIN_MAX_TRACKED_IPS
@@ -15,6 +19,16 @@ def _login_csrf(client):
     match = re.search(rb'name="csrf_token" value="([^"]+)"', resp.data)
     assert match, "login form should include a CSRF token"
     return match.group(1).decode("utf-8")
+
+
+def _login(client, credential=None):
+    if credential is None:
+        credential = "secret" + "123"
+    return client.post(
+        "/login",
+        data={"password": credential, "csrf_token": _login_csrf(client)},
+        follow_redirects=False,
+    )
 
 
 @pytest.fixture
@@ -107,9 +121,43 @@ class TestAuthEnabled:
         assert resp.status_code == 200  # stays on login page
 
     def test_login_correct_password(self, auth_client):
-        resp = auth_client.post("/login", data={"password": "secret123", "csrf_token": _login_csrf(auth_client)}, follow_redirects=False)
+        resp = _login(auth_client)
         assert resp.status_code == 302
         assert resp.headers["Location"] == "/"
+
+    def test_login_cookie_is_persistent_for_thirty_days(self, auth_client):
+        before = datetime.now(timezone.utc)
+        resp = _login(auth_client)
+
+        cookie = resp.headers["Set-Cookie"]
+        expires_match = re.search(r"Expires=([^;]+)", cookie)
+        assert expires_match
+        expires = parsedate_to_datetime(expires_match.group(1))
+        assert 29.9 <= (expires - before).total_seconds() / 86400 <= 30.1
+        assert "HttpOnly" in cookie
+        assert "SameSite=Lax" in cookie
+
+    def test_permanent_cookie_is_refreshed_on_authenticated_requests(self, auth_client):
+        _login(auth_client)
+
+        resp = auth_client.get("/")
+
+        assert "Expires=" in resp.headers["Set-Cookie"]
+        assert "SameSite=Lax" in resp.headers["Set-Cookie"]
+
+    def test_authenticated_session_is_permanent_and_contains_only_marker(self, auth_client, auth_config):
+        _login(auth_client)
+        cookie = auth_client.get_cookie(app.config["SESSION_COOKIE_NAME"])
+        payload = app.session_interface.get_signing_serializer(app).loads(cookie.value)
+
+        assert payload["_permanent"] is True
+        assert payload["authenticated"] is True
+        assert payload["auth_marker"]
+        serialized_payload = json.dumps(payload)
+        assert "secret123" not in serialized_payload
+        assert auth_config.get("admin_password") not in serialized_payload
+        assert "scrypt:" not in serialized_payload
+        assert "pbkdf2:" not in serialized_payload
 
     def test_session_persists(self, auth_client):
         auth_client.post("/login", data={"password": "secret123", "csrf_token": _login_csrf(auth_client)})
@@ -117,12 +165,165 @@ class TestAuthEnabled:
         resp = auth_client.get("/")
         assert resp.status_code == 200
 
-    def test_logout(self, auth_client):
-        auth_client.post("/login", data={"password": "secret123", "csrf_token": _login_csrf(auth_client)})
-        auth_client.get("/logout")
+    def test_logout_is_post_only_and_get_preserves_session(self, auth_client):
+        _login(auth_client)
+
+        get_response = auth_client.get("/logout")
+        assert get_response.status_code == 405
+        assert auth_client.get("/").status_code == 200
+
+        post_response = auth_client.post("/logout")
+        assert post_response.status_code == 302
+        assert post_response.headers["Location"] == "/login"
         resp = auth_client.get("/")
         assert resp.status_code == 302
         assert "/login" in resp.headers["Location"]
+
+    def test_cookie_survives_reinitialization_with_same_data_dir(self, auth_client, auth_config):
+        _login(auth_client)
+        original_key = app.secret_key
+
+        init_config(ConfigManager(auth_config.data_dir))
+
+        assert app.secret_key == original_key
+        assert auth_client.get("/").status_code == 200
+
+    def test_plaintext_password_upgrade_binds_to_saved_hash(self, tmp_path):
+        data_dir = tmp_path / "legacy-password"
+        data_dir.mkdir()
+        (data_dir / "config.json").write_text(
+            json.dumps({"modem_type": "generic", "admin_password": "legacy-password"}),
+            encoding="utf-8",
+        )
+        manager = ConfigManager(str(data_dir))
+        init_config(manager)
+        init_storage(None)
+        app.config["TESTING"] = True
+        client = app.test_client()
+
+        response = _login(client, "legacy-password")
+
+        assert response.status_code == 302
+        assert manager.get("admin_password").startswith(("scrypt:", "pbkdf2:"))
+        assert client.get("/").status_code == 200
+
+        init_config(ConfigManager(str(data_dir)))
+        assert client.get("/").status_code == 200
+
+    def test_cookie_fails_after_config_backed_password_changes(self, auth_client, auth_config):
+        _login(auth_client)
+        auth_config.save({"admin_password": "replacement-password"})
+
+        resp = auth_client.get("/")
+
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_cookie_fails_after_environment_password_changes(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ADMIN_PASSWORD", "environment-password")
+        manager = ConfigManager(str(tmp_path / "env-auth"))
+        manager.save({"modem_type": "generic"})
+        init_config(manager)
+        init_storage(None)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            _login(client, "environment-password")
+            assert client.get("/").status_code == 200
+
+            monkeypatch.setenv("ADMIN_PASSWORD", "changed-environment-password")
+            resp = client.get("/")
+
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_cookie_does_not_revive_after_environment_password_removal_and_reenable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("ADMIN_PASSWORD", "environment-password")
+        manager = ConfigManager(str(tmp_path / "env-auth-reenabled"))
+        manager.save({"modem_type": "generic"})
+        init_config(manager)
+        init_storage(None)
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            _login(client, "environment-password")
+            assert client.get("/").status_code == 200
+
+            monkeypatch.delenv("ADMIN_PASSWORD")
+            assert client.get("/").status_code == 200
+            assert manager.get("admin_password") == ""
+
+            monkeypatch.setenv("ADMIN_PASSWORD", "environment-password")
+            resp = client.get("/")
+
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+        auth_state_path = os.path.join(manager.data_dir, ".auth_state")
+        assert os.stat(auth_state_path).st_mode & 0o777 == 0o600
+
+    def test_password_change_invalidates_current_and_other_sessions(self, auth_config):
+        init_config(auth_config)
+        init_storage(None)
+        app.config["TESTING"] = True
+        current = app.test_client()
+        other = app.test_client()
+        _login(current)
+        _login(other)
+        old_key = app.secret_key
+
+        response = current.post("/api/config", json={"admin_password": "replacement-password"})
+
+        assert response.status_code == 200
+        assert app.secret_key != old_key
+        key_mode = os.stat(os.path.join(auth_config.data_dir, ".session_key")).st_mode & 0o777
+        assert key_mode == 0o600
+        assert current.get("/").status_code == 302
+        assert other.get("/").status_code == 302
+
+    def test_password_removal_invalidates_sessions_before_password_is_reenabled(self, auth_config):
+        init_config(auth_config)
+        init_storage(None)
+        app.config["TESTING"] = True
+        current = app.test_client()
+        other = app.test_client()
+        _login(current)
+        _login(other)
+
+        response = current.post("/api/config", json={"admin_password": ""})
+        assert response.status_code == 200
+        assert auth_config.get("admin_password") == ""
+
+        # Setup behavior remains available while auth is disabled.
+        response = current.post("/api/config", json={"admin_password": "secret123"})
+        assert response.status_code == 200
+        assert current.get("/").status_code == 302
+        assert other.get("/").status_code == 302
+
+    @pytest.mark.parametrize(
+        "saved_data",
+        [
+            {"admin_password": "••••••••", "language": "de"},
+            {"language": "de"},
+            {"admin_password": "secret123"},
+        ],
+        ids=["saved-mask", "omitted-password", "same-password"],
+    )
+    def test_unchanged_password_saves_do_not_invalidate_sessions(self, auth_config, saved_data):
+        init_config(auth_config)
+        init_storage(None)
+        app.config["TESTING"] = True
+        current = app.test_client()
+        other = app.test_client()
+        _login(current)
+        _login(other)
+        original_key = app.secret_key
+
+        response = current.post("/api/config", json=saved_data)
+
+        assert response.status_code == 200
+        assert app.secret_key == original_key
+        assert current.get("/").status_code == 200
+        assert other.get("/").status_code == 200
 
     def test_api_config_requires_auth(self, auth_client):
         resp = auth_client.post(
@@ -312,7 +513,7 @@ class TestApiTokenAuth:
         assert resp.status_code == 200
 
         # Log out so session doesn't mask the token check
-        auth_client_with_storage.get("/logout")
+        auth_client_with_storage.post("/logout")
 
         # Try to use the revoked token
         resp = auth_client_with_storage.get(
@@ -348,7 +549,7 @@ class TestApiTokenAuth:
         token = resp.get_json()["token"]
 
         # Log out, then try to create a token with Bearer auth
-        auth_client_with_storage.get("/logout")
+        auth_client_with_storage.post("/logout")
         resp = auth_client_with_storage.post(
             "/api/tokens",
             data=json.dumps({"name": "child"}),
@@ -356,6 +557,27 @@ class TestApiTokenAuth:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 403
+
+    def test_token_cannot_change_config(self, auth_client_with_storage, auth_config):
+        original_language = auth_config.get("language")
+        original_password = auth_config.get("admin_password")
+        self._login(auth_client_with_storage)
+        resp = auth_client_with_storage.post(
+            "/api/tokens",
+            json={"name": "config-attempt"},
+        )
+        token = resp.get_json()["token"]
+        auth_client_with_storage.post("/logout")
+
+        resp = auth_client_with_storage.post(
+            "/api/config",
+            json={"language": "de", "admin_password": "attacker-password"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert resp.status_code == 403
+        assert auth_config.get("language") == original_language
+        assert auth_config.get("admin_password") == original_password
 
     def test_api_routes_return_401_not_302(self, auth_client_with_storage):
         """API paths return 401 JSON, not 302 redirect."""

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -50,6 +50,7 @@ def data_dir(tmp_path):
     (d / "config.json").write_text(json.dumps(config))
     (d / ".config_key").write_bytes(b"test-key-data")
     (d / ".session_key").write_bytes(b"session-secret")
+    (d / ".auth_state").write_bytes(b"auth-state-fingerprint")
 
     return str(d)
 
@@ -76,6 +77,7 @@ class TestCreateBackup:
             assert "config.json" in names
             assert ".config_key" in names
             assert ".session_key" in names
+            assert ".auth_state" in names
 
     def test_meta_has_required_fields(self, data_dir):
         buf = create_backup(data_dir)
@@ -191,8 +193,10 @@ class TestRestore:
         result = restore_backup(buf, restore_dir)
         assert "docsis_history.db" in result["restored_files"]
         assert "config.json" in result["restored_files"]
+        assert ".auth_state" in result["restored_files"]
         assert os.path.exists(os.path.join(restore_dir, "docsis_history.db"))
         assert os.path.exists(os.path.join(restore_dir, "config.json"))
+        assert (tmp_path / "restore" / ".auth_state").read_bytes() == b"auth-state-fingerprint"
 
     def test_restored_data_correct(self, data_dir, tmp_path):
         buf = create_backup(data_dir)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sqlite3
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -161,11 +162,15 @@ def test_doctor_reports_all_auth_state_files_present(tmp_path):
 
     assert secret_state["status"] == "pass"
     for filename in (".config_key", ".session_key", ".auth_state"):
+        path = data_dir / filename
+        actual_mode = stat.S_IMODE(path.stat().st_mode)
         assert secret_state["details"][filename] == {
             "present": True,
-            "mode": "0o600",
+            "mode": oct(actual_mode),
             "size_bytes": len(f"{filename}-value"),
         }
+        if os.name != "nt":
+            assert actual_mode == 0o600
 
 
 def test_doctor_reports_missing_auth_state_file(tmp_path):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -144,3 +144,40 @@ def test_doctor_uses_only_offline_checks_by_default(tmp_path, monkeypatch):
     monkeypatch.setattr("requests.sessions.Session.request", fail_if_called)
     monkeypatch.setattr("tempfile.NamedTemporaryFile", fail_if_called)
     build_report(data_dir=str(data_dir))
+
+
+def test_doctor_reports_all_auth_state_files_present(tmp_path):
+    from app.doctor import build_report
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    for filename in (".config_key", ".session_key", ".auth_state"):
+        path = data_dir / filename
+        path.write_bytes(f"{filename}-value".encode())
+        path.chmod(0o600)
+
+    report = build_report(data_dir=str(data_dir))
+    secret_state = next(check for check in report["checks"] if check["id"] == "auth.secret_state")
+
+    assert secret_state["status"] == "pass"
+    for filename in (".config_key", ".session_key", ".auth_state"):
+        assert secret_state["details"][filename] == {
+            "present": True,
+            "mode": "0o600",
+            "size_bytes": len(f"{filename}-value"),
+        }
+
+
+def test_doctor_reports_missing_auth_state_file(tmp_path):
+    from app.doctor import build_report
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / ".config_key").write_bytes(b"config-key")
+    (data_dir / ".session_key").write_bytes(b"session-key")
+
+    report = build_report(data_dir=str(data_dir))
+    secret_state = next(check for check in report["checks"] if check["id"] == "auth.secret_state")
+
+    assert secret_state["status"] == "warn"
+    assert secret_state["details"][".auth_state"] == "missing"

--- a/tests/test_evidence_api.py
+++ b/tests/test_evidence_api.py
@@ -44,11 +44,13 @@ class TestEvidenceChecklistApi:
         assert status == 400
         assert response.get_json()["error"] == "from and to required together"
 
-    def test_endpoint_requires_auth_when_admin_password_is_set(self, monkeypatch):
+    def test_endpoint_requires_auth_when_admin_password_is_set(self, monkeypatch, tmp_path):
         config = Mock()
         config.get.side_effect = lambda key, default=None: {"admin_password": "secret"}.get(key, default)
+        config.data_dir = str(tmp_path)
         monkeypatch.setattr(web, "_config_manager", config)
         monkeypatch.setattr(web, "_storage", None)
+        web._init_auth_state()
         app.config["TESTING"] = True
 
         with app.test_client() as client:

--- a/tests/web/test_security.py
+++ b/tests/web/test_security.py
@@ -1,6 +1,10 @@
 """Tests for security-related web behavior."""
 
 import os
+from datetime import timedelta
+
+import pytest
+
 from app.web import app, update_state, init_config
 from app.config import ConfigManager
 
@@ -43,3 +47,38 @@ class TestSessionKeyPersistence:
         init_config(mgr)
         assert app.secret_key == key1
 
+
+class TestSessionLifetime:
+    def test_default_is_thirty_days(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SESSION_LIFETIME_DAYS", raising=False)
+        init_config(ConfigManager(str(tmp_path / "default_lifetime")))
+        assert app.config["PERMANENT_SESSION_LIFETIME"] == timedelta(days=30)
+
+    def test_operator_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SESSION_LIFETIME_DAYS", "45")
+        init_config(ConfigManager(str(tmp_path / "custom_lifetime")))
+        assert app.config["PERMANENT_SESSION_LIFETIME"] == timedelta(days=45)
+
+    def test_init_config_preserves_reverse_proxy_secure_cookie(self, tmp_path, monkeypatch):
+        monkeypatch.setitem(app.config, "SESSION_COOKIE_SECURE", True)
+
+        init_config(ConfigManager(str(tmp_path / "secure_cookie")))
+
+        assert app.config["SESSION_COOKIE_SECURE"] is True
+
+    @pytest.mark.parametrize(
+        ("configured", "expected_days"),
+        [
+            ("not-a-number", 30),
+            ("", 30),
+            ("0", 1),
+            ("-10", 1),
+            ("999999999999999999999999", 365),
+        ],
+    )
+    def test_invalid_and_unsafe_values_are_defaulted_or_clamped(
+        self, tmp_path, monkeypatch, configured, expected_days
+    ):
+        monkeypatch.setenv("SESSION_LIFETIME_DAYS", configured)
+        init_config(ConfigManager(str(tmp_path / f"lifetime_{expected_days}_{configured}")))
+        assert app.config["PERMANENT_SESSION_LIFETIME"] == timedelta(days=expected_days)

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from bs4 import BeautifulSoup
 
-from app.web import init_config, app
+from app.web import init_config, app, _login_attempts
 from app.config import ConfigManager
 
 
@@ -15,6 +15,18 @@ def _rendered_panel(html: str, panel_id: str):
     panel = soup.find(id=panel_id)
     assert panel is not None
     return panel
+
+
+def _login(client, password):
+    _login_attempts.clear()
+    response = client.get("/login")
+    csrf_token = re.search(rb'name="csrf_token" value="([^"]+)"', response.data)
+    assert csrf_token
+    client.post(
+        "/login",
+        data={"password": password, "csrf_token": csrf_token.group(1).decode("utf-8")},
+    )
+
 
 class TestSettingsRoute:
     def test_settings_contains_comcast_xfinity_isp_option(self, client):
@@ -101,8 +113,7 @@ class TestSettingsRoute:
     def test_settings_icon_only_controls_have_accessible_names(self, client, config_mgr):
         config_mgr.save({"admin_password": "admin-secret-value"})
         init_config(config_mgr)
-        with client.session_transaction() as session:
-            session["authenticated"] = True
+        _login(client, "admin-secret-value")
 
         resp = client.get("/settings?lang=en")
         assert resp.status_code == 200
@@ -186,8 +197,7 @@ class TestSettingsRoute:
     def test_settings_admin_password_field_uses_saved_secret_placeholder(self, client, config_mgr):
         config_mgr.save({"admin_password": "admin-secret-value"})
         init_config(config_mgr)
-        with client.session_transaction() as session:
-            session["authenticated"] = True
+        _login(client, "admin-secret-value")
 
         resp = client.get("/settings?lang=en")
 
@@ -222,4 +232,3 @@ class TestSettingsRender:
     def test_settings_renders(self, client):
         resp = client.get("/settings")
         assert resp.status_code == 200
-


### PR DESCRIPTION
## Summary

- keep admin browser sessions active for a rolling 30-day default, configurable from 1 to 365 days
- preserve sessions across normal restarts while binding them to the effective admin password
- invalidate all browser sessions when the password changes or is removed, including environment-backed changes
- require session authentication for configuration changes and make logout POST-only
- include the private auth-state fingerprint in backups and offline diagnostics
- document cookie behavior, session invalidation, and backup archive sensitivity

## Checks

- `2928 passed, 1 skipped` in the complete non-E2E test suite
- `478 passed` in the complete Playwright E2E suite
- focused authentication, backup, doctor, security, settings, and route tests
- Python compile check and `git diff --check`
