### PR TITLE
Fix release asset upload repository targeting

### DIFF
--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -108,4 +108,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG_NAME" release-assets/*.zip release-assets/*.sha256 --clobber
+        run: gh release upload "$TAG_NAME" --repo "$GITHUB_REPOSITORY" release-assets/*.zip release-assets/*.sha256 --clobber

--- a/tests/test_windows_desktop_ci.py
+++ b/tests/test_windows_desktop_ci.py
@@ -81,7 +81,7 @@ def test_windows_desktop_workflow_attaches_release_assets():
     release_block = named_step_block(workflow, "Attach assets to release")
     assert "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in release_block
     assert "TAG_NAME: ${{ github.event.release.tag_name }}" in release_block
-    assert "gh release upload" in release_block
+    assert 'gh release upload "$TAG_NAME" --repo "$GITHUB_REPOSITORY"' in release_block
     assert "release-assets/*.zip" in release_block
     assert "release-assets/*.sha256" in release_block
 


### PR DESCRIPTION
## Summary

- explicitly target the repository when attaching Windows release assets
- add a regression check for checkout-less release upload jobs

## Checks

- Windows workflow static tests
- Windows packaging and CI contract tests
- workflow diff validation
