### PR TITLE
Refine full browser E2E triggers

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -2,7 +2,7 @@ name: Full browser E2E
 
 on:
   schedule:
-    - cron: "23 3 * * *"
+    - cron: "23 3 * * 1"
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
@@ -11,11 +11,38 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      browser: ${{ steps.filter.outputs.browser }}
+    steps:
+      - name: Filter browser-relevant changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            browser:
+              - 'app/templates/**'
+              - 'app/static/**'
+              - 'app/modules/**'
+              - 'app/web.py'
+              - 'tests/e2e/**'
+              - 'requirements.txt'
+              - '.github/workflows/full-e2e.yml'
+
   full-e2e:
+    needs: changes
     if: >-
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'full-e2e')
+      !cancelled() &&
+      (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'full-e2e') ||
+        needs.changes.outputs.browser == 'true'
+      )
     runs-on: ubuntu-latest
 
     steps:

--- a/tests/test_full_e2e_ci.py
+++ b/tests/test_full_e2e_ci.py
@@ -1,4 +1,4 @@
-"""Regression checks for the scheduled/labeled full browser E2E gate."""
+"""Regression checks for the full browser E2E workflow contract."""
 
 from pathlib import Path
 
@@ -6,12 +6,44 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "full-e2e.yml"
 
 
-def test_full_e2e_workflow_is_scheduled_and_label_gated():
+def test_full_e2e_workflow_contract():
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    assert "schedule:" in workflow
+    assert workflow.count("cron:") == 1
+    assert '- cron: "23 3 * * 1"' in workflow
     assert "workflow_dispatch:" in workflow
+    assert "types: [opened, synchronize, reopened, labeled]" in workflow
+
+    trigger_block = workflow[workflow.index("on:") : workflow.index("permissions:")]
+    assert "paths:" not in trigger_block
+
+    assert "if: github.event_name == 'pull_request'" in workflow
+    assert "pull-requests: read" in workflow
+    assert "browser: ${{ steps.filter.outputs.browser }}" in workflow
+    assert (
+        "dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706"
+        in workflow
+    )
+    for path in (
+        "app/templates/**",
+        "app/static/**",
+        "app/modules/**",
+        "app/web.py",
+        "tests/e2e/**",
+        "requirements.txt",
+        ".github/workflows/full-e2e.yml",
+    ):
+        assert path in workflow
+
+    assert "!cancelled()" in workflow
+    assert "needs: changes" in workflow
     assert "contains(github.event.pull_request.labels.*.name, 'full-e2e')" in workflow
+    assert "needs.changes.outputs.browser == 'true'" in workflow
     assert "TZ=UTC python -m pytest -q tests/e2e --tb=short" in workflow
     assert "actions/upload-artifact" in workflow
+    assert "if: always()" in workflow
+    assert "name: full-e2e-artifacts" in workflow
+    assert "if-no-files-found: ignore" in workflow
+    assert "test-results/" in workflow
+    assert "playwright-report/" in workflow
     assert "tests/e2e/screenshots/" in workflow


### PR DESCRIPTION
## Summary

- run the complete browser E2E suite automatically for browser-relevant pull request changes
- preserve manual dispatch and the `full-e2e` label override without trigger-level path filters
- reduce the scheduled environment-drift backstop from daily to weekly
- lock the workflow policy with focused regression coverage

## Tests

- `pytest -q tests/test_*ci.py`
- non-E2E test suite
- actionlint 1.7.12
- workflow contract mutation check for forbidden trigger-level path filters
