### PR TITLE
Correlation: render Speedtest results as discrete point-in-time marks

### DIFF
--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -751,6 +751,8 @@
   "correlation_events": "Събития",
   "correlation_poor_signal": "Слаб сигнал",
   "correlation_toggle_hint": "Щракнете за превключване",
+  "correlation_speedtest_hint": "Стойностите от Speedtest са отделни измервания и не показват наличност между тестовете.",
+  "correlation_chart_aria_label": "Диаграма за корелация на сигнала с моментни измервания от Speedtest",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX мощност",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -751,6 +751,8 @@
   "correlation_events": "Události",
   "correlation_poor_signal": "Slabý signál",
   "correlation_toggle_hint": "Kliknutím přepnete",
+  "correlation_speedtest_hint": "Hodnoty Speedtest jsou jednotlivá měření a nevypovídají o dostupnosti mezi testy.",
+  "correlation_chart_aria_label": "Graf korelace signálu s měřeními Speedtest v konkrétních okamžicích",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX Power",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -751,6 +751,8 @@
   "correlation_events": "Begivenheder",
   "correlation_poor_signal": "Dårligt signal",
   "correlation_toggle_hint": "Klik for at skifte",
+  "correlation_speedtest_hint": "Speedtest-værdier er enkeltstående målinger og angiver ikke tilgængelighed mellem test.",
+  "correlation_chart_aria_label": "Signalkorrelationsdiagram med punktvise Speedtest-målinger",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX Power",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -751,6 +751,8 @@
   "correlation_events": "Ereignisse",
   "correlation_poor_signal": "Schlechtes Signal",
   "correlation_toggle_hint": "Klicken zum Ein-/Ausblenden",
+  "correlation_speedtest_hint": "Speedtest-Werte sind Einzelmessungen und sagen nichts über die Verfügbarkeit zwischen den Tests aus.",
+  "correlation_chart_aria_label": "Signal-Korrelationsdiagramm mit punktuellen Speedtest-Messungen",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "Sendeleistung",
   "correlation_tt_ds_power": "DS Pegel",

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -751,6 +751,8 @@
   "correlation_events": "Εκδηλώσεις",
   "correlation_poor_signal": "Κακό σήμα",
   "correlation_toggle_hint": "Κάντε κλικ για εναλλαγή",
+  "correlation_speedtest_hint": "Οι τιμές Speedtest είναι μεμονωμένες μετρήσεις και δεν υποδεικνύουν διαθεσιμότητα μεταξύ των δοκιμών.",
+  "correlation_chart_aria_label": "Γράφημα συσχέτισης σήματος με στιγμιαίες μετρήσεις Speedtest",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX Power",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -751,6 +751,8 @@
   "correlation_events": "Events",
   "correlation_poor_signal": "Poor Signal",
   "correlation_toggle_hint": "Click to toggle",
+  "correlation_speedtest_hint": "Speedtest values are individual measurements and do not indicate availability between tests.",
+  "correlation_chart_aria_label": "Signal correlation chart with point-in-time Speedtest measurements",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX Power",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -746,6 +746,8 @@
   "correlation_events": "Eventos",
   "correlation_poor_signal": "Señal deficiente",
   "correlation_toggle_hint": "Clic para alternar",
+  "correlation_speedtest_hint": "Los valores de Speedtest son mediciones individuales y no indican disponibilidad entre pruebas.",
+  "correlation_chart_aria_label": "Gráfico de correlación de señal con mediciones puntuales de Speedtest",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "Potencia TX",
   "correlation_tt_ds_power": "Potencia DS",

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -751,6 +751,8 @@
   "correlation_events": "Sündmused",
   "correlation_poor_signal": "Halb signaal",
   "correlation_toggle_hint": "Klõpsake ümberlülitamiseks",
+  "correlation_speedtest_hint": "Speedtesti väärtused on üksikud mõõtmised ega näita testidevahelist kättesaadavust.",
+  "correlation_chart_aria_label": "Signaali korrelatsioonigraafik ajahetke Speedtesti mõõtmistega",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX võimsus",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -751,6 +751,8 @@
   "correlation_events": "Tapahtumat",
   "correlation_poor_signal": "Huono signaali",
   "correlation_toggle_hint": "Napsauta vaihtaaksesi",
+  "correlation_speedtest_hint": "Speedtest-arvot ovat yksittäisiä mittauksia eivätkä osoita saatavuutta testien välillä.",
+  "correlation_chart_aria_label": "Signaalin korrelaatiokaavio hetkellisillä Speedtest-mittauksilla",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX-teho",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -743,6 +743,8 @@
   "correlation_events": "Événements",
   "correlation_poor_signal": "Signal faible",
   "correlation_toggle_hint": "Cliquer pour basculer",
+  "correlation_speedtest_hint": "Les valeurs Speedtest sont des mesures individuelles et n'indiquent pas la disponibilité entre les tests.",
+  "correlation_chart_aria_label": "Graphique de corrélation du signal avec des mesures Speedtest ponctuelles",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "Puissance TX",
   "correlation_tt_ds_power": "Puissance DS",

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -751,6 +751,8 @@
   "correlation_events": "Imeachtaí",
   "correlation_poor_signal": "Comhartha bocht",
   "correlation_toggle_hint": "Cliceáil chun scoránaigh",
+  "correlation_speedtest_hint": "Is tomhais aonair iad luachanna Speedtest agus ní léiríonn siad infhaighteacht idir tástálacha.",
+  "correlation_chart_aria_label": "Cairt chomhghaolmhaireachta comhartha le tomhais Speedtest ag pointí ama",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX Cumhacht",
   "correlation_tt_ds_power": "DS Cumhacht",

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -751,6 +751,8 @@
   "correlation_events": "Događaji",
   "correlation_poor_signal": "Loš signal",
   "correlation_toggle_hint": "Kliknite za prebacivanje",
+  "correlation_speedtest_hint": "Vrijednosti Speedtesta pojedinačna su mjerenja i ne pokazuju dostupnost između testova.",
+  "correlation_chart_aria_label": "Grafikon korelacije signala s trenutnim mjerenjima Speedtesta",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX snaga",
   "correlation_tt_ds_power": "DS Snaga",

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -751,6 +751,8 @@
   "correlation_events": "Események",
   "correlation_poor_signal": "Gyenge jel",
   "correlation_toggle_hint": "Kattintson a váltáshoz",
+  "correlation_speedtest_hint": "A Speedtest-értékek egyedi mérések, és nem jelzik a tesztek közötti rendelkezésre állást.",
+  "correlation_chart_aria_label": "Jelkorrelációs diagram időponthoz kötött Speedtest-mérésekkel",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX teljesítmény",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -751,6 +751,8 @@
   "correlation_events": "Eventi",
   "correlation_poor_signal": "Segnale scarso",
   "correlation_toggle_hint": "Fare clic per attivare/disattivare",
+  "correlation_speedtest_hint": "I valori Speedtest sono misurazioni individuali e non indicano la disponibilità tra un test e l'altro.",
+  "correlation_chart_aria_label": "Grafico di correlazione del segnale con misurazioni Speedtest puntuali",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "Potenza TX",
   "correlation_tt_ds_power": "Potenza DS",

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -751,6 +751,8 @@
   "correlation_events": "Renginiai",
   "correlation_poor_signal": "Blogas signalas",
   "correlation_toggle_hint": "Spustelėkite, kad perjungtumėte",
+  "correlation_speedtest_hint": "Speedtest reikšmės yra atskiri matavimai ir nerodo pasiekiamumo tarp testų.",
+  "correlation_chart_aria_label": "Signalo koreliacijos diagrama su momentiniais Speedtest matavimais",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX galia",
   "correlation_tt_ds_power": "DS galia",

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -751,6 +751,8 @@
   "correlation_events": "Notikumi",
   "correlation_poor_signal": "Slikts signāls",
   "correlation_toggle_hint": "Noklikšķiniet, lai pārslēgtu",
+  "correlation_speedtest_hint": "Speedtest vērtības ir atsevišķi mērījumi un nenorāda pieejamību starp testiem.",
+  "correlation_chart_aria_label": "Signāla korelācijas diagramma ar konkrēta laika Speedtest mērījumiem",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX jauda",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -751,6 +751,8 @@
   "correlation_events": "Arrangementer",
   "correlation_poor_signal": "Dårlig signal",
   "correlation_toggle_hint": "Klikk for å veksle",
+  "correlation_speedtest_hint": "Speedtest-verdier er enkeltmålinger og sier ikke noe om tilgjengelighet mellom testene.",
+  "correlation_chart_aria_label": "Signalkorrelasjonsdiagram med punktvise Speedtest-målinger",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX Power",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -751,6 +751,8 @@
   "correlation_events": "Evenementen",
   "correlation_poor_signal": "Slecht signaal",
   "correlation_toggle_hint": "Klik om te schakelen",
+  "correlation_speedtest_hint": "Speedtest-waarden zijn afzonderlijke metingen en geven geen beschikbaarheid tussen tests aan.",
+  "correlation_chart_aria_label": "Signaalcorrelatiegrafiek met tijdstipgebonden Speedtest-metingen",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX-vermogen",
   "correlation_tt_ds_power": "DS Vermogen",

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -751,6 +751,8 @@
   "correlation_events": "Wydarzenia",
   "correlation_poor_signal": "Słaby sygnał",
   "correlation_toggle_hint": "Kliknij, aby przełączyć",
+  "correlation_speedtest_hint": "Wartości Speedtest są pojedynczymi pomiarami i nie wskazują dostępności między testami.",
+  "correlation_chart_aria_label": "Wykres korelacji sygnału z punktowymi pomiarami Speedtest",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "Moc TX",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -751,6 +751,8 @@
   "correlation_events": "Eventos",
   "correlation_poor_signal": "Sinal fraco",
   "correlation_toggle_hint": "Clique para alternar",
+  "correlation_speedtest_hint": "Os valores do Speedtest são medições individuais e não indicam disponibilidade entre testes.",
+  "correlation_chart_aria_label": "Gráfico de correlação do sinal com medições pontuais do Speedtest",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "Potência TX",
   "correlation_tt_ds_power": "DS Potência",

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -751,6 +751,8 @@
   "correlation_events": "Evenimente",
   "correlation_poor_signal": "Semnal slab",
   "correlation_toggle_hint": "Faceți clic pentru a comuta",
+  "correlation_speedtest_hint": "Valorile Speedtest sunt măsurători individuale și nu indică disponibilitatea între teste.",
+  "correlation_chart_aria_label": "Grafic de corelare a semnalului cu măsurători Speedtest punctuale",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "Putere TX",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -751,6 +751,8 @@
   "correlation_events": "Udalosti",
   "correlation_poor_signal": "Slabý signál",
   "correlation_toggle_hint": "Kliknutím prepnete",
+  "correlation_speedtest_hint": "Hodnoty Speedtest sú jednotlivé merania a nevypovedajú o dostupnosti medzi testami.",
+  "correlation_chart_aria_label": "Graf korelácie signálu s meraniami Speedtest v konkrétnych okamihoch",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX Power",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -751,6 +751,8 @@
   "correlation_events": "Dogodki",
   "correlation_poor_signal": "Slab signal",
   "correlation_toggle_hint": "Kliknite za preklop",
+  "correlation_speedtest_hint": "Vrednosti Speedtest so posamezne meritve in ne kažejo razpoložljivosti med testi.",
+  "correlation_chart_aria_label": "Graf korelacije signala s trenutnimi meritvami Speedtest",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX moč",
   "correlation_tt_ds_power": "DS Power",

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -751,6 +751,8 @@
   "correlation_events": "Händelser",
   "correlation_poor_signal": "Dålig signal",
   "correlation_toggle_hint": "Klicka för att växla",
+  "correlation_speedtest_hint": "Speedtest-värden är enskilda mätningar och anger inte tillgänglighet mellan testerna.",
+  "correlation_chart_aria_label": "Signalkorrelationsdiagram med punktvisa Speedtest-mätningar",
   "correlation_tt_snr": "SNR",
   "correlation_tt_tx_power": "TX Power",
   "correlation_tt_ds_power": "DS Power",

--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -794,6 +794,14 @@
 .correlation-chart-legend span[data-metric].disabled:hover {
     opacity: 0.5;
 }
+.correlation-speedtest-hint {
+    max-width: 760px;
+    margin: 2px auto 0;
+    color: var(--text-muted, var(--muted));
+    font-size: 0.74em;
+    line-height: 1.45;
+    text-align: center;
+}
 
 .corr-legend-events {
     position: relative;

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -85,6 +85,98 @@ function _corrFilteredEvents(events) {
     });
 }
 
+function _corrMeasurement(value) {
+    return typeof value === 'number' && isFinite(value) && value >= 0 ? value : null;
+}
+
+function _corrFormatTimestamp(timestamp) {
+    var date = new Date(timestamp);
+    if (isNaN(date.getTime())) return String(timestamp || '');
+    return date.getFullYear() + '-' + String(date.getMonth() + 1).padStart(2, '0') + '-' + String(date.getDate()).padStart(2, '0') +
+        ' ' + String(date.getHours()).padStart(2, '0') + ':' + String(date.getMinutes()).padStart(2, '0') + ':' + String(date.getSeconds()).padStart(2, '0');
+}
+
+function _corrBuildSpeedMarks(speedtests, xScale, yScale, tMin, tMax, visibleMetrics) {
+    var visiblePoints = [];
+    for (var i = 0; i < speedtests.length; i++) {
+        var timestampMs = new Date(speedtests[i].timestamp).getTime();
+        if (isFinite(timestampMs) && timestampMs >= tMin && timestampMs <= tMax) {
+            visiblePoints.push({ index: i, x: xScale(timestampMs) });
+        }
+    }
+
+    var nearestVisibleDistances = [];
+    for (var vi = 0; vi < visiblePoints.length; vi++) {
+        var previousDistance = vi > 0 ? Math.abs(visiblePoints[vi].x - visiblePoints[vi - 1].x) : Infinity;
+        var nextDistance = vi < visiblePoints.length - 1 ? Math.abs(visiblePoints[vi + 1].x - visiblePoints[vi].x) : Infinity;
+        nearestVisibleDistances[visiblePoints[vi].index] = Math.min(previousDistance, nextDistance);
+    }
+
+    var singleVisibleSample = visiblePoints.length === 1;
+    return speedtests.map(function(sample, index) {
+        var timestampMs = new Date(sample.timestamp).getTime();
+        var timestampX = xScale(timestampMs);
+        var visible = isFinite(timestampMs) && timestampMs >= tMin && timestampMs <= tMax;
+        var nearestVisibleDistance = visible ? nearestVisibleDistances[index] : Infinity;
+
+        var download = _corrMeasurement(sample.download_mbps);
+        var upload = _corrMeasurement(sample.upload_mbps);
+        var canSeparatePair = visibleMetrics.download && visibleMetrics.upload && download !== null && upload !== null && nearestVisibleDistance >= 8;
+        var offset = canSeparatePair ? Math.min(2, nearestVisibleDistance / 4) : 0;
+        return {
+            timestamp: sample.timestamp,
+            timestampMs: timestampMs,
+            timestampX: timestampX,
+            visible: visible,
+            nearestVisibleDistance: nearestVisibleDistance,
+            offset: offset,
+            stemWidth: nearestVisibleDistance < 8 ? 1 : 1.5,
+            headRadius: singleVisibleSample ? 4.5 : 3.5,
+            hasDownload: download !== null,
+            hasUpload: upload !== null,
+            downloadX: timestampX - offset,
+            uploadX: timestampX + offset,
+            downloadY: download !== null ? yScale(download) : null,
+            uploadY: upload !== null ? yScale(upload) : null
+        };
+    });
+}
+
+function _corrDrawSpeedMarks(ctx, marks, baselineY, colors, visibleMetrics) {
+    if (visibleMetrics.download) {
+        for (var di = 0; di < marks.length; di++) {
+            var mark = marks[di];
+            if (!mark.visible || !mark.hasDownload) continue;
+            ctx.beginPath();
+            ctx.moveTo(mark.downloadX, baselineY);
+            ctx.lineTo(mark.downloadX, mark.downloadY);
+            ctx.strokeStyle = colors.download;
+            ctx.lineWidth = mark.stemWidth;
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.arc(mark.downloadX, mark.downloadY, mark.headRadius, 0, Math.PI * 2);
+            ctx.fillStyle = colors.download;
+            ctx.fill();
+        }
+    }
+    if (visibleMetrics.upload) {
+        for (var ui = 0; ui < marks.length; ui++) {
+            var mark = marks[ui];
+            if (!mark.visible || !mark.hasUpload) continue;
+            ctx.beginPath();
+            ctx.moveTo(mark.uploadX, baselineY);
+            ctx.lineTo(mark.uploadX, mark.uploadY);
+            ctx.strokeStyle = colors.upload;
+            ctx.lineWidth = mark.stemWidth;
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.arc(mark.uploadX, mark.uploadY, mark.headRadius, 0, Math.PI * 2);
+            ctx.fillStyle = colors.upload;
+            ctx.fill();
+        }
+    }
+}
+
 // Re-render chart on container resize
 (function() {
     var resizeTimer;
@@ -209,9 +301,10 @@ function renderCorrelationChart(data) {
     function ySnr(v) { return pad.top + plotH - (v - snrMin) / (snrMax - snrMin) * plotH; }
 
     // Speed axis (right, for speedtest download/upload)
-    var dlValues = speedtest.map(function(d) { return d.download_mbps || 0; });
-    var ulValues = speedtest.map(function(d) { return d.upload_mbps || 0; });
-    var speedMax = dlValues.length ? Math.ceil(Math.max.apply(null, dlValues) * 1.1) : 500;
+    var dlValues = speedtest.map(function(d) { return _corrMeasurement(d.download_mbps); }).filter(function(v) { return v !== null; });
+    var ulValues = speedtest.map(function(d) { return _corrMeasurement(d.upload_mbps); }).filter(function(v) { return v !== null; });
+    var speedValues = dlValues.concat(ulValues);
+    var speedMax = speedValues.length ? Math.max(1, Math.ceil(Math.max.apply(null, speedValues) * 1.1)) : 500;
     var dlMax = speedMax;
     var dlMin = 0;
     function yDl(v) { return pad.top + plotH - (v - dlMin) / (dlMax - dlMin) * plotH; }
@@ -270,6 +363,10 @@ function renderCorrelationChart(data) {
     var sortedSpeedtest = speedtest.slice().sort(function(a, b) {
         return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
     });
+    var speedMarks = _corrBuildSpeedMarks(sortedSpeedtest, xScale, yDl, tMin, tMax, {
+        download: _corrVisible.download,
+        upload: _corrVisible.upload
+    });
     _corrChartState = {
         pad: pad, plotW: plotW, plotH: plotH, W: W, H: H,
         tMin: tMin, tMax: tMax, tMinFull: tMinFull, tMaxFull: tMaxFull,
@@ -277,7 +374,7 @@ function renderCorrelationChart(data) {
         dsPowerMin: dsPowerMin, dsPowerMax: dsPowerMax, errorMax: errorMax,
         tempMin: tempMin, tempMax: tempMax,
         dlMin: dlMin, dlMax: dlMax,
-        modem: modem, speedtest: sortedSpeedtest, events: events, data: data,
+        modem: modem, speedtest: sortedSpeedtest, speedMarks: speedMarks, events: events, data: data,
         weather: weather, segment: segment,
         xScale: xScale, ySnr: ySnr, yTx: yTx, yDsPower: yDsPower, yDl: yDl, yTemp: yTemp, ySegment: ySegment,
         colors: { snr: snrColor, txPower: txColor, dsPower: dsPowerColor, download: downloadColor, upload: uploadColor, event: warnColor, errors: errorColor, temperature: tempColor, segmentDs: segDsColor, segmentUs: segUsColor, text: textColor, grid: gridColor },
@@ -322,6 +419,35 @@ function renderCorrelationChart(data) {
         ctx.fillText('Mbps', 0, 0);
         ctx.restore();
     }
+
+    // Draw modem health background bands behind every evidence source.
+    if (_corrVisible.poorSignal) {
+        for (var i = 0; i < modem.length; i++) {
+            var x1 = xScale(new Date(modem[i].timestamp).getTime());
+            var x2 = i < modem.length - 1 ? xScale(new Date(modem[i + 1].timestamp).getTime()) : x1 + 2;
+            var h = modem[i].health;
+            if (h === 'critical') {
+                ctx.fillStyle = 'rgba(244,67,54,0.08)';
+            } else if (h === 'marginal') {
+                ctx.fillStyle = 'rgba(255,152,0,0.06)';
+            } else if (h === 'tolerated') {
+                ctx.fillStyle = 'rgba(132,204,22,0.06)';
+            } else {
+                continue;
+            }
+            ctx.fillRect(x1, pad.top, x2 - x1, plotH);
+        }
+    }
+
+    // Speedtests are point-in-time measurements. Draw their stems and heads
+    // before signal/error/event evidence so those sources remain visually on top.
+    _corrDrawSpeedMarks(ctx, speedMarks, yDl(0), {
+        download: downloadColor,
+        upload: uploadColor
+    }, {
+        download: _corrVisible.download,
+        upload: _corrVisible.upload
+    });
 
     // Draw modem SNR line without an area fill to keep the chart uncluttered
     if (_corrVisible.snr && modem.length > 1) {
@@ -407,97 +533,6 @@ function renderCorrelationChart(data) {
             if (spikeH < 2) spikeH = 2;
             ctx.fillStyle = errorColor;
             ctx.fillRect(x - 1.5, pad.top + plotH - spikeH, 3, spikeH);
-        }
-    }
-
-    // Draw modem health background bands
-    if (_corrVisible.poorSignal) {
-        for (var i = 0; i < modem.length; i++) {
-            var x1 = xScale(new Date(modem[i].timestamp).getTime());
-            var x2 = i < modem.length - 1 ? xScale(new Date(modem[i + 1].timestamp).getTime()) : x1 + 2;
-            var h = modem[i].health;
-            if (h === 'critical') {
-                ctx.fillStyle = 'rgba(244,67,54,0.08)';
-            } else if (h === 'marginal') {
-                ctx.fillStyle = 'rgba(255,152,0,0.06)';
-            } else if (h === 'tolerated') {
-                ctx.fillStyle = 'rgba(132,204,22,0.06)';
-            } else {
-                continue;
-            }
-            ctx.fillRect(x1, pad.top, x2 - x1, plotH);
-        }
-    }
-
-    // Draw speedtest lines
-    if (sortedSpeedtest.length > 1) {
-        // Download line without an area fill
-        if (_corrVisible.download) {
-            ctx.beginPath();
-            for (var i = 0; i < sortedSpeedtest.length; i++) {
-                var x = xScale(new Date(sortedSpeedtest[i].timestamp).getTime());
-                var y = yDl(sortedSpeedtest[i].download_mbps || 0);
-                if (i === 0) { ctx.moveTo(x, y); }
-                else {
-                    var x0 = xScale(new Date(sortedSpeedtest[i - 1].timestamp).getTime());
-                    var y0 = yDl(sortedSpeedtest[i - 1].download_mbps || 0);
-                    var cpx = x0 + (x - x0) * 0.4;
-                    ctx.bezierCurveTo(cpx, y0, x - (x - x0) * 0.4, y, x, y);
-                }
-            }
-            ctx.strokeStyle = downloadColor;
-            ctx.lineWidth = 2;
-            ctx.stroke();
-        }
-
-        // Upload line
-        if (_corrVisible.upload) {
-            ctx.beginPath();
-            for (var i = 0; i < sortedSpeedtest.length; i++) {
-                var x = xScale(new Date(sortedSpeedtest[i].timestamp).getTime());
-                var y = yDl(sortedSpeedtest[i].upload_mbps || 0);
-                if (i === 0) { ctx.moveTo(x, y); }
-                else {
-                    var x0 = xScale(new Date(sortedSpeedtest[i - 1].timestamp).getTime());
-                    var y0 = yDl(sortedSpeedtest[i - 1].upload_mbps || 0);
-                    var cpx = x0 + (x - x0) * 0.4;
-                    ctx.bezierCurveTo(cpx, y0, x - (x - x0) * 0.4, y, x, y);
-                }
-            }
-            ctx.strokeStyle = uploadColor;
-            ctx.lineWidth = 2;
-            ctx.stroke();
-        }
-
-        // Data point dots
-        for (var i = 0; i < sortedSpeedtest.length; i++) {
-            var x = xScale(new Date(sortedSpeedtest[i].timestamp).getTime());
-            if (_corrVisible.download) {
-                ctx.beginPath();
-                ctx.arc(x, yDl(sortedSpeedtest[i].download_mbps || 0), 3, 0, Math.PI * 2);
-                ctx.fillStyle = downloadColor;
-                ctx.fill();
-            }
-            if (_corrVisible.upload) {
-                ctx.beginPath();
-                ctx.arc(x, yDl(sortedSpeedtest[i].upload_mbps || 0), 3, 0, Math.PI * 2);
-                ctx.fillStyle = uploadColor;
-                ctx.fill();
-            }
-        }
-    } else if (sortedSpeedtest.length === 1) {
-        var x = xScale(new Date(sortedSpeedtest[0].timestamp).getTime());
-        if (_corrVisible.download) {
-            ctx.beginPath();
-            ctx.arc(x, yDl(sortedSpeedtest[0].download_mbps || 0), 5, 0, Math.PI * 2);
-            ctx.fillStyle = downloadColor;
-            ctx.fill();
-        }
-        if (_corrVisible.upload) {
-            ctx.beginPath();
-            ctx.arc(x, yDl(sortedSpeedtest[0].upload_mbps || 0), 5, 0, Math.PI * 2);
-            ctx.fillStyle = uploadColor;
-            ctx.fill();
         }
     }
 
@@ -600,8 +635,8 @@ function renderCorrelationChart(data) {
         }
     }
     if (speedtest.length > 0) {
-        legendItems.push({ metric: 'download', color: downloadColor, label: '&#9644; ' + (T.correlation_download || 'Download (Mbps)') });
-        legendItems.push({ metric: 'upload', color: uploadColor, label: '&#9644; ' + (T.correlation_upload || 'Upload (Mbps)') });
+        legendItems.push({ metric: 'download', color: downloadColor, label: '&#9474;&#9679; ' + (T.correlation_download || 'Download (Mbps)') });
+        legendItems.push({ metric: 'upload', color: uploadColor, label: '&#9474;&#9679; ' + (T.correlation_upload || 'Upload (Mbps)') });
     }
     if (events.length > 0) {
         // Populate filters for all event types/severities in current data
@@ -856,12 +891,18 @@ function _setupCorrelationTooltip(overlay, octx) {
 
         // Find nearest speedtest point
         var nearestSpeed = null;
+        var nearestSpeedMark = null;
         if (st.speedtest.length > 0 && (_corrVisible.download || _corrVisible.upload)) {
             var bestDist = Infinity;
             for (var i = 0; i < st.speedtest.length; i++) {
+                if (!st.speedMarks[i] || !st.speedMarks[i].visible) continue;
                 var ts = new Date(st.speedtest[i].timestamp).getTime();
                 var dist = Math.abs(ts - tHover);
-                if (dist < bestDist) { bestDist = dist; nearestSpeed = st.speedtest[i]; }
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    nearestSpeed = st.speedtest[i];
+                    nearestSpeedMark = st.speedMarks[i];
+                }
             }
         }
 
@@ -933,10 +974,10 @@ function _setupCorrelationTooltip(overlay, octx) {
             newOctx.lineWidth = 2;
             newOctx.stroke();
         }
-        if (nearestSpeed) {
-            if (_corrVisible.download) {
-                var dx = st.xScale(new Date(nearestSpeed.timestamp).getTime());
-                var dy = st.yDl(nearestSpeed.download_mbps || 0);
+        if (nearestSpeed && nearestSpeedMark) {
+            if (_corrVisible.download && nearestSpeedMark.hasDownload) {
+                var dx = nearestSpeedMark.downloadX;
+                var dy = nearestSpeedMark.downloadY;
                 newOctx.beginPath();
                 newOctx.arc(dx, dy, 5, 0, Math.PI * 2);
                 newOctx.fillStyle = st.colors.download;
@@ -945,9 +986,9 @@ function _setupCorrelationTooltip(overlay, octx) {
                 newOctx.lineWidth = 2;
                 newOctx.stroke();
             }
-            if (_corrVisible.upload) {
-                var dx = st.xScale(new Date(nearestSpeed.timestamp).getTime());
-                var dy = st.yDl(nearestSpeed.upload_mbps || 0);
+            if (_corrVisible.upload && nearestSpeedMark.hasUpload) {
+                var dx = nearestSpeedMark.uploadX;
+                var dy = nearestSpeedMark.uploadY;
                 newOctx.beginPath();
                 newOctx.arc(dx, dy, 5, 0, Math.PI * 2);
                 newOctx.fillStyle = st.colors.upload;
@@ -999,11 +1040,28 @@ function _setupCorrelationTooltip(overlay, octx) {
         if (nearestModem && _corrVisible.errors && (nearestModem.ds_uncorrectable_errors || 0) > 0) {
             html += '<div class="tt-row"><span class="tt-dot" style="background:' + st.colors.errors + ';"></span> ' + (T.correlation_tt_errors || 'Errors') + ': ' + nearestModem.ds_uncorrectable_errors.toLocaleString() + '</div>';
         }
-        if (nearestSpeed && _corrVisible.download) {
-            html += '<div class="tt-row"><span class="tt-dot" style="background:' + st.colors.download + ';"></span> ' + (T.correlation_tt_download || 'Download') + ': ' + (nearestSpeed.download_mbps || 0).toFixed(1) + ' Mbps</div>';
-        }
-        if (nearestSpeed && _corrVisible.upload) {
-            html += '<div class="tt-row"><span class="tt-dot" style="background:' + st.colors.upload + ';"></span> ' + (T.correlation_tt_upload || 'Upload') + ': ' + (nearestSpeed.upload_mbps || 0).toFixed(1) + ' Mbps</div>';
+        if (nearestSpeed) {
+            var speedDownload = _corrMeasurement(nearestSpeed.download_mbps);
+            var speedUpload = _corrMeasurement(nearestSpeed.upload_mbps);
+            var speedPing = _corrMeasurement(nearestSpeed.ping_ms);
+            var speedJitter = _corrMeasurement(nearestSpeed.jitter_ms);
+            var speedPacketLoss = _corrMeasurement(nearestSpeed.packet_loss_pct);
+            html += '<div class="tt-row tt-speedtest-time">' + (T.timestamp || 'Timestamp') + ': ' + escapeHtml(_corrFormatTimestamp(nearestSpeed.timestamp)) + '</div>';
+            if (_corrVisible.download && speedDownload !== null) {
+                html += '<div class="tt-row"><span class="tt-dot" style="background:' + st.colors.download + ';"></span> ' + (T.correlation_tt_download || 'Download') + ': ' + speedDownload.toFixed(1) + ' Mbps</div>';
+            }
+            if (_corrVisible.upload && speedUpload !== null) {
+                html += '<div class="tt-row"><span class="tt-dot" style="background:' + st.colors.upload + ';"></span> ' + (T.correlation_tt_upload || 'Upload') + ': ' + speedUpload.toFixed(1) + ' Mbps</div>';
+            }
+            if (speedPing !== null) {
+                html += '<div class="tt-row">' + (T.speedtest_ping || T.ping || 'Ping') + ': ' + speedPing.toFixed(1) + ' ms</div>';
+            }
+            if (speedJitter !== null) {
+                html += '<div class="tt-row">' + (T.jitter || 'Jitter') + ': ' + speedJitter.toFixed(1) + ' ms</div>';
+            }
+            if (speedPacketLoss !== null) {
+                html += '<div class="tt-row">' + (T.packet_loss || 'Packet Loss') + ': ' + speedPacketLoss.toFixed(1) + '%</div>';
+            }
         }
         if (nearestEvent && _corrVisible.events) {
             html += '<div class="tt-row"><span class="tt-dot" style="background:' + st.colors.event + ';"></span> ' + (T.correlation_tt_event || 'Event') + ': ' + escapeHtml(nearestEvent.message || nearestEvent.severity || '') + '</div>';
@@ -1169,20 +1227,19 @@ function _corrHighlightFromTable(timestamp, source) {
     } else if (source === 'speedtest') {
         for (var i = 0; i < st.speedtest.length; i++) {
             if (st.speedtest[i].timestamp === timestamp) {
-                if (_corrVisible.download) {
-                    var dy = st.yDl(st.speedtest[i].download_mbps || 0);
+                var speedMark = st.speedMarks[i];
+                if (_corrVisible.download && speedMark.hasDownload) {
                     octx.beginPath();
-                    octx.arc(x, dy, 6, 0, Math.PI * 2);
+                    octx.arc(speedMark.downloadX, speedMark.downloadY, 6, 0, Math.PI * 2);
                     octx.fillStyle = st.colors.download;
                     octx.fill();
                     octx.strokeStyle = '#fff';
                     octx.lineWidth = 2;
                     octx.stroke();
                 }
-                if (_corrVisible.upload) {
-                    var dy = st.yDl(st.speedtest[i].upload_mbps || 0);
+                if (_corrVisible.upload && speedMark.hasUpload) {
                     octx.beginPath();
-                    octx.arc(x, dy, 6, 0, Math.PI * 2);
+                    octx.arc(speedMark.uploadX, speedMark.uploadY, 6, 0, Math.PI * 2);
                     octx.fillStyle = st.colors.upload;
                     octx.fill();
                     octx.strokeStyle = '#fff';

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1655,10 +1655,11 @@
             </div>
             <div class="correlation-chart-wrap">
                 <canvas id="correlation-chart"></canvas>
-                <canvas id="correlation-overlay" class="correlation-overlay" role="img" aria-label="Signal correlation chart"></canvas>
+                <canvas id="correlation-overlay" class="correlation-overlay" role="img" aria-label="{{ t.correlation_chart_aria_label }}" aria-describedby="correlation-speedtest-hint"></canvas>
                 <div class="correlation-tooltip" id="correlation-tooltip"></div>
                 <button type="button" class="correlation-zoom-reset" id="correlation-zoom-reset" style="display:none;" onclick="_corrResetZoom()">{{ t.chart_reset_zoom }}</button>
                 <div class="correlation-chart-legend" id="correlation-legend"></div>
+                <p class="correlation-speedtest-hint" id="correlation-speedtest-hint">{{ t.correlation_speedtest_hint }}</p>
             </div>
         </div>
     </div>

--- a/tests/e2e/test_correlation_ui.py
+++ b/tests/e2e/test_correlation_ui.py
@@ -123,6 +123,217 @@ def _sample_correlation_severity_edge_data():
     ]
 
 
+def _point_measurement_data():
+    """Sparse Speedtests with modem and event evidence between the tests."""
+    base = datetime.now(timezone.utc).replace(microsecond=0)
+
+    def ts(hours):
+        return (base + timedelta(hours=hours)).isoformat().replace("+00:00", "Z")
+
+    return [
+        {
+            "source": "speedtest",
+            "timestamp": ts(0),
+            "download_mbps": 310.5,
+            "upload_mbps": 51.25,
+            "ping_ms": 11.75,
+            "jitter_ms": 1.5,
+            "packet_loss_pct": 0.25,
+        },
+        {
+            "source": "modem",
+            "timestamp": ts(2),
+            "health": "good",
+            "ds_snr_min": 37.0,
+            "ds_power_avg": 1.0,
+            "us_power_avg": 42.0,
+            "ds_uncorrectable_errors": 4,
+        },
+        {
+            "source": "modem",
+            "timestamp": ts(4),
+            "health": "marginal",
+            "ds_snr_min": 35.0,
+            "ds_power_avg": 0.5,
+            "us_power_avg": 43.0,
+            "ds_uncorrectable_errors": 12,
+        },
+        {
+            "source": "event",
+            "timestamp": ts(5),
+            "event_type": "health_change",
+            "severity": "warning",
+            "message": "Signal degraded between tests",
+        },
+        {
+            "source": "speedtest",
+            "timestamp": ts(6),
+            "download_mbps": 180.75,
+            "upload_mbps": 34.5,
+            "ping_ms": 19.25,
+            "jitter_ms": 3.25,
+            "packet_loss_pct": 1.5,
+        },
+    ]
+
+
+def _single_point_measurement_data():
+    base = datetime.now(timezone.utc).replace(microsecond=0)
+
+    def ts(hours):
+        return (base + timedelta(hours=hours)).isoformat().replace("+00:00", "Z")
+
+    return [
+        {
+            "source": "modem",
+            "timestamp": ts(0),
+            "health": "good",
+            "ds_snr_min": 38.0,
+            "ds_power_avg": 1.0,
+            "us_power_avg": 42.0,
+            "ds_uncorrectable_errors": 0,
+        },
+        {
+            "source": "speedtest",
+            "timestamp": ts(3),
+            "download_mbps": 222.2,
+            "upload_mbps": 44.4,
+            "ping_ms": 12.3,
+            "jitter_ms": 2.1,
+            "packet_loss_pct": 0.4,
+        },
+        {
+            "source": "event",
+            "timestamp": ts(6),
+            "event_type": "monitoring_started",
+            "severity": "info",
+            "message": "Range boundary",
+        },
+    ]
+
+
+def _dense_point_measurement_data():
+    base = datetime.now(timezone.utc).replace(microsecond=0)
+
+    def ts(seconds):
+        return (base + timedelta(seconds=seconds)).isoformat().replace("+00:00", "Z")
+
+    samples = []
+    for index, seconds in enumerate((0, 10, 20, 21600)):
+        samples.append({
+            "source": "speedtest",
+            "timestamp": ts(seconds),
+            "download_mbps": 200 + index * 10,
+            "upload_mbps": 40 + index,
+        })
+    return samples
+
+
+def _partial_point_measurement_data():
+    base = datetime.now(timezone.utc).replace(microsecond=0)
+
+    def ts(hours):
+        return (base + timedelta(hours=hours)).isoformat().replace("+00:00", "Z")
+
+    return [
+        {
+            "source": "speedtest",
+            "timestamp": ts(0),
+            "download_mbps": 120.0,
+            "ping_ms": -5.0,
+            "jitter_ms": 1.0,
+            "packet_loss_pct": 0.0,
+        },
+        {
+            "source": "speedtest",
+            "timestamp": ts(1),
+            "download_mbps": -20.0,
+            "upload_mbps": 0.0,
+            "ping_ms": 0.0,
+            "jitter_ms": -1.0,
+            "packet_loss_pct": -1.0,
+        },
+        {
+            "source": "speedtest",
+            "timestamp": ts(1),
+            "download_mbps": 33.0,
+            "upload_mbps": -2.0,
+            "ping_ms": 7.0,
+            "jitter_ms": 2.0,
+            "packet_loss_pct": 0.0,
+        },
+        {
+            "source": "speedtest",
+            "timestamp": ts(2),
+            "download_mbps": 0.0,
+            "upload_mbps": -4.0,
+        },
+    ]
+
+
+def _record_correlation_canvas_operations(page):
+    """Record paths on the real chart canvas without replacing canvas drawing."""
+    page.add_init_script(
+        """
+        (() => {
+            const proto = CanvasRenderingContext2D.prototype;
+            const paths = new WeakMap();
+            window.__corrCanvasOps = [];
+            const originalClearRect = proto.clearRect;
+            proto.clearRect = function(...args) {
+                if (this.canvas && this.canvas.id === 'correlation-chart' && args[0] === 0 && args[1] === 0) {
+                    window.__corrCanvasOps = [];
+                }
+                return originalClearRect.apply(this, args);
+            };
+            const recordPathMethod = (name) => {
+                const original = proto[name];
+                proto[name] = function(...args) {
+                    if (this.canvas && this.canvas.id === 'correlation-chart') {
+                        const path = paths.get(this) || [];
+                        path.push({ kind: name, args: args.map(Number) });
+                        paths.set(this, path);
+                    }
+                    return original.apply(this, args);
+                };
+            };
+            const originalBeginPath = proto.beginPath;
+            proto.beginPath = function(...args) {
+                if (this.canvas && this.canvas.id === 'correlation-chart') paths.set(this, []);
+                return originalBeginPath.apply(this, args);
+            };
+            ['moveTo', 'lineTo', 'bezierCurveTo', 'arc'].forEach(recordPathMethod);
+            ['stroke', 'fill'].forEach((name) => {
+                const original = proto[name];
+                proto[name] = function(...args) {
+                    if (this.canvas && this.canvas.id === 'correlation-chart') {
+                        window.__corrCanvasOps.push({
+                            kind: name,
+                            strokeStyle: String(this.strokeStyle),
+                            fillStyle: String(this.fillStyle),
+                            lineWidth: this.lineWidth,
+                            path: (paths.get(this) || []).map((part) => ({ ...part })),
+                        });
+                    }
+                    return original.apply(this, args);
+                };
+            });
+            const originalFillRect = proto.fillRect;
+            proto.fillRect = function(...args) {
+                if (this.canvas && this.canvas.id === 'correlation-chart') {
+                    window.__corrCanvasOps.push({
+                        kind: 'fillRect',
+                        fillStyle: String(this.fillStyle),
+                        args: args.map(Number),
+                    });
+                }
+                return originalFillRect.apply(this, args);
+            };
+        })();
+        """
+    )
+
+
 def _route_correlation(page, payload=None):
     page.route("**/api/correlation?**", lambda route: route.fulfill(json=payload or _sample_correlation_data()))
     page.route("**/api/weather/range?**", lambda route: route.fulfill(json=[]))
@@ -133,13 +344,312 @@ def _route_sample_correlation(page):
     _route_correlation(page)
 
 
-def _open_correlation(page):
-    page.set_viewport_size(DESKTOP_VIEWPORT)
+def _open_correlation(page, viewport=DESKTOP_VIEWPORT):
+    page.set_viewport_size(viewport)
     base_url = page.url.split("#", 1)[0].split("?", 1)[0].rstrip("/")
     page.goto(f"{base_url}/?lang=en#correlation", wait_until="networkidle")
     page.wait_for_selector("#view-correlation.active", state="visible")
     page.wait_for_selector("#correlation-chart-container", state="visible")
     page.wait_for_selector("#correlation-table-card", state="visible")
+
+
+def _hover_correlation_timestamp(page, timestamp):
+    point = page.evaluate(
+        """
+        (timestamp) => ({
+            x: window._corrChartState.xScale(new Date(timestamp).getTime()),
+            y: window._corrChartState.pad.top + window._corrChartState.plotH / 2,
+        })
+        """,
+        timestamp,
+    )
+    overlay = page.locator("#correlation-overlay")
+    box = overlay.bounding_box()
+    assert box is not None
+    page.mouse.move(box["x"] + point["x"] - 1, box["y"] + point["y"])
+    page.mouse.move(box["x"] + point["x"], box["y"] + point["y"])
+    tooltip = page.locator("#correlation-tooltip")
+    expect(tooltip).to_be_visible()
+    return tooltip
+
+
+def test_correlation_renders_sparse_speedtests_as_unconnected_point_measurements(demo_page):
+    page = demo_page
+    payload = _point_measurement_data()
+    _record_correlation_canvas_operations(page)
+    _route_correlation(page, payload)
+    _open_correlation(page)
+    page.evaluate("() => { window._corrVisible.events = true; window.renderCorrelationChart(window._correlationData); }")
+
+    rendered = page.evaluate(
+        """
+        () => ({
+            marks: window._corrChartState.speedMarks,
+            colors: window._corrChartState.colors,
+            operations: window.__corrCanvasOps,
+        })
+        """
+    )
+    marks = rendered["marks"]
+    assert [mark["timestamp"] for mark in marks] == [payload[0]["timestamp"], payload[-1]["timestamp"]]
+    assert all(mark["visible"] for mark in marks)
+    assert all(abs(mark["downloadX"] - (mark["timestampX"] - mark["offset"])) < 0.01 for mark in marks)
+    assert all(abs(mark["uploadX"] - (mark["timestampX"] + mark["offset"])) < 0.01 for mark in marks)
+    assert all(1 <= mark["stemWidth"] <= 2 for mark in marks)
+
+    speed_colors = {rendered["colors"]["download"], rendered["colors"]["upload"]}
+    speed_strokes = [
+        operation for operation in rendered["operations"]
+        if operation["kind"] == "stroke" and operation["strokeStyle"] in speed_colors
+    ]
+    assert speed_strokes
+    assert all(
+        part["kind"] in {"moveTo", "lineTo"}
+        for operation in speed_strokes
+        for part in operation["path"]
+    )
+    speed_lines = [
+        operation["path"]
+        for operation in speed_strokes
+        if any(part["kind"] == "lineTo" for part in operation["path"])
+    ]
+    assert sum(sum(part["kind"] == "lineTo" for part in path) for path in speed_lines) == 4
+    for path in speed_lines:
+        for start, end in zip(path, path[1:]):
+            if start["kind"] == "moveTo" and end["kind"] == "lineTo":
+                assert abs(start["args"][0] - end["args"][0]) < 0.01
+
+    speed_operation_indexes = [
+        index for index, operation in enumerate(rendered["operations"])
+        if (
+            operation["kind"] == "stroke" and operation.get("strokeStyle") in speed_colors
+        ) or (
+            operation["kind"] == "fill" and operation.get("fillStyle") in speed_colors
+        )
+    ]
+    signal_indexes = [
+        index for index, operation in enumerate(rendered["operations"])
+        if operation.get("strokeStyle") == rendered["colors"]["snr"]
+    ]
+    error_indexes = [
+        index for index, operation in enumerate(rendered["operations"])
+        if operation["kind"] == "fillRect" and "239" in operation.get("fillStyle", "")
+    ]
+    event_indexes = [
+        index for index, operation in enumerate(rendered["operations"])
+        if operation["kind"] == "stroke" and operation.get("strokeStyle") == rendered["colors"]["event"]
+    ]
+    assert signal_indexes and error_indexes and event_indexes
+    assert max(speed_operation_indexes) < min(signal_indexes)
+    assert max(speed_operation_indexes) < min(error_indexes)
+    assert max(speed_operation_indexes) < min(event_indexes)
+
+
+def test_correlation_single_speedtest_uses_stem_and_larger_head(demo_page):
+    page = demo_page
+    payload = _single_point_measurement_data()
+    _record_correlation_canvas_operations(page)
+    _route_correlation(page, payload)
+    _open_correlation(page, MOBILE_VIEWPORT)
+
+    result = page.evaluate(
+        """
+        () => ({
+            marks: window._corrChartState.speedMarks,
+            colors: window._corrChartState.colors,
+            operations: window.__corrCanvasOps,
+        })
+        """
+    )
+    assert len(result["marks"]) == 1
+    mark = result["marks"][0]
+    assert mark["timestamp"] == payload[1]["timestamp"]
+    assert mark["headRadius"] >= 4
+    assert 1 <= mark["stemWidth"] <= 2
+    speed_strokes = [
+        operation for operation in result["operations"]
+        if operation["kind"] == "stroke"
+        and operation["strokeStyle"] in {result["colors"]["download"], result["colors"]["upload"]}
+    ]
+    assert sum(
+        sum(part["kind"] == "lineTo" for part in operation["path"])
+        for operation in speed_strokes
+    ) == 2
+
+
+def test_correlation_adapts_dense_mobile_and_zoomed_marks_without_merging(demo_page):
+    page = demo_page
+    payload = _dense_point_measurement_data()
+    _route_correlation(page, payload)
+    _open_correlation(page, MOBILE_VIEWPORT)
+
+    dense_marks = page.evaluate("() => window._corrChartState.speedMarks")
+    assert len(dense_marks) == len(payload)
+    assert len({mark["timestamp"] for mark in dense_marks}) == len(payload)
+    assert all(mark["offset"] == 0 for mark in dense_marks[:3])
+    assert all(mark["downloadX"] == mark["uploadX"] == mark["timestampX"] for mark in dense_marks[:3])
+
+    first_ts = datetime.fromisoformat(payload[0]["timestamp"].replace("Z", "+00:00")).timestamp() * 1000
+    third_ts = datetime.fromisoformat(payload[2]["timestamp"].replace("Z", "+00:00")).timestamp() * 1000
+    zoomed_marks = page.evaluate(
+        """
+        ({ firstTs, thirdTs }) => {
+            window._corrZoom = { tMin: firstTs - 1000, tMax: thirdTs + 1000 };
+            window.renderCorrelationChart(window._correlationData);
+            return window._corrChartState.speedMarks;
+        }
+        """,
+        {"firstTs": first_ts, "thirdTs": third_ts},
+    )
+    assert len(zoomed_marks) == len(payload)
+    visible_marks = [mark for mark in zoomed_marks if mark["visible"]]
+    assert len(visible_marks) == 3
+    for index, mark in enumerate(visible_marks):
+        neighbor_distances = []
+        if index > 0:
+            neighbor_distances.append(abs(mark["timestampX"] - visible_marks[index - 1]["timestampX"]))
+        if index < len(visible_marks) - 1:
+            neighbor_distances.append(abs(visible_marks[index + 1]["timestampX"] - mark["timestampX"]))
+        assert abs(mark["nearestVisibleDistance"] - min(neighbor_distances)) < 0.01
+    assert all(mark["offset"] > 0 for mark in visible_marks)
+    assert all(mark["downloadX"] < mark["timestampX"] < mark["uploadX"] for mark in visible_marks)
+    assert all(mark["offset"] < mark["nearestVisibleDistance"] / 2 for mark in visible_marks)
+
+
+def test_correlation_speedtest_help_accessibility_and_tooltip_details(demo_page):
+    page = demo_page
+    payload = _single_point_measurement_data()
+    _route_correlation(page, payload)
+    _open_correlation(page)
+
+    help_text = page.locator("#correlation-speedtest-hint")
+    expect(help_text).to_be_visible()
+    expect(help_text).to_contain_text("individual measurements")
+    expect(help_text).to_contain_text("between tests")
+    overlay = page.locator("#correlation-overlay")
+    expect(overlay).to_have_attribute("aria-describedby", "correlation-speedtest-hint")
+    aria_label = overlay.get_attribute("aria-label")
+    assert aria_label
+    assert "chart" in aria_label.lower()
+    assert "speedtest" in aria_label.lower()
+
+    speed_timestamp = payload[1]["timestamp"]
+    tooltip = _hover_correlation_timestamp(page, speed_timestamp)
+    tooltip_text = tooltip.inner_text()
+    assert "Timestamp" in tooltip_text
+    assert speed_timestamp[:10] in tooltip_text
+    assert "Download: 222.2 Mbps" in tooltip_text
+    assert "Upload: 44.4 Mbps" in tooltip_text
+    assert "Ping: 12.3 ms" in tooltip_text
+    assert "Jitter: 2.1 ms" in tooltip_text
+    assert "Packet Loss: 0.4%" in tooltip_text
+
+
+def test_correlation_tooltip_respects_each_speed_legend_toggle_at_exact_timestamp(demo_page):
+    page = demo_page
+    payload = _single_point_measurement_data()
+    _route_correlation(page, payload)
+    _open_correlation(page)
+    speed_timestamp = payload[1]["timestamp"]
+
+    page.locator('#correlation-legend span[data-metric="download"]').click()
+    tooltip_text = _hover_correlation_timestamp(page, speed_timestamp).inner_text()
+    assert "Download:" not in tooltip_text
+    assert "Upload: 44.4 Mbps" in tooltip_text
+    assert "Ping: 12.3 ms" in tooltip_text
+    assert speed_timestamp[:10] in tooltip_text
+
+    page.locator('#correlation-legend span[data-metric="download"]').click()
+    page.locator('#correlation-legend span[data-metric="upload"]').click()
+    tooltip_text = _hover_correlation_timestamp(page, speed_timestamp).inner_text()
+    assert "Download: 222.2 Mbps" in tooltip_text
+    assert "Upload:" not in tooltip_text
+    assert "Packet Loss: 0.4%" in tooltip_text
+    assert speed_timestamp[:10] in tooltip_text
+
+
+def test_correlation_zoom_without_visible_speedtests_has_no_speed_tooltip_or_highlight(demo_page):
+    page = demo_page
+    payload = _point_measurement_data()
+    _route_correlation(page, payload)
+    _open_correlation(page)
+
+    zoom_start = datetime.fromisoformat(payload[1]["timestamp"].replace("Z", "+00:00")).timestamp() * 1000
+    zoom_end = datetime.fromisoformat(payload[2]["timestamp"].replace("Z", "+00:00")).timestamp() * 1000
+    result = page.evaluate(
+        """
+        ({ zoomStart, zoomEnd }) => {
+            const proto = CanvasRenderingContext2D.prototype;
+            const originalArc = proto.arc;
+            window.__corrOverlayArcs = [];
+            proto.arc = function(...args) {
+                if (this.canvas && this.canvas.id === 'correlation-overlay') {
+                    window.__corrOverlayArcs.push(args.map(Number));
+                }
+                return originalArc.apply(this, args);
+            };
+            Object.keys(window._corrVisible).forEach((metric) => { window._corrVisible[metric] = false; });
+            window._corrVisible.download = true;
+            window._corrZoom = { tMin: zoomStart, tMax: zoomEnd };
+            window.renderCorrelationChart(window._correlationData);
+            window.__corrOverlayArcs = [];
+            return window._corrChartState.speedMarks.map((mark) => mark.visible);
+        }
+        """,
+        {"zoomStart": zoom_start, "zoomEnd": zoom_end},
+    )
+    assert result == [False, False]
+
+    mid_timestamp = datetime.fromtimestamp((zoom_start + zoom_end) / 2000, tz=timezone.utc).isoformat()
+    tooltip_text = _hover_correlation_timestamp(page, mid_timestamp).inner_text()
+    assert "Download:" not in tooltip_text
+    assert page.locator("#correlation-tooltip .tt-speedtest-time").count() == 0
+    assert page.locator('#correlation-tbody tr[data-src="speedtest"].corr-highlight').count() == 0
+    assert page.evaluate("() => window.__corrOverlayArcs") == []
+
+
+def test_correlation_partial_and_negative_speedtests_keep_samples_without_invalid_marks(demo_page):
+    page = demo_page
+    payload = _partial_point_measurement_data()
+    _record_correlation_canvas_operations(page)
+    _route_correlation(page, payload)
+    _open_correlation(page)
+
+    rendered = page.evaluate(
+        """
+        () => ({
+            marks: window._corrChartState.speedMarks,
+            baselineY: window._corrChartState.yDl(0),
+            colors: window._corrChartState.colors,
+            operations: window.__corrCanvasOps,
+        })
+        """
+    )
+    marks = rendered["marks"]
+    assert len(marks) == len(payload)
+    assert [mark["timestamp"] for mark in marks] == [sample["timestamp"] for sample in payload]
+    assert [mark["hasDownload"] for mark in marks] == [True, False, True, True]
+    assert [mark["hasUpload"] for mark in marks] == [False, True, False, False]
+    assert marks[1]["uploadY"] == rendered["baselineY"]
+    assert marks[3]["downloadY"] == rendered["baselineY"]
+
+    speed_colors = {rendered["colors"]["download"], rendered["colors"]["upload"]}
+    speed_strokes = [
+        operation for operation in rendered["operations"]
+        if operation["kind"] == "stroke" and operation["strokeStyle"] in speed_colors
+    ]
+    speed_lines = [
+        part for operation in speed_strokes for part in operation["path"] if part["kind"] == "lineTo"
+    ]
+    assert len(speed_lines) == 4
+    assert all(part["args"][1] <= rendered["baselineY"] + 0.01 for part in speed_lines)
+
+    tooltip_text = _hover_correlation_timestamp(page, payload[1]["timestamp"]).inner_text()
+    assert "Download:" not in tooltip_text
+    assert "Upload: 0.0 Mbps" in tooltip_text
+    assert "Ping: 0.0 ms" in tooltip_text
+    assert "Jitter:" not in tooltip_text
+    assert "Packet Loss:" not in tooltip_text
 
 
 def test_correlation_signal_legend_matches_home_chart_order(demo_page):


### PR DESCRIPTION
## Summary

- render Download and Upload as discrete point-in-time stems instead of connected curves
- keep sparse and dense Speedtest samples at their exact timestamps without interpolation or merging
- add localized guidance that Speedtest measurements do not indicate availability between tests
- expand tooltips with the measured timestamp, ping, jitter, and packet loss when available
- preserve zoom, metric toggles, exports, and the existing evidence layering

## Verification

- `41 passed` focused correlation and i18n tests
- `14 passed` Correlation Playwright tests
- `2919 passed, 11 skipped` non-E2E suite
- desktop and mobile visual checks completed without console or page errors
- `node --check app/static/js/correlation.js`
- `git diff --check`

Related to #743.