### PR TITLE
Correlation: add Connection Monitor reachability evidence

### DIFF
--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview е пробна версия",
   "desktop_preview_notice_body": "Използвайте DOCSight Desktop Preview, за да разгледате приложението локално. За надеждно 24/7 наблюдение използвайте Docker; заспиване или хибернация на лаптопа спира събирането на данни.",
-  "desktop_preview_notice_link": "Прочетете възможности и ограничения"
+  "desktop_preview_notice_link": "Прочетете възможности и ограничения",
+  "correlation_reachability": "Достъпност",
+  "correlation_reachability_hint": "Интервалите за достъпност показват наблюдаваното покритие от Монитора на връзката; активирайте диаграмата, за да отворите подробностите.",
+  "correlation_reachability_ok": "Нормално",
+  "correlation_reachability_degraded": "Влошено",
+  "correlation_reachability_down": "Недостъпно",
+  "correlation_reachability_unknown": "Неизвестно",
+  "correlation_reachability_state": "Състояние",
+  "correlation_reachability_window": "Интервал",
+  "correlation_reachability_loss": "Наблюдавана загуба на пакети",
+  "correlation_reachability_samples": "Проби",
+  "correlation_reachability_targets": "Наблюдавани цели",
+  "correlation_reachability_scope": "Обхват на целите",
+  "correlation_reachability_drilldown": "Отваряне на подробностите в Монитор на връзката",
+  "correlation_reachability_aria": "Обобщение на достъпността"
 }

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview je zkušební sestavení",
   "desktop_preview_notice_body": "Použijte DOCSight Desktop Preview k místnímu vyzkoušení aplikace. Pro spolehlivý monitoring 24/7 použijte Docker; spánek nebo hibernace notebooku pozastaví sběr dat.",
-  "desktop_preview_notice_link": "Přečíst možnosti a omezení"
+  "desktop_preview_notice_link": "Přečíst možnosti a omezení",
+  "correlation_reachability": "Dostupnost",
+  "correlation_reachability_hint": "Intervaly dostupnosti zobrazují pozorované pokrytí Monitoru připojení; aktivací grafu otevřete podrobnosti.",
+  "correlation_reachability_ok": "V pořádku",
+  "correlation_reachability_degraded": "Zhoršené",
+  "correlation_reachability_down": "Nedostupné",
+  "correlation_reachability_unknown": "Neznámé",
+  "correlation_reachability_state": "Stav",
+  "correlation_reachability_window": "Časové okno",
+  "correlation_reachability_loss": "Pozorovaná ztráta paketů",
+  "correlation_reachability_samples": "Vzorky",
+  "correlation_reachability_targets": "Pozorované cíle",
+  "correlation_reachability_scope": "Rozsah cílů",
+  "correlation_reachability_drilldown": "Otevřít podrobnosti Monitoru připojení",
+  "correlation_reachability_aria": "Souhrn dostupnosti"
 }

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview er en prøveversion",
   "desktop_preview_notice_body": "Brug DOCSight Desktop Preview til at udforske appen lokalt. Til pålidelig 24/7-overvågning skal du bruge Docker; slumre- eller dvaletilstand pauser dataindsamlingen.",
-  "desktop_preview_notice_link": "Læs funktioner og begrænsninger"
+  "desktop_preview_notice_link": "Læs funktioner og begrænsninger",
+  "correlation_reachability": "Tilgængelighed",
+  "correlation_reachability_hint": "Tilgængelighedsintervaller viser den observerede dækning fra Forbindelsesovervågning; aktivér diagrammet for at åbne detaljerne.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Forringet",
+  "correlation_reachability_down": "Nede",
+  "correlation_reachability_unknown": "Ukendt",
+  "correlation_reachability_state": "Tilstand",
+  "correlation_reachability_window": "Tidsrum",
+  "correlation_reachability_loss": "Observeret pakketab",
+  "correlation_reachability_samples": "Målinger",
+  "correlation_reachability_targets": "Observerede mål",
+  "correlation_reachability_scope": "Målomfang",
+  "correlation_reachability_drilldown": "Åbn detaljer i Forbindelsesovervågning",
+  "correlation_reachability_aria": "Oversigt over tilgængelighed"
 }

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview ist eine Testversion",
   "desktop_preview_notice_body": "Nutze DOCSight Desktop Preview, um die App lokal auszuprobieren. Für zuverlässiges 24/7-Monitoring verwende Docker; Energiesparen oder Ruhezustand pausiert die Datenerfassung.",
-  "desktop_preview_notice_link": "Funktionen und Grenzen lesen"
+  "desktop_preview_notice_link": "Funktionen und Grenzen lesen",
+  "correlation_reachability": "Erreichbarkeit",
+  "correlation_reachability_hint": "Erreichbarkeitsintervalle zeigen die beobachtete Abdeckung des Verbindungsmonitors; aktivieren Sie das Diagramm, um die Details des Verbindungsmonitors zu öffnen.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Beeinträchtigt",
+  "correlation_reachability_down": "Nicht erreichbar",
+  "correlation_reachability_unknown": "Unbekannt",
+  "correlation_reachability_state": "Status",
+  "correlation_reachability_window": "Zeitfenster",
+  "correlation_reachability_loss": "Beobachteter Paketverlust",
+  "correlation_reachability_samples": "Messwerte",
+  "correlation_reachability_targets": "Beobachtete Ziele",
+  "correlation_reachability_scope": "Zielbereich",
+  "correlation_reachability_drilldown": "Details des Verbindungsmonitors öffnen",
+  "correlation_reachability_aria": "Zusammenfassung der Erreichbarkeit"
 }

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Το Desktop Preview είναι δοκιμαστική έκδοση",
   "desktop_preview_notice_body": "Χρησιμοποιήστε το DOCSight Desktop Preview για τοπική δοκιμή της εφαρμογής. Για αξιόπιστη παρακολούθηση 24/7, χρησιμοποιήστε Docker· η αναστολή ή αδρανοποίηση του φορητού διακόπτει τη συλλογή δεδομένων.",
-  "desktop_preview_notice_link": "Διαβάστε δυνατότητες και όρια"
+  "desktop_preview_notice_link": "Διαβάστε δυνατότητες και όρια",
+  "correlation_reachability": "Προσβασιμότητα",
+  "correlation_reachability_hint": "Τα διαστήματα προσβασιμότητας δείχνουν την παρατηρούμενη κάλυψη της Παρακολούθησης σύνδεσης· ενεργοποιήστε το γράφημα για να ανοίξετε τις λεπτομέρειες.",
+  "correlation_reachability_ok": "Κανονική",
+  "correlation_reachability_degraded": "Υποβαθμισμένη",
+  "correlation_reachability_down": "Εκτός λειτουργίας",
+  "correlation_reachability_unknown": "Άγνωστη",
+  "correlation_reachability_state": "Κατάσταση",
+  "correlation_reachability_window": "Χρονικό διάστημα",
+  "correlation_reachability_loss": "Παρατηρούμενη απώλεια πακέτων",
+  "correlation_reachability_samples": "Δείγματα",
+  "correlation_reachability_targets": "Παρατηρούμενοι στόχοι",
+  "correlation_reachability_scope": "Εύρος στόχων",
+  "correlation_reachability_drilldown": "Άνοιγμα λεπτομερειών Παρακολούθησης σύνδεσης",
+  "correlation_reachability_aria": "Σύνοψη προσβασιμότητας"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview is a tryout build",
   "desktop_preview_notice_body": "Use DOCSight Desktop Preview to explore the app locally. For reliable 24/7 monitoring, use Docker; laptop sleep or hibernate pauses data collection.",
-  "desktop_preview_notice_link": "Read capabilities and limits"
+  "desktop_preview_notice_link": "Read capabilities and limits",
+  "correlation_reachability": "Reachability",
+  "correlation_reachability_hint": "Reachability buckets show observed Connection Monitor coverage; activate the chart to open Connection Monitor details.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Degraded",
+  "correlation_reachability_down": "Down",
+  "correlation_reachability_unknown": "Unknown",
+  "correlation_reachability_state": "State",
+  "correlation_reachability_window": "Window",
+  "correlation_reachability_loss": "Observed packet loss",
+  "correlation_reachability_samples": "Samples",
+  "correlation_reachability_targets": "Observed targets",
+  "correlation_reachability_scope": "Target scope",
+  "correlation_reachability_drilldown": "Open Connection Monitor details",
+  "correlation_reachability_aria": "Reachability summary"
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1097,5 +1097,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview es una versión de prueba",
   "desktop_preview_notice_body": "Use DOCSight Desktop Preview para explorar la app localmente. Para monitorización fiable 24/7, use Docker; la suspensión o hibernación del equipo pausa la recopilación de datos.",
-  "desktop_preview_notice_link": "Ver capacidades y límites"
+  "desktop_preview_notice_link": "Ver capacidades y límites",
+  "correlation_reachability": "Disponibilidad",
+  "correlation_reachability_hint": "Los intervalos de disponibilidad muestran la cobertura observada por el Monitor de conexión; active el gráfico para abrir los detalles.",
+  "correlation_reachability_ok": "Correcta",
+  "correlation_reachability_degraded": "Degradada",
+  "correlation_reachability_down": "Caída",
+  "correlation_reachability_unknown": "Desconocida",
+  "correlation_reachability_state": "Estado",
+  "correlation_reachability_window": "Intervalo",
+  "correlation_reachability_loss": "Pérdida de paquetes observada",
+  "correlation_reachability_samples": "Muestras",
+  "correlation_reachability_targets": "Destinos observados",
+  "correlation_reachability_scope": "Ámbito de destinos",
+  "correlation_reachability_drilldown": "Abrir detalles del Monitor de conexión",
+  "correlation_reachability_aria": "Resumen de disponibilidad"
 }

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview on prooviversioon",
   "desktop_preview_notice_body": "Kasuta DOCSight Desktop Preview’d rakenduse kohalikuks proovimiseks. Usaldusväärseks 24/7 jälgimiseks kasuta Dockerit; sülearvuti unerežiim või talveuni peatab andmete kogumise.",
-  "desktop_preview_notice_link": "Loe võimalusi ja piiranguid"
+  "desktop_preview_notice_link": "Loe võimalusi ja piiranguid",
+  "correlation_reachability": "Kättesaadavus",
+  "correlation_reachability_hint": "Kättesaadavuse vahemikud näitavad Ühenduse jälgija vaadeldud katvust; üksikasjade avamiseks aktiveeri diagramm.",
+  "correlation_reachability_ok": "Korras",
+  "correlation_reachability_degraded": "Halvenenud",
+  "correlation_reachability_down": "Maha",
+  "correlation_reachability_unknown": "Teadmata",
+  "correlation_reachability_state": "Olek",
+  "correlation_reachability_window": "Ajavahemik",
+  "correlation_reachability_loss": "Vaadeldud paketkadu",
+  "correlation_reachability_samples": "Proovid",
+  "correlation_reachability_targets": "Vaadeldud sihtmärgid",
+  "correlation_reachability_scope": "Sihtmärkide ulatus",
+  "correlation_reachability_drilldown": "Ava Ühenduse jälgija üksikasjad",
+  "correlation_reachability_aria": "Kättesaadavuse kokkuvõte"
 }

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview on kokeiluversio",
   "desktop_preview_notice_body": "Käytä DOCSight Desktop Previewiä sovelluksen paikalliseen kokeiluun. Luotettavaan 24/7-valvontaan käytä Dockeria; lepotila tai horrostila keskeyttää datan keruun.",
-  "desktop_preview_notice_link": "Lue ominaisuudet ja rajoitukset"
+  "desktop_preview_notice_link": "Lue ominaisuudet ja rajoitukset",
+  "correlation_reachability": "Tavoitettavuus",
+  "correlation_reachability_hint": "Tavoitettavuusjaksot näyttävät Yhteysmonitorin havaitseman kattavuuden; avaa tiedot aktivoimalla kaavio.",
+  "correlation_reachability_ok": "Kunnossa",
+  "correlation_reachability_degraded": "Heikentynyt",
+  "correlation_reachability_down": "Ei tavoitettavissa",
+  "correlation_reachability_unknown": "Tuntematon",
+  "correlation_reachability_state": "Tila",
+  "correlation_reachability_window": "Aikaväli",
+  "correlation_reachability_loss": "Havaittu pakettihäviö",
+  "correlation_reachability_samples": "Näytteet",
+  "correlation_reachability_targets": "Havaitut kohteet",
+  "correlation_reachability_scope": "Kohteiden laajuus",
+  "correlation_reachability_drilldown": "Avaa Yhteysmonitorin tiedot",
+  "correlation_reachability_aria": "Tavoitettavuuden yhteenveto"
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -1094,5 +1094,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview est une version d’essai",
   "desktop_preview_notice_body": "Utilisez DOCSight Desktop Preview pour découvrir l’app localement. Pour une surveillance fiable 24/7, utilisez Docker; la veille ou l’hibernation de l’ordinateur interrompt la collecte.",
-  "desktop_preview_notice_link": "Lire les capacités et limites"
+  "desktop_preview_notice_link": "Lire les capacités et limites",
+  "correlation_reachability": "Accessibilité",
+  "correlation_reachability_hint": "Les intervalles d’accessibilité montrent la couverture observée par le Moniteur de connexion ; activez le graphique pour ouvrir les détails.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Dégradée",
+  "correlation_reachability_down": "Indisponible",
+  "correlation_reachability_unknown": "Inconnue",
+  "correlation_reachability_state": "État",
+  "correlation_reachability_window": "Fenêtre",
+  "correlation_reachability_loss": "Perte de paquets observée",
+  "correlation_reachability_samples": "Échantillons",
+  "correlation_reachability_targets": "Cibles observées",
+  "correlation_reachability_scope": "Périmètre des cibles",
+  "correlation_reachability_drilldown": "Ouvrir les détails du Moniteur de connexion",
+  "correlation_reachability_aria": "Résumé de l’accessibilité"
 }

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Is leagan trialach é Desktop Preview",
   "desktop_preview_notice_body": "Úsáid DOCSight Desktop Preview chun an aip a thriail go háitiúil. Le haghaidh monatóireacht iontaofa 24/7, úsáid Docker; cuireann codladh nó geimhriú ríomhaire glúine bailiú sonraí ar sos.",
-  "desktop_preview_notice_link": "Léigh cumais agus teorainneacha"
+  "desktop_preview_notice_link": "Léigh cumais agus teorainneacha",
+  "correlation_reachability": "Infhaighteacht",
+  "correlation_reachability_hint": "Léiríonn na buicéid infhaighteachta an clúdach a breathnaíodh sa Mhonatóir Ceangail; gníomhachtaigh an chairt chun na sonraí a oscailt.",
+  "correlation_reachability_ok": "Ceart go leor",
+  "correlation_reachability_degraded": "Díghrádaithe",
+  "correlation_reachability_down": "Síos",
+  "correlation_reachability_unknown": "Anaithnid",
+  "correlation_reachability_state": "Staid",
+  "correlation_reachability_window": "Tréimhse",
+  "correlation_reachability_loss": "Caillteanas paicéad breathnaithe",
+  "correlation_reachability_samples": "Samplaí",
+  "correlation_reachability_targets": "Spriocanna breathnaithe",
+  "correlation_reachability_scope": "Raon na spriocanna",
+  "correlation_reachability_drilldown": "Oscail sonraí an Mhonatóra Ceangail",
+  "correlation_reachability_aria": "Achoimre infhaighteachta"
 }

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview je probna verzija",
   "desktop_preview_notice_body": "Koristite DOCSight Desktop Preview za lokalno upoznavanje aplikacije. Za pouzdano 24/7 praćenje koristite Docker; mirovanje ili hibernacija prijenosnika pauzira prikupljanje podataka.",
-  "desktop_preview_notice_link": "Pročitaj mogućnosti i ograničenja"
+  "desktop_preview_notice_link": "Pročitaj mogućnosti i ograničenja",
+  "correlation_reachability": "Dostupnost",
+  "correlation_reachability_hint": "Intervali dostupnosti prikazuju opaženu pokrivenost Nadzora veze; aktivirajte grafikon za otvaranje pojedinosti.",
+  "correlation_reachability_ok": "U redu",
+  "correlation_reachability_degraded": "Pogoršano",
+  "correlation_reachability_down": "Nedostupno",
+  "correlation_reachability_unknown": "Nepoznato",
+  "correlation_reachability_state": "Stanje",
+  "correlation_reachability_window": "Vremenski raspon",
+  "correlation_reachability_loss": "Opaženi gubitak paketa",
+  "correlation_reachability_samples": "Uzorci",
+  "correlation_reachability_targets": "Opažena odredišta",
+  "correlation_reachability_scope": "Opseg odredišta",
+  "correlation_reachability_drilldown": "Otvori pojedinosti Nadzora veze",
+  "correlation_reachability_aria": "Sažetak dostupnosti"
 }

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "A Desktop Preview próba build",
   "desktop_preview_notice_body": "A DOCSight Desktop Preview helyi kipróbálásra való. Megbízható 24/7 monitorozáshoz használj Dockert; a laptop alvó vagy hibernált állapota szünetelteti az adatgyűjtést.",
-  "desktop_preview_notice_link": "Képességek és korlátok"
+  "desktop_preview_notice_link": "Képességek és korlátok",
+  "correlation_reachability": "Elérhetőség",
+  "correlation_reachability_hint": "Az elérhetőségi időszakok a Kapcsolatfigyelő által megfigyelt lefedettséget mutatják; a részletek megnyitásához aktiválja a diagramot.",
+  "correlation_reachability_ok": "Rendben",
+  "correlation_reachability_degraded": "Romlott",
+  "correlation_reachability_down": "Nem elérhető",
+  "correlation_reachability_unknown": "Ismeretlen",
+  "correlation_reachability_state": "Állapot",
+  "correlation_reachability_window": "Időablak",
+  "correlation_reachability_loss": "Megfigyelt csomagvesztés",
+  "correlation_reachability_samples": "Minták",
+  "correlation_reachability_targets": "Megfigyelt célok",
+  "correlation_reachability_scope": "Célok köre",
+  "correlation_reachability_drilldown": "Kapcsolatfigyelő részleteinek megnyitása",
+  "correlation_reachability_aria": "Elérhetőségi összefoglaló"
 }

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview è una versione di prova",
   "desktop_preview_notice_body": "Usa DOCSight Desktop Preview per esplorare l’app localmente. Per monitoraggio affidabile 24/7, usa Docker; sospensione o ibernazione del PC interrompono la raccolta dati.",
-  "desktop_preview_notice_link": "Leggi funzionalità e limiti"
+  "desktop_preview_notice_link": "Leggi funzionalità e limiti",
+  "correlation_reachability": "Raggiungibilità",
+  "correlation_reachability_hint": "Gli intervalli di raggiungibilità mostrano la copertura osservata dal Monitor connessione; attiva il grafico per aprire i dettagli.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Degradata",
+  "correlation_reachability_down": "Non raggiungibile",
+  "correlation_reachability_unknown": "Sconosciuta",
+  "correlation_reachability_state": "Stato",
+  "correlation_reachability_window": "Intervallo",
+  "correlation_reachability_loss": "Perdita di pacchetti osservata",
+  "correlation_reachability_samples": "Campioni",
+  "correlation_reachability_targets": "Destinazioni osservate",
+  "correlation_reachability_scope": "Ambito delle destinazioni",
+  "correlation_reachability_drilldown": "Apri i dettagli del Monitor connessione",
+  "correlation_reachability_aria": "Riepilogo della raggiungibilità"
 }

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview yra bandomoji versija",
   "desktop_preview_notice_body": "Naudokite DOCSight Desktop Preview programai vietoje išbandyti. Patikimam 24/7 stebėjimui naudokite Docker; kompiuterio miegas ar hibernacija sustabdo duomenų rinkimą.",
-  "desktop_preview_notice_link": "Skaityti galimybes ir ribas"
+  "desktop_preview_notice_link": "Skaityti galimybes ir ribas",
+  "correlation_reachability": "Pasiekiamumas",
+  "correlation_reachability_hint": "Pasiekiamumo intervalai rodo Ryšio stebėjimo priemonės užfiksuotą aprėptį; suaktyvinkite diagramą, kad atvertumėte išsamią informaciją.",
+  "correlation_reachability_ok": "Gerai",
+  "correlation_reachability_degraded": "Pablogėjęs",
+  "correlation_reachability_down": "Nepasiekiamas",
+  "correlation_reachability_unknown": "Nežinomas",
+  "correlation_reachability_state": "Būsena",
+  "correlation_reachability_window": "Laiko intervalas",
+  "correlation_reachability_loss": "Stebėtas paketų praradimas",
+  "correlation_reachability_samples": "Mėginiai",
+  "correlation_reachability_targets": "Stebėti tikslai",
+  "correlation_reachability_scope": "Tikslų aprėptis",
+  "correlation_reachability_drilldown": "Atverti Ryšio stebėjimo informaciją",
+  "correlation_reachability_aria": "Pasiekiamumo suvestinė"
 }

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview ir izmēģinājuma versija",
   "desktop_preview_notice_body": "Izmantojiet DOCSight Desktop Preview, lai lokāli iepazītu lietotni. Uzticamai 24/7 uzraudzībai izmantojiet Docker; klēpjdatora miegs vai hibernācija aptur datu vākšanu.",
-  "desktop_preview_notice_link": "Lasīt iespējas un ierobežojumus"
+  "desktop_preview_notice_link": "Lasīt iespējas un ierobežojumus",
+  "correlation_reachability": "Sasniedzamība",
+  "correlation_reachability_hint": "Sasniedzamības intervāli rāda Savienojuma pārrauga novēroto pārklājumu; aktivizējiet diagrammu, lai atvērtu detalizētu informāciju.",
+  "correlation_reachability_ok": "Labi",
+  "correlation_reachability_degraded": "Pasliktināta",
+  "correlation_reachability_down": "Nav sasniedzams",
+  "correlation_reachability_unknown": "Nezināma",
+  "correlation_reachability_state": "Stāvoklis",
+  "correlation_reachability_window": "Laika intervāls",
+  "correlation_reachability_loss": "Novērotais pakešu zudums",
+  "correlation_reachability_samples": "Paraugi",
+  "correlation_reachability_targets": "Novērotie mērķi",
+  "correlation_reachability_scope": "Mērķu tvērums",
+  "correlation_reachability_drilldown": "Atvērt Savienojuma pārrauga informāciju",
+  "correlation_reachability_aria": "Sasniedzamības kopsavilkums"
 }

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview er en prøveversjon",
   "desktop_preview_notice_body": "Bruk DOCSight Desktop Preview for å utforske appen lokalt. For pålitelig 24/7-overvåking, bruk Docker; hvilemodus eller dvalemodus pauser datainnsamlingen.",
-  "desktop_preview_notice_link": "Les funksjoner og begrensninger"
+  "desktop_preview_notice_link": "Les funksjoner og begrensninger",
+  "correlation_reachability": "Tilgjengelighet",
+  "correlation_reachability_hint": "Tilgjengelighetsintervallene viser observert dekning fra Tilkoblingsmonitoren; aktiver diagrammet for å åpne detaljene.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Forringet",
+  "correlation_reachability_down": "Nede",
+  "correlation_reachability_unknown": "Ukjent",
+  "correlation_reachability_state": "Tilstand",
+  "correlation_reachability_window": "Tidsvindu",
+  "correlation_reachability_loss": "Observert pakketap",
+  "correlation_reachability_samples": "Målinger",
+  "correlation_reachability_targets": "Observerte mål",
+  "correlation_reachability_scope": "Målomfang",
+  "correlation_reachability_drilldown": "Åpne detaljer i Tilkoblingsmonitoren",
+  "correlation_reachability_aria": "Sammendrag av tilgjengelighet"
 }

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview is een proefversie",
   "desktop_preview_notice_body": "Gebruik DOCSight Desktop Preview om de app lokaal te verkennen. Gebruik Docker voor betrouwbare 24/7-monitoring; slaapstand of sluimerstand pauzeert de gegevensverzameling.",
-  "desktop_preview_notice_link": "Lees mogelijkheden en beperkingen"
+  "desktop_preview_notice_link": "Lees mogelijkheden en beperkingen",
+  "correlation_reachability": "Bereikbaarheid",
+  "correlation_reachability_hint": "Bereikbaarheidsvakken tonen de waargenomen dekking van de Verbindingsmonitor; activeer de grafiek om de details te openen.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Verminderd",
+  "correlation_reachability_down": "Niet bereikbaar",
+  "correlation_reachability_unknown": "Onbekend",
+  "correlation_reachability_state": "Status",
+  "correlation_reachability_window": "Tijdvenster",
+  "correlation_reachability_loss": "Waargenomen pakketverlies",
+  "correlation_reachability_samples": "Metingen",
+  "correlation_reachability_targets": "Waargenomen doelen",
+  "correlation_reachability_scope": "Doelbereik",
+  "correlation_reachability_drilldown": "Details van Verbindingsmonitor openen",
+  "correlation_reachability_aria": "Samenvatting bereikbaarheid"
 }

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview to wersja próbna",
   "desktop_preview_notice_body": "Użyj DOCSight Desktop Preview, aby lokalnie poznać aplikację. Do niezawodnego monitoringu 24/7 użyj Dockera; uśpienie lub hibernacja laptopa wstrzymuje zbieranie danych.",
-  "desktop_preview_notice_link": "Zobacz możliwości i ograniczenia"
+  "desktop_preview_notice_link": "Zobacz możliwości i ograniczenia",
+  "correlation_reachability": "Osiągalność",
+  "correlation_reachability_hint": "Przedziały osiągalności pokazują pokrycie zaobserwowane przez Monitor połączenia; aktywuj wykres, aby otworzyć szczegóły.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Pogorszona",
+  "correlation_reachability_down": "Niedostępna",
+  "correlation_reachability_unknown": "Nieznana",
+  "correlation_reachability_state": "Stan",
+  "correlation_reachability_window": "Przedział czasu",
+  "correlation_reachability_loss": "Zaobserwowana utrata pakietów",
+  "correlation_reachability_samples": "Próbki",
+  "correlation_reachability_targets": "Zaobserwowane cele",
+  "correlation_reachability_scope": "Zakres celów",
+  "correlation_reachability_drilldown": "Otwórz szczegóły Monitora połączenia",
+  "correlation_reachability_aria": "Podsumowanie osiągalności"
 }

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview é uma versão de teste",
   "desktop_preview_notice_body": "Use o DOCSight Desktop Preview para explorar a app localmente. Para monitorização fiável 24/7, use Docker; suspensão ou hibernação do portátil pausa a recolha de dados.",
-  "desktop_preview_notice_link": "Ler capacidades e limites"
+  "desktop_preview_notice_link": "Ler capacidades e limites",
+  "correlation_reachability": "Acessibilidade",
+  "correlation_reachability_hint": "Os intervalos de acessibilidade mostram a cobertura observada pelo Monitor de ligação; ative o gráfico para abrir os detalhes.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Degradada",
+  "correlation_reachability_down": "Indisponível",
+  "correlation_reachability_unknown": "Desconhecida",
+  "correlation_reachability_state": "Estado",
+  "correlation_reachability_window": "Intervalo",
+  "correlation_reachability_loss": "Perda de pacotes observada",
+  "correlation_reachability_samples": "Amostras",
+  "correlation_reachability_targets": "Destinos observados",
+  "correlation_reachability_scope": "Âmbito dos destinos",
+  "correlation_reachability_drilldown": "Abrir detalhes do Monitor de ligação",
+  "correlation_reachability_aria": "Resumo da acessibilidade"
 }

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview este o versiune de probă",
   "desktop_preview_notice_body": "Folosiți DOCSight Desktop Preview pentru a explora aplicația local. Pentru monitorizare fiabilă 24/7, folosiți Docker; somnul sau hibernarea laptopului oprește temporar colectarea datelor.",
-  "desktop_preview_notice_link": "Citiți capabilitățile și limitele"
+  "desktop_preview_notice_link": "Citiți capabilitățile și limitele",
+  "correlation_reachability": "Accesibilitate",
+  "correlation_reachability_hint": "Intervalele de accesibilitate arată acoperirea observată de Monitorul conexiunii; activați graficul pentru a deschide detaliile.",
+  "correlation_reachability_ok": "În regulă",
+  "correlation_reachability_degraded": "Degradată",
+  "correlation_reachability_down": "Indisponibilă",
+  "correlation_reachability_unknown": "Necunoscută",
+  "correlation_reachability_state": "Stare",
+  "correlation_reachability_window": "Interval",
+  "correlation_reachability_loss": "Pierdere de pachete observată",
+  "correlation_reachability_samples": "Eșantioane",
+  "correlation_reachability_targets": "Ținte observate",
+  "correlation_reachability_scope": "Domeniul țintelor",
+  "correlation_reachability_drilldown": "Deschide detaliile Monitorului conexiunii",
+  "correlation_reachability_aria": "Rezumatul accesibilității"
 }

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview je skúšobné zostavenie",
   "desktop_preview_notice_body": "Použite DOCSight Desktop Preview na lokálne vyskúšanie aplikácie. Na spoľahlivé monitorovanie 24/7 použite Docker; spánok alebo hibernácia notebooku pozastaví zber dát.",
-  "desktop_preview_notice_link": "Prečítať možnosti a obmedzenia"
+  "desktop_preview_notice_link": "Prečítať možnosti a obmedzenia",
+  "correlation_reachability": "Dostupnosť",
+  "correlation_reachability_hint": "Intervaly dostupnosti zobrazujú pozorované pokrytie Monitoru pripojenia; aktivovaním grafu otvoríte podrobnosti.",
+  "correlation_reachability_ok": "V poriadku",
+  "correlation_reachability_degraded": "Zhoršená",
+  "correlation_reachability_down": "Nedostupná",
+  "correlation_reachability_unknown": "Neznáma",
+  "correlation_reachability_state": "Stav",
+  "correlation_reachability_window": "Časové okno",
+  "correlation_reachability_loss": "Pozorovaná strata paketov",
+  "correlation_reachability_samples": "Vzorky",
+  "correlation_reachability_targets": "Pozorované ciele",
+  "correlation_reachability_scope": "Rozsah cieľov",
+  "correlation_reachability_drilldown": "Otvoriť podrobnosti Monitoru pripojenia",
+  "correlation_reachability_aria": "Súhrn dostupnosti"
 }

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview je preizkusna različica",
   "desktop_preview_notice_body": "Uporabite DOCSight Desktop Preview za lokalno spoznavanje aplikacije. Za zanesljiv nadzor 24/7 uporabite Docker; spanje ali hibernacija prenosnika začasno ustavi zbiranje podatkov.",
-  "desktop_preview_notice_link": "Preberi zmožnosti in omejitve"
+  "desktop_preview_notice_link": "Preberi zmožnosti in omejitve",
+  "correlation_reachability": "Dosegljivost",
+  "correlation_reachability_hint": "Intervali dosegljivosti prikazujejo opaženo pokritost Nadzornika povezave; aktivirajte grafikon, da odprete podrobnosti.",
+  "correlation_reachability_ok": "V redu",
+  "correlation_reachability_degraded": "Poslabšana",
+  "correlation_reachability_down": "Nedosegljiva",
+  "correlation_reachability_unknown": "Neznana",
+  "correlation_reachability_state": "Stanje",
+  "correlation_reachability_window": "Časovno okno",
+  "correlation_reachability_loss": "Opažena izguba paketov",
+  "correlation_reachability_samples": "Vzorci",
+  "correlation_reachability_targets": "Opaženi cilji",
+  "correlation_reachability_scope": "Obseg ciljev",
+  "correlation_reachability_drilldown": "Odpri podrobnosti Nadzornika povezave",
+  "correlation_reachability_aria": "Povzetek dosegljivosti"
 }

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -1102,5 +1102,19 @@
   "desktop_preview_badge": "Desktop Preview",
   "desktop_preview_notice_title": "Desktop Preview är en testversion",
   "desktop_preview_notice_body": "Använd DOCSight Desktop Preview för att utforska appen lokalt. För tillförlitlig övervakning dygnet runt, använd Docker; viloläge eller strömsparläge pausar datainsamlingen.",
-  "desktop_preview_notice_link": "Läs funktioner och begränsningar"
+  "desktop_preview_notice_link": "Läs funktioner och begränsningar",
+  "correlation_reachability": "Nåbarhet",
+  "correlation_reachability_hint": "Nåbarhetsintervallen visar observerad täckning från Anslutningsövervakaren; aktivera diagrammet för att öppna detaljerna.",
+  "correlation_reachability_ok": "OK",
+  "correlation_reachability_degraded": "Försämrad",
+  "correlation_reachability_down": "Nere",
+  "correlation_reachability_unknown": "Okänd",
+  "correlation_reachability_state": "Tillstånd",
+  "correlation_reachability_window": "Tidsfönster",
+  "correlation_reachability_loss": "Observerad paketförlust",
+  "correlation_reachability_samples": "Mätningar",
+  "correlation_reachability_targets": "Observerade mål",
+  "correlation_reachability_scope": "Målomfattning",
+  "correlation_reachability_drilldown": "Öppna detaljer i Anslutningsövervakaren",
+  "correlation_reachability_aria": "Sammanfattning av nåbarhet"
 }

--- a/app/modules/connection_monitor/routes.py
+++ b/app/modules/connection_monitor/routes.py
@@ -288,6 +288,7 @@ def _compress_samples(samples: list[dict], start: float | None, end: float | Non
 
         compressed.append({
             "timestamp": bucket["timestamp"],
+            "bucket_seconds": bucket_seconds,
             "latency_ms": avg_latency,
             "min_latency_ms": bucket["min_latency_ms"],
             "max_latency_ms": bucket["max_latency_ms"],
@@ -309,6 +310,7 @@ def _append_raw_samples(samples: list[dict], raw_rows: list[dict]) -> int:
     for s in raw_rows:
         samples.append({
             "timestamp": s["timestamp"],
+            "bucket_seconds": None,
             "latency_ms": s["latency_ms"],
             "min_latency_ms": None,
             "max_latency_ms": None,
@@ -325,6 +327,7 @@ def _append_aggregated_samples(samples: list[dict], agg_rows: list[dict]) -> int
     for a in agg_rows:
         samples.append({
             "timestamp": a["bucket_start"],
+            "bucket_seconds": a["bucket_seconds"],
             "latency_ms": a["avg_latency_ms"],
             "min_latency_ms": a["min_latency_ms"],
             "max_latency_ms": a["max_latency_ms"],

--- a/app/modules/connection_monitor/templates/connection_monitor_detail.html
+++ b/app/modules/connection_monitor/templates/connection_monitor_detail.html
@@ -3,7 +3,7 @@
      data-l-raw-log-download="{{ t.get('docsight.connection_monitor.cm_raw_log_download', 'Download raw log') }}">
     <div class="view-page-header cm-page-header">
         <div class="view-page-header-left">
-            <h2 class="view-page-title">{{ t.get('docsight.connection_monitor.cm_detail_title', 'Connection Monitor') }}</h2>
+            <h2 class="view-page-title" tabindex="-1">{{ t.get('docsight.connection_monitor.cm_detail_title', 'Connection Monitor') }}</h2>
             <span class="view-page-subtitle">{{ t.get('docsight.connection_monitor.connection_monitor_desc', 'Always-on latency monitoring for cable troubleshooting') }}</span>
         </div>
         <div class="view-page-actions cm-header-actions">

--- a/app/static/css/views.css
+++ b/app/static/css/views.css
@@ -682,6 +682,10 @@
     left: 0;
     pointer-events: auto;
 }
+.correlation-chart-wrap canvas.correlation-overlay:focus-visible {
+    outline: 2px solid var(--amethyst, var(--accent));
+    outline-offset: 2px;
+}
 .correlation-tooltip {
     position: absolute;
     pointer-events: none;

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -3,9 +3,12 @@
 /* ═══ Correlation Analysis ═══ */
 var _correlationData = [];
 var _correlationChart = null;
-var _corrVisible = { snr: true, txPower: true, dsPower: true, download: true, upload: true, events: false, errors: true, poorSignal: false, temperature: true, segmentDs: true, segmentUs: false };
+var _corrVisible = { snr: true, txPower: true, dsPower: true, download: true, upload: true, events: false, errors: true, poorSignal: false, temperature: true, segmentDs: true, segmentUs: false, reachability: true };
 var _corrWeatherData = [];
 var _corrSegmentData = [];
+var _corrTargetData = [];
+var _corrCmState = typeof CORRELATION_CM_AVAILABLE !== 'undefined' && CORRELATION_CM_AVAILABLE ? 'targets_absent' : 'module_absent';
+var _corrSelectedRange = null;
 var _corrChartState = null; // Stores scales/data for tooltip lookups
 var _corrZoom = null; // { tMin, tMax } when zoomed in
 // Event type/severity sub-filter: operational events hidden by default
@@ -96,6 +99,157 @@ function _corrFormatTimestamp(timestamp) {
         ' ' + String(date.getHours()).padStart(2, '0') + ':' + String(date.getMinutes()).padStart(2, '0') + ':' + String(date.getSeconds()).padStart(2, '0');
 }
 
+function _corrTarget(entry) {
+    return entry && entry.target ? entry.target : (entry || {});
+}
+
+function _corrSampleInterval(sample, target) {
+    if (!sample || typeof sample.timestamp !== 'number' || !isFinite(sample.timestamp)) return null;
+    var coverageSeconds = typeof sample.bucket_seconds === 'number' && isFinite(sample.bucket_seconds) && sample.bucket_seconds > 0
+        ? sample.bucket_seconds
+        : Number(target && target.poll_interval_ms) / 1000;
+    if (!isFinite(coverageSeconds) || coverageSeconds <= 0) return null;
+    var startMs = sample.timestamp * 1000;
+    return { startMs: startMs, endMs: startMs + coverageSeconds * 1000 };
+}
+
+function _corrSetOverlayActionable(overlay, actionable) {
+    if (!overlay) return;
+    overlay.setAttribute('role', actionable ? 'button' : 'img');
+    if (actionable) overlay.setAttribute('tabindex', '0');
+    else overlay.removeAttribute('tabindex');
+}
+
+/**
+ * Re-bucket loaded Connection Monitor samples into time-proportional display buckets.
+ * CM timestamps are epoch seconds; this helper normalizes them to milliseconds.
+ */
+function _corrBucketReachability(targetData, tMinMs, tMaxMs, bucketCount) {
+    var requestedCount = Math.floor(Number(bucketCount));
+    var count = Math.min(300, Math.max(1, isFinite(requestedCount) ? requestedCount : 1));
+    if (!isFinite(tMinMs) || !isFinite(tMaxMs) || tMaxMs <= tMinMs) return [];
+    var widthMs = (tMaxMs - tMinMs) / count;
+    var buckets = [];
+    for (var bi = 0; bi < count; bi++) {
+        var bucketStart = tMinMs + bi * widthMs;
+        var bucketEnd = bi === count - 1 ? tMaxMs : tMinMs + (bi + 1) * widthMs;
+        var sampleCount = 0;
+        var weightedLoss = 0;
+        var allDown = true;
+        var targetKeys = {};
+        var targetLabels = [];
+
+        (targetData || []).forEach(function(entry, targetIndex) {
+            var target = _corrTarget(entry);
+            var key = target.id != null ? 'id:' + target.id : 'index:' + targetIndex;
+            var label = target.label || target.host || String(target.id != null ? target.id : targetIndex + 1);
+            var targetObserved = false;
+            (entry.samples || []).forEach(function(sample) {
+                var interval = _corrSampleInterval(sample, target);
+                if (!interval || interval.startMs >= bucketEnd || interval.endMs <= bucketStart) return;
+                var loss = Number(sample.packet_loss_pct);
+                if (!isFinite(loss) || loss < 0 || loss > 100) return;
+                var weight = Number(sample.sample_count);
+                if (!isFinite(weight) || weight <= 0) weight = 1;
+                sampleCount += weight;
+                weightedLoss += loss * weight;
+                if (loss !== 100) allDown = false;
+                targetObserved = true;
+            });
+            if (targetObserved && !targetKeys[key]) {
+                targetKeys[key] = true;
+                targetLabels.push(label);
+            }
+        });
+
+        var lossPct = sampleCount > 0 ? weightedLoss / sampleCount : null;
+        var state = 'unknown';
+        if (sampleCount > 0) {
+            if (allDown && lossPct === 100) state = 'down';
+            else if (lossPct === 0) state = 'ok';
+            else state = 'degraded';
+        }
+        buckets.push({
+            startMs: bucketStart,
+            endMs: bucketEnd,
+            state: state,
+            lossPct: lossPct,
+            sampleCount: sampleCount,
+            targetsObserved: targetLabels.length,
+            targetScope: targetLabels.join(' | ')
+        });
+    }
+    return buckets;
+}
+
+function _corrFetchReachability(startEpoch, endEpoch, maxPoints) {
+    if (typeof CORRELATION_CM_AVAILABLE === 'undefined' || !CORRELATION_CM_AVAILABLE) {
+        _corrCmState = 'module_absent';
+        _corrTargetData = [];
+        return Promise.resolve(null);
+    }
+    var boundedPoints = Math.min(1000, Math.max(1, Number(maxPoints) || 300));
+    return fetch('/api/connection-monitor/targets')
+        .then(function(response) {
+            if (!response.ok) throw new Error('Connection Monitor targets unavailable');
+            return response.json();
+        })
+        .catch(function() { return null; })
+        .then(function(targets) {
+            if (!targets) {
+                _corrCmState = 'fetch_error';
+                _corrTargetData = [];
+                return null;
+            }
+            var enabled = targets.filter(function(target) { return !!target.enabled; });
+            if (enabled.length === 0) {
+                _corrCmState = 'targets_absent';
+                _corrTargetData = [];
+                return [];
+            }
+            var requests = enabled.map(function(target) {
+                var url = '/api/connection-monitor/samples/' + target.id
+                    + '?start=' + encodeURIComponent(startEpoch)
+                    + '&end=' + encodeURIComponent(endEpoch)
+                    + '&resolution=auto&max_points=' + encodeURIComponent(boundedPoints)
+                    + '&limit=0';
+                return fetch(url)
+                    .then(function(response) {
+                        if (!response.ok) throw new Error('Connection Monitor samples unavailable');
+                        return response.json();
+                    })
+                    .then(function(payload) {
+                        return { target: target, samples: Array.isArray(payload.samples) ? payload.samples : [], meta: payload.meta || null };
+                    })
+                    .catch(function() { return null; });
+            });
+            return Promise.all(requests).then(function(results) {
+                if (results.some(function(result) { return result === null; })) {
+                    _corrCmState = 'fetch_error';
+                    _corrTargetData = [];
+                    return null;
+                }
+                _corrTargetData = results;
+                var allSamples = results.reduce(function(total, entry) { return total + entry.samples.length; }, 0);
+                if (allSamples === 0) {
+                    _corrCmState = 'no_samples';
+                    return results;
+                }
+                var startMs = startEpoch * 1000;
+                var endMs = endEpoch * 1000;
+                var intersects = results.some(function(entry) {
+                    return entry.samples.some(function(sample) {
+                        var interval = _corrSampleInterval(sample, entry.target);
+                        return interval && interval.startMs < endMs && interval.endMs > startMs;
+                    });
+                });
+                _corrCmState = intersects ? 'ready' : 'samples_outside_range';
+                if (!intersects) _corrTargetData = [];
+                return results;
+            });
+        });
+}
+
 function _corrBuildSpeedMarks(speedtests, xScale, yScale, tMin, tMax, visibleMetrics) {
     var visiblePoints = [];
     for (var i = 0; i < speedtests.length; i++) {
@@ -183,7 +337,7 @@ function _corrDrawSpeedMarks(ctx, marks, baselineY, colors, visibleMetrics) {
     var observer = new ResizeObserver(function() {
         clearTimeout(resizeTimer);
         resizeTimer = setTimeout(function() {
-            if (_correlationData && _correlationData.length > 0) {
+            if ((_correlationData && _correlationData.length > 0) || _corrTargetData.length > 0) {
                 renderCorrelationChart(_correlationData);
             }
         }, 150);
@@ -201,6 +355,9 @@ function loadCorrelationData() {
     var noData = document.getElementById('correlation-no-data');
     var chartContainer = document.getElementById('correlation-chart-container');
     var tableCard = document.getElementById('correlation-table-card');
+    var overlay = document.getElementById('correlation-overlay');
+    _corrSetOverlayActionable(overlay, false);
+    if (overlay) overlay.setAttribute('aria-label', T.correlation_chart_aria_label || 'Signal correlation chart');
     loading.style.display = 'flex';
     noData.style.display = 'none';
     chartContainer.style.display = 'none';
@@ -210,6 +367,9 @@ function loadCorrelationData() {
     var now = new Date();
     var wEnd = now.toISOString().substring(0, 19) + 'Z';
     var wStart = new Date(now.getTime() - parseInt(hours) * 3600000).toISOString().substring(0, 19) + 'Z';
+    var startEpoch = Math.floor(new Date(wStart).getTime() / 1000);
+    var endEpoch = Math.ceil(new Date(wEnd).getTime() / 1000);
+    _corrSelectedRange = { startMs: startEpoch * 1000, endMs: endEpoch * 1000 };
     var weatherUrl = '/api/weather/range?start=' + encodeURIComponent(wStart) + '&end=' + encodeURIComponent(wEnd);
 
     var segmentUrl = '/api/fritzbox/segment-utilization/range?start=' + encodeURIComponent(wStart) + '&end=' + encodeURIComponent(wEnd);
@@ -217,22 +377,28 @@ function loadCorrelationData() {
     Promise.all([
         fetch('/api/correlation?hours=' + hours + '&sources=modem,speedtest,events,capture').then(function(r) { return r.json(); }),
         fetch(weatherUrl).then(function(r) { return r.json(); }).catch(function() { return []; }),
-        fetch(segmentUrl).then(function(r) { return r.json(); }).catch(function() { return []; })
+        fetch(segmentUrl).then(function(r) { return r.json(); }).catch(function() { return []; }),
+        _corrFetchReachability(startEpoch, endEpoch, 300).catch(function() {
+            _corrCmState = 'fetch_error';
+            _corrTargetData = [];
+            return null;
+        })
     ]).then(function(results) {
-            var data = results[0];
+            var data = Array.isArray(results[0]) ? results[0] : [];
             _corrWeatherData = results[1] || [];
             _corrSegmentData = results[2] || [];
             loading.style.display = 'none';
             _correlationData = data;
-            if (!data || data.length === 0) {
+            var hasReachability = _corrTargetData.some(function(entry) { return entry.samples && entry.samples.length > 0; });
+            if (data.length === 0 && !hasReachability) {
                 noData.textContent = T.correlation_no_data;
                 noData.style.display = 'block';
                 return;
             }
             chartContainer.style.display = 'block';
-            tableCard.style.display = 'block';
+            tableCard.style.display = data.length > 0 ? 'block' : 'none';
             renderCorrelationChart(data);
-            renderCorrelationTable(data);
+            if (data.length > 0) renderCorrelationTable(data);
         })
         .catch(function() {
             loading.style.display = 'none';
@@ -250,7 +416,12 @@ function renderCorrelationChart(data) {
     var dpr = window.devicePixelRatio || 1;
     var rect = canvas.parentElement.getBoundingClientRect();
     var W = rect.width;
-    var H = 280;
+    var hasLoadedReachability = _corrTargetData.some(function(entry) {
+        var target = _corrTarget(entry);
+        return (entry.samples || []).some(function(sample) { return !!_corrSampleInterval(sample, target); });
+    });
+    var reachabilityLaneHeight = hasLoadedReachability ? 26 : 0;
+    var H = 280 + reachabilityLaneHeight;
     canvas.width = W * dpr;
     canvas.height = H * dpr;
     canvas.style.width = W + 'px';
@@ -260,6 +431,8 @@ function renderCorrelationChart(data) {
 
     // Setup overlay canvas to match main canvas
     var overlay = document.getElementById('correlation-overlay');
+    _corrSetOverlayActionable(overlay, false);
+    overlay.setAttribute('aria-label', T.correlation_chart_aria_label || 'Signal correlation chart');
     overlay.width = W * dpr;
     overlay.height = H * dpr;
     overlay.style.width = W + 'px';
@@ -268,7 +441,7 @@ function renderCorrelationChart(data) {
     octx.scale(dpr, dpr);
     octx.clearRect(0, 0, W, H);
 
-    var pad = { top: 20, right: 60, bottom: 40, left: 60 };
+    var pad = { top: 20, right: 60, bottom: 40 + reachabilityLaneHeight, left: 60 };
     var plotW = W - pad.left - pad.right;
     var plotH = H - pad.top - pad.bottom;
 
@@ -276,7 +449,7 @@ function renderCorrelationChart(data) {
     var speedtest = data.filter(function(d) { return d.source === 'speedtest'; });
     var events = data.filter(function(d) { return d.source === 'event'; });
 
-    if (modem.length === 0 && speedtest.length === 0) {
+    if (modem.length === 0 && speedtest.length === 0 && !hasLoadedReachability) {
         ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--muted').trim() || '#888';
         ctx.font = '13px system-ui, sans-serif';
         ctx.textAlign = 'center';
@@ -285,9 +458,22 @@ function renderCorrelationChart(data) {
     }
 
     // Time range (with zoom support)
-    var allTs = data.map(function(d) { return new Date(d.timestamp).getTime(); });
-    var tMinFull = Math.min.apply(null, allTs);
-    var tMaxFull = Math.max.apply(null, allTs);
+    var allTs = data.map(function(d) { return new Date(d.timestamp).getTime(); }).filter(function(ts) { return isFinite(ts); });
+    _corrTargetData.forEach(function(entry) {
+        var target = _corrTarget(entry);
+        (entry.samples || []).forEach(function(sample) {
+            var interval = _corrSampleInterval(sample, target);
+            if (!interval) return;
+            allTs.push(interval.startMs, interval.endMs);
+        });
+    });
+    var hasValidSelectedRange = _corrSelectedRange
+        && typeof _corrSelectedRange.startMs === 'number' && isFinite(_corrSelectedRange.startMs)
+        && typeof _corrSelectedRange.endMs === 'number' && isFinite(_corrSelectedRange.endMs)
+        && _corrSelectedRange.endMs > _corrSelectedRange.startMs;
+    if (!hasValidSelectedRange && allTs.length === 0) return;
+    var tMinFull = hasValidSelectedRange ? _corrSelectedRange.startMs : Math.min.apply(null, allTs);
+    var tMaxFull = hasValidSelectedRange ? _corrSelectedRange.endMs : Math.max.apply(null, allTs);
     if (tMinFull === tMaxFull) { tMaxFull = tMinFull + 3600000; }
     var tMin = _corrZoom ? _corrZoom.tMin : tMinFull;
     var tMax = _corrZoom ? _corrZoom.tMax : tMaxFull;
@@ -358,6 +544,12 @@ function renderCorrelationChart(data) {
     var warnColor = _cssColor('--warn', '#ff9800');
     var critColor = _cssColor('--crit', '#f44336');
     var accentColor = _cssColor('--accent', '#2196f3');
+    var reachabilityColors = { ok: goodColor, degraded: warnColor, down: critColor, unknown: textColor };
+    var reachabilityBucketCount = Math.min(300, Math.max(1, Math.floor(plotW / 3)));
+    var reachabilityBuckets = hasLoadedReachability
+        ? _corrBucketReachability(_corrTargetData, tMin, tMax, reachabilityBucketCount)
+        : [];
+    var reachabilityLane = reachabilityBuckets.length > 0 ? { y: H - 22, height: 18 } : null;
 
     // Store chart state for tooltip lookups
     var sortedSpeedtest = speedtest.slice().sort(function(a, b) {
@@ -375,11 +567,37 @@ function renderCorrelationChart(data) {
         tempMin: tempMin, tempMax: tempMax,
         dlMin: dlMin, dlMax: dlMax,
         modem: modem, speedtest: sortedSpeedtest, speedMarks: speedMarks, events: events, data: data,
-        weather: weather, segment: segment,
+        weather: weather, segment: segment, reachabilityBuckets: reachabilityBuckets, reachabilityLane: reachabilityLane,
         xScale: xScale, ySnr: ySnr, yTx: yTx, yDsPower: yDsPower, yDl: yDl, yTemp: yTemp, ySegment: ySegment,
-        colors: { snr: snrColor, txPower: txColor, dsPower: dsPowerColor, download: downloadColor, upload: uploadColor, event: warnColor, errors: errorColor, temperature: tempColor, segmentDs: segDsColor, segmentUs: segUsColor, text: textColor, grid: gridColor },
+        colors: { snr: snrColor, txPower: txColor, dsPower: dsPowerColor, download: downloadColor, upload: uploadColor, event: warnColor, errors: errorColor, temperature: tempColor, segmentDs: segDsColor, segmentUs: segUsColor, reachability: reachabilityColors, text: textColor, grid: gridColor },
         dpr: dpr
     };
+
+    if (reachabilityLane && _corrVisible.reachability) {
+        ctx.save();
+        for (var rb = 0; rb < reachabilityBuckets.length; rb++) {
+            var reachBucket = reachabilityBuckets[rb];
+            var reachX1 = Math.max(pad.left, xScale(reachBucket.startMs));
+            var reachX2 = Math.min(pad.left + plotW, xScale(reachBucket.endMs));
+            if (reachX2 <= reachX1) continue;
+            ctx.globalAlpha = reachBucket.state === 'unknown' ? 0.35 : 0.82;
+            ctx.fillStyle = reachabilityColors[reachBucket.state];
+            ctx.fillRect(reachX1, reachabilityLane.y, Math.max(1, reachX2 - reachX1), reachabilityLane.height);
+            ctx.globalAlpha = 0.7;
+            ctx.strokeStyle = gridColor;
+            ctx.lineWidth = 0.5;
+            ctx.strokeRect(reachX1, reachabilityLane.y, Math.max(1, reachX2 - reachX1), reachabilityLane.height);
+            if (reachX2 - reachX1 >= 18) {
+                ctx.globalAlpha = 0.95;
+                ctx.fillStyle = reachBucket.state === 'unknown' ? textColor : '#fff';
+                ctx.font = 'bold 9px system-ui, sans-serif';
+                ctx.textAlign = 'center';
+                var stateMark = reachBucket.state === 'ok' ? '\u2713' : reachBucket.state === 'degraded' ? '!' : reachBucket.state === 'down' ? '\u00d7' : '?';
+                ctx.fillText(stateMark, (reachX1 + reachX2) / 2, reachabilityLane.y + 12);
+            }
+        }
+        ctx.restore();
+    }
 
     // Grid lines
     ctx.strokeStyle = gridColor;
@@ -662,15 +880,32 @@ function renderCorrelationChart(data) {
         legendItems.push({ metric: 'segmentDs', color: segDsColor, label: '&#9644; ' + (T.seg_correlation_ds || 'Segment DS (%)') });
         legendItems.push({ metric: 'segmentUs', color: segUsColor, label: '&#9644; ' + (T.seg_correlation_us || 'Segment US (%)') });
     }
+    if (reachabilityBuckets.length > 0) {
+        legendItems.push({ metric: 'reachability', color: accentColor, label: '&#9646; ' + (T.correlation_reachability || 'Reachability') });
+    }
     legend.innerHTML = legendItems.map(function(item) {
-        var cls = _corrVisible[item.metric] ? '' : ' disabled';
+        var cls = _corrVisible[item.metric] ? '' : 'disabled';
         if (item.metric === 'events') {
             var filterBadge = item.visibleEventCount < item.totalEventCount ? ' <span style="font-size:0.7em;opacity:0.7;">(' + item.visibleEventCount + '/' + item.totalEventCount + ')</span>' : '';
-            return '<span data-metric="events" tabindex="0" role="button" class="' + cls + ' corr-legend-events" title="' + (T.correlation_toggle_hint || 'Click to toggle') + '" style="color:' + item.color + ';">' + item.label + filterBadge +
+            var eventCls = cls ? cls + ' corr-legend-events' : 'corr-legend-events';
+            return '<span data-metric="events" tabindex="0" role="button" class="' + eventCls + '" title="' + (T.correlation_toggle_hint || 'Click to toggle') + '" style="color:' + item.color + ';">' + item.label + filterBadge +
                 ' <span class="corr-event-filter-btn" title="' + (T.correlation_event_filter || 'Event Filter') + '">&#9881;</span></span>';
         }
         return '<span data-metric="' + item.metric + '" tabindex="0" role="button" class="' + cls + '" title="' + (T.correlation_toggle_hint || 'Click to toggle') + '" style="color:' + item.color + ';">' + item.label + '</span>';
     }).join('') + '<span data-metric="poorSignal" tabindex="0" role="button" class="corr-poor-signal-badge' + (_corrVisible.poorSignal ? '' : ' disabled') + '" title="' + (T.correlation_toggle_hint || 'Click to toggle') + '">' + (T.correlation_poor_signal || 'Poor Signal') + '</span>';
+
+    var overlayLabel = T.correlation_chart_aria_label || 'Signal correlation chart';
+    if (reachabilityBuckets.length > 0) {
+        var reachabilityCounts = { ok: 0, degraded: 0, down: 0, unknown: 0 };
+        reachabilityBuckets.forEach(function(bucket) { reachabilityCounts[bucket.state]++; });
+        overlayLabel += '. ' + (T.correlation_reachability_aria || 'Reachability summary') + ': '
+            + (T.correlation_reachability_ok || 'OK') + ' ' + reachabilityCounts.ok + ', '
+            + (T.correlation_reachability_degraded || 'Degraded') + ' ' + reachabilityCounts.degraded + ', '
+            + (T.correlation_reachability_down || 'Down') + ' ' + reachabilityCounts.down + ', '
+            + (T.correlation_reachability_unknown || 'Unknown') + ' ' + reachabilityCounts.unknown + '.';
+    }
+    overlay.setAttribute('aria-label', overlayLabel);
+    _corrSetOverlayActionable(overlay, !!(reachabilityLane && _corrVisible.reachability));
 
     // Event filter popover
     var filterBtn = legend.querySelector('.corr-event-filter-btn');
@@ -792,13 +1027,14 @@ function renderCorrelationChart(data) {
 
 function _corrResetZoom() {
     _corrZoom = null;
-    if (_correlationData && _correlationData.length > 0) {
+    if ((_correlationData && _correlationData.length > 0) || _corrTargetData.length > 0) {
         renderCorrelationChart(_correlationData);
     }
 }
 
 function _setupCorrelationTooltip(overlay, octx) {
     var tooltip = document.getElementById('correlation-tooltip');
+    var suppressNextClick = overlay._corrSuppressNextClick === true;
 
     // Remove old listeners by replacing the overlay node
     var newOverlay = overlay.cloneNode(true);
@@ -807,6 +1043,9 @@ function _setupCorrelationTooltip(overlay, octx) {
     var st = _corrChartState;
     if (!st) return;
     newOctx.setTransform(st.dpr, 0, 0, st.dpr, 0, 0);
+    if (suppressNextClick) {
+        setTimeout(function() { suppressNextClick = false; }, 0);
+    }
 
     // Drag-zoom state
     var dragStart = null; // mouseX where drag started
@@ -834,10 +1073,45 @@ function _setupCorrelationTooltip(overlay, octx) {
             var t2 = st.tMin + (x2 - st.pad.left) / st.plotW * (st.tMax - st.tMin);
             _corrZoom = { tMin: t1, tMax: t2 };
             dragStart = null;
+            // Carry suppression to the replacement overlay rendered below so
+            // the click synthesized for this drag cannot trigger drill-down.
+            suppressNextClick = true;
+            newOverlay._corrSuppressNextClick = true;
             renderCorrelationChart(st.data);
             return;
         }
         dragStart = null;
+    });
+
+    function openReachabilityDetail() {
+        if (!st.reachabilityLane || !_corrVisible.reachability) return;
+        if (typeof switchView !== 'function') return;
+        switchView('connection-monitor');
+        var detailView = document.getElementById('view-connection-monitor');
+        var detailTitle = document.querySelector('#cm-detail-view .view-page-title');
+        if (detailView && detailView.classList.contains('active') && detailTitle) detailTitle.focus();
+    }
+
+    newOverlay.addEventListener('click', function(e) {
+        if (suppressNextClick) {
+            suppressNextClick = false;
+            return;
+        }
+        if (!st.reachabilityLane || !_corrVisible.reachability) return;
+        var rect = newOverlay.getBoundingClientRect();
+        var mouseX = e.clientX - rect.left;
+        var mouseY = e.clientY - rect.top;
+        if (mouseX >= st.pad.left && mouseX <= st.pad.left + st.plotW
+                && mouseY >= st.reachabilityLane.y && mouseY <= st.reachabilityLane.y + st.reachabilityLane.height) {
+            openReachabilityDetail();
+        }
+    });
+
+    newOverlay.addEventListener('keydown', function(e) {
+        if ((e.key === 'Enter' || e.key === ' ') && st.reachabilityLane && _corrVisible.reachability) {
+            e.preventDefault();
+            openReachabilityDetail();
+        }
     });
 
     newOverlay.addEventListener('mousemove', function(e) {
@@ -863,8 +1137,11 @@ function _setupCorrelationTooltip(overlay, octx) {
             return;
         }
 
-        // Only interact within plot area
-        if (mouseX < st.pad.left || mouseX > st.pad.left + st.plotW || mouseY < st.pad.top || mouseY > st.pad.top + st.plotH) {
+        var inPlot = mouseY >= st.pad.top && mouseY <= st.pad.top + st.plotH;
+        var inReachabilityLane = st.reachabilityLane && _corrVisible.reachability
+            && mouseY >= st.reachabilityLane.y && mouseY <= st.reachabilityLane.y + st.reachabilityLane.height;
+        // Only interact within the shared time axis or the Reachability lane.
+        if (mouseX < st.pad.left || mouseX > st.pad.left + st.plotW || (!inPlot && !inReachabilityLane)) {
             newOctx.clearRect(0, 0, st.W, st.H);
             tooltip.style.display = 'none';
             return;
@@ -872,6 +1149,17 @@ function _setupCorrelationTooltip(overlay, octx) {
 
         // Convert mouseX to timestamp
         var tHover = st.tMin + (mouseX - st.pad.left) / st.plotW * (st.tMax - st.tMin);
+
+        var reachabilityBucket = null;
+        if (st.reachabilityBuckets && _corrVisible.reachability) {
+            for (var rbi = 0; rbi < st.reachabilityBuckets.length; rbi++) {
+                var candidateBucket = st.reachabilityBuckets[rbi];
+                if (tHover >= candidateBucket.startMs && (tHover < candidateBucket.endMs || (rbi === st.reachabilityBuckets.length - 1 && tHover === candidateBucket.endMs))) {
+                    reachabilityBucket = candidateBucket;
+                    break;
+                }
+            }
+        }
 
         // Find nearest modem point whenever any modem-derived series is visible.
         // Previously gated on SNR alone, which hid TX Power / DS Power / Errors from
@@ -1068,6 +1356,27 @@ function _setupCorrelationTooltip(overlay, octx) {
         }
         if (nearestWeather && _corrVisible.temperature && nearestWeather.temperature != null) {
             html += '<div class="tt-row"><span class="tt-dot" style="background:' + st.colors.temperature + ';"></span> ' + (T.temperature || 'Temperature') + ': ' + fmtTemp(nearestWeather.temperature) + '</div>';
+        }
+        if (reachabilityBucket) {
+            var stateLabels = {
+                ok: T.correlation_reachability_ok || 'OK',
+                degraded: T.correlation_reachability_degraded || 'Degraded',
+                down: T.correlation_reachability_down || 'Down',
+                unknown: T.correlation_reachability_unknown || 'Unknown'
+            };
+            html += '<div class="tt-row"><span class="tt-dot" style="background:' + st.colors.reachability[reachabilityBucket.state] + ';"></span> '
+                + (T.correlation_reachability || 'Reachability') + ' — '
+                + (T.correlation_reachability_state || 'State') + ': ' + stateLabels[reachabilityBucket.state] + '</div>';
+            html += '<div class="tt-row">' + (T.correlation_reachability_window || 'Window') + ': '
+                + escapeHtml(_corrFormatTimestamp(new Date(reachabilityBucket.startMs).toISOString())) + ' — '
+                + escapeHtml(_corrFormatTimestamp(new Date(reachabilityBucket.endMs).toISOString())) + '</div>';
+            html += '<div class="tt-row">' + (T.correlation_reachability_loss || 'Observed packet loss') + ': '
+                + (reachabilityBucket.lossPct == null ? '—' : reachabilityBucket.lossPct.toFixed(2) + '%') + '</div>';
+            html += '<div class="tt-row">' + (T.correlation_reachability_samples || 'Samples') + ': ' + reachabilityBucket.sampleCount + '</div>';
+            html += '<div class="tt-row">' + (T.correlation_reachability_targets || 'Observed targets') + ': ' + reachabilityBucket.targetsObserved + '</div>';
+            html += '<div class="tt-row">' + (T.correlation_reachability_scope || 'Target scope') + ': '
+                + (reachabilityBucket.targetScope ? escapeHtml(reachabilityBucket.targetScope) : '—') + '</div>';
+            html += '<div class="tt-row">' + (T.correlation_reachability_drilldown || 'Open Connection Monitor details') + '</div>';
         }
         // Segment utilization tooltip (numeric-only server data, same innerHTML pattern as above)
         if (st.segment && st.segment.length > 0) {
@@ -1343,21 +1652,52 @@ function _corrExportPNG() {
     link.click();
 }
 
+function _corrEncodeCSVCell(value) {
+    if (value == null || value === '') return '';
+    if (typeof value !== 'string') return value;
+
+    var firstMeaningful = value.search(/\S/);
+    var hasLeadingControlPrefix = /^[\s]*[\t\r]/.test(value);
+    if (hasLeadingControlPrefix
+            || (firstMeaningful !== -1 && '=+-@'.indexOf(value.charAt(firstMeaningful)) !== -1)) {
+        value = "'" + value;
+    }
+    if (/[",\r\n]/.test(value)) return '"' + value.replace(/"/g, '""') + '"';
+    return value;
+}
+
 function _corrExportCSV() {
-    if (!_correlationData || _correlationData.length === 0) return;
-    var headers = ['timestamp', 'source', 'health', 'ds_snr_min', 'ds_power_avg', 'us_power_avg', 'ds_uncorrectable_errors', 'download_mbps', 'upload_mbps', 'ping_ms', 'severity', 'message'];
-    var rows = [headers.join(',')];
+    var reachabilityBuckets = _corrChartState && _corrChartState.reachabilityBuckets ? _corrChartState.reachabilityBuckets : [];
+    if ((!_correlationData || _correlationData.length === 0) && reachabilityBuckets.length === 0) return;
+    var baseHeaders = ['timestamp', 'source', 'health', 'ds_snr_min', 'ds_power_avg', 'us_power_avg', 'ds_uncorrectable_errors', 'download_mbps', 'upload_mbps', 'ping_ms', 'severity', 'message'];
+    var reachabilityHeaders = ['state', 'packet_loss_pct', 'sample_count', 'bucket_start', 'bucket_end', 'target_scope'];
+    var headers = baseHeaders.concat(reachabilityHeaders);
+    var rows = [headers.map(_corrEncodeCSVCell).join(',')];
     for (var i = 0; i < _correlationData.length; i++) {
         var d = _correlationData[i];
         var row = headers.map(function(h) {
+            if (reachabilityHeaders.indexOf(h) !== -1) return '';
             var v = d[h];
-            if (v == null) return '';
-            if (typeof v === 'string' && (v.indexOf(',') !== -1 || v.indexOf('"') !== -1)) {
-                return '"' + v.replace(/"/g, '""') + '"';
-            }
-            return v;
+            return _corrEncodeCSVCell(v);
         });
         rows.push(row.join(','));
+    }
+    for (var ri = 0; ri < reachabilityBuckets.length; ri++) {
+        var bucket = reachabilityBuckets[ri];
+        var reachabilityRow = {
+            timestamp: new Date(bucket.startMs).toISOString(),
+            source: 'connection_monitor',
+            state: bucket.state,
+            packet_loss_pct: bucket.lossPct == null ? '' : Number(bucket.lossPct.toFixed(4)),
+            sample_count: bucket.sampleCount,
+            bucket_start: new Date(bucket.startMs).toISOString(),
+            bucket_end: new Date(bucket.endMs).toISOString(),
+            target_scope: bucket.targetScope || ''
+        };
+        rows.push(headers.map(function(h) {
+            var v = reachabilityRow[h];
+            return _corrEncodeCSVCell(v);
+        }).join(','));
     }
     var blob = new Blob([rows.join('\n')], { type: 'text/csv' });
     var link = document.createElement('a');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -42,6 +42,7 @@
     <script src="/static/vendor/lucide.min.js?v={{ version|urlencode }}"></script>
 </head>
 <body>
+{% set connection_monitor_installed = modules|selectattr('id', 'equalto', 'docsight.connection_monitor')|list %}
 <div id="offline-status-banner" class="offline-status-banner" role="status" aria-live="polite" hidden>
     <strong>Offline</strong>
     <span>Showing last-known dashboard shell in read-only mode. Live modem data and manual refresh are unavailable until DOCSight reconnects.</span>
@@ -112,7 +113,7 @@
         {% endif %}
         <!-- Secondary analysis views (collapsible) -->
         {% set analysis_items = [] %}
-        {% if speedtest_configured or bqm_configured %}{% if analysis_items.append('correlation') %}{% endif %}{% endif %}
+        {% if speedtest_configured or bqm_configured or connection_monitor_installed %}{% if analysis_items.append('correlation') %}{% endif %}{% endif %}
         {% if modules|selectattr('id', 'equalto', 'docsight.connection_monitor')|list %}{% if analysis_items.append('connection_monitor') %}{% endif %}{% endif %}
         {% if is_fritzbox and segment_utilization_enabled %}{% if analysis_items.append('segment') %}{% endif %}{% endif %}
         {% if modules|selectattr('id', 'equalto', 'docsight.comparison')|list %}{% if analysis_items.append('comparison') %}{% endif %}{% endif %}
@@ -125,7 +126,7 @@
                 <i data-lucide="chevron-down" class="nav-toggle-icon"></i>
             </div>
             <div class="nav-section-items">
-                {% if speedtest_configured or bqm_configured %}
+                {% if speedtest_configured or bqm_configured or connection_monitor_installed %}
                 <button class="nav-item" data-view="correlation" data-nav-icon="bar-chart-3" data-nav-title="{{ t.correlation_analysis }}">
                     <i data-lucide="bar-chart-3"></i> {{ t.correlation_analysis }}
                 </button>
@@ -1604,7 +1605,7 @@
 {% endif %}
 
 <!-- ═══ View: Correlation Analysis ═══ -->
-{% if speedtest_configured or bqm_configured %}
+{% if speedtest_configured or bqm_configured or connection_monitor_installed %}
 <div id="view-correlation" class="view">
     <div class="view-page-header">
         <div class="view-page-header-left">
@@ -1655,11 +1656,14 @@
             </div>
             <div class="correlation-chart-wrap">
                 <canvas id="correlation-chart"></canvas>
-                <canvas id="correlation-overlay" class="correlation-overlay" role="img" aria-label="{{ t.correlation_chart_aria_label }}" aria-describedby="correlation-speedtest-hint"></canvas>
+                <canvas id="correlation-overlay" class="correlation-overlay" role="img" tabindex="0" aria-label="{{ t.correlation_chart_aria_label }}" aria-describedby="correlation-speedtest-hint{% if connection_monitor_installed %} correlation-reachability-hint{% endif %}"></canvas>
                 <div class="correlation-tooltip" id="correlation-tooltip"></div>
                 <button type="button" class="correlation-zoom-reset" id="correlation-zoom-reset" style="display:none;" onclick="_corrResetZoom()">{{ t.chart_reset_zoom }}</button>
                 <div class="correlation-chart-legend" id="correlation-legend"></div>
                 <p class="correlation-speedtest-hint" id="correlation-speedtest-hint">{{ t.correlation_speedtest_hint }}</p>
+                {% if connection_monitor_installed %}
+                <p class="correlation-speedtest-hint" id="correlation-reachability-hint">{{ t.get('correlation_reachability_hint', 'Reachability buckets show observed Connection Monitor coverage; activate the chart to open Connection Monitor details.') }}</p>
+                {% endif %}
             </div>
         </div>
     </div>
@@ -2826,6 +2830,7 @@
 var T = {{ t|tojson }};
 var currentLang = {{ lang|tojson }};
 var TEMPERATURE_UNIT = {{ temperature_unit|tojson }};
+var CORRELATION_CM_AVAILABLE = {{ (connection_monitor_installed|length > 0)|tojson }};
 
 (function() {
     var LAST_KNOWN_STORAGE_KEY = 'docsight:last-known-dashboard-shell';

--- a/tests/e2e/test_correlation_ui.py
+++ b/tests/e2e/test_correlation_ui.py
@@ -1,7 +1,11 @@
 """Browser coverage for the correlation timeline UI."""
 
+import csv
+import io
+
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from playwright.sync_api import expect
 
 DESKTOP_VIEWPORT = {"width": 1440, "height": 1000}
@@ -125,7 +129,7 @@ def _sample_correlation_severity_edge_data():
 
 def _point_measurement_data():
     """Sparse Speedtests with modem and event evidence between the tests."""
-    base = datetime.now(timezone.utc).replace(microsecond=0)
+    base = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=8)
 
     def ts(hours):
         return (base + timedelta(hours=hours)).isoformat().replace("+00:00", "Z")
@@ -178,7 +182,7 @@ def _point_measurement_data():
 
 
 def _single_point_measurement_data():
-    base = datetime.now(timezone.utc).replace(microsecond=0)
+    base = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=8)
 
     def ts(hours):
         return (base + timedelta(hours=hours)).isoformat().replace("+00:00", "Z")
@@ -213,7 +217,7 @@ def _single_point_measurement_data():
 
 
 def _dense_point_measurement_data():
-    base = datetime.now(timezone.utc).replace(microsecond=0)
+    base = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=7)
 
     def ts(seconds):
         return (base + timedelta(seconds=seconds)).isoformat().replace("+00:00", "Z")
@@ -230,7 +234,7 @@ def _dense_point_measurement_data():
 
 
 def _partial_point_measurement_data():
-    base = datetime.now(timezone.utc).replace(microsecond=0)
+    base = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=3)
 
     def ts(hours):
         return (base + timedelta(hours=hours)).isoformat().replace("+00:00", "Z")
@@ -335,22 +339,61 @@ def _record_correlation_canvas_operations(page):
 
 
 def _route_correlation(page, payload=None):
-    page.route("**/api/correlation?**", lambda route: route.fulfill(json=payload or _sample_correlation_data()))
+    page.route("**/api/correlation?**", lambda route: route.fulfill(json=_sample_correlation_data() if payload is None else payload))
     page.route("**/api/weather/range?**", lambda route: route.fulfill(json=[]))
     page.route("**/api/fritzbox/segment-utilization/range?**", lambda route: route.fulfill(json=[]))
+    page.route("**/api/connection-monitor/targets", lambda route: route.fulfill(json=[]))
+    page.route(
+        "**/api/connection-monitor/samples/**",
+        lambda route: route.fulfill(
+            json={
+                "meta": {"resolution": "raw", "bucket_seconds": None, "blended": False, "mixed": False},
+                "samples": [],
+            }
+        ),
+    )
 
 
 def _route_sample_correlation(page):
     _route_correlation(page)
 
 
-def _open_correlation(page, viewport=DESKTOP_VIEWPORT):
+def _route_reachability(page, samples_by_target, targets=None, request_count=None):
+    targets = targets if targets is not None else [
+        {"id": target_id, "label": f"Target {target_id}", "enabled": True, "poll_interval_ms": 10000}
+        for target_id in sorted(samples_by_target)
+    ]
+
+    def targets_handler(route):
+        if request_count is not None:
+            request_count["targets"] = request_count.get("targets", 0) + 1
+        route.fulfill(json=targets)
+
+    def samples_handler(route):
+        target_id = int(route.request.url.split("/samples/", 1)[1].split("?", 1)[0])
+        if request_count is not None:
+            request_count["samples"] = request_count.get("samples", 0) + 1
+        route.fulfill(
+            json={
+                "meta": {"resolution": "raw", "bucket_seconds": None, "blended": False, "mixed": False},
+                "samples": samples_by_target.get(target_id, []),
+            }
+        )
+
+    page.unroute("**/api/connection-monitor/targets")
+    page.unroute("**/api/connection-monitor/samples/**")
+    page.route("**/api/connection-monitor/targets", targets_handler)
+    page.route("**/api/connection-monitor/samples/**", samples_handler)
+
+
+def _open_correlation(page, viewport=DESKTOP_VIEWPORT, expect_table=True):
     page.set_viewport_size(viewport)
     base_url = page.url.split("#", 1)[0].split("?", 1)[0].rstrip("/")
     page.goto(f"{base_url}/?lang=en#correlation", wait_until="networkidle")
     page.wait_for_selector("#view-correlation.active", state="visible")
     page.wait_for_selector("#correlation-chart-container", state="visible")
-    page.wait_for_selector("#correlation-table-card", state="visible")
+    if expect_table:
+        page.wait_for_selector("#correlation-table-card", state="visible")
 
 
 def _hover_correlation_timestamp(page, timestamp):
@@ -371,6 +414,524 @@ def _hover_correlation_timestamp(page, timestamp):
     tooltip = page.locator("#correlation-tooltip")
     expect(tooltip).to_be_visible()
     return tooltip
+
+
+def test_reachability_bucket_helper_uses_coverage_weighting_and_unknown_gaps(demo_page):
+    page = demo_page
+    result = page.evaluate(
+        """
+        () => window._corrBucketReachability([
+            {
+                target: { id: 1, label: 'Gateway', poll_interval_ms: 10000 },
+                samples: [
+                    { timestamp: 1000, bucket_seconds: null, packet_loss_pct: 100, sample_count: 1 },
+                    { timestamp: 1040, bucket_seconds: 20, packet_loss_pct: 0, sample_count: 3 },
+                ],
+            },
+            {
+                target: { id: 2, label: 'Resolver', poll_interval_ms: 20000 },
+                samples: [
+                    { timestamp: 1005, bucket_seconds: null, packet_loss_pct: 0, sample_count: 1 },
+                    { timestamp: 1040, bucket_seconds: 20, packet_loss_pct: 100, sample_count: 1 },
+                ],
+            },
+        ], 1000000, 1080000, 8)
+        """
+    )
+
+    assert len(result) == 8
+    assert [bucket["startMs"] for bucket in result] == list(range(1000000, 1080000, 10000))
+    # A failed target plus a healthy target is degraded, never down.
+    assert result[0]["state"] == "degraded"
+    assert result[0]["lossPct"] == 50
+    assert result[0]["sampleCount"] == 2
+    assert result[0]["targetsObserved"] == 2
+    # Offset coverage intersects both adjacent display buckets.
+    assert result[1]["state"] == "ok"
+    assert result[2]["state"] == "ok"
+    assert result[3]["state"] == "unknown"
+    # Aggregate sample_count weights loss: (0*3 + 100*1) / 4.
+    assert result[4]["state"] == "degraded"
+    assert result[4]["lossPct"] == 25
+    assert result[4]["sampleCount"] == 4
+    assert result[4]["targetsObserved"] == 2
+    assert result[5]["state"] == "degraded"
+    assert result[6]["state"] == "unknown"
+
+
+def test_reachability_bucket_helper_empty_never_ok_and_caps_long_ranges(demo_page):
+    page = demo_page
+    result = page.evaluate(
+        """
+        () => ({
+            empty: window._corrBucketReachability([], 0, 1000, 10),
+            long: window._corrBucketReachability([
+                {
+                    target: { id: 1, poll_interval_ms: 5000 },
+                    samples: [{ timestamp: 1700000000, bucket_seconds: 3600, packet_loss_pct: 100, sample_count: 720 }],
+                },
+            ], 1700000000000, 1707776000000, 1000),
+        })
+        """
+    )
+
+    assert len(result["empty"]) == 10
+    assert {bucket["state"] for bucket in result["empty"]} == {"unknown"}
+    assert len(result["long"]) == 300
+    assert result["long"][0]["startMs"] == 1700000000000
+    assert result["long"][-1]["endMs"] == 1707776000000
+
+
+def test_reachability_bucket_helper_classifies_all_four_states_and_all_target_down(demo_page):
+    page = demo_page
+    result = page.evaluate(
+        """
+        () => window._corrBucketReachability([
+            {
+                target: { id: 1, poll_interval_ms: 10000 },
+                samples: [
+                    { timestamp: 2000, packet_loss_pct: 0, sample_count: 1 },
+                    { timestamp: 2010, packet_loss_pct: 25, sample_count: 2 },
+                    { timestamp: 2020, packet_loss_pct: 100, sample_count: 1 },
+                ],
+            },
+            {
+                target: { id: 2, poll_interval_ms: 10000 },
+                samples: [
+                    { timestamp: 2020, packet_loss_pct: 100, sample_count: 3 },
+                ],
+            },
+        ], 2000000, 2040000, 4)
+        """
+    )
+
+    assert [bucket["state"] for bucket in result] == ["ok", "degraded", "down", "unknown"]
+    assert result[2]["lossPct"] == 100
+    assert result[2]["sampleCount"] == 4
+    assert result[2]["targetsObserved"] == 2
+
+
+@pytest.mark.parametrize("viewport", [DESKTOP_VIEWPORT, MOBILE_VIEWPORT])
+def test_correlation_renders_aligned_reachability_lane_and_legend(demo_page, viewport):
+    page = demo_page
+    page.set_viewport_size(viewport)
+    now = int(datetime.now(timezone.utc).timestamp())
+    _record_correlation_canvas_operations(page)
+    _route_correlation(page)
+    _route_reachability(
+        page,
+        {
+            1: [
+                {"timestamp": now - 2400, "bucket_seconds": 600, "packet_loss_pct": 0, "sample_count": 120},
+                {"timestamp": now - 1200, "bucket_seconds": 600, "packet_loss_pct": 100, "sample_count": 120},
+            ],
+            2: [
+                {"timestamp": now - 1200, "bucket_seconds": 600, "packet_loss_pct": 0, "sample_count": 120},
+            ],
+        },
+    )
+    _open_correlation(page, viewport)
+
+    state = page.evaluate(
+        """
+        () => ({
+            lane: window._corrChartState.reachabilityLane,
+            buckets: window._corrChartState.reachabilityBuckets,
+            height: document.querySelector('#correlation-chart').height / devicePixelRatio,
+            fills: window.__corrCanvasOps.filter((op) => op.kind === 'fillRect'),
+        })
+        """
+    )
+    assert state["lane"]
+    assert state["height"] == 306
+    assert len(state["buckets"]) <= 300
+    assert any(bucket["state"] == "ok" for bucket in state["buckets"])
+    assert any(bucket["state"] == "degraded" for bucket in state["buckets"])
+    assert any(bucket["state"] == "unknown" for bucket in state["buckets"])
+    assert any(abs(fill["args"][1] - state["lane"]["y"]) < 0.01 for fill in state["fills"])
+    expect(page.locator('#correlation-legend [data-metric="reachability"]')).to_be_visible()
+    described_by = page.locator("#correlation-overlay").get_attribute("aria-describedby").split()
+    assert "correlation-reachability-hint" in described_by
+
+
+def test_sparse_cm_only_chart_uses_complete_selected_range_with_unknown_edges(demo_page):
+    page = demo_page
+    _route_correlation(page)
+    _open_correlation(page)
+
+    result = page.evaluate(
+        """
+        () => {
+            const startMs = Date.UTC(2024, 0, 1, 0, 0, 0);
+            const endMs = startMs + 24 * 60 * 60 * 1000;
+            const sampleStartMs = startMs + 12 * 60 * 60 * 1000;
+            const sampleEndMs = sampleStartMs + 5 * 60 * 1000;
+            window._corrSelectedRange = { startMs, endMs };
+            window._corrTargetData = [{
+                target: { id: 1, label: 'Fixed healthy target', poll_interval_ms: 5000 },
+                samples: [{
+                    timestamp: sampleStartMs / 1000,
+                    bucket_seconds: 300,
+                    packet_loss_pct: 0,
+                    sample_count: 60,
+                }],
+            }];
+            window._correlationData = [];
+            window._corrZoom = null;
+            window.renderCorrelationChart([]);
+
+            const state = window._corrChartState;
+            const observedBuckets = state.reachabilityBuckets.filter(
+                (bucket) => bucket.startMs < sampleEndMs && bucket.endMs > sampleStartMs
+            );
+            const unknownCount = state.reachabilityBuckets.filter(
+                (bucket) => bucket.state === 'unknown'
+            ).length;
+            return {
+                startMs,
+                endMs,
+                tMin: state.tMin,
+                tMax: state.tMax,
+                tMinFull: state.tMinFull,
+                tMaxFull: state.tMaxFull,
+                firstState: state.reachabilityBuckets[0].state,
+                lastState: state.reachabilityBuckets[state.reachabilityBuckets.length - 1].state,
+                observedStates: observedBuckets.map((bucket) => bucket.state),
+                unknownCount,
+                ariaLabel: document.querySelector('#correlation-overlay').getAttribute('aria-label'),
+            };
+        }
+        """
+    )
+
+    assert result["tMin"] == result["tMinFull"] == result["startMs"]
+    assert result["tMax"] == result["tMaxFull"] == result["endMs"]
+    assert result["firstState"] == "unknown"
+    assert result["lastState"] == "unknown"
+    assert result["observedStates"]
+    assert set(result["observedStates"]) == {"ok"}
+    assert result["unknownCount"] > 0
+    assert f'Unknown {result["unknownCount"]}' in result["ariaLabel"]
+
+
+def test_reachability_legend_tooltip_and_mouse_keyboard_drilldown(demo_page):
+    page = demo_page
+    now = int(datetime.now(timezone.utc).timestamp())
+    _route_correlation(page)
+    _route_reachability(
+        page,
+        {1: [{"timestamp": now - 1800, "bucket_seconds": 900, "packet_loss_pct": 12.5, "sample_count": 18}]},
+        targets=[{"id": 1, "label": "Gateway", "enabled": True, "poll_interval_ms": 5000}],
+    )
+    _open_correlation(page)
+
+    overlay = page.locator("#correlation-overlay")
+    expect(overlay).to_have_attribute("role", "button")
+    expect(overlay).to_have_attribute("tabindex", "0")
+
+    legend = page.locator('#correlation-legend [data-metric="reachability"]')
+    legend.click()
+    expect(legend).to_have_class("disabled")
+    assert page.evaluate("() => window._corrVisible.reachability") is False
+    expect(overlay).to_have_attribute("role", "img")
+    assert overlay.get_attribute("tabindex") is None
+    legend.click()
+    assert page.evaluate("() => window._corrVisible.reachability") is True
+    expect(overlay).to_have_attribute("role", "button")
+    expect(overlay).to_have_attribute("tabindex", "0")
+
+    lane_point = page.evaluate(
+        """
+        () => {
+            const st = window._corrChartState;
+            const bucket = st.reachabilityBuckets.find((item) => item.sampleCount > 0);
+            return {
+                x: st.xScale((bucket.startMs + bucket.endMs) / 2),
+                y: st.reachabilityLane.y + st.reachabilityLane.height / 2,
+            };
+        }
+        """
+    )
+    box = overlay.bounding_box()
+    page.mouse.move(box["x"] + lane_point["x"], box["y"] + lane_point["y"])
+    tooltip = page.locator("#correlation-tooltip")
+    expect(tooltip).to_be_visible()
+    tooltip_text = tooltip.inner_text()
+    for expected in ("Reachability", "State", "Window", "Observed packet loss", "Samples", "Observed targets", "Target scope", "Gateway"):
+        assert expected in tooltip_text
+
+    overlay.focus()
+    overlay.press("Enter")
+    expect(page.locator("#view-connection-monitor.active")).to_be_visible()
+    destination_title = page.locator("#cm-detail-view .view-page-title")
+    expect(destination_title).to_have_attribute("tabindex", "-1")
+    expect(destination_title).to_be_focused()
+    page.evaluate("() => window.switchView('correlation')")
+    page.wait_for_selector("#view-correlation.active")
+    page.wait_for_selector("#correlation-chart-container", state="visible")
+    overlay.focus()
+    overlay.press("Space")
+    expect(page.locator("#view-connection-monitor.active")).to_be_visible()
+    expect(destination_title).to_be_focused()
+    page.evaluate("() => window.switchView('correlation')")
+    page.wait_for_selector("#view-correlation.active")
+    page.wait_for_selector("#correlation-chart-container", state="visible")
+    overlay = page.locator("#correlation-overlay")
+    box = overlay.bounding_box()
+    lane_point = page.evaluate(
+        "() => ({ x: window._corrChartState.pad.left + 2, y: window._corrChartState.reachabilityLane.y + 2 })"
+    )
+    page.mouse.click(box["x"] + lane_point["x"], box["y"] + lane_point["y"])
+    expect(page.locator("#view-connection-monitor.active")).to_be_visible()
+    expect(destination_title).to_be_focused()
+
+
+def test_correlation_zoom_rebuckets_loaded_samples_without_cm_refetch(demo_page):
+    page = demo_page
+    now = int(datetime.now(timezone.utc).timestamp())
+    request_count = {}
+    _route_correlation(page)
+    _route_reachability(
+        page,
+        {1: [{"timestamp": now - 3600, "bucket_seconds": 1800, "packet_loss_pct": 100, "sample_count": 360}]},
+        request_count=request_count,
+    )
+    _open_correlation(page)
+    initial_requests = dict(request_count)
+    result = page.evaluate(
+        """
+        () => {
+            const before = window._corrChartState.reachabilityBuckets;
+            const observed = before.find((bucket) => bucket.sampleCount > 0);
+            window._corrZoom = { tMin: observed.startMs, tMax: observed.endMs };
+            window.renderCorrelationChart(window._correlationData);
+            return {
+                beforeWidth: before[0].endMs - before[0].startMs,
+                afterWidth: window._corrChartState.reachabilityBuckets[0].endMs - window._corrChartState.reachabilityBuckets[0].startMs,
+            };
+        }
+        """
+    )
+    assert request_count == initial_requests
+    assert result["afterWidth"] < result["beforeWidth"]
+
+
+def test_drag_zoom_ending_in_reachability_lane_suppresses_drilldown(demo_page):
+    page = demo_page
+    now = int(datetime.now(timezone.utc).timestamp())
+    request_count = {}
+    _route_correlation(page)
+    _route_reachability(
+        page,
+        {1: [{"timestamp": now - 3600, "bucket_seconds": 1800, "packet_loss_pct": 25, "sample_count": 360}]},
+        request_count=request_count,
+    )
+    _open_correlation(page)
+    initial_requests = dict(request_count)
+    drag = page.evaluate(
+        """
+        () => {
+            const st = window._corrChartState;
+            return {
+                startX: st.pad.left + st.plotW * 0.2,
+                startY: st.pad.top + st.plotH / 2,
+                endX: st.pad.left + st.plotW * 0.7,
+                endY: st.reachabilityLane.y + st.reachabilityLane.height / 2,
+                initialSpan: st.tMax - st.tMin,
+            };
+        }
+        """
+    )
+    overlay = page.locator("#correlation-overlay")
+    box = overlay.bounding_box()
+    assert box is not None
+
+    page.mouse.move(box["x"] + drag["startX"], box["y"] + drag["startY"])
+    page.mouse.down()
+    page.mouse.move(box["x"] + drag["endX"], box["y"] + drag["endY"])
+    page.mouse.up()
+    page.wait_for_function("() => window._corrZoom !== null")
+
+    zoom_span = page.evaluate("() => window._corrZoom.tMax - window._corrZoom.tMin")
+    assert zoom_span < drag["initialSpan"]
+    expect(page.locator("#view-correlation.active")).to_be_visible()
+    expect(page.locator("#view-connection-monitor.active")).to_have_count(0)
+    assert request_count == initial_requests
+
+
+@pytest.mark.parametrize("mode", ["zero_targets", "no_samples", "samples_outside", "api_error"])
+def test_correlation_cm_empty_and_error_states_leave_base_chart_usable(demo_page, mode):
+    page = demo_page
+    console_errors = []
+    page.on("console", lambda message: console_errors.append(message.text) if message.type == "error" else None)
+    _route_correlation(page)
+    if mode == "zero_targets":
+        _route_reachability(page, {}, targets=[])
+    elif mode == "no_samples":
+        _route_reachability(page, {1: []})
+    elif mode == "samples_outside":
+        old_timestamp = int((datetime.now(timezone.utc) - timedelta(days=2)).timestamp())
+        _route_reachability(
+            page,
+            {1: [{"timestamp": old_timestamp, "bucket_seconds": 60, "packet_loss_pct": 0, "sample_count": 12}]},
+        )
+    else:
+        page.route("**/api/connection-monitor/targets", lambda route: route.fulfill(json=None))
+    _open_correlation(page)
+
+    expect(page.locator("#correlation-chart-container")).to_be_visible()
+    assert page.evaluate("() => window._corrChartState.reachabilityLane") is None
+    assert page.locator('#correlation-legend [data-metric="reachability"]').count() == 0
+    overlay = page.locator("#correlation-overlay")
+    expect(overlay).to_have_attribute("role", "img")
+    assert overlay.get_attribute("tabindex") is None
+    expected_state = {
+        "zero_targets": "targets_absent",
+        "no_samples": "no_samples",
+        "samples_outside": "samples_outside_range",
+        "api_error": "fetch_error",
+    }[mode]
+    assert page.evaluate("() => window._corrCmState") == expected_state
+    assert console_errors == []
+
+
+def test_cm_only_correlation_remains_available_with_paused_collector_history(demo_page):
+    page = demo_page
+    now = int(datetime.now(timezone.utc).timestamp())
+    _route_correlation(page, payload=[])
+    _route_reachability(
+        page,
+        {1: [{"timestamp": now - 600, "bucket_seconds": 300, "packet_loss_pct": 0, "sample_count": 60}]},
+        targets=[{"id": 1, "label": "Historical target", "enabled": True, "poll_interval_ms": 5000}],
+    )
+    _open_correlation(page, expect_table=False)
+
+    expect(page.locator('.nav-item[data-view="correlation"]')).to_be_attached()
+    expect(page.locator("#correlation-chart-container")).to_be_visible()
+    expect(page.locator('#correlation-legend [data-metric="reachability"]')).to_be_visible()
+    expect(page.locator("#correlation-table-card")).to_be_hidden()
+    assert page.evaluate("() => window._corrCmState") == "ready"
+
+
+def test_correlation_fetches_samples_only_for_enabled_targets(demo_page):
+    page = demo_page
+    now = int(datetime.now(timezone.utc).timestamp())
+    fetched_target_ids = []
+    _route_correlation(page)
+    targets = [
+        {"id": 1, "label": "Enabled history", "enabled": True, "poll_interval_ms": 5000},
+        {"id": 2, "label": "Disabled target", "enabled": False, "poll_interval_ms": 5000},
+    ]
+    page.route("**/api/connection-monitor/targets", lambda route: route.fulfill(json=targets))
+
+    def sample_handler(route):
+        target_id = int(route.request.url.split("/samples/", 1)[1].split("?", 1)[0])
+        fetched_target_ids.append(target_id)
+        route.fulfill(
+            json={
+                "meta": {"resolution": "raw", "bucket_seconds": None},
+                "samples": [{"timestamp": now - 300, "bucket_seconds": 60, "packet_loss_pct": 0, "sample_count": 12}],
+            }
+        )
+
+    page.route("**/api/connection-monitor/samples/**", sample_handler)
+    _open_correlation(page)
+
+    assert fetched_target_ids
+    assert set(fetched_target_ids) == {1}
+
+
+def test_module_absent_gate_makes_no_connection_monitor_requests(demo_page):
+    page = demo_page
+    _route_correlation(page)
+    request_count = {}
+    _route_reachability(page, {}, targets=[], request_count=request_count)
+    _open_correlation(page)
+    request_count.clear()
+    page.evaluate(
+        """
+        () => {
+            window.CORRELATION_CM_AVAILABLE = false;
+            window.loadCorrelationData();
+        }
+        """
+    )
+    page.wait_for_function("() => document.querySelector('#correlation-loading').style.display === 'none'")
+    assert request_count == {}
+    assert page.evaluate("() => window._corrCmState") == "module_absent"
+
+
+def test_reachability_csv_contract_and_png_composition(demo_page):
+    page = demo_page
+    now = int(datetime.now(timezone.utc).timestamp())
+    page.add_init_script(
+        """
+        (() => {
+            window.__corrExport = { drawSources: [], legendText: [], csv: null };
+            const drawImage = CanvasRenderingContext2D.prototype.drawImage;
+            CanvasRenderingContext2D.prototype.drawImage = function(source, ...args) {
+                if (source && source.id) window.__corrExport.drawSources.push(source.id);
+                return drawImage.call(this, source, ...args);
+            };
+            const fillText = CanvasRenderingContext2D.prototype.fillText;
+            CanvasRenderingContext2D.prototype.fillText = function(value, ...args) {
+                if (!this.canvas.id) window.__corrExport.legendText.push(String(value));
+                return fillText.call(this, value, ...args);
+            };
+            const createObjectURL = URL.createObjectURL.bind(URL);
+            URL.createObjectURL = function(blob) {
+                blob.text().then((text) => { window.__corrExport.csv = text; });
+                return createObjectURL(blob);
+            };
+            HTMLAnchorElement.prototype.click = function() {};
+        })();
+        """
+    )
+    payload = _single_point_measurement_data()
+    _route_correlation(page, payload)
+    malicious_label = '  =HYPERLINK("https://evil.invalid","click")'
+    _route_reachability(
+        page,
+        {1: [{"timestamp": now - 900, "bucket_seconds": 300, "packet_loss_pct": 25, "sample_count": 60}]},
+        targets=[{"id": 1, "label": malicious_label, "enabled": True, "poll_interval_ms": 5000}],
+    )
+    _open_correlation(page)
+    page.evaluate("() => { window._corrExportPNG(); window._corrExportCSV(); }")
+    page.wait_for_function("() => window.__corrExport.csv !== null")
+    exported = page.evaluate("() => window.__corrExport")
+
+    assert "correlation-chart" in exported["drawSources"]
+    assert "correlation-overlay" in exported["drawSources"]
+    assert any("Reachability" in text for text in exported["legendText"])
+    lines = exported["csv"].splitlines()
+    assert lines[0].split(",") == [
+        "timestamp", "source", "health", "ds_snr_min", "ds_power_avg", "us_power_avg",
+        "ds_uncorrectable_errors", "download_mbps", "upload_mbps", "ping_ms", "severity", "message",
+        "state", "packet_loss_pct", "sample_count", "bucket_start", "bucket_end", "target_scope",
+    ]
+    speed_row = next(line for line in lines[1:] if ",speedtest," in line)
+    assert speed_row.split(",")[-6:] == ["", "", "", "", "", ""]
+    cm_rows = [line for line in lines[1:] if ",connection_monitor," in line]
+    assert cm_rows
+    assert any(",degraded,25,60," in line for line in cm_rows)
+    parsed_rows = list(csv.DictReader(io.StringIO(exported["csv"])))
+    target_scopes = [row["target_scope"] for row in parsed_rows if row["source"] == "connection_monitor"]
+    assert "'" + malicious_label in target_scopes
+    assert malicious_label not in target_scopes
+
+
+def test_localized_reachability_aria_summary(demo_page):
+    page = demo_page
+    now = int(datetime.now(timezone.utc).timestamp())
+    _route_correlation(page)
+    _route_reachability(page, {1: [{"timestamp": now - 600, "bucket_seconds": 300, "packet_loss_pct": 0, "sample_count": 60}]})
+    base_url = page.url.split("#", 1)[0].split("?", 1)[0].rstrip("/")
+    page.goto(f"{base_url}/?lang=de#correlation", wait_until="networkidle")
+    page.wait_for_selector("#correlation-chart-container", state="visible")
+    aria_label = page.locator("#correlation-overlay").get_attribute("aria-label")
+    assert "Erreichbarkeit" in aria_label
+    assert "Zusammenfassung" in aria_label
+    assert "Reachability summary" not in aria_label
 
 
 def test_correlation_renders_sparse_speedtests_as_unconnected_point_measurements(demo_page):
@@ -527,7 +1088,8 @@ def test_correlation_speedtest_help_accessibility_and_tooltip_details(demo_page)
     expect(help_text).to_contain_text("individual measurements")
     expect(help_text).to_contain_text("between tests")
     overlay = page.locator("#correlation-overlay")
-    expect(overlay).to_have_attribute("aria-describedby", "correlation-speedtest-hint")
+    described_by = overlay.get_attribute("aria-describedby").split()
+    assert "correlation-speedtest-hint" in described_by
     aria_label = overlay.get_attribute("aria-label")
     assert aria_label
     assert "chart" in aria_label.lower()

--- a/tests/modules/connection_monitor/test_routes.py
+++ b/tests/modules/connection_monitor/test_routes.py
@@ -181,6 +181,7 @@ class TestSamplesResolution:
         assert "packet_loss_pct" in s
         assert "sample_count" in s
         assert s["sample_count"] == 1
+        assert s["bucket_seconds"] is None
         assert s["min_latency_ms"] is None
         assert s["max_latency_ms"] is None
         assert s["p95_latency_ms"] is None
@@ -200,8 +201,14 @@ class TestSamplesResolution:
         assert s["packet_loss_pct"] == 100.0
         assert s["latency_ms"] is None
 
-    def test_forced_resolution(self, client):
-        """Explicit resolution param should force that tier."""
+    @pytest.mark.parametrize(
+        ("resolution", "bucket_seconds"),
+        (("1min", 60), ("5min", 300), ("1hr", 3600)),
+    )
+    def test_forced_resolution_reports_per_sample_tier_width(
+        self, client, resolution, bucket_seconds
+    ):
+        """Explicit aggregate tiers expose the row's coverage on every sample."""
         c, storage = client
         tid = storage.create_target("Test", "1.1.1.1")
         now = time.time()
@@ -211,15 +218,18 @@ class TestSamplesResolution:
                    (target_id, bucket_start, bucket_seconds,
                     avg_latency_ms, min_latency_ms, max_latency_ms,
                     p95_latency_ms, packet_loss_pct, sample_count)
-                   VALUES (?, ?, 60, 15.0, 10.0, 20.0, 18.0, 0.0, 12)""",
-                (tid, now - 500),
+                   VALUES (?, ?, ?, 15.0, 10.0, 20.0, 18.0, 0.0, 12)""",
+                (tid, now - 500, bucket_seconds),
             )
-        resp = c.get(f"/api/connection-monitor/samples/{tid}?resolution=1min&start={now - 600}&end={now}")
+        resp = c.get(
+            f"/api/connection-monitor/samples/{tid}?resolution={resolution}&start={now - 600}&end={now}"
+        )
         data = resp.get_json()
-        assert data["meta"]["resolution"] == "1min"
-        assert data["meta"]["bucket_seconds"] == 60
+        assert data["meta"]["resolution"] == resolution
+        assert data["meta"]["bucket_seconds"] == bucket_seconds
         assert len(data["samples"]) == 1
         s = data["samples"][0]
+        assert s["bucket_seconds"] == bucket_seconds
         assert s["min_latency_ms"] == 10.0
         assert s["max_latency_ms"] == 20.0
         assert s["sample_count"] == 12
@@ -252,6 +262,7 @@ class TestSamplesResolution:
         assert data["samples"][0]["timestamp"] < data["samples"][1]["timestamp"]
         assert data["samples"][0]["min_latency_ms"] is not None
         assert data["samples"][1]["min_latency_ms"] is None
+        assert [sample["bucket_seconds"] for sample in data["samples"]] == [60, None]
 
     def test_auto_90d_range_keeps_recent_raw_data(self, client):
         """A 90d range should still show current raw data even before older buckets exist."""
@@ -307,6 +318,7 @@ class TestSamplesResolution:
         assert data["samples"][0]["min_latency_ms"] is not None
         assert data["samples"][1]["min_latency_ms"] is not None
         assert data["samples"][2]["min_latency_ms"] is None
+        assert [sample["bucket_seconds"] for sample in data["samples"]] == [300, 60, None]
 
     def test_auto_without_explicit_range_stays_raw_only(self, client):
         """Without start/end, auto resolution should keep the legacy raw-only behavior."""
@@ -404,6 +416,7 @@ class TestSamplesResolution:
         assert "sample_count" in data["samples"][0]
         assert "packet_loss_pct" in data["samples"][0]
         assert sum(sample["sample_count"] for sample in data["samples"]) == 120
+        assert {sample["bucket_seconds"] for sample in data["samples"]} == {12}
 
 
 class TestPinnedDaysAPI:


### PR DESCRIPTION
## Summary
- add `bucket_seconds` sample-coverage metadata to the existing Connection Monitor samples response
- render Connection Monitor reachability as a separate `ok` / `degraded` / `down` / `unknown` lane without treating missing observations as healthy
- support zoom, tooltips, Connection Monitor drilldown, PNG/CSV export, responsive layouts, localization, and keyboard/screen-reader semantics
- keep speed tests as discrete observations and avoid causal or provider-responsibility claims

## Checks
- 36 focused Correlation and Connection Monitor Playwright tests
- 2,921 non-E2E tests passed; 11 skipped
- desktop and mobile visual captures with no console or page errors
- `node --check app/static/js/correlation.js`
- `git diff --check`