### PR TITLE
Align OFDM event and report thresholds

### DIFF
--- a/app/event_detector.py
+++ b/app/event_detector.py
@@ -264,7 +264,9 @@ class EventDetector:
             return
 
         health_affected = self._snr_affected_channels_by_health(cur_analysis, prev_analysis)
-        if health_affected:
+        if health_affected is not None:
+            if not health_affected:
+                return
             worst = max(
                 health_affected,
                 key=lambda channel: {"good": 0, "tolerated": 1, "warning": 2, "critical": 3}.get(channel.get("current_health"), 0),
@@ -329,8 +331,9 @@ class EventDetector:
 
     @staticmethod
     def _snr_affected_channels_by_health(cur_analysis, prev_analysis):
-        """Identify SNR/MER health degradations from analyzer channel metadata."""
+        """Return analyzer health degradations, or ``None`` for legacy data."""
         health_rank = {"missing": -1, "good": 0, "tolerated": 1, "warning": 2, "critical": 3}
+        analyzer_families = {"sc_qam", "ofdm"}
         prev_channels = {}
         for ch in prev_analysis.get("ds_channels", []):
             key = _normalize_channel_id(ch.get("channel_id"))
@@ -338,6 +341,7 @@ class EventDetector:
                 prev_channels[key] = ch
 
         affected = []
+        found_comparable = False
         for cur_ch in cur_analysis.get("ds_channels", []):
             key = _normalize_channel_id(cur_ch.get("channel_id"))
             if key is None:
@@ -345,17 +349,24 @@ class EventDetector:
             prev_ch = prev_channels.get(key)
             if not prev_ch:
                 continue
+            prev_snr = _coerce_float(prev_ch.get("snr"))
+            cur_snr = _coerce_float(cur_ch.get("snr"))
+            if prev_snr is None or cur_snr is None:
+                continue
+            found_comparable = True
             prev_health = prev_ch.get("snr_health")
             cur_health = cur_ch.get("snr_health")
+            if not prev_health and prev_ch.get("channel_family") in analyzer_families:
+                prev_health = "good"
+            if not cur_health and cur_ch.get("channel_family") in analyzer_families:
+                cur_health = "good"
             if not prev_health or not cur_health:
-                continue
+                return None
             if health_rank.get(cur_health, 0) <= health_rank.get(prev_health, 0):
                 continue
             if health_rank.get(cur_health, 0) <= health_rank.get("good", 0):
                 continue
-            prev_snr = _coerce_float(prev_ch.get("snr"))
-            cur_snr = _coerce_float(cur_ch.get("snr"))
-            delta = None if prev_snr is None or cur_snr is None else round(cur_snr - prev_snr, 1)
+            delta = round(cur_snr - prev_snr, 1)
             affected.append({
                 "channel": cur_ch.get("channel_id"),
                 "frequency": cur_ch.get("frequency") or prev_ch.get("frequency") or "",
@@ -364,13 +375,13 @@ class EventDetector:
                 "modulation": cur_ch.get("modulation") or prev_ch.get("modulation") or "",
                 "prev": prev_snr,
                 "current": cur_snr,
-                "delta": None if delta is None else (0.0 if delta == -0.0 else delta),
+                "delta": 0.0 if delta == -0.0 else delta,
                 "prev_health": prev_health,
                 "current_health": cur_health,
                 "threshold": cur_health,
             })
         affected.sort(key=lambda ch: ({"critical": 0, "warning": 1, "tolerated": 2}.get(ch.get("current_health"), 3), ch.get("current") is None, ch.get("current") or 0, str(ch.get("channel"))))
-        return affected
+        return affected if found_comparable else None
 
     @staticmethod
     def _snr_affected_channels(cur_analysis, prev_analysis, thresholds):

--- a/app/modules/reports/report.py
+++ b/app/modules/reports/report.py
@@ -8,11 +8,10 @@ from datetime import datetime
 
 from fpdf import FPDF
 
-from app.analyzer import get_thresholds
+from app.analyzer import _get_ds_power_thresholds, _get_snr_thresholds, get_thresholds
 from app.docsis_utils import (
     channel_type_label as _channel_type_label,
     classify_channel_family as _classify_channel_family,
-    modulation_threshold_key as _modulation_threshold_key,
 )
 
 log = logging.getLogger("docsis.report")
@@ -82,7 +81,7 @@ def _format_threshold_table():
     return rows
 
 
-def _default_warn_thresholds():
+def _default_warn_thresholds(ds_snr_warn_min=None):
     """Get default warning thresholds as display strings for report."""
     t = get_thresholds()
     ds = t.get("downstream_power", {}).get("256QAM", {})
@@ -93,7 +92,7 @@ def _default_warn_thresholds():
     return {
         "ds_power": f"{ds_w[0]} to {ds_w[1]} dBmV",
         "us_power": f"{us_w[0]} to {us_w[1]} dBmV",
-        "snr": f">= {snr.get('warning_min', 31.0)} dB",
+        "snr": f">= {ds_snr_warn_min if ds_snr_warn_min is not None else snr.get('warning_min', 31.0)} dB",
     }
 
 
@@ -109,8 +108,6 @@ def _build_diagnostic_notes(current_analysis):
     notes = []
     t = get_thresholds()
     us_thresholds = t.get("upstream_power", {})
-    ds_thresholds = t.get("downstream_power", {})
-    snr_thresholds = t.get("snr", {})
 
     def metric_allows_note(ch, metric_key):
         health = ch.get(metric_key)
@@ -154,42 +151,40 @@ def _build_diagnostic_notes(current_analysis):
 
     for ch in current_analysis.get("ds_channels", []):
         mod = (ch.get("modulation") or "256QAM").upper()
-        lookup = _modulation_threshold_key(mod, ds_thresholds)
+        family = ch.get("channel_family") or _classify_channel_family("ds", ch)
         channel_label = _channel_type_label("ds", ch) or mod
         power = ch.get("power")
         if power is not None and metric_allows_note(ch, "power_health"):
-            spec = ds_thresholds.get(lookup, ds_thresholds.get("256QAM", {}))
-            crit = spec.get("critical", [-8.0, 20.0])
-            if power > crit[1]:
-                deviation = round((power - crit[1]) / max(abs(crit[1]), 1) * 100)
+            spec = _get_ds_power_thresholds(mod, channel_family=family)
+            if power > spec["crit_max"]:
+                deviation = round((power - spec["crit_max"]) / max(abs(spec["crit_max"]), 1) * 100)
                 notes.append({
                     "type": "ds_power_high",
                     "channel_id": ch.get("channel_id", "?"),
                     "channel_type": channel_label,
                     "metric": "downstream power",
                     "value": power,
-                    "spec_max": crit[1],
+                    "spec_max": spec["crit_max"],
                     "deviation_pct": deviation,
                     "severity": "extreme" if deviation > 50 else "critical",
                 })
-            elif power < crit[0]:
-                deviation = round((crit[0] - power) / max(abs(crit[0]), 1) * 100)
+            elif power < spec["crit_min"]:
+                deviation = round((spec["crit_min"] - power) / max(abs(spec["crit_min"]), 1) * 100)
                 notes.append({
                     "type": "ds_power_low",
                     "channel_id": ch.get("channel_id", "?"),
                     "channel_type": channel_label,
                     "metric": "downstream power",
                     "value": power,
-                    "spec_min": crit[0],
+                    "spec_min": spec["crit_min"],
                     "deviation_pct": deviation,
                     "severity": "extreme" if deviation > 50 else "critical",
                 })
 
         snr = ch.get("snr")
         if snr is not None and metric_allows_note(ch, "snr_health"):
-            snr_lookup = _modulation_threshold_key(mod, snr_thresholds)
-            snr_spec = snr_thresholds.get(snr_lookup, snr_thresholds.get("256QAM", {}))
-            snr_crit = snr_spec.get("critical_min", 29.0)
+            snr_spec = _get_snr_thresholds(mod, channel_family=family)
+            snr_crit = snr_spec["crit_min"]
             if snr < snr_crit:
                 deviation = round((snr_crit - snr) / max(snr_crit, 1) * 100)
                 notes.append({
@@ -385,6 +380,7 @@ def _compute_worst_values(snapshots):
         "ds_power_min": 0,
         "us_power_max": 0,
         "ds_snr_min": 999,
+        "ds_snr_warn_min": None,
         "ds_uncorrectable_max": None,
         "ds_correctable_max": None,
         "health_critical_count": 0,
@@ -400,8 +396,27 @@ def _compute_worst_values(snapshots):
             worst["ds_power_min"] = s.get("ds_power_min", 0)
         if s.get("us_power_max", 0) > worst["us_power_max"]:
             worst["us_power_max"] = s.get("us_power_max", 0)
-        if s.get("ds_snr_min", 999) < worst["ds_snr_min"]:
-            worst["ds_snr_min"] = s.get("ds_snr_min", 999)
+        ds_snr_min = s.get("ds_snr_min", 999)
+        if ds_snr_min < worst["ds_snr_min"]:
+            worst["ds_snr_min"] = ds_snr_min
+            worst["ds_snr_warn_min"] = None
+        if ds_snr_min == worst["ds_snr_min"] and worst["ds_snr_warn_min"] is None:
+            try:
+                target_snr = float(ds_snr_min)
+            except (TypeError, ValueError):
+                target_snr = None
+            if target_snr is not None:
+                for ch in snap.get("ds_channels") or []:
+                    try:
+                        channel_snr = float(ch.get("snr"))
+                    except (TypeError, ValueError):
+                        continue
+                    if channel_snr != target_snr:
+                        continue
+                    family = ch.get("channel_family") or _classify_channel_family("ds", ch)
+                    snr_spec = _get_snr_thresholds(ch.get("modulation"), channel_family=family)
+                    worst["ds_snr_warn_min"] = snr_spec["warn_min"]
+                    break
         errors_supported = s.get("errors_supported", True)
         uncorr_errors = s.get("ds_uncorrectable_errors") if errors_supported else None
         corr_errors = s.get("ds_correctable_errors") if errors_supported else None
@@ -698,7 +713,7 @@ def generate_report(
         pdf.cell(0, 6, s["worst_recorded"], new_x="LMARGIN", new_y="NEXT")
         pdf.set_font("dejavu", "", 10)
 
-        warn = _default_warn_thresholds()
+        warn = _default_warn_thresholds(worst["ds_snr_warn_min"])
         pdf._key_value(s["ds_power_worst"], f"{worst['ds_power_max']} dBmV (threshold: {warn['ds_power']})")
         pdf._key_value(s["us_power_worst"], f"{worst['us_power_max']} dBmV (threshold: {warn['us_power']})")
         pdf._key_value(s["ds_snr_worst"], f"{worst['ds_snr_min']} dB (threshold: {warn['snr']})")
@@ -749,7 +764,7 @@ def generate_report(
 
     if snapshots:
         worst = _compute_worst_values(snapshots)
-        warn = _default_warn_thresholds()
+        warn = _default_warn_thresholds(worst["ds_snr_warn_min"])
         start = snapshots[0]["timestamp"][:10]
         end = snapshots[-1]["timestamp"][:10]
         poor_pct = round(worst['health_critical_count'] / max(worst['total_snapshots'], 1) * 100)
@@ -881,7 +896,7 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
         pdf.cell(0, 6, s["worst_recorded"], new_x="LMARGIN", new_y="NEXT")
         pdf.set_font("dejavu", "", 10)
 
-        warn = _default_warn_thresholds()
+        warn = _default_warn_thresholds(worst["ds_snr_warn_min"])
         pdf._key_value(s["ds_power_worst"], f"{worst['ds_power_max']} dBmV (threshold: {warn['ds_power']})")
         pdf._key_value(s["us_power_worst"], f"{worst['us_power_max']} dBmV (threshold: {warn['us_power']})")
         pdf._key_value(s["ds_snr_worst"], f"{worst['ds_snr_min']} dB (threshold: {warn['snr']})")
@@ -1042,7 +1057,7 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
 
     if snapshots:
         worst = _compute_worst_values(snapshots)
-        warn = _default_warn_thresholds()
+        warn = _default_warn_thresholds(worst["ds_snr_warn_min"])
         start = snapshots[0]["timestamp"][:10]
         end = snapshots[-1]["timestamp"][:10]
         poor_pct = round(worst['health_critical_count'] / max(worst['total_snapshots'], 1) * 100)
@@ -1184,7 +1199,7 @@ def generate_complaint_text(snapshots, config=None, connection_info=None, lang="
 
     if snapshots:
         worst = _compute_worst_values(snapshots)
-        warn = _default_warn_thresholds()
+        warn = _default_warn_thresholds(worst["ds_snr_warn_min"])
         start = snapshots[0]["timestamp"][:10]
         end = snapshots[-1]["timestamp"][:10]
         poor_pct = round(worst['health_critical_count'] / max(worst['total_snapshots'], 1) * 100)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from app.storage import SnapshotStorage
+from app.analyzer import analyze
 from app.event_detector import EventDetector
 from app.web import app, init_config, init_storage
 from app.config import ConfigManager
@@ -39,6 +40,23 @@ def events_client(tmp_path, storage):
 @pytest.fixture
 def detector():
     return EventDetector()
+
+
+def _analyze_ofdm(mer):
+    return analyze({
+        "docsis": "3.1",
+        "downstream": [{
+            "channelID": 1,
+            "frequency": "602 MHz",
+            "powerLevel": "-8.2",
+            "type": "OFDM",
+            "modulation": "4096QAM",
+            "mer": str(mer),
+            "corrErrors": 0,
+            "nonCorrErrors": 0,
+        }],
+        "upstream": [],
+    })
 
 
 def _make_analysis(health="good", ds_power_avg=2.5, us_power_avg=42.0,
@@ -445,6 +463,7 @@ class TestEventDetector:
         snr_events = [e for e in events if e["event_type"] == "snr_change"]
         assert len(snr_events) == 1
         assert snr_events[0]["severity"] == "warning"
+        assert snr_events[0]["details"]["threshold_value"] == 33.0
 
     def test_snr_drop_warning_includes_affected_channel_details(self, detector):
         prev_channels = [
@@ -1604,6 +1623,40 @@ def test_snr_change_uses_analyzer_channel_health_when_available(detector):
     affected = snr_events[0]["details"]["affected_channels"][0]
     assert affected["current_health"] == "critical"
     assert affected["channel_type"] == "OFDM"
+
+
+def test_ofdm_good_mer_change_does_not_emit_snr_change(detector):
+    previous = _analyze_ofdm(33.0)
+    current = _analyze_ofdm(32.0)
+    assert previous["ds_channels"][0]["health"] == "good"
+    assert current["ds_channels"][0]["health"] == "good"
+    assert previous["summary"]["signal_families"]["downstream"]["families"]["ofdm"]["mer"]["health"] == "good"
+    assert current["summary"]["signal_families"]["downstream"]["families"]["ofdm"]["mer"]["health"] == "good"
+
+    detector.check(previous)
+    events = detector.check(current)
+
+    assert [event for event in events if event["event_type"] == "snr_change"] == []
+
+
+def test_ofdm_analyzer_health_transition_emits_snr_change(detector):
+    previous = _analyze_ofdm(27.0)
+    current = _analyze_ofdm(26.5)
+    previous_channel = previous["ds_channels"][0]
+    current_channel = current["ds_channels"][0]
+    assert "snr_health" not in previous_channel
+    assert current_channel["snr_health"] == "tolerated"
+
+    detector.check(previous)
+    events = detector.check(current)
+
+    snr_events = [event for event in events if event["event_type"] == "snr_change"]
+    assert len(snr_events) == 1
+    assert snr_events[0]["details"]["threshold"] == "tolerated"
+    assert "threshold_value" not in snr_events[0]["details"]
+    affected = snr_events[0]["details"]["affected_channels"]
+    assert affected[0]["prev_health"] == "good"
+    assert affected[0]["current_health"] == "tolerated"
 
 
 def test_modulation_change_includes_analyzer_modulation_health(detector):

--- a/tests/web/test_reports.py
+++ b/tests/web/test_reports.py
@@ -1,7 +1,26 @@
 """Tests for report/comparison helpers exposed through web routes."""
 
 from unittest.mock import Mock, patch
+from app.analyzer import analyze
 from app.web import app
+
+
+def _analyze_downstream_channel(*, docsis, power, quality, modulation, channel_type):
+    channel = {
+        "channelID": 1,
+        "frequency": "602 MHz",
+        "powerLevel": str(power),
+        "type": channel_type,
+        "modulation": modulation,
+        "corrErrors": 0,
+        "nonCorrErrors": 0,
+    }
+    channel["mer" if docsis == "3.1" else "mse"] = str(quality)
+    return analyze({
+        "docsis": docsis,
+        "downstream": [channel],
+        "upstream": [],
+    })
 
 
 class TestReportHelpers:
@@ -100,6 +119,174 @@ class TestReportHelpers:
 
         assert [note["type"] for note in notes] == ["us_power_high"]
         assert notes[0]["channel_type"] == "OFDMA"
+
+    def test_ofdm_good_analyzer_metric_health_produces_no_diagnostic_note(self):
+        from app.modules.reports.report import _build_diagnostic_notes
+
+        analysis = _analyze_downstream_channel(
+            docsis="3.1",
+            power=-8.2,
+            quality=33.0,
+            modulation="4096QAM",
+            channel_type="OFDM",
+        )
+        channel = analysis["ds_channels"][0]
+        channel["power_health"] = "good"
+        channel["snr_health"] = "good"
+        assert channel["power_health"] == "good"
+        assert channel["snr_health"] == "good"
+
+        assert _build_diagnostic_notes(analysis) == []
+
+    def test_ofdm_legacy_metric_health_fallback_uses_ofdm_thresholds(self):
+        from app.modules.reports.report import _build_diagnostic_notes
+
+        analysis = _analyze_downstream_channel(
+            docsis="3.1",
+            power=-8.2,
+            quality=33.0,
+            modulation="4096QAM",
+            channel_type="OFDM",
+        )
+        assert "power_health" not in analysis["ds_channels"][0]
+        assert "snr_health" not in analysis["ds_channels"][0]
+
+        assert _build_diagnostic_notes(analysis) == []
+
+    def test_bad_ofdm_values_produce_notes_with_ofdm_limits(self):
+        from app.modules.reports.report import _build_diagnostic_notes
+
+        analysis = _analyze_downstream_channel(
+            docsis="3.1",
+            power=-15.1,
+            quality=24.4,
+            modulation="4096QAM",
+            channel_type="OFDM",
+        )
+
+        notes = _build_diagnostic_notes(analysis)
+
+        assert [note["type"] for note in notes] == ["ds_power_low", "snr_low"]
+        assert notes[0]["spec_min"] == -15.0
+        assert notes[1]["spec_min"] == 24.5
+
+    def test_sc_qam_diagnostic_thresholds_remain_unchanged(self):
+        from app.modules.reports.report import _build_diagnostic_notes
+
+        analysis = _analyze_downstream_channel(
+            docsis="3.0",
+            power=-8.2,
+            quality=-28.9,
+            modulation="256QAM",
+            channel_type="SC-QAM",
+        )
+
+        notes = _build_diagnostic_notes(analysis)
+
+        assert [note["type"] for note in notes] == ["ds_power_low", "snr_low"]
+        assert notes[0]["spec_min"] == -8.0
+        assert notes[1]["spec_min"] == 29.0
+
+    def test_ofdm_historical_minimum_uses_ofdm_warning_reference(self):
+        from app.modules.reports.report import _compute_worst_values, _default_warn_thresholds
+
+        snapshots = [{
+            "summary": {"ds_snr_min": 32.0, "health": "good"},
+            "ds_channels": [{
+                "channel_id": 1,
+                "docsis_version": "3.1",
+                "type": "OFDM",
+                "modulation": "4096QAM",
+                "snr": 32.0,
+            }],
+        }]
+
+        worst = _compute_worst_values(snapshots)
+
+        assert worst["ds_snr_min"] == 32.0
+        assert worst["ds_snr_warn_min"] == 25.5
+        assert _default_warn_thresholds(worst["ds_snr_warn_min"])["snr"] == ">= 25.5 dB"
+
+    def test_mixed_family_historical_minimum_uses_supplying_channel_reference(self):
+        from app.modules.reports.report import _compute_worst_values, _default_warn_thresholds
+
+        snapshots = [
+            {
+                "summary": {"ds_snr_min": 34.0, "health": "good"},
+                "ds_channels": [
+                    {
+                        "channel_id": 1,
+                        "docsis_version": "3.0",
+                        "type": "SC-QAM",
+                        "modulation": "256QAM",
+                        "snr": 34.0,
+                    },
+                    {
+                        "channel_id": 2,
+                        "docsis_version": "3.1",
+                        "type": "OFDM",
+                        "modulation": "4096QAM",
+                        "snr": 35.0,
+                    },
+                ],
+            },
+            {
+                "summary": {"ds_snr_min": 32.0, "health": "good"},
+                "ds_channels": [
+                    {
+                        "channel_id": 1,
+                        "docsis_version": "3.0",
+                        "type": "SC-QAM",
+                        "modulation": "256QAM",
+                        "snr": 33.0,
+                    },
+                    {
+                        "channel_id": 2,
+                        "docsis_version": "3.1",
+                        "type": "OFDM",
+                        "modulation": "4096QAM",
+                        "snr": 32.0,
+                    },
+                ],
+            },
+        ]
+
+        worst = _compute_worst_values(snapshots)
+
+        assert worst["ds_snr_min"] == 32.0
+        assert worst["ds_snr_warn_min"] == 25.5
+        assert _default_warn_thresholds(worst["ds_snr_warn_min"])["snr"] == ">= 25.5 dB"
+
+    def test_legacy_historical_minimum_keeps_256qam_fallback(self):
+        from app.modules.reports.report import _compute_worst_values, _default_warn_thresholds
+
+        worst = _compute_worst_values([{
+            "summary": {"ds_snr_min": 32.0, "health": "good"},
+        }])
+
+        assert worst["ds_snr_min"] == 32.0
+        assert worst["ds_snr_warn_min"] is None
+        assert _default_warn_thresholds(worst["ds_snr_warn_min"])["snr"] == ">= 31.0 dB"
+
+    def test_complaint_historical_summary_uses_ofdm_warning_reference(self):
+        from app.modules.reports.report import generate_complaint_text
+
+        snapshots = [{
+            "timestamp": "2026-07-22T10:00:00Z",
+            "summary": {"ds_snr_min": 33.0, "health": "good"},
+            "ds_channels": [{
+                "channel_id": 1,
+                "docsis_version": "3.1",
+                "type": "OFDM",
+                "modulation": "4096QAM",
+                "snr": 33.0,
+            }],
+        }]
+
+        complaint = generate_complaint_text(snapshots)
+
+        assert "Worst downstream SNR: 33.0 dB (threshold: >= 25.5 dB)" in complaint
+        assert ">= 31.0 dB" not in complaint
 
 
 class TestComplaintRoutes:


### PR DESCRIPTION
## Summary
- use analyzer channel health for family-tagged SNR/MER event transitions so good-range OFDM changes do not fall back to SC-QAM thresholds
- use family-aware downstream power and SNR/MER thresholds in report diagnostics
- show the threshold for the channel that supplied the historical downstream minimum, while preserving the legacy fallback when channel evidence is unavailable

Related to #743.

## Testing
- `python -m pytest -q tests/test_events.py tests/web/test_reports.py tests/analyzer tests/test_docsis_case_fixtures.py`: 300 passed
- `python -m pytest -q tests --ignore=tests/e2e`: 2965 passed, 1 skipped
- browser E2E by file: 502 passed; `test_correlation_hover_shows_tooltip_and_highlights_timeline` fails locally on both this branch and unchanged `origin/main`
