### PR TITLE
feat: add Sagemcom F3896LG driver (Virgin Media Hub 5 / Liberty Global REST API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  <strong>Self-hosted</strong> • <strong>Local data</strong> • <strong>Demo</strong> • <strong>Reports</strong> • <strong>18 modem families</strong> • <strong>MIT</strong>
+  <strong>Self-hosted</strong> • <strong>Local data</strong> • <strong>Demo</strong> • <strong>Reports</strong> • <strong>19 modem families</strong> • <strong>MIT</strong>
 </p>
 
 <p align="center">
@@ -279,7 +279,7 @@ More views from the product:
 
 ## Supported Hardware
 
-DOCSight supports **18 modem families** out of the box and also offers **Generic Router mode** for fiber, DSL, and satellite connections.
+DOCSight supports **19 modem families** out of the box and also offers **Generic Router mode** for fiber, DSL, and satellite connections.
 
 ### Common setups
 
@@ -288,7 +288,7 @@ DOCSight supports **18 modem families** out of the box and also offers **Generic
 - **Sercomm Ultra Hub 7 class gateways**
 - **CH7465 Connect Box family**
 - **Sagemcom F@st 3896:** JSON-RPC API
-- **Sagemcom F3896LG** (Virgin Media Hub 5, Liberty Global firmware): unauthenticated REST API, works in modem mode
+- **Sagemcom F3896LG** (Hub 5 / Liberty Global REST firmware): unauthenticated API, works in modem mode
 - **Technicolor TC4400**
 - **Arris SURFboard** (S33, S34, SB8200): HNAP1 API
 - **Arris SB6183:** HTTP status pages, no authentication required

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ DOCSight supports **18 modem families** out of the box and also offers **Generic
 - **Sercomm Ultra Hub 7 class gateways**
 - **CH7465 Connect Box family**
 - **Sagemcom F@st 3896:** JSON-RPC API
+- **Sagemcom F3896LG** (Virgin Media Hub 5, Liberty Global firmware): unauthenticated REST API, works in modem mode
 - **Technicolor TC4400**
 - **Arris SURFboard** (S33, S34, SB8200): HNAP1 API
 - **Arris SB6183:** HTTP status pages, no authentication required

--- a/app/drivers/__init__.py
+++ b/app/drivers/__init__.py
@@ -46,6 +46,10 @@ driver_registry.register_builtin("hitron_coda_4680", "app.drivers.hitron_coda_46
 driver_registry.register_builtin("sagemcom", "app.drivers.sagemcom.SagemcomDriver",
                                  "Sagemcom F@st 3896",
                                  hints={"default_url": "http://192.168.100.1", "default_user": "admin"})
+driver_registry.register_builtin("f3896lg", "app.drivers.f3896lg.F3896LGDriver",
+                                 "Sagemcom F3896LG (Virgin Media Hub 5 / Liberty Global)",
+                                 hints={"default_url": "https://192.168.100.1",
+                                        "credentials_required": False})
 driver_registry.register_builtin("sercom_dm1000", "app.drivers.sercom_dm1000.SercomDM1000Driver",
                                  "Sercom DM1000",
                                  hints={"default_url": "http://192.168.100.1", "default_user": "technician"})

--- a/app/drivers/f3896lg.py
+++ b/app/drivers/f3896lg.py
@@ -168,10 +168,12 @@ class F3896LGDriver(ModemDriver):
                     if mer == 0:
                         mer = None
                     profile_modulation = self._modulation(ch.get("modulation", ""))
+                    # firstActiveSubcarrier is an index; without a subcarrier-zero/base
+                    # frequency from the API, the channel frequency remains unknown.
                     channel: RawChannel = {
                         "channelID": ch.get("channelId", 0),
                         "type": "OFDM",
-                        "frequency": self._mhz(ch.get("firstActiveSubcarrier")),
+                        "frequency": "",
                         "powerLevel": power,
                         "mer": mer,
                         "mse": None,
@@ -218,10 +220,12 @@ class F3896LGDriver(ModemDriver):
                         log.warning("Invalid F3896LG OFDMA power %r; using no power", ch.get("power"))
                         power = None
                     profile_modulation = self._modulation(ch.get("modulation", ""))
+                    # firstActiveSubcarrier is an index; without a subcarrier-zero/base
+                    # frequency from the API, the channel frequency remains unknown.
                     channel: RawChannel = {
                         "channelID": ch.get("channelId", 0),
                         "type": "OFDMA",
-                        "frequency": self._mhz(ch.get("firstActiveSubcarrier")),
+                        "frequency": "",
                         "powerLevel": power,
                         "modulation": "OFDMA",
                         "multiplex": "",
@@ -249,13 +253,6 @@ class F3896LGDriver(ModemDriver):
         if not freq_hz:
             return ""
         return f"{float(freq_hz) / 1_000_000:g} MHz"
-
-    @staticmethod
-    def _mhz(freq_mhz) -> str:
-        """Format the lower/first active subcarrier frequency, not channel center."""
-        if not freq_mhz:
-            return ""
-        return f"{float(freq_mhz):g} MHz"
 
     @staticmethod
     def _unscale(power) -> float | None:

--- a/app/drivers/f3896lg.py
+++ b/app/drivers/f3896lg.py
@@ -15,11 +15,14 @@ usually https://192.168.100.1 -- self-signed certificate):
     /rest/v1/cablemodem/downstream    channels: sc_qam + ofdm
     /rest/v1/cablemodem/upstream      channels: atdma + ofdma
     /rest/v1/cablemodem/state_        docsisVersion/uptime/status
+                                        (docsisVersion is not firmware)
     /rest/v1/cablemodem/serviceflows  provisioned max rates
     /rest/v1/cablemodem/registration  used as the connectivity/login check
 
-Firmware quirk: OFDM/OFDMA channel `power` is reported scaled x10
-(380 == 38.0 dBmV, -118 == -11.8 dBmV). SC-QAM/ATDMA power is not scaled.
+Firmware quirk: OFDM/OFDMA channel `power` and OFDM `rxMer` are reported
+scaled x10 (380 == 38.0 dBmV, -118 == -11.8 dBmV, 390 == 39.0 dB).
+SC-QAM/ATDMA values are not scaled.
+This API does not expose a firmware/software version.
 Verified against a Virgin Media (UK) Hub 5 in modem mode.
 """
 
@@ -28,10 +31,9 @@ from __future__ import annotations
 import logging
 
 import requests
-import urllib3
 
-from .base import ModemDriver
 from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
+from .base import ModemDriver
 
 log = logging.getLogger("docsis.driver.f3896lg")
 
@@ -45,14 +47,26 @@ class F3896LGDriver(ModemDriver):
         super().__init__(url.rstrip("/"), user, password)
         self._session = requests.Session()
         self._session.verify = False  # self-signed cert on the modem
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # -- transport --
 
     def _get(self, path: str) -> dict:
         r = self._session.get(f"{self._url}/rest/v1/{path}", timeout=_TIMEOUT)
         r.raise_for_status()
-        return r.json()
+        payload = r.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError("F3896LG REST API returned a non-object JSON payload")
+        return payload
+
+    def _get_channels(self, path: str, section_name: str) -> list[dict]:
+        payload = self._get(path)
+        section = payload.get(section_name)
+        if not isinstance(section, dict):
+            raise RuntimeError(f"F3896LG REST API returned invalid {section_name} payload")
+        channels = section.get("channels")
+        if not isinstance(channels, list):
+            raise RuntimeError(f"F3896LG REST API returned invalid {section_name} channels")
+        return channels
 
     # -- ModemDriver interface --
 
@@ -62,12 +76,12 @@ class F3896LGDriver(ModemDriver):
             data = self._get("cablemodem/registration")
         except requests.RequestException as e:
             raise RuntimeError(f"F3896LG REST API not reachable: {e}") from e
-        if "registration" not in data:
-            raise RuntimeError("F3896LG REST API returned unexpected payload")
+        if not isinstance(data.get("registration"), dict):
+            raise RuntimeError("F3896LG REST API returned unexpected registration payload")
 
     def get_docsis_data(self) -> DocsisData:
-        ds = self._get("cablemodem/downstream").get("downstream", {}).get("channels", [])
-        us = self._get("cablemodem/upstream").get("upstream", {}).get("channels", [])
+        ds = self._get_channels("cablemodem/downstream", "downstream")
+        us = self._get_channels("cablemodem/upstream", "upstream")
 
         ds30, ds31 = self._parse_downstream(ds)
         us30, us31 = self._parse_upstream(us)
@@ -83,30 +97,44 @@ class F3896LGDriver(ModemDriver):
         }
         try:
             cm = self._get("cablemodem/state_").get("cablemodem", {})
-            info["sw_version"] = f"DOCSIS {cm.get('docsisVersion', '?')}"
             if cm.get("status"):
                 info["docsis_status"] = str(cm["status"])
             if cm.get("upTime") is not None:
                 info["uptime_seconds"] = int(cm["upTime"])
-        except (requests.RequestException, ValueError, TypeError) as e:
+        except (requests.RequestException, RuntimeError, ValueError, TypeError) as e:
             log.warning("F3896LG device info fetch failed: %s", e)
         return info
 
     def get_connection_info(self) -> ConnectionInfo:
-        out: ConnectionInfo = {}
+        out: ConnectionInfo = {"connection_type": "DOCSIS 3.1"}
+        max_rates: dict[str, int] = {}
         try:
             flows = self._get("cablemodem/serviceflows").get("serviceFlows", [])
             for entry in flows:
-                flow = entry.get("serviceFlow", {})
-                rate = flow.get("maxTrafficRate")
-                if not rate:
+                if not isinstance(entry, dict):
                     continue
-                if flow.get("direction") == "downstream":
-                    out["max_downstream_kbps"] = int(rate) // 1000
-                elif flow.get("direction") == "upstream":
-                    out["max_upstream_kbps"] = int(rate) // 1000
-            out["connection_type"] = "DOCSIS 3.1"
-        except (requests.RequestException, ValueError, TypeError) as e:
+                flow = entry.get("serviceFlow", {})
+                if not isinstance(flow, dict):
+                    continue
+                try:
+                    rate = int(flow.get("maxTrafficRate"))
+                except (TypeError, ValueError):
+                    continue
+                if rate <= 0:
+                    continue
+                direction = flow.get("direction")
+                if direction == "downstream":
+                    key = "max_downstream_kbps"
+                elif direction == "upstream":
+                    key = "max_upstream_kbps"
+                else:
+                    continue
+                max_rates[key] = max(max_rates.get(key, 0), rate)
+            if "max_downstream_kbps" in max_rates:
+                out["max_downstream_kbps"] = max_rates["max_downstream_kbps"] // 1000
+            if "max_upstream_kbps" in max_rates:
+                out["max_upstream_kbps"] = max_rates["max_upstream_kbps"] // 1000
+        except (requests.RequestException, RuntimeError, ValueError, TypeError) as e:
             log.warning("F3896LG connection info fetch failed: %s", e)
         return out
 
@@ -116,21 +144,44 @@ class F3896LGDriver(ModemDriver):
         ds30: list[RawChannel] = []
         ds31: list[RawChannel] = []
         for ch in channels:
+            if not isinstance(ch, dict):
+                continue
             if not ch.get("lockStatus", False):
+                continue
+            channel_type = ch.get("channelType")
+            if channel_type not in {"sc_qam", "ofdm"}:
+                log.debug("Skipping unknown downstream channel type %r", channel_type)
                 continue
             try:
                 mer = ch.get("rxMer")
-                if ch.get("channelType") == "ofdm":
-                    ds31.append({
+                if channel_type == "ofdm":
+                    try:
+                        power = self._unscale(ch.get("power"))
+                    except (ValueError, TypeError):
+                        log.warning("Invalid F3896LG OFDM power %r; using no power", ch.get("power"))
+                        power = None
+                    try:
+                        mer = self._unscale(mer)
+                    except (ValueError, TypeError):
+                        log.warning("Invalid F3896LG OFDM rxMer %r; using no MER", mer)
+                        mer = None
+                    if mer == 0:
+                        mer = None
+                    profile_modulation = self._modulation(ch.get("modulation", ""))
+                    channel: RawChannel = {
                         "channelID": ch.get("channelId", 0),
                         "type": "OFDM",
-                        "frequency": self._hz_to_mhz(ch.get("frequency")),
-                        "powerLevel": self._unscale(ch.get("power")),
-                        "mer": mer if mer else None,
+                        "frequency": self._mhz(ch.get("firstActiveSubcarrier")),
+                        "powerLevel": power,
+                        "mer": mer,
                         "mse": None,
+                        "modulation": "OFDM",
                         "corrErrors": ch.get("correctedErrors"),
                         "nonCorrErrors": ch.get("uncorrectedErrors"),
-                    })
+                    }
+                    if profile_modulation:
+                        channel["profile_modulation"] = profile_modulation
+                    ds31.append(channel)
                 else:
                     snr = ch.get("snr") or mer
                     ds30.append({
@@ -151,18 +202,33 @@ class F3896LGDriver(ModemDriver):
         us30: list[RawChannel] = []
         us31: list[RawChannel] = []
         for ch in channels:
+            if not isinstance(ch, dict):
+                continue
             if not ch.get("lockStatus", False):
                 continue
+            channel_type = ch.get("channelType")
+            if channel_type not in {"atdma", "ofdma"}:
+                log.debug("Skipping unknown upstream channel type %r", channel_type)
+                continue
             try:
-                if ch.get("channelType") == "ofdma":
-                    us31.append({
+                if channel_type == "ofdma":
+                    try:
+                        power = self._unscale(ch.get("power"))
+                    except (ValueError, TypeError):
+                        log.warning("Invalid F3896LG OFDMA power %r; using no power", ch.get("power"))
+                        power = None
+                    profile_modulation = self._modulation(ch.get("modulation", ""))
+                    channel: RawChannel = {
                         "channelID": ch.get("channelId", 0),
                         "type": "OFDMA",
-                        "frequency": self._hz_to_mhz(ch.get("frequency")),
-                        "powerLevel": self._unscale(ch.get("power")),
+                        "frequency": self._mhz(ch.get("firstActiveSubcarrier")),
+                        "powerLevel": power,
                         "modulation": "OFDMA",
                         "multiplex": "",
-                    })
+                    }
+                    if profile_modulation:
+                        channel["profile_modulation"] = profile_modulation
+                    us31.append(channel)
                 else:
                     us30.append({
                         "channelID": ch.get("channelId", 0),
@@ -183,6 +249,13 @@ class F3896LGDriver(ModemDriver):
         if not freq_hz:
             return ""
         return f"{float(freq_hz) / 1_000_000:g} MHz"
+
+    @staticmethod
+    def _mhz(freq_mhz) -> str:
+        """Format the lower/first active subcarrier frequency, not channel center."""
+        if not freq_mhz:
+            return ""
+        return f"{float(freq_mhz):g} MHz"
 
     @staticmethod
     def _unscale(power) -> float | None:

--- a/app/drivers/f3896lg.py
+++ b/app/drivers/f3896lg.py
@@ -1,0 +1,200 @@
+"""Sagemcom F3896LG driver (Liberty Global firmware: Virgin Media Hub 5, Ziggo).
+
+The F@st 3896 ships with (at least) two incompatible firmware families:
+
+* Tele2/Com Hem ("Wi-Fi Hub C3/C4"): Sagemcom XMO JSON-RPC at /cgi/json-req
+  with SHA-512 digest login -- handled by app.drivers.sagemcom (issue #163).
+* Liberty Global (Virgin Media Hub 5 "F3896LG-VMB", Ziggo, etc.): a read-only
+  REST API at /rest/v1/ that requires NO authentication for cable-modem
+  status. The community client github.com/ties/sagemcom-f3896-py documents
+  the same API. /cgi/json-req does not exist on this firmware (404).
+
+Endpoints used (unauthenticated GETs against the modem management IP,
+usually https://192.168.100.1 -- self-signed certificate):
+
+    /rest/v1/cablemodem/downstream    channels: sc_qam + ofdm
+    /rest/v1/cablemodem/upstream      channels: atdma + ofdma
+    /rest/v1/cablemodem/state_        docsisVersion/uptime/status
+    /rest/v1/cablemodem/serviceflows  provisioned max rates
+    /rest/v1/cablemodem/registration  used as the connectivity/login check
+
+Firmware quirk: OFDM/OFDMA channel `power` is reported scaled x10
+(380 == 38.0 dBmV, -118 == -11.8 dBmV). SC-QAM/ATDMA power is not scaled.
+Verified against a Virgin Media (UK) Hub 5 in modem mode.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+import urllib3
+
+from .base import ModemDriver
+from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
+
+log = logging.getLogger("docsis.driver.f3896lg")
+
+_TIMEOUT = 10
+
+
+class F3896LGDriver(ModemDriver):
+    """Virgin Media Hub 5 / Sagemcom F3896LG (Liberty Global REST API)."""
+
+    def __init__(self, url: str, user: str, password: str):
+        super().__init__(url.rstrip("/"), user, password)
+        self._session = requests.Session()
+        self._session.verify = False  # self-signed cert on the modem
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    # -- transport --
+
+    def _get(self, path: str) -> dict:
+        r = self._session.get(f"{self._url}/rest/v1/{path}", timeout=_TIMEOUT)
+        r.raise_for_status()
+        return r.json()
+
+    # -- ModemDriver interface --
+
+    def login(self) -> None:
+        """No auth needed; verify the REST API answers so setup test is real."""
+        try:
+            data = self._get("cablemodem/registration")
+        except requests.RequestException as e:
+            raise RuntimeError(f"F3896LG REST API not reachable: {e}") from e
+        if "registration" not in data:
+            raise RuntimeError("F3896LG REST API returned unexpected payload")
+
+    def get_docsis_data(self) -> DocsisData:
+        ds = self._get("cablemodem/downstream").get("downstream", {}).get("channels", [])
+        us = self._get("cablemodem/upstream").get("upstream", {}).get("channels", [])
+
+        ds30, ds31 = self._parse_downstream(ds)
+        us30, us31 = self._parse_upstream(us)
+        return {
+            "channelDs": {"docsis30": ds30, "docsis31": ds31},
+            "channelUs": {"docsis30": us30, "docsis31": us31},
+        }
+
+    def get_device_info(self) -> DeviceInfo:
+        info: DeviceInfo = {
+            "manufacturer": "Sagemcom",
+            "model": "F3896LG (Virgin Media Hub 5)",
+        }
+        try:
+            cm = self._get("cablemodem/state_").get("cablemodem", {})
+            info["sw_version"] = f"DOCSIS {cm.get('docsisVersion', '?')}"
+            if cm.get("status"):
+                info["docsis_status"] = str(cm["status"])
+            if cm.get("upTime") is not None:
+                info["uptime_seconds"] = int(cm["upTime"])
+        except (requests.RequestException, ValueError, TypeError) as e:
+            log.warning("F3896LG device info fetch failed: %s", e)
+        return info
+
+    def get_connection_info(self) -> ConnectionInfo:
+        out: ConnectionInfo = {}
+        try:
+            flows = self._get("cablemodem/serviceflows").get("serviceFlows", [])
+            for entry in flows:
+                flow = entry.get("serviceFlow", {})
+                rate = flow.get("maxTrafficRate")
+                if not rate:
+                    continue
+                if flow.get("direction") == "downstream":
+                    out["max_downstream_kbps"] = int(rate) // 1000
+                elif flow.get("direction") == "upstream":
+                    out["max_upstream_kbps"] = int(rate) // 1000
+            out["connection_type"] = "DOCSIS 3.1"
+        except (requests.RequestException, ValueError, TypeError) as e:
+            log.warning("F3896LG connection info fetch failed: %s", e)
+        return out
+
+    # -- parsing --
+
+    def _parse_downstream(self, channels: list[dict]) -> tuple[list[RawChannel], list[RawChannel]]:
+        ds30: list[RawChannel] = []
+        ds31: list[RawChannel] = []
+        for ch in channels:
+            if not ch.get("lockStatus", False):
+                continue
+            try:
+                mer = ch.get("rxMer")
+                if ch.get("channelType") == "ofdm":
+                    ds31.append({
+                        "channelID": ch.get("channelId", 0),
+                        "type": "OFDM",
+                        "frequency": self._hz_to_mhz(ch.get("frequency")),
+                        "powerLevel": self._unscale(ch.get("power")),
+                        "mer": mer if mer else None,
+                        "mse": None,
+                        "corrErrors": ch.get("correctedErrors"),
+                        "nonCorrErrors": ch.get("uncorrectedErrors"),
+                    })
+                else:
+                    snr = ch.get("snr") or mer
+                    ds30.append({
+                        "channelID": ch.get("channelId", 0),
+                        "frequency": self._hz_to_mhz(ch.get("frequency")),
+                        "powerLevel": ch.get("power"),
+                        "mer": snr,
+                        "mse": -snr if snr else None,
+                        "modulation": self._modulation(ch.get("modulation", "")),
+                        "corrErrors": ch.get("correctedErrors"),
+                        "nonCorrErrors": ch.get("uncorrectedErrors"),
+                    })
+            except (ValueError, TypeError) as e:
+                log.warning("Failed to parse F3896LG DS channel %s: %s", ch, e)
+        return ds30, ds31
+
+    def _parse_upstream(self, channels: list[dict]) -> tuple[list[RawChannel], list[RawChannel]]:
+        us30: list[RawChannel] = []
+        us31: list[RawChannel] = []
+        for ch in channels:
+            if not ch.get("lockStatus", False):
+                continue
+            try:
+                if ch.get("channelType") == "ofdma":
+                    us31.append({
+                        "channelID": ch.get("channelId", 0),
+                        "type": "OFDMA",
+                        "frequency": self._hz_to_mhz(ch.get("frequency")),
+                        "powerLevel": self._unscale(ch.get("power")),
+                        "modulation": "OFDMA",
+                        "multiplex": "",
+                    })
+                else:
+                    us30.append({
+                        "channelID": ch.get("channelId", 0),
+                        "frequency": self._hz_to_mhz(ch.get("frequency")),
+                        "powerLevel": ch.get("power"),
+                        "modulation": self._modulation(ch.get("modulation", "")),
+                        "multiplex": str(ch.get("channelType", "")).upper(),
+                        "symbolRate": ch.get("symbolRate"),
+                    })
+            except (ValueError, TypeError) as e:
+                log.warning("Failed to parse F3896LG US channel %s: %s", ch, e)
+        return us30, us31
+
+    # -- helpers --
+
+    @staticmethod
+    def _hz_to_mhz(freq_hz) -> str:
+        if not freq_hz:
+            return ""
+        return f"{float(freq_hz) / 1_000_000:g} MHz"
+
+    @staticmethod
+    def _unscale(power) -> float | None:
+        """OFDM/OFDMA power is reported x10 on this firmware."""
+        if power is None:
+            return None
+        return float(power) / 10.0
+
+    @staticmethod
+    def _modulation(raw: str) -> str:
+        """qam_256 -> 256QAM (matches other drivers' display convention)."""
+        raw = (raw or "").lower()
+        if raw.startswith("qam_"):
+            return f"{raw[4:]}QAM"
+        return raw.upper()

--- a/docs/index.html
+++ b/docs/index.html
@@ -216,7 +216,7 @@
             <li>Local data</li>
             <li>Demo mode</li>
             <li>Reports</li>
-            <li>16 modem families</li>
+            <li>19 modem families</li>
             <li>MIT licensed</li>
           </ul>
           <div class="trust-promise" aria-label="Local-first trust promise">

--- a/tests/drivers/f3896lg/_data.py
+++ b/tests/drivers/f3896lg/_data.py
@@ -1,0 +1,77 @@
+"""Fixture payloads captured from a Virgin Media (UK) Hub 5 in modem mode.
+
+Sagemcom F3896LG-VMB, Liberty Global firmware, /rest/v1/ REST API.
+Identifiers (MAC/serial) are anonymised; signal values are real.
+"""
+
+DOWNSTREAM = {
+    "downstream": {
+        "channels": [
+            {"channelType": "sc_qam", "channelId": 1, "frequency": 411000000,
+             "power": -4.3, "modulation": "qam_256", "snr": 39, "rxMer": 39,
+             "correctedErrors": 26, "uncorrectedErrors": 0, "lockStatus": True},
+            {"channelType": "sc_qam", "channelId": 2, "frequency": 419000000,
+             "power": -4.5, "modulation": "qam_256", "snr": 39, "rxMer": 39,
+             "correctedErrors": 30, "uncorrectedErrors": 0, "lockStatus": True},
+            # unlocked channel must be skipped
+            {"channelType": "sc_qam", "channelId": 3, "frequency": 427000000,
+             "power": -4.4, "modulation": "qam_256", "snr": 38, "rxMer": 38,
+             "correctedErrors": 0, "uncorrectedErrors": 0, "lockStatus": False},
+            # OFDM (DOCSIS 3.1): power scaled x10 by firmware, no frequency key
+            {"channelType": "ofdm", "channelId": 41, "channelWidth": 94000000,
+             "fftType": "4K", "numberOfActiveSubCarriers": 1840,
+             "modulation": "qam_4096", "firstActiveSubcarrier": 1108,
+             "lockStatus": True, "rxMer": 0, "power": -118,
+             "correctedErrors": 1361678039, "uncorrectedErrors": 483483438},
+        ]
+    }
+}
+
+UPSTREAM = {
+    "upstream": {
+        "channels": [
+            {"channelId": 6, "frequency": 49600000, "lockStatus": True,
+             "power": 42.5, "symbolRate": 5120, "modulation": "qam_64",
+             "t1Timeout": 0, "t2Timeout": 0, "t3Timeout": 0, "t4Timeout": 0,
+             "channelType": "atdma"},
+            {"channelId": 7, "frequency": 43100000, "lockStatus": True,
+             "power": 42, "symbolRate": 5120, "modulation": "qam_64",
+             "t1Timeout": 0, "t2Timeout": 0, "t3Timeout": 0, "t4Timeout": 0,
+             "channelType": "atdma"},
+            # OFDMA (DOCSIS 3.1): power scaled x10 by firmware
+            {"channelId": 12, "channelWidth": 10400000, "lockStatus": True,
+             "power": 380, "fftType": "2K", "modulation": "qam_256",
+             "channelType": "ofdma", "numberOfActiveSubCarriers": 208,
+             "firstActiveSubcarrier": 74, "t3Timeout": 0, "t4Timeout": 0},
+        ]
+    }
+}
+
+STATE = {
+    "cablemodem": {
+        "bootFilename": "cmreg-example.cm",
+        "docsisVersion": "3.1",
+        "macAddress": "00:11:22:33:44:55",
+        "serialNumber": "EXAMPLE000000",
+        "upTime": 72394,
+        "accessAllowed": True,
+        "status": "operational",
+        "maxCPEs": 1,
+        "baselinePrivacyEnabled": True,
+    }
+}
+
+REGISTRATION = {"registration": {"registrationComplete": True, "downstreamLocked": True}}
+
+SERVICEFLOWS = {
+    "serviceFlows": [
+        {"serviceFlow": {"serviceFlowId": 217640, "direction": "downstream",
+                         "maxTrafficRate": 1230000450, "maxTrafficBurst": 42600,
+                         "minReservedRate": 0, "maxConcatenatedBurst": 0,
+                         "scheduleType": "undefined"}},
+        {"serviceFlow": {"serviceFlowId": 217639, "direction": "upstream",
+                         "maxTrafficRate": 110000274, "maxTrafficBurst": 42600,
+                         "minReservedRate": 0, "maxConcatenatedBurst": 42600,
+                         "scheduleType": "best_effort"}},
+    ]
+}

--- a/tests/drivers/f3896lg/conftest.py
+++ b/tests/drivers/f3896lg/conftest.py
@@ -1,0 +1,32 @@
+"""Fixtures for F3896LG driver tests: fake requests session serving REST paths."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.drivers.f3896lg import F3896LGDriver
+from . import _data
+
+_ROUTES = {
+    "cablemodem/downstream": _data.DOWNSTREAM,
+    "cablemodem/upstream": _data.UPSTREAM,
+    "cablemodem/state_": _data.STATE,
+    "cablemodem/registration": _data.REGISTRATION,
+    "cablemodem/serviceflows": _data.SERVICEFLOWS,
+}
+
+
+@pytest.fixture
+def driver():
+    d = F3896LGDriver("https://192.168.100.1", "", "")
+
+    def fake_get(url, timeout=None):
+        path = url.split("/rest/v1/", 1)[1]
+        resp = MagicMock()
+        resp.json.return_value = _ROUTES[path]
+        resp.raise_for_status.return_value = None
+        return resp
+
+    d._session = MagicMock()
+    d._session.get.side_effect = fake_get
+    return d

--- a/tests/drivers/f3896lg/test_parsing.py
+++ b/tests/drivers/f3896lg/test_parsing.py
@@ -114,7 +114,7 @@ class TestDownstream:
         assert ch["type"] == "OFDM"
         # firmware reports OFDM power scaled x10: -118 -> -11.8 dBmV
         assert ch["powerLevel"] == -11.8
-        assert ch["frequency"] == "1108 MHz"
+        assert ch["frequency"] == ""
         assert ch["modulation"] == "OFDM"
         assert ch["profile_modulation"] == "4096QAM"
         # rxMer 0 means "not reported" on this firmware
@@ -159,7 +159,7 @@ class TestDownstream:
 
         assert len(ds31) == 1
         assert ds31[0]["mer"] is None
-        assert ds31[0]["frequency"] == "1108 MHz"
+        assert ds31[0]["frequency"] == ""
         assert ds31[0]["powerLevel"] == -11.8
         assert ds31[0]["profile_modulation"] == "4096QAM"
         assert ds31[0]["corrErrors"] == 12
@@ -221,7 +221,7 @@ class TestUpstream:
         assert ch["type"] == "OFDMA"
         # firmware reports OFDMA power scaled x10: 380 -> 38.0 dBmV
         assert ch["powerLevel"] == 38.0
-        assert ch["frequency"] == "74 MHz"
+        assert ch["frequency"] == ""
         assert ch["modulation"] == "OFDMA"
         assert ch["profile_modulation"] == "256QAM"
 

--- a/tests/drivers/f3896lg/test_parsing.py
+++ b/tests/drivers/f3896lg/test_parsing.py
@@ -1,9 +1,87 @@
 """Tests for F3896LG (Liberty Global REST) channel parsing and derived values."""
 
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from app.analyzer import analyze
+from app.drivers.f3896lg import F3896LGDriver
+
 
 class TestLogin:
     def test_login_ok(self, driver):
         driver.login()  # must not raise
+
+    def test_login_accepts_registration_in_progress(self, driver):
+        with patch.object(
+            driver,
+            "_get",
+            return_value={"registration": {"registrationComplete": False}},
+        ):
+            driver.login()
+
+    @pytest.mark.parametrize(
+        "payload",
+        [{}, {"registration": None}, {"registration": []}],
+    )
+    def test_login_rejects_missing_or_invalid_registration(self, driver, payload):
+        with (
+            patch.object(driver, "_get", return_value=payload),
+            pytest.raises(
+                RuntimeError,
+                match="F3896LG REST API returned unexpected registration payload",
+            ),
+        ):
+            driver.login()
+
+    def test_login_wraps_connection_error(self, driver):
+        with (
+            patch.object(
+                driver,
+                "_get",
+                side_effect=requests.ConnectionError("connection refused"),
+            ),
+            pytest.raises(
+                RuntimeError,
+                match=r"^F3896LG REST API not reachable:",
+            ),
+        ):
+            driver.login()
+
+
+class TestTransport:
+    @pytest.mark.parametrize("payload", [None, []])
+    def test_get_rejects_non_object_json(self, driver, payload):
+        response = MagicMock()
+        response.json.return_value = payload
+        driver._session.get.side_effect = None
+        driver._session.get.return_value = response
+
+        with pytest.raises(
+            RuntimeError,
+            match="F3896LG REST API returned a non-object JSON payload",
+        ):
+            driver._get("cablemodem/downstream")
+
+    def test_tls_verification_is_local_to_session(self):
+        with patch("urllib3.disable_warnings") as disable_warnings:
+            driver = F3896LGDriver("https://192.168.100.1", "", "")
+
+        assert driver._session.verify is False
+        disable_warnings.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "payload",
+        [{}, {"downstream": []}, {"downstream": {"channels": {}}}],
+    )
+    def test_get_docsis_data_rejects_invalid_nested_payload(self, driver, payload):
+        with patch.object(driver, "_get", return_value=payload), pytest.raises(
+            RuntimeError,
+            match=r"invalid downstream (payload|channels)",
+        ):
+            driver.get_docsis_data()
 
 
 class TestDownstream:
@@ -36,10 +114,92 @@ class TestDownstream:
         assert ch["type"] == "OFDM"
         # firmware reports OFDM power scaled x10: -118 -> -11.8 dBmV
         assert ch["powerLevel"] == -11.8
+        assert ch["frequency"] == "1108 MHz"
+        assert ch["modulation"] == "OFDM"
+        assert ch["profile_modulation"] == "4096QAM"
         # rxMer 0 means "not reported" on this firmware
         assert ch["mer"] is None
         assert ch["corrErrors"] == 1361678039
         assert ch["nonCorrErrors"] == 483483438
+
+    @pytest.mark.parametrize(
+        ("rx_mer", "expected"),
+        [(0, None), (0.0, None), ("0", None), ("0.0", None), (390, 39.0), ("390", 39.0)],
+    )
+    def test_ofdm_rxmer_is_normalized(self, driver, rx_mer, expected):
+        channels = [{
+            "channelType": "ofdm",
+            "channelId": 41,
+            "firstActiveSubcarrier": 1108,
+            "modulation": "qam_4096",
+            "lockStatus": True,
+            "rxMer": rx_mer,
+            "power": -118,
+        }]
+
+        _, ds31 = driver._parse_downstream(channels)
+
+        assert ds31[0]["mer"] == expected
+
+    def test_invalid_ofdm_rxmer_retains_channel(self, driver, caplog):
+        channels = [{
+            "channelType": "ofdm",
+            "channelId": 41,
+            "firstActiveSubcarrier": 1108,
+            "modulation": "qam_4096",
+            "lockStatus": True,
+            "rxMer": "invalid",
+            "power": -118,
+            "correctedErrors": 12,
+            "uncorrectedErrors": 3,
+        }]
+
+        with caplog.at_level(logging.WARNING, logger="docsis.driver.f3896lg"):
+            _, ds31 = driver._parse_downstream(channels)
+
+        assert len(ds31) == 1
+        assert ds31[0]["mer"] is None
+        assert ds31[0]["frequency"] == "1108 MHz"
+        assert ds31[0]["powerLevel"] == -11.8
+        assert ds31[0]["profile_modulation"] == "4096QAM"
+        assert ds31[0]["corrErrors"] == 12
+        assert ds31[0]["nonCorrErrors"] == 3
+        assert caplog.messages == [
+            "Invalid F3896LG OFDM rxMer 'invalid'; using no MER",
+        ]
+
+    def test_invalid_ofdm_power_retains_channel(self, driver, caplog):
+        channels = [{
+            "channelType": "ofdm",
+            "channelId": 41,
+            "firstActiveSubcarrier": 1108,
+            "modulation": "qam_4096",
+            "lockStatus": True,
+            "rxMer": 390,
+            "power": "invalid",
+        }]
+
+        with caplog.at_level(logging.WARNING, logger="docsis.driver.f3896lg"):
+            _, ds31 = driver._parse_downstream(channels)
+
+        assert len(ds31) == 1
+        assert ds31[0]["powerLevel"] is None
+        assert ds31[0]["mer"] == 39.0
+        assert caplog.messages == [
+            "Invalid F3896LG OFDM power 'invalid'; using no power",
+        ]
+
+    def test_unknown_channel_type_is_skipped(self, driver, caplog):
+        with caplog.at_level(logging.DEBUG, logger="docsis.driver.f3896lg"):
+            ds30, ds31 = driver._parse_downstream([
+                {"channelType": "mystery", "lockStatus": True},
+            ])
+
+        assert ds30 == []
+        assert ds31 == []
+        assert caplog.messages == [
+            "Skipping unknown downstream channel type 'mystery'",
+        ]
 
 
 class TestUpstream:
@@ -61,7 +221,61 @@ class TestUpstream:
         assert ch["type"] == "OFDMA"
         # firmware reports OFDMA power scaled x10: 380 -> 38.0 dBmV
         assert ch["powerLevel"] == 38.0
+        assert ch["frequency"] == "74 MHz"
         assert ch["modulation"] == "OFDMA"
+        assert ch["profile_modulation"] == "256QAM"
+
+    def test_unknown_channel_type_is_skipped(self, driver, caplog):
+        with caplog.at_level(logging.DEBUG, logger="docsis.driver.f3896lg"):
+            us30, us31 = driver._parse_upstream([
+                {"channelType": "mystery", "lockStatus": True},
+            ])
+
+        assert us30 == []
+        assert us31 == []
+        assert caplog.messages == [
+            "Skipping unknown upstream channel type 'mystery'",
+        ]
+
+    def test_invalid_ofdma_power_retains_channel(self, driver, caplog):
+        channels = [{
+            "channelType": "ofdma",
+            "channelId": 12,
+            "firstActiveSubcarrier": 74,
+            "modulation": "qam_256",
+            "lockStatus": True,
+            "power": "invalid",
+        }]
+
+        with caplog.at_level(logging.WARNING, logger="docsis.driver.f3896lg"):
+            _, us31 = driver._parse_upstream(channels)
+
+        assert len(us31) == 1
+        assert us31[0]["powerLevel"] is None
+        assert us31[0]["profile_modulation"] == "256QAM"
+        assert caplog.messages == [
+            "Invalid F3896LG OFDMA power 'invalid'; using no power",
+        ]
+
+
+@pytest.mark.parametrize(
+    "parser_name",
+    ["_parse_downstream", "_parse_upstream"],
+)
+def test_non_object_channel_entries_are_skipped(driver, parser_name):
+    assert getattr(driver, parser_name)([None, "invalid", []]) == ([], [])
+
+
+class TestAnalyzerIntegration:
+    def test_ofdm_profile_modulations_survive_normalization(self, driver):
+        analysis = analyze(driver.get_docsis_data())
+
+        ofdm = next(ch for ch in analysis["ds_channels"] if ch["channel_family"] == "ofdm")
+        ofdma = next(ch for ch in analysis["us_channels"] if ch["channel_family"] == "ofdma")
+        assert ofdm["modulation"] == "OFDM"
+        assert ofdm["profile_modulation"] == "4096QAM"
+        assert ofdma["modulation"] == "OFDMA"
+        assert ofdma["profile_modulation"] == "256QAM"
 
 
 class TestDeviceInfo:
@@ -69,7 +283,7 @@ class TestDeviceInfo:
         info = driver.get_device_info()
         assert info["manufacturer"] == "Sagemcom"
         assert info["model"] == "F3896LG (Virgin Media Hub 5)"
-        assert info["sw_version"] == "DOCSIS 3.1"
+        assert "sw_version" not in info
         assert info["docsis_status"] == "operational"
         assert info["uptime_seconds"] == 72394
 
@@ -81,8 +295,84 @@ class TestConnectionInfo:
         assert conn["max_upstream_kbps"] == 110000
         assert conn["connection_type"] == "DOCSIS 3.1"
 
+    def test_highest_positive_rate_wins_independently_of_flow_order(self, driver):
+        flows = {
+            "serviceFlows": [
+                {"serviceFlow": {
+                    "direction": "downstream",
+                    "maxTrafficRate": 1230000450,
+                }},
+                {"serviceFlow": {
+                    "direction": "downstream",
+                    "maxTrafficRate": "invalid",
+                }},
+                {"serviceFlow": {
+                    "direction": "upstream",
+                    "maxTrafficRate": 110000274,
+                }},
+                {"serviceFlow": {
+                    "direction": "downstream",
+                    "maxTrafficRate": 100000000,
+                }},
+                {"serviceFlow": {
+                    "direction": "upstream",
+                    "maxTrafficRate": 0,
+                }},
+                {"serviceFlow": {
+                    "direction": "upstream",
+                    "maxTrafficRate": -1,
+                }},
+                {"serviceFlow": {"direction": "downstream"}},
+                {"serviceFlow": {
+                    "direction": "upstream",
+                    "maxTrafficRate": 20000000,
+                }},
+            ],
+        }
+        with patch.object(driver, "_get", return_value=flows):
+            conn = driver.get_connection_info()
+
+        assert conn == {
+            "max_downstream_kbps": 1230000,
+            "max_upstream_kbps": 110000,
+            "connection_type": "DOCSIS 3.1",
+        }
+
+
+@pytest.mark.parametrize(
+    ("method_name", "expected"),
+    [
+        (
+            "get_device_info",
+            {
+                "manufacturer": "Sagemcom",
+                "model": "F3896LG (Virgin Media Hub 5)",
+            },
+        ),
+        ("get_connection_info", {"connection_type": "DOCSIS 3.1"}),
+    ],
+)
+def test_optional_metadata_is_fail_soft_for_non_object_json(
+    driver,
+    method_name,
+    expected,
+):
+    response = MagicMock()
+    response.json.return_value = []
+    driver._session.get.side_effect = None
+    driver._session.get.return_value = response
+
+    assert getattr(driver, method_name)() == expected
+
 
 class TestRegistry:
     def test_registered(self):
         from app.drivers import driver_registry
         assert "f3896lg" in driver_registry.get_all_type_keys()
+
+    def test_setup_hints(self):
+        from app.drivers import driver_registry
+
+        hints = driver_registry.get_driver_hints()["f3896lg"]
+        assert hints["default_url"] == "https://192.168.100.1"
+        assert hints["credentials_required"] is False

--- a/tests/drivers/f3896lg/test_parsing.py
+++ b/tests/drivers/f3896lg/test_parsing.py
@@ -1,0 +1,88 @@
+"""Tests for F3896LG (Liberty Global REST) channel parsing and derived values."""
+
+
+class TestLogin:
+    def test_login_ok(self, driver):
+        driver.login()  # must not raise
+
+
+class TestDownstream:
+    def test_locked_scqam_count(self, driver):
+        data = driver.get_docsis_data()
+        # 3 sc_qam in fixture, 1 unlocked -> skipped
+        assert len(data["channelDs"]["docsis30"]) == 2
+
+    def test_unlocked_channel_skipped(self, driver):
+        data = driver.get_docsis_data()
+        ids = [ch["channelID"] for ch in data["channelDs"]["docsis30"]]
+        assert 3 not in ids
+
+    def test_scqam_fields(self, driver):
+        ch = driver.get_docsis_data()["channelDs"]["docsis30"][0]
+        assert ch["channelID"] == 1
+        assert ch["frequency"] == "411 MHz"
+        assert ch["powerLevel"] == -4.3
+        assert ch["mer"] == 39
+        assert ch["mse"] == -39
+        assert ch["modulation"] == "256QAM"
+        assert ch["corrErrors"] == 26
+        assert ch["nonCorrErrors"] == 0
+
+    def test_ofdm_channel(self, driver):
+        ds31 = driver.get_docsis_data()["channelDs"]["docsis31"]
+        assert len(ds31) == 1
+        ch = ds31[0]
+        assert ch["channelID"] == 41
+        assert ch["type"] == "OFDM"
+        # firmware reports OFDM power scaled x10: -118 -> -11.8 dBmV
+        assert ch["powerLevel"] == -11.8
+        # rxMer 0 means "not reported" on this firmware
+        assert ch["mer"] is None
+        assert ch["corrErrors"] == 1361678039
+        assert ch["nonCorrErrors"] == 483483438
+
+
+class TestUpstream:
+    def test_atdma_channels(self, driver):
+        us30 = driver.get_docsis_data()["channelUs"]["docsis30"]
+        assert len(us30) == 2
+        ch = us30[0]
+        assert ch["channelID"] == 6
+        assert ch["frequency"] == "49.6 MHz"
+        assert ch["powerLevel"] == 42.5
+        assert ch["modulation"] == "64QAM"
+        assert ch["multiplex"] == "ATDMA"
+
+    def test_ofdma_channel(self, driver):
+        us31 = driver.get_docsis_data()["channelUs"]["docsis31"]
+        assert len(us31) == 1
+        ch = us31[0]
+        assert ch["channelID"] == 12
+        assert ch["type"] == "OFDMA"
+        # firmware reports OFDMA power scaled x10: 380 -> 38.0 dBmV
+        assert ch["powerLevel"] == 38.0
+        assert ch["modulation"] == "OFDMA"
+
+
+class TestDeviceInfo:
+    def test_device_info(self, driver):
+        info = driver.get_device_info()
+        assert info["manufacturer"] == "Sagemcom"
+        assert info["model"] == "F3896LG (Virgin Media Hub 5)"
+        assert info["sw_version"] == "DOCSIS 3.1"
+        assert info["docsis_status"] == "operational"
+        assert info["uptime_seconds"] == 72394
+
+
+class TestConnectionInfo:
+    def test_provisioned_rates(self, driver):
+        conn = driver.get_connection_info()
+        assert conn["max_downstream_kbps"] == 1230000
+        assert conn["max_upstream_kbps"] == 110000
+        assert conn["connection_type"] == "DOCSIS 3.1"
+
+
+class TestRegistry:
+    def test_registered(self):
+        from app.drivers import driver_registry
+        assert "f3896lg" in driver_registry.get_all_type_keys()

--- a/tests/test_public_launch_surface.py
+++ b/tests/test_public_launch_surface.py
@@ -383,3 +383,12 @@ def test_public_surface_avoids_real_provider_names_outside_setup_docs() -> None:
     pattern = re.compile(r"\b(Vodafone|Unitymedia|Telekom|Comcast|Xfinity|Spectrum|Virgin Media|Rogers|Bell)\b", re.I)
     for path in paths:
         assert not pattern.search(path.read_text(encoding="utf-8")), path
+
+
+def test_public_modem_family_counts_match_registry() -> None:
+    from app.drivers import driver_registry
+
+    family_count = len(driver_registry.get_all_type_keys() - {"generic"})
+    claim = f"{family_count} modem families"
+    assert claim in README.read_text(encoding="utf-8")
+    assert claim in INDEX.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds a driver for the **Liberty Global firmware variant** of the Sagemcom F@st 3896 — the **Virgin Media Hub 5 (F3896LG-VMB)**, also used by Ziggo (NL) and other LG-footprint ISPs.

This follows up on #163: the existing `sagemcom` driver targets the Tele2/Com Hem XMO JSON-RPC firmware (`/cgi/json-req`, SHA-512 login). On Liberty Global units that endpoint simply doesn't exist (404 — which is exactly how I found this, trying to add my Hub 5 with the existing driver). The LG firmware instead exposes a **read-only REST API at `/rest/v1/`** that requires **no authentication** for cable-modem status. It's the same API documented by the community client [ties/sagemcom-f3896-py](https://github.com/ties/sagemcom-f3896-py), which you referenced in #163 before it turned out the Swedish units were the other firmware.

## What the driver does

- `login()` — no real auth exists, so it verifies `/rest/v1/cablemodem/registration` answers, making the setup-wizard connection test meaningful
- Downstream: SC-QAM → `docsis30`, OFDM → `docsis31` (channel ID, frequency, power, SNR/MER, corrected/uncorrected errors, modulation)
- Upstream: ATDMA → `docsis30`, OFDMA → `docsis31`
- Device info from `/rest/v1/cablemodem/state_` (DOCSIS version, status, uptime)
- Provisioned max rates from `/rest/v1/cablemodem/serviceflows` → `ConnectionInfo`
- **Firmware quirk handled:** OFDM/OFDMA channel `power` is reported scaled ×10 (`380` = 38.0 dBmV, `-118` = −11.8 dBmV) while SC-QAM/ATDMA power is unscaled. Confirmed against the modem GUI values.
- `rxMer: 0` on the OFDM channel is treated as "not reported" → `None`

## Testing

- Unit tests in `tests/drivers/f3896lg/` with fixture payloads captured from a real Hub 5 (identifiers anonymised): parsing for all four channel types, unlocked-channel skipping, the ×10 power quirk, device/connection info, registry entry
- `pytest tests/drivers/` → **125 passed** (Python 3.13)
- Verified live against a Virgin Media (UK) Hub 5 in modem mode running a production DOCSight container: 31 SC-QAM + 1 OFDM downstream, 5 ATDMA + 1 OFDMA upstream, all values matching the hub GUI; running in my own deployment right now

## Notes

- Default URL is `https://192.168.100.1` (modem-mode management IP, self-signed cert — driver uses `verify=False` like other HTTPS-modem drivers)
- `credentials_required: False` hint, since the API is unauthenticated
- Happy to iterate if you'd rather fold this into the existing sagemcom driver with auto-detection, but the two firmwares share literally nothing (transport, auth, schema), so a separate driver seemed cleaner.
