### PR TITLE
Fix long-running backup resource handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 
 from . import analyzer, web
 from .config import ConfigManager
@@ -27,6 +27,8 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 log = logging.getLogger("docsis.main")
+
+COLLECTOR_LONG_RUNNING_SECONDS = 120
 
 
 class _AuditJsonFormatter(logging.Formatter):
@@ -233,8 +235,52 @@ def polling_loop(config_mgr, storage, stop_event):
     executor = ThreadPoolExecutor(
         max_workers=len(collectors), thread_name_prefix="collector"
     )
+    in_flight = {}
+
+    def _process_in_flight():
+        """Record completed collector runs and warn once for long-running work."""
+        now = time.monotonic()
+        for future, state in list(in_flight.items()):
+            collector = state["collector"]
+            if not future.done():
+                elapsed = now - state["submitted_at"]
+                if (
+                    elapsed >= COLLECTOR_LONG_RUNNING_SECONDS
+                    and not state["warned"]
+                ):
+                    state["warned"] = True
+                    log.warning(
+                        "%s: still running after %ds",
+                        collector.name,
+                        COLLECTOR_LONG_RUNNING_SECONDS,
+                    )
+                continue
+
+            del in_flight[future]
+            try:
+                _, result = future.result()
+                if result is None:
+                    continue  # skipped (collect lock busy)
+                if result.success:
+                    collector.record_success()
+                else:
+                    collector.record_failure()
+                    log.warning("%s: %s", collector.name, result.error)
+            except _TransientHtmlError:
+                collector.record_skip()
+                log.warning(
+                    "%s: transient HTML response, skipping poll", collector.name
+                )
+            except Exception as e:
+                collector.record_failure()
+                log.error("%s error: %s", collector.name, e)
+                if collector.name in ("modem", "demo"):
+                    web.update_state(error=e)
+
     try:
         while not stop_event.is_set():
+            _process_in_flight()
+
             # ── Driver hot-swap: detect modem config change ──
             if modem_config_key is not None and modem_collector:
                 new_key = _get_modem_config_key(config_mgr)
@@ -268,44 +314,26 @@ def polling_loop(config_mgr, storage, stop_event):
                     modem_config_key = new_key
                     log.info("Driver hot-swapped to %s", new_key[0])
 
-            futures = {}
             for collector in collectors:
                 if stop_event.is_set():
                     break
+                if any(
+                    state["collector"].name == collector.name
+                    for state in in_flight.values()
+                ):
+                    continue
                 if not collector.is_enabled():
                     continue
                 if not collector.should_poll():
                     continue
                 future = executor.submit(_run_collector, collector)
-                futures[future] = collector
+                in_flight[future] = {
+                    "collector": collector,
+                    "submitted_at": time.monotonic(),
+                    "warned": False,
+                }
 
-            try:
-                for future in as_completed(futures, timeout=120):
-                    if stop_event.is_set():
-                        break
-                    collector = futures[future]
-                    try:
-                        _, result = future.result()
-                        if result is None:
-                            continue  # skipped (collect lock busy)
-                        if result.success:
-                            collector.record_success()
-                        else:
-                            collector.record_failure()
-                            log.warning("%s: %s", collector.name, result.error)
-                    except _TransientHtmlError:
-                        collector.record_skip()
-                        log.warning("%s: transient HTML response, skipping poll", collector.name)
-                    except Exception as e:
-                        collector.record_failure()
-                        log.error("%s error: %s", collector.name, e)
-                        if collector.name in ("modem", "demo"):
-                            web.update_state(error=e)
-            except TimeoutError:
-                for future, collector in futures.items():
-                    if not future.done():
-                        log.error("%s: timed out after 120s", collector.name)
-                        future.cancel()
+            _process_in_flight()
 
             # ── Smart Capture expiry check (every 60s) ──
             if smart_capture:

--- a/app/modules/backup/backup.py
+++ b/app/modules/backup/backup.py
@@ -94,10 +94,21 @@ def create_backup(data_dir):
     Returns:
         BytesIO containing the .tar.gz archive.
     """
-    db_files = {"docsis_history.db", "connection_monitor.db"}
-
     buf = BytesIO()
-    with tempfile.TemporaryDirectory() as tmp:
+    _write_backup_archive(data_dir, buf, work_dir=data_dir)
+    buf.seek(0)
+    return buf
+
+
+def _write_backup_archive(data_dir, archive_target, work_dir=None):
+    """Write a backup archive to a path or binary file object."""
+    db_files = {"docsis_history.db", "connection_monitor.db"}
+    if work_dir is None:
+        work_dir = data_dir
+
+    with tempfile.TemporaryDirectory(
+        prefix=".docsight-backup-work-", dir=work_dir
+    ) as tmp:
         # Vacuum all databases for consistent copies
         vacuumed = {}
         for db_name in db_files:
@@ -116,7 +127,12 @@ def create_backup(data_dir):
         with open(meta_path, "w") as f:
             json.dump(meta, f, indent=2)
 
-        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        if isinstance(archive_target, (str, bytes, os.PathLike)):
+            tar_context = tarfile.open(name=archive_target, mode="w:gz")
+        else:
+            tar_context = tarfile.open(fileobj=archive_target, mode="w:gz")
+
+        with tar_context as tar:
             tar.add(meta_path, arcname=BACKUP_META_FILE)
             for db_name, has_db in vacuumed.items():
                 if has_db:
@@ -128,12 +144,9 @@ def create_backup(data_dir):
                 if os.path.exists(fpath):
                     tar.add(fpath, arcname=fname)
 
-    buf.seek(0)
-    return buf
-
 
 def create_backup_to_file(data_dir, dest_dir):
-    """Create a backup and write it to dest_dir.
+    """Create a backup and atomically publish it in dest_dir.
 
     Returns:
         Filename of the created backup.
@@ -143,9 +156,26 @@ def create_backup_to_file(data_dir, dest_dir):
     filename = f"docsight_backup_{ts}.tar.gz"
     dest_path = os.path.join(dest_dir, filename)
 
-    buf = create_backup(data_dir)
-    with open(dest_path, "wb") as f:
-        f.write(buf.read())
+    temp_fd, temp_path = tempfile.mkstemp(
+        prefix=f".{filename}.", suffix=".tmp", dir=dest_dir
+    )
+    try:
+        os.close(temp_fd)
+        temp_fd = None
+        _write_backup_archive(data_dir, temp_path, work_dir=data_dir)
+        os.replace(temp_path, dest_path)
+        temp_path = None
+    finally:
+        if temp_fd is not None:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        if temp_path is not None:
+            try:
+                os.remove(temp_path)
+            except FileNotFoundError:
+                pass
 
     log.info("Backup saved to %s", dest_path)
     return filename

--- a/app/modules/backup/routes.py
+++ b/app/modules/backup/routes.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import shutil
+import tempfile
 import time
 from collections import defaultdict
 from datetime import datetime
@@ -17,7 +19,7 @@ from app.web import (
 from werkzeug.utils import secure_filename
 
 from .backup import (
-    browse_directory, cleanup_old_backups, create_backup, create_backup_to_file,
+    _write_backup_archive, browse_directory, cleanup_old_backups, create_backup_to_file,
     list_backups, restore_backup, validate_backup,
 )
 
@@ -30,6 +32,33 @@ bp = Blueprint("backup_bp", __name__)
 _restore_attempts: dict[str, list[float]] = defaultdict(list)
 _RESTORE_MAX_ATTEMPTS = 5
 _RESTORE_WINDOW = 3600  # 1 hour
+
+
+class _CleanupOnClose:
+    """Proxy a WSGI iterable and run cleanup when the iterable is closed."""
+
+    def __init__(self, iterable, cleanup):
+        self._iterator = iter(iterable)
+        self._iterable = iterable
+        self._cleanup = cleanup
+        self._closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._iterator)
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            close = getattr(self._iterable, "close", None)
+            if close is not None:
+                close()
+        finally:
+            self._cleanup()
 
 
 def _check_restore_rate_limit() -> bool:
@@ -62,13 +91,40 @@ def api_backup_download():
     _config_manager = get_config_manager()
     if not _config_manager:
         return jsonify({"error": "Not initialized"}), 500
+    temp_dir = None
+    response = None
     try:
-        buf = create_backup(_config_manager.data_dir)
         ts = datetime.now().strftime("%Y-%m-%d_%H%M%S")
         filename = f"docsight_backup_{ts}.tar.gz"
+        temp_dir = tempfile.mkdtemp(
+            prefix=".docsight-backup-download-",
+            dir=_config_manager.data_dir,
+        )
+        archive_path = os.path.join(temp_dir, filename)
+        _write_backup_archive(
+            _config_manager.data_dir,
+            archive_path,
+            work_dir=temp_dir,
+        )
+        response = send_file(
+            archive_path,
+            mimetype="application/gzip",
+            as_attachment=True,
+            download_name=filename,
+        )
+        cleanup_dir = temp_dir
+        response.response = _CleanupOnClose(
+            response.response,
+            lambda: shutil.rmtree(cleanup_dir, ignore_errors=True),
+        )
+        temp_dir = None
         audit_log.info("Backup downloaded: ip=%s", _get_client_ip())
-        return send_file(buf, mimetype="application/gzip", as_attachment=True, download_name=filename)
+        return response
     except Exception as e:
+        if response is not None:
+            response.close()
+        if temp_dir is not None:
+            shutil.rmtree(temp_dir, ignore_errors=True)
         log.error("Backup creation failed: %s", e)
         return jsonify({"error": str(e)}), 500
 

--- a/tests/collectors/test_discovery_orchestrator.py
+++ b/tests/collectors/test_discovery_orchestrator.py
@@ -4,9 +4,12 @@
 
 import os
 import tempfile
+import threading
 import time
-import pytest
+from concurrent.futures import Future
 from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
 
 from app.collectors.base import Collector, CollectorResult
 from app.collectors.modem import ModemCollector
@@ -229,6 +232,187 @@ class TestPollingLoopOrchestrator:
         mgr.is_backup_configured.return_value = False
         mgr.get.return_value = ""
         return mgr
+
+    @patch("app.main.discover_collectors")
+    @patch("app.main.web")
+    def test_long_running_collector_is_tracked_until_result(
+        self, mock_web, mock_discover, caplog, monkeypatch
+    ):
+        """A collector crossing the old observation window is not resubmitted."""
+        from app import main
+
+        polling_loop = main.polling_loop
+        monkeypatch.setattr(main, "COLLECTOR_LONG_RUNNING_SECONDS", 0)
+
+        started = threading.Event()
+        release = threading.Event()
+        success_recorded = threading.Event()
+
+        class SlowCollector(Collector):
+            name = "slow"
+
+            def __init__(self):
+                super().__init__(poll_interval_seconds=3600)
+                self.collect_calls = 0
+                self.success_calls = 0
+                self.failure_calls = 0
+                self.skip_calls = 0
+
+            def collect(self):
+                self.collect_calls += 1
+                started.set()
+                assert release.wait(2)
+                return CollectorResult(source=self.name)
+
+            def record_success(self):
+                self.success_calls += 1
+                super().record_success()
+                success_recorded.set()
+
+            def record_failure(self):
+                self.failure_calls += 1
+                super().record_failure()
+
+            def record_skip(self):
+                self.skip_calls += 1
+                super().record_skip()
+
+        collector = SlowCollector()
+        mock_discover.return_value = [collector]
+        config_mgr = self._make_config_mgr()
+        storage = self._make_storage()
+        stop = threading.Event()
+        tick = 0
+        deadline = None
+
+        def advance_tick(timeout=None):
+            nonlocal tick, deadline
+            tick += 1
+            if tick == 1:
+                assert started.wait(1)
+            elif tick == 2:
+                assert collector.collect_calls == 1
+                release.set()
+                deadline = time.monotonic() + 2
+            elif success_recorded.is_set():
+                stop.set()
+                return True
+            else:
+                assert deadline is not None
+                assert time.monotonic() < deadline
+            return False
+
+        stop.wait = advance_tick
+
+        polling_loop(config_mgr, storage, stop)
+
+        assert collector.collect_calls == 1
+        assert collector.success_calls == 1
+        assert collector.failure_calls == 0
+        assert collector.skip_calls == 0
+        warnings = [
+            record for record in caplog.records
+            if "slow: still running after" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+
+    @patch("app.drivers.driver_registry.load_driver")
+    @patch("app.collectors.modem.ModemCollector")
+    @patch("app.main.discover_collectors")
+    @patch("app.main.web")
+    def test_hot_swap_waits_for_in_flight_collector_with_same_name(
+        self, mock_web, mock_discover, mock_modem_cls, mock_load, monkeypatch
+    ):
+        """A replacement modem waits for the prior modem future to finish."""
+        from app import main
+
+        class ControlledCollector(Collector):
+            name = "modem"
+
+            def __init__(self):
+                super().__init__(poll_interval_seconds=3600)
+                self.success_calls = 0
+                self.success_recorded = threading.Event()
+
+            def collect(self):
+                raise AssertionError("controlled executor should not invoke collect()")
+
+            def record_success(self):
+                self.success_calls += 1
+                super().record_success()
+                self.success_recorded.set()
+
+        old_collector = ControlledCollector()
+        replacement_collector = ControlledCollector()
+        mock_discover.return_value = [old_collector]
+        mock_modem_cls.return_value = replacement_collector
+
+        submissions = []
+        futures = {}
+
+        class ControlledExecutor:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def submit(self, fn, collector):
+                future = Future()
+                submissions.append(collector)
+                futures[collector] = future
+                if collector is replacement_collector:
+                    future.set_result(
+                        (collector, CollectorResult(source=collector.name))
+                    )
+                return future
+
+            def shutdown(self, *args, **kwargs):
+                pass
+
+        monkeypatch.setattr(main, "ThreadPoolExecutor", ControlledExecutor)
+
+        config_mgr = self._make_config_mgr()
+        modem_type = "fritzbox"
+
+        def get_config(key, default=None):
+            return {
+                "modem_type": modem_type,
+                "modem_url": "http://fritz.box",
+                "modem_user": "admin",
+                "modem_password": "pass",
+            }.get(key, default)
+
+        config_mgr.get.side_effect = get_config
+        storage = self._make_storage()
+        stop = threading.Event()
+        tick = 0
+
+        def advance_tick(timeout=None):
+            nonlocal tick, modem_type
+            tick += 1
+            if tick == 1:
+                assert submissions == [old_collector]
+                modem_type = "tc4400"
+            elif tick == 2:
+                assert submissions == [old_collector]
+                futures[old_collector].set_result(
+                    (
+                        old_collector,
+                        CollectorResult(source=old_collector.name),
+                    )
+                )
+            elif tick == 3:
+                assert submissions == [old_collector, replacement_collector]
+                assert old_collector.success_recorded.is_set()
+                assert replacement_collector.success_recorded.is_set()
+                stop.set()
+                return True
+            return False
+
+        stop.wait = advance_tick
+
+        main.polling_loop(config_mgr, storage, stop)
+
+        assert old_collector.success_calls == 1
+        assert replacement_collector.success_calls == 1
 
     @patch("app.drivers.driver_registry.load_driver")
     @patch("app.main.web")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -4,11 +4,15 @@ import json
 import os
 import sqlite3
 import tarfile
+from datetime import datetime as real_datetime
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from io import BytesIO
 
+from app.modules.backup import backup as backup_module
 from app.modules.backup.backup import (
     BACKUP_META_FILE,
     FORMAT_VERSION,
@@ -119,11 +123,200 @@ class TestCreateBackup:
             assert "docsis_history.db" not in names
             assert BACKUP_META_FILE in names
 
+    def test_compatibility_backup_uses_data_volume_for_vacuum_workspace(
+        self, data_dir, monkeypatch
+    ):
+        real_temporary_directory = backup_module.tempfile.TemporaryDirectory
+        temporary_directories = []
+
+        def checked_temporary_directory(*args, **kwargs):
+            temporary_directories.append(kwargs)
+            return real_temporary_directory(*args, **kwargs)
+
+        monkeypatch.setattr(
+            backup_module.tempfile,
+            "TemporaryDirectory",
+            checked_temporary_directory,
+        )
+
+        create_backup(data_dir)
+
+        assert len(temporary_directories) == 1
+        assert temporary_directories[0]["dir"] == data_dir
+        assert temporary_directories[0]["prefix"].startswith(".")
+
     def test_create_to_file(self, data_dir, backup_dir):
         filename = create_backup_to_file(data_dir, backup_dir)
         assert filename.startswith("docsight_backup_")
         assert filename.endswith(".tar.gz")
         assert os.path.exists(os.path.join(backup_dir, filename))
+
+    def test_create_to_file_uses_atomic_file_backed_archive(
+        self, data_dir, backup_dir, monkeypatch
+    ):
+        """Scheduled backups build on disk and publish only a complete archive."""
+        real_replace = os.replace
+        real_write_backup_archive = backup_module._write_backup_archive
+        replace_calls = []
+        work_dirs = []
+
+        def fail_in_memory_path(*args, **kwargs):
+            raise AssertionError("scheduled backup used create_backup()")
+
+        def checked_replace(src, dst):
+            src_path = Path(src)
+            dst_path = Path(dst)
+            assert src_path.parent == Path(backup_dir)
+            assert dst_path.parent == Path(backup_dir)
+            assert tarfile.is_tarfile(src_path)
+            replace_calls.append((src_path, dst_path))
+            real_replace(src, dst)
+
+        def checked_archive_write(data_path, archive_target, work_dir=None):
+            work_dirs.append(work_dir)
+            return real_write_backup_archive(
+                data_path, archive_target, work_dir=work_dir
+            )
+
+        monkeypatch.setattr(backup_module, "create_backup", fail_in_memory_path)
+        monkeypatch.setattr(backup_module.os, "replace", checked_replace)
+        monkeypatch.setattr(
+            backup_module, "_write_backup_archive", checked_archive_write
+        )
+
+        filename = create_backup_to_file(data_dir, backup_dir)
+        archive_path = Path(backup_dir) / filename
+
+        assert len(replace_calls) == 1
+        assert replace_calls[0][1] == archive_path
+        assert work_dirs == [data_dir]
+        assert archive_path.is_file()
+        with tarfile.open(archive_path, mode="r:gz") as tar:
+            assert BACKUP_META_FILE in tar.getnames()
+            assert "docsis_history.db" in tar.getnames()
+            assert "config.json" in tar.getnames()
+        assert set(Path(backup_dir).iterdir()) == {archive_path}
+
+    def test_create_to_file_removes_partial_temp_after_archive_failure(
+        self, data_dir, backup_dir, monkeypatch
+    ):
+        """A failed archive write leaves an existing completed backup untouched."""
+
+        class FixedDatetime:
+            @classmethod
+            def now(cls, tz=None):
+                return real_datetime(2026, 7, 28, 12, 34, 56, tzinfo=tz)
+
+        completed = Path(backup_dir) / "docsight_backup_2026-07-28_123456.tar.gz"
+        completed.write_bytes(b"existing-complete-backup")
+
+        def fail_archive_write(_data_dir, archive_target, work_dir=None):
+            assert work_dir == data_dir
+            Path(archive_target).write_bytes(b"partial")
+            raise RuntimeError("injected archive failure")
+
+        monkeypatch.setattr(backup_module, "datetime", FixedDatetime)
+        monkeypatch.setattr(
+            backup_module, "_write_backup_archive", fail_archive_write, raising=False
+        )
+
+        with pytest.raises(RuntimeError, match="injected archive failure"):
+            create_backup_to_file(data_dir, backup_dir)
+
+        assert completed.read_bytes() == b"existing-complete-backup"
+        assert set(Path(backup_dir).iterdir()) == {completed}
+
+
+class TestBackupDownloadRoute:
+    @staticmethod
+    def _app(data_dir, monkeypatch):
+        from flask import Flask
+        from app.modules.backup import routes
+
+        config_mgr = MagicMock()
+        config_mgr.data_dir = data_dir
+
+        test_app = Flask(__name__)
+        test_app.config.update(TESTING=True, SECRET_KEY="test-secret")
+        test_app.register_blueprint(routes.bp)
+        monkeypatch.setattr(routes, "get_config_manager", lambda: config_mgr)
+        monkeypatch.setattr("app.web._auth_required", lambda: False)
+        return test_app
+
+    def test_download_is_file_backed_and_cleans_up_on_close(
+        self, data_dir, tmp_path, monkeypatch
+    ):
+        from app.modules.backup import routes
+
+        temp_dir = tmp_path / "manual-backup"
+        archive_work_dirs = []
+
+        def make_temp_dir(*args, **kwargs):
+            assert kwargs["dir"] == data_dir
+            assert kwargs["prefix"].startswith(".")
+            temp_dir.mkdir()
+            return str(temp_dir)
+
+        real_write_backup_archive = routes._write_backup_archive
+
+        def checked_archive_write(data_path, archive_target, work_dir=None):
+            archive_work_dirs.append(work_dir)
+            return real_write_backup_archive(
+                data_path, archive_target, work_dir=work_dir
+            )
+
+        monkeypatch.setattr(
+            routes, "_write_backup_archive", checked_archive_write
+        )
+        monkeypatch.setattr(
+            routes, "tempfile", SimpleNamespace(mkdtemp=make_temp_dir), raising=False
+        )
+        app = self._app(data_dir, monkeypatch)
+
+        response = app.test_client().post("/api/backup", buffered=False)
+
+        assert response.status_code == 200
+        assert response.mimetype == "application/gzip"
+        assert "attachment" in response.headers["Content-Disposition"]
+        assert not isinstance(response.response, BytesIO)
+        assert archive_work_dirs == [str(temp_dir)]
+        archives = list(temp_dir.glob("*.tar.gz"))
+        assert len(archives) == 1
+        assert tarfile.is_tarfile(archives[0])
+
+        response.close()
+
+        assert not temp_dir.exists()
+
+    def test_download_cleans_up_after_archive_write_exception(
+        self, data_dir, tmp_path, monkeypatch
+    ):
+        from app.modules.backup import routes
+
+        temp_dir = tmp_path / "failed-manual-backup"
+
+        def make_temp_dir(*args, **kwargs):
+            assert kwargs["dir"] == data_dir
+            assert kwargs["prefix"].startswith(".")
+            temp_dir.mkdir()
+            return str(temp_dir)
+
+        def fail_archive_write(*args, **kwargs):
+            raise RuntimeError("injected route archive failure")
+
+        monkeypatch.setattr(
+            routes, "tempfile", SimpleNamespace(mkdtemp=make_temp_dir), raising=False
+        )
+        monkeypatch.setattr(
+            routes, "_write_backup_archive", fail_archive_write, raising=False
+        )
+        app = self._app(data_dir, monkeypatch)
+
+        response = app.test_client().post("/api/backup")
+
+        assert response.status_code == 500
+        assert response.get_json() == {"error": "injected route archive failure"}
+        assert not temp_dir.exists()
 
 
 # ── TestValidateBackup ──


### PR DESCRIPTION
## Summary

- write scheduled and manual backup archives to disk-backed temporary files instead of buffering complete archives in memory
- publish scheduled backups atomically and clean temporary files after failures or completed downloads
- retain long-running collector futures until completion and prevent duplicate submissions, including during collector hot-swaps
- add regression coverage for backup lifecycle and delayed collector completion

## Verification

- `python -m pytest tests --ignore=tests/e2e -q`: 3002 passed, 1 skipped
- focused backup and collector tests: 84 passed
- 64 MiB incompressible archive smoke test: peak RSS reduced from 156.0 MiB to 27.7 MiB with the same archive size
- `git diff --check` and Python compilation passed

Fixes #738
