### PR TITLE
Fix report support in the Windows package

### DIFF
--- a/packaging/windows/docsight.spec
+++ b/packaging/windows/docsight.spec
@@ -74,7 +74,6 @@ a = Analysis(
     excludes=[
         "tkinter",
         "pytest",
-        "unittest",
     ],
     noarchive=False,
     optimize=0,

--- a/packaging/windows/smoke_test.ps1
+++ b/packaging/windows/smoke_test.ps1
@@ -7,23 +7,29 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.Net.Http
 
 $BundleDir = [System.IO.Path]::GetFullPath($BundleDir)
-$Executable = Join-Path $BundleDir "DOCSight.exe"
-if (-not (Test-Path $Executable)) {
-    throw "DOCSight executable not found: $Executable"
+$SourceExecutable = Join-Path $BundleDir "DOCSight.exe"
+if (-not (Test-Path $SourceExecutable)) {
+    throw "DOCSight executable not found: $SourceExecutable"
 }
 
-$SmokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("docsight-desktop-smoke-" + [guid]::NewGuid().ToString("N"))
+$SmokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("DOCSight smoke " + [char]0x00FC + " " + [guid]::NewGuid().ToString("N"))
+$LaunchBundleDir = Join-Path $SmokeRoot "Packaged App"
+$Executable = Join-Path $LaunchBundleDir "DOCSight.exe"
 $LocalAppData = Join-Path $SmokeRoot "LocalAppData"
-New-Item -ItemType Directory -Force -Path $LocalAppData | Out-Null
 
 $PreviousLocalAppData = $env:LOCALAPPDATA
 $PreviousWebPort = $env:WEB_PORT
 $PreviousSkipBrowser = $env:DOCSIGHT_SKIP_BROWSER
 $Process = $null
+$HttpHandler = $null
+$HttpClient = $null
 $LogFile = Join-Path $LocalAppData "DOCSight\logs\docsight.log"
 $HealthUrl = "http://127.0.0.1:$Port/health"
+$ReportUrl = "http://127.0.0.1:$Port/api/report"
+$ConfigUrl = "http://127.0.0.1:$Port/api/config"
 
 function Write-SmokeLog {
     if (Test-Path $LogFile) {
@@ -35,12 +41,65 @@ function Write-SmokeLog {
     }
 }
 
+function Invoke-SmokeHttpRequest {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [ValidateSet("GET", "POST")][string]$Method = "GET",
+        [string]$JsonBody
+    )
+
+    $Request = [System.Net.Http.HttpRequestMessage]::new(
+        [System.Net.Http.HttpMethod]::new($Method),
+        [System.Uri]::new($Url)
+    )
+    try {
+        if ($PSBoundParameters.ContainsKey("JsonBody")) {
+            $Request.Content = [System.Net.Http.StringContent]::new(
+                $JsonBody,
+                [System.Text.Encoding]::UTF8,
+                "application/json"
+            )
+        }
+
+        $Response = $HttpClient.SendAsync($Request).GetAwaiter().GetResult()
+        try {
+            $Bytes = $Response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+            $ContentType = ""
+            if ($null -ne $Response.Content.Headers.ContentType) {
+                $ContentType = $Response.Content.Headers.ContentType.MediaType
+            }
+            return [pscustomobject]@{
+                StatusCode = [int]$Response.StatusCode
+                ContentType = $ContentType
+                Bytes = $Bytes
+                Body = [System.Text.Encoding]::UTF8.GetString($Bytes)
+            }
+        } finally {
+            $Response.Dispose()
+        }
+    } finally {
+        $Request.Dispose()
+    }
+}
+
 try {
+    New-Item -ItemType Directory -Force -Path $SmokeRoot | Out-Null
+    Copy-Item -LiteralPath $BundleDir -Destination $LaunchBundleDir -Recurse -Force
+    New-Item -ItemType Directory -Force -Path $LocalAppData | Out-Null
+    if (-not (Test-Path $Executable)) {
+        throw "Copied DOCSight executable not found: $Executable"
+    }
+
     $env:LOCALAPPDATA = $LocalAppData
     $env:WEB_PORT = [string]$Port
     $env:DOCSIGHT_SKIP_BROWSER = "1"
 
-    $Process = Start-Process -FilePath $Executable -PassThru -WindowStyle Hidden
+    $HttpHandler = [System.Net.Http.HttpClientHandler]::new()
+    $HttpHandler.UseProxy = $false
+    $HttpClient = [System.Net.Http.HttpClient]::new($HttpHandler)
+    $HttpClient.Timeout = [TimeSpan]::FromSeconds([Math]::Max(3, $TimeoutSeconds))
+
+    $Process = Start-Process -FilePath $Executable -WorkingDirectory $LaunchBundleDir -PassThru -WindowStyle Hidden
     $Deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     $Payload = $null
 
@@ -83,11 +142,100 @@ try {
         throw "DOCSight is not listening on 127.0.0.1:$Port. Observed listener addresses: $Addresses"
     }
 
-    Write-Host "DOCSight Desktop smoke passed: $HealthUrl returned status=ok version=$($Payload.version), listener=127.0.0.1:$Port"
+    $EmptyReportResponse = Invoke-SmokeHttpRequest -Url $ReportUrl
+    if ($EmptyReportResponse.StatusCode -ne 404) {
+        Write-SmokeLog
+        throw "Expected clean /api/report to return HTTP 404, got $($EmptyReportResponse.StatusCode): $($EmptyReportResponse.Body)"
+    }
+    try {
+        $EmptyReportPayload = $EmptyReportResponse.Body | ConvertFrom-Json
+    } catch {
+        Write-SmokeLog
+        throw "Clean /api/report did not return the Reports module JSON response: $($EmptyReportResponse.Body)"
+    }
+    if ($EmptyReportPayload.error -ne "No data available") {
+        Write-SmokeLog
+        throw "Clean /api/report returned unexpected JSON error '$($EmptyReportPayload.error)'."
+    }
+
+    $SetupJson = @{modem_type = "generic"} | ConvertTo-Json -Compress
+    $SetupResponse = Invoke-SmokeHttpRequest -Url $ConfigUrl -Method "POST" -JsonBody $SetupJson
+    if ($SetupResponse.StatusCode -ne 200) {
+        Write-SmokeLog
+        throw "Generic local setup failed with HTTP $($SetupResponse.StatusCode): $($SetupResponse.Body)"
+    }
+    try {
+        $SetupPayload = $SetupResponse.Body | ConvertFrom-Json
+    } catch {
+        Write-SmokeLog
+        throw "Generic local setup returned invalid JSON: $($SetupResponse.Body)"
+    }
+    if ($SetupPayload.success -ne $true) {
+        Write-SmokeLog
+        throw "Generic local setup did not succeed: $($SetupResponse.Body)"
+    }
+
+    $PdfResponse = $null
+    $LastReportResponse = $null
+    $ReportDeadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $ReportDeadline) {
+        $LastReportResponse = Invoke-SmokeHttpRequest -Url $ReportUrl
+        if ($LastReportResponse.StatusCode -eq 200) {
+            $PdfResponse = $LastReportResponse
+            break
+        }
+        if (
+            $LastReportResponse.StatusCode -ne 404 -or
+            $LastReportResponse.Body -notmatch "No data available"
+        ) {
+            Write-SmokeLog
+            throw "Packaged /api/report failed with HTTP $($LastReportResponse.StatusCode): $($LastReportResponse.Body)"
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    if ($null -eq $PdfResponse) {
+        Write-SmokeLog
+        $LastStatus = if ($null -ne $LastReportResponse) { $LastReportResponse.StatusCode } else { "no response" }
+        throw "Packaged /api/report did not produce a PDF within $TimeoutSeconds seconds (last status: $LastStatus)."
+    }
+    if ($PdfResponse.ContentType -ne "application/pdf") {
+        Write-SmokeLog
+        throw "Packaged /api/report returned Content-Type '$($PdfResponse.ContentType)' instead of 'application/pdf'."
+    }
+    if (
+        $PdfResponse.Bytes.Length -lt 5 -or
+        [System.Text.Encoding]::ASCII.GetString($PdfResponse.Bytes, 0, 5) -ne "%PDF-"
+    ) {
+        Write-SmokeLog
+        throw "Packaged /api/report response does not begin with %PDF-."
+    }
+
+    if (-not (Test-Path $LogFile)) {
+        throw "DOCSight Desktop log not found for post-smoke validation: $LogFile"
+    }
+    $LogText = Get-Content -Path $LogFile -Raw
+    if ($LogText -match "Module 'docsight\.reports': failed to import routes") {
+        Write-SmokeLog
+        throw "DOCSight Desktop log contains a Reports route import failure."
+    }
+    if ($LogText -match "No module named ['`"]unittest['`"]") {
+        Write-SmokeLog
+        throw "DOCSight Desktop log contains a missing unittest import."
+    }
+
+    Write-Host "DOCSight Desktop smoke passed: copied package path supports spaces/non-ASCII, health/version and loopback listener are valid, Reports route is registered, and /api/report returned application/pdf beginning %PDF-."
+} catch {
+    Write-SmokeLog
+    throw
 } finally {
     if ($null -ne $Process -and -not $Process.HasExited) {
         Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
         $Process.WaitForExit(10000) | Out-Null
+    }
+    if ($null -ne $HttpClient) {
+        $HttpClient.Dispose()
+    } elseif ($null -ne $HttpHandler) {
+        $HttpHandler.Dispose()
     }
 
     $env:LOCALAPPDATA = $PreviousLocalAppData

--- a/tests/test_windows_desktop_ci.py
+++ b/tests/test_windows_desktop_ci.py
@@ -100,6 +100,64 @@ def test_smoke_script_launches_built_exe_and_checks_loopback_health():
     assert "python -m app.main" not in script
 
 
+def test_smoke_script_runs_copied_bundle_from_hostile_temp_path():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    smoke_root = re.search(r"(?m)^\$SmokeRoot\s*=(?P<assignment>.+)$", script)
+    assert smoke_root
+    smoke_root_assignment = smoke_root.group("assignment")
+    assert '"DOCSight smoke "' in smoke_root_assignment
+    code_point = re.search(r"\[char\]0x(?P<hex>[0-9A-Fa-f]+)", smoke_root_assignment)
+    assert code_point
+    assert int(code_point.group("hex"), 16) > 127
+    assert "Copy-Item -LiteralPath $BundleDir" in script
+    assert "$Executable = Join-Path $LaunchBundleDir" in script
+    assert "-WorkingDirectory $LaunchBundleDir" in script
+    assert script.index("Copy-Item -LiteralPath $BundleDir") < script.index(
+        "Start-Process -FilePath $Executable"
+    )
+
+
+def test_smoke_script_proves_reports_route_before_seeding_generic_state():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "/api/report" in script
+    assert "$EmptyReportResponse.StatusCode -ne 404" in script
+    assert '$EmptyReportPayload.error -ne "No data available"' in script
+    assert "/api/config" in script
+    assert 'modem_type = "generic"' in script
+    assert "$SetupPayload.success -ne $true" in script
+    assert script.index("$EmptyReportResponse") < script.index("$SetupResponse")
+
+
+def test_smoke_script_checks_real_pdf_response_from_packaged_process():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "Add-Type -AssemblyName System.Net.Http" in script
+    assert "$PdfResponse.ContentType" in script
+    assert '"application/pdf"' in script
+    assert "$PdfResponse.Bytes" in script
+    assert '"%PDF-"' in script
+    assert script.index("$SetupResponse") < script.index("$PdfResponse")
+
+
+def test_smoke_script_rejects_reports_import_errors_and_preserves_cleanup():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "docsight\\.reports" in script
+    assert "failed to import routes" in script
+    assert "No module named" in script
+    assert "unittest" in script
+    assert script.index("$PdfResponse.ContentType") < script.index("$LogText")
+    assert re.search(
+        r"}\s*catch\s*{\s*Write-SmokeLog\s*throw\s*}\s*finally\s*{",
+        script,
+    )
+    assert "Stop-Process -Id $Process.Id -Force" in script
+    assert "$env:LOCALAPPDATA = $PreviousLocalAppData" in script
+    assert "Remove-Item -Recurse -Force $SmokeRoot" in script
+
+
 def test_step_block_helper_does_not_capture_next_step():
     workflow = WORKFLOW.read_text(encoding="utf-8")
     build_block = named_step_block(workflow, "Build portable package")

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -35,6 +36,26 @@ def test_pyinstaller_spec_collects_app_tree_and_version_file():
     assert "(str(VERSION_FILE), \".\")" in spec_text
     assert "docsight-icmp-helper" not in spec_text
     assert "docsight-traceroute-helper" not in spec_text
+
+
+def test_pyinstaller_spec_keeps_intended_exclusions_without_unittest():
+    spec_path = WINDOWS_PACKAGING / "docsight.spec"
+    tree = ast.parse(spec_path.read_text(encoding="utf-8"), filename=str(spec_path))
+    analysis_call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Analysis"
+    )
+    excludes_keyword = next(
+        keyword for keyword in analysis_call.keywords if keyword.arg == "excludes"
+    )
+    exclusions = ast.literal_eval(excludes_keyword.value)
+
+    assert "tkinter" in exclusions
+    assert "pytest" in exclusions
+    assert "unittest" not in exclusions
 
 
 def test_build_script_uses_hash_pinned_requirements_and_creates_zip_hash():


### PR DESCRIPTION
## Summary

- keep the Python standard-library runtime required by PDF report generation in the Windows package
- run the packaged application from a path containing spaces and non-ASCII characters
- extend the Windows artifact smoke test to verify Reports route registration, real PDF output, loopback binding, and actionable import-log failures

## Tests

- `python -m pytest -q tests/test_windows_packaging.py tests/test_windows_desktop_ci.py tests/test_report.py tests/web/test_reports.py` (51 passed)
- `python -m pytest tests/ -q --tb=short --ignore=tests/e2e` (3007 passed, 1 skipped)
- `git diff --check`
