### PR TITLE
Document Windows code signing policy

### DIFF
--- a/CODE_SIGNING.md
+++ b/CODE_SIGNING.md
@@ -1,0 +1,89 @@
+# Code signing policy
+
+## Status and provider
+
+DOCSight is preparing to onboard with the SignPath Foundation OSS program.
+Provider verification and signing configuration are still in progress.
+Current Windows artifacts remain unsigned until onboarding succeeds.
+
+## Conditional provider attribution
+
+The following attribution will apply only if provider approval and onboarding
+succeed:
+
+Free code signing provided by SignPath.io, certificate by SignPath Foundation
+
+The official public download surface is
+[GitHub Releases](https://github.com/itsDNNS/docsight/releases). Release pages
+identify the available artifacts and publish their checksums.
+
+## Project roles and approval
+
+DOCSight is an MIT-licensed project maintained by its repository owner,
+[itsDNNS](https://github.com/itsDNNS). The current project roles are:
+
+| Role | Holder |
+| --- | --- |
+| Maintainer, committer, and reviewer | itsDNNS |
+| Signing approver | itsDNNS |
+
+As a compensating control for this sole-maintainer role structure, the
+source-control account and any future signing-approval account must use
+multi-factor authentication (MFA). Signing approval requires review of the
+release source, workflow result, artifact identity, and expected version.
+
+Trusted release signing requires an approved release context. Approval is
+limited to an official tagged release from the DOCSight repository. A pull
+request, fork, workflow run from an untrusted context, or local build is not
+eligible for signing. Pull requests and forks do not receive signing credentials
+or signing-service access.
+
+## Signing scope and verification
+
+If onboarding succeeds, the signing scope is limited to Windows executable
+files in official DOCSight release assets. Signing is not available for
+third-party builds, forks, pull request artifacts, or general development
+builds. Signed files are expected to receive a trusted timestamp through the
+approved signing service.
+
+Once signed artifacts exist, Windows users can validate an extracted executable
+with the Windows SDK SignTool:
+
+```powershell
+signtool verify /pa /v .\DOCSight\DOCSight.exe
+```
+
+Until then, preview artifacts are unsigned. Download the ZIP and its
+corresponding `.sha256` file from the same release, calculate the ZIP's SHA-256
+digest, and compare the values before use:
+
+```powershell
+Get-FileHash -Algorithm SHA256 .\DOCSight-Desktop-Preview-win64-<version>.zip
+```
+
+A matching checksum verifies download integrity against the published checksum.
+It does not provide publisher authentication or replace a code signature.
+
+## Privacy and security reporting
+
+DOCSight does not transfer information to other networked systems unless
+explicitly configured or requested by the operator. The
+[security policy](SECURITY.md) documents the local-first, no-telemetry model and
+the private channels for reporting security concerns.
+
+## Revocation and incidents
+
+Signing approval is withheld if the release context, artifact identity, or
+signing authorization cannot be verified. If signing access, a certificate, or
+a signed artifact may have been compromised or misused, the maintainer will:
+
+1. Stop approving and publishing affected Windows artifacts.
+2. Notify SignPath and SignPath Foundation as appropriate, and request
+   revocation when required.
+3. Investigate affected versions and publish corrected artifacts only from a
+   newly verified release context.
+4. Publish relevant impact and verification guidance after containment, without
+   disclosing credentials or details that would enable further misuse.
+
+Report suspected signing incidents through the private channels in
+[SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="#supported-hardware">Supported Hardware</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="https://github.com/itsDNNS/docsight/wiki">Wiki</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="DATA_CONTRACT.md">Data contract</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
+  <a href="CODE_SIGNING.md">Code signing</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="https://github.com/itsDNNS/docsight/releases">Releases</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="https://github.com/itsDNNS/docsight/wiki/Roadmap">Roadmap</a>
 </p>

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -71,6 +71,11 @@ packaging/windows/dist/DOCSight-Desktop-Preview-win64-<version>.zip
 packaging/windows/dist/DOCSight-Desktop-Preview-win64-<version>.zip.sha256
 ```
 
+Current preview artifacts are unsigned while provider onboarding is pending.
+Downloaders should verify the preview ZIP against its published `.sha256` file.
+See the [code signing policy](../../CODE_SIGNING.md) for the onboarding status,
+intended release scope, and verification guidance.
+
 The build uses a Windows-resolved, hash-pinned runtime install from
 `requirements-runtime-windows.txt` and a cross-platform, hash-pinned build-tool
 install from `requirements-build.txt`. The generated `VERSION` file is bundled
@@ -111,4 +116,4 @@ Windows packaging tree out of the Docker build context as well.
 
 - No tray icon, WebView shell, auto-start, updater, installer, MSI, or MSIX.
 - No native Windows ICMP/traceroute diagnostics.
-- No code signing.
+- No code-signing integration while provider onboarding is pending.

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WINDOWS_PACKAGING = ROOT / "packaging" / "windows"
+CODE_SIGNING_POLICY = ROOT / "CODE_SIGNING.md"
 
 
 def test_windows_packaging_files_exist():
@@ -79,3 +80,52 @@ def test_gitignore_excludes_windows_build_outputs():
 
     assert "packaging/windows/build/" in gitignore
     assert "packaging/windows/dist/" in gitignore
+
+
+def test_windows_code_signing_policy_public_contract():
+    policy = CODE_SIGNING_POLICY.read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    windows_readme = (WINDOWS_PACKAGING / "README.md").read_text(encoding="utf-8")
+    normalized_policy = " ".join(policy.split())
+    policy_lower = normalized_policy.lower()
+    windows_readme_lower = " ".join(windows_readme.split()).lower()
+    attribution = (
+        "Free code signing provided by SignPath.io, "
+        "certificate by SignPath Foundation"
+    )
+    conditional_heading = "## Conditional provider attribution"
+    status_text, conditional_text = policy.split(conditional_heading, maxsplit=1)
+
+    assert policy.startswith("# Code signing policy\n")
+    assert attribution not in status_text
+    assert attribution in conditional_text
+    assert (
+        "will apply only if provider approval and onboarding succeed"
+        in policy_lower
+    )
+    assert "windows artifacts remain unsigned" in policy_lower
+    assert "still in progress" in policy_lower
+    assert "official tagged release" in policy_lower
+    for excluded_context in ("pull request", "fork", "untrusted context"):
+        assert excluded_context in policy_lower
+    assert "not eligible for signing" in policy_lower
+    assert "source-control account" in policy_lower
+    assert "future signing-approval account" in policy_lower
+    assert "must use multi-factor authentication (mfa)" in policy_lower
+    for approval_check in (
+        "release source",
+        "workflow result",
+        "artifact identity",
+        "expected version",
+    ):
+        assert approval_check in policy_lower
+    assert "## Revocation and incidents" in policy
+    assert "stop approving and publishing" in policy_lower
+    assert "request revocation" in policy_lower
+    assert "impact and verification guidance" in policy_lower
+    assert "https://github.com/itsDNNS/docsight/releases" in policy
+    assert "[SECURITY.md](SECURITY.md)" in policy
+    assert '<a href="CODE_SIGNING.md">Code signing</a>' in readme
+    assert "[code signing policy](../../CODE_SIGNING.md)" in windows_readme
+    assert "preview artifacts are unsigned" in windows_readme_lower
+    assert "provider onboarding is pending" in windows_readme_lower


### PR DESCRIPTION
## Summary

- publish the Windows code signing policy, approval boundaries, and incident handling
- document that provider onboarding is pending and current preview artifacts remain unsigned
- link the policy from the project and Windows packaging documentation
- protect the public signing contract with focused regression coverage

## Testing

- `python3 -m pytest -q tests/test_windows_packaging.py tests/test_public_launch_surface.py tests/test_defensive_review_docs.py` (`30 passed`)
- `git diff --check`