### PR TITLE
Detect browser language during initial setup

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -351,6 +351,10 @@ class ConfigManager:
             return default
         return DEFAULTS.get(key)
 
+    def has_stored_value(self, key):
+        """Return whether config.json contains this key, excluding defaults/env."""
+        return key in self._file_config
+
     @staticmethod
     def _validate_url(key, value):
         """Validate that URL keys use http or https scheme only."""

--- a/app/web.py
+++ b/app/web.py
@@ -21,7 +21,7 @@ from markupsafe import Markup
 from werkzeug.security import check_password_hash
 from zoneinfo import available_timezones
 
-from .config import MODULE_SECRET_KEYS, PASSWORD_MASK, POLL_MIN, POLL_MAX
+from .config import DEFAULTS, MODULE_SECRET_KEYS, PASSWORD_MASK, POLL_MIN, POLL_MAX
 from .analyzer import get_thresholds
 from .docsis_utils import qam_rank
 from .gaming_index import compute_gaming_index
@@ -428,6 +428,35 @@ def _get_lang():
     if _config_manager:
         return _config_manager.get("language", "en")
     return "en"
+
+
+def _get_setup_lang():
+    """Resolve and persist the language for the unconfigured setup route."""
+    lang = request.args.get("lang")
+    if lang in LANGUAGES:
+        if _config_manager:
+            _config_manager.save({"language": lang})
+        return lang
+
+    if _config_manager and _config_manager.has_stored_value("language"):
+        return _config_manager.get("language", DEFAULTS["language"])
+
+    inferred = DEFAULTS["language"]
+    for requested, quality in request.accept_languages:
+        if quality <= 0:
+            continue
+        normalized = requested.lower().replace("_", "-")
+        if normalized in LANGUAGES:
+            inferred = normalized
+            break
+        base = normalized.split("-", 1)[0]
+        if base in LANGUAGES:
+            inferred = base
+            break
+
+    if _config_manager:
+        _config_manager.save({"language": inferred})
+    return inferred
 
 
 def _get_tz_name():
@@ -1655,7 +1684,7 @@ def setup():
     if _config_manager and (_config_manager.is_configured() or _config_manager.is_demo_mode()):
         return redirect("/")
     config = _config_manager.get_all(mask_secrets=True) if _config_manager else {}
-    lang = _get_lang()
+    lang = _get_setup_lang()
     t = get_translations(lang)
     tz_name, tz_offset = _server_tz_info()
     from .drivers import driver_registry

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -326,6 +326,28 @@ def setup_server(_setup_data_dir):
 
 
 @pytest.fixture()
+def isolated_setup_server(tmp_path):
+    """Start an unconfigured server with fresh data for one language test."""
+    data_dir = str(tmp_path / "isolated-setup")
+    port = _find_free_port()
+    proc = _MP_CTX.Process(
+        target=_start_unconfigured_server,
+        args=(data_dir, port),
+        daemon=True,
+    )
+    proc.start()
+    try:
+        _wait_for_server(port)
+        yield {
+            "url": f"http://127.0.0.1:{port}",
+            "data_dir": data_dir,
+        }
+    finally:
+        proc.terminate()
+        proc.join(timeout=5)
+
+
+@pytest.fixture()
 def setup_page(page, setup_server):
     """Navigate to the unconfigured server — lands on /setup."""
     page.goto(setup_server)

--- a/tests/e2e/test_i18n.py
+++ b/tests/e2e/test_i18n.py
@@ -1,5 +1,8 @@
 """E2E tests for internationalization (language switching)."""
 
+import json
+from pathlib import Path
+
 import pytest
 
 EUROPEAN_LANGUAGE_PACK = {
@@ -7,6 +10,11 @@ EUROPEAN_LANGUAGE_PACK = {
     "ga", "hr", "hu", "it", "lt", "lv", "nb", "nl", "pl", "pt",
     "ro", "sk", "sl", "sv",
 }
+
+
+def _stored_language(server):
+    config_path = Path(server["data_dir"]) / "config.json"
+    return json.loads(config_path.read_text(encoding="utf-8"))["language"]
 
 
 class TestLanguageSwitching:
@@ -69,3 +77,61 @@ class TestLanguageSwitching:
         )
         assert metrics["doc"] <= metrics["viewport"]
         assert metrics["selectorRight"] <= metrics["viewport"]
+
+
+class TestFirstRunLanguageInference:
+    """First-run browser inference is isolated from shared demo fixtures."""
+
+    @pytest.mark.parametrize(
+        ("accept_language", "expected"),
+        [
+            ("de-DE,de;q=0.9", "de"),
+            ("en-US,en;q=0.9", "en"),
+            ("zz-ZZ,xx;q=0.9", "en"),
+        ],
+    )
+    def test_fresh_setup_infers_and_persists_browser_language(
+        self, browser, isolated_setup_server, accept_language, expected
+    ):
+        context = browser.new_context(
+            extra_http_headers={"Accept-Language": accept_language}
+        )
+        try:
+            page = context.new_page()
+            page.goto(isolated_setup_server["url"] + "/setup")
+            page.wait_for_load_state("networkidle")
+
+            assert page.locator("html").get_attribute("lang") == expected
+            assert page.locator("#lang-select").input_value() == expected
+            assert _stored_language(isolated_setup_server) == expected
+        finally:
+            context.close()
+
+    def test_explicit_setup_override_persists_across_header_change(
+        self, browser, isolated_setup_server
+    ):
+        context = browser.new_context(
+            extra_http_headers={"Accept-Language": "de-DE"}
+        )
+        try:
+            page = context.new_page()
+            page.goto(isolated_setup_server["url"] + "/setup")
+            page.wait_for_load_state("networkidle")
+            assert page.locator("html").get_attribute("lang") == "de"
+
+            page.goto(isolated_setup_server["url"] + "/setup?lang=fr")
+            page.wait_for_load_state("networkidle")
+
+            assert page.locator("html").get_attribute("lang") == "fr"
+            assert page.locator("#lang-select").input_value() == "fr"
+            assert _stored_language(isolated_setup_server) == "fr"
+
+            page.set_extra_http_headers({"Accept-Language": "en-US"})
+            page.goto(isolated_setup_server["url"] + "/setup")
+            page.wait_for_load_state("networkidle")
+
+            assert page.locator("html").get_attribute("lang") == "fr"
+            assert page.locator("#lang-select").input_value() == "fr"
+            assert _stored_language(isolated_setup_server) == "fr"
+        finally:
+            context.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,10 @@ class TestConfigDefaults:
     def test_smokeping_module_disabled_by_default(self, config):
         assert config.get("disabled_modules") == "docsight.smokeping"
 
+    def test_default_value_is_not_reported_as_stored(self, config):
+        assert config.get("language") == "en"
+        assert config.has_stored_value("language") is False
+
 
 class TestConfigSaveLoad:
     def test_save_and_load(self, tmp_data_dir):
@@ -50,6 +54,14 @@ class TestConfigSaveLoad:
     def test_save_creates_file(self, config, tmp_data_dir):
         config.save({"modem_user": "test"})
         assert os.path.exists(os.path.join(tmp_data_dir, "config.json"))
+
+    def test_saved_value_is_reported_as_stored_after_reload(self, tmp_data_dir):
+        config = ConfigManager(tmp_data_dir)
+        config.save({"language": "de"})
+
+        reloaded = ConfigManager(tmp_data_dir)
+
+        assert reloaded.has_stored_value("language") is True
 
     def test_int_keys_cast(self, tmp_data_dir):
         config = ConfigManager(tmp_data_dir)

--- a/tests/web/test_setup_language.py
+++ b/tests/web/test_setup_language.py
@@ -1,0 +1,144 @@
+"""Focused contracts for first-run setup language selection."""
+
+import json
+import re
+
+import pytest
+
+from app.config import ConfigManager
+from app.i18n import LANGUAGES
+from app.web import app, init_config, init_storage
+
+
+def _html_lang(response):
+    match = re.search(r'<html lang="([^"]+)"', response.get_data(as_text=True))
+    assert match is not None
+    return match.group(1)
+
+
+def _stored_config(manager):
+    with open(manager.config_path, encoding="utf-8") as config_file:
+        return json.load(config_file)
+
+
+@pytest.fixture
+def fresh_manager(tmp_path):
+    manager = ConfigManager(str(tmp_path / "data"))
+    init_config(manager)
+    init_storage(None)
+    app.config["TESTING"] = True
+    return manager
+
+
+@pytest.mark.parametrize(
+    ("accept_language", "expected"),
+    [
+        ("de-DE,de;q=0.9,en;q=0.8", "de"),
+        ("en-US,en;q=0.9", "en"),
+        ("pt-BR,pt;q=0.9", "pt"),
+        ("fr", "fr"),
+        ("fr;q=0.1,de-DE;q=0.9", "de"),
+        ("zz-ZZ,xx;q=0.9", "en"),
+    ],
+)
+def test_fresh_setup_negotiates_and_persists_supported_language(
+    fresh_manager, accept_language, expected
+):
+    with app.test_client() as client:
+        response = client.get(
+            "/setup", headers={"Accept-Language": accept_language}
+        )
+
+    assert response.status_code == 200
+    assert _html_lang(response) == expected
+    assert fresh_manager.has_stored_value("language") is True
+    assert _stored_config(fresh_manager)["language"] == expected
+
+
+def test_fresh_setup_without_accept_language_persists_product_default(fresh_manager):
+    with app.test_client() as client:
+        response = client.get("/setup")
+
+    assert response.status_code == 200
+    assert _html_lang(response) == "en"
+    assert _stored_config(fresh_manager)["language"] == "en"
+
+
+def test_first_inference_survives_new_manager_client_and_changed_header(
+    fresh_manager
+):
+    with app.test_client() as first_client:
+        first_response = first_client.get(
+            "/setup", headers={"Accept-Language": "de-DE"}
+        )
+
+    reloaded = ConfigManager(fresh_manager.data_dir)
+    init_config(reloaded)
+    with app.test_client() as second_client:
+        second_response = second_client.get(
+            "/setup", headers={"Accept-Language": "fr-FR"}
+        )
+
+    assert _html_lang(first_response) == "de"
+    assert _html_lang(second_response) == "de"
+    assert _stored_config(reloaded)["language"] == "de"
+
+
+def test_valid_explicit_setup_language_overrides_and_persists(fresh_manager):
+    fresh_manager.save({"language": "de"})
+
+    with app.test_client() as client:
+        explicit_response = client.get("/setup?lang=fr")
+        later_response = client.get(
+            "/setup", headers={"Accept-Language": "de-DE"}
+        )
+
+    assert _html_lang(explicit_response) == "fr"
+    assert _html_lang(later_response) == "fr"
+    assert _stored_config(fresh_manager)["language"] == "fr"
+
+
+def test_existing_stored_preference_wins_over_browser_header(fresh_manager):
+    fresh_manager.save({"language": "pl"})
+
+    with app.test_client() as client:
+        response = client.get(
+            "/setup", headers={"Accept-Language": "de-DE"}
+        )
+
+    assert _html_lang(response) == "pl"
+    assert _stored_config(fresh_manager)["language"] == "pl"
+
+
+def test_invalid_query_is_ignored_and_never_persisted(fresh_manager):
+    with app.test_client() as client:
+        response = client.get(
+            "/setup?lang=not-a-locale",
+            headers={"Accept-Language": "de-DE"},
+        )
+
+    assert _html_lang(response) == "de"
+    assert _stored_config(fresh_manager)["language"] == "de"
+
+
+def test_setup_renders_every_registered_locale_option(fresh_manager):
+    with app.test_client() as client:
+        response = client.get("/setup", headers={"Accept-Language": "en-US"})
+
+    html = response.get_data(as_text=True)
+    language_select = html.split('id="lang-select"', 1)[1].split("</select>", 1)[0]
+    rendered_options = set(
+        re.findall(r'<option value="([^"]+)"', language_select)
+    )
+    assert rendered_options == set(LANGUAGES)
+
+
+def test_non_setup_language_query_remains_transient(fresh_manager):
+    fresh_manager.save({"modem_type": "fritzbox"})
+
+    with app.test_client() as client:
+        response = client.get("/settings?lang=de")
+
+    assert response.status_code == 200
+    assert _html_lang(response) == "de"
+    assert fresh_manager.has_stored_value("language") is False


### PR DESCRIPTION
## Summary

- detect the preferred supported browser language on the first setup visit
- persist the resolved language through the existing configuration manager
- keep stored preferences and ordinary page language overrides unchanged

## Validation

- `uv run --with-requirements requirements-test.txt pytest -q tests --ignore=tests/e2e --tb=short` (`3075 passed, 1 skipped`)
- issue-focused Playwright setup and i18n tests (`37 passed`)
- full Playwright denominator: `513 passed`; the remaining correlation-tooltip hover test fails identically on this branch and unchanged `main`
- `uv run --with-requirements requirements-test.txt python scripts/i18n_check.py --validate`
- `git diff --check`
- `python3 -m compileall -q app/config.py app/web.py tests/web/test_setup_language.py tests/e2e/test_i18n.py tests/e2e/conftest.py`

## Documentation

No documentation change is needed. This transparently initializes the existing language setting and does not change the setup procedure or operator-facing configuration contract.
