### PR TITLE
feat(windows): add visible startup recovery

### DIFF
--- a/.github/workflows/windows-desktop.yml
+++ b/.github/workflows/windows-desktop.yml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   build:
+    timeout-minutes: 30
     runs-on: windows-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -45,6 +46,7 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
+          architecture: x64
           cache: pip
           cache-dependency-path: |
             packaging/windows/requirements-runtime-windows.txt

--- a/docs/windows-desktop-preview.md
+++ b/docs/windows-desktop-preview.md
@@ -61,6 +61,18 @@ DOCSight starts a local web app and opens your default browser. The address is l
 http://127.0.0.1:8765
 ```
 
+A small DOCSight startup window appears first. It shows the current local
+address with a **Copy** action from **Start DOCSight** onward and reports
+progress while it prepares local data, starts DOCSight, waits for readiness,
+and attempts to open the browser. After DOCSight is ready and the browser-open
+attempt succeeds, the startup window closes.
+
+If startup cannot finish or the browser cannot be opened, the window stays
+available instead of exiting silently. You can copy the displayed local
+address, choose **Retry** to start a fresh attempt, open the log folder, or
+close DOCSight. A browser-open failure does not mean the local app is
+unavailable: copy the address into a browser to continue.
+
 ## What works in the Desktop Preview
 
 The preview uses the same DOCSight web app and is useful for exploring the product:
@@ -102,7 +114,20 @@ Typical subfolders:
 |---|---|
 | `%LOCALAPPDATA%\DOCSight\data` | Configuration and local monitoring database |
 | `%LOCALAPPDATA%\DOCSight\modules` | Community modules and themes |
-| `%LOCALAPPDATA%\DOCSight\logs` | Desktop launcher and runtime logs |
+| `%LOCALAPPDATA%\DOCSight\logs` | Privacy-filtered launcher diagnostics in `launcher.log`; separate application diagnostics in `runtime.log` |
+
+`launcher.log` contains only sanitized startup/recovery events and is intended
+to be shareable. `runtime.log` contains separate application diagnostics;
+review it before sharing because it can contain instance-specific operational
+details.
+
+The release smoke runs later on `windows-latest`; Linux tests only enforce its
+static contract. The Windows run requires exactly one listener on the smoke
+port and exactly one IPv4 loopback listener owned by the launched process,
+requires `runtime.log` without packaged route/import degradation, and deletes
+the first launcher's log before requiring fresh **Prepare local data** evidence
+from the injected recovery process. That recovery process must also have a
+nonzero main-window handle with the title exactly `DOCSight`.
 
 ## Remove the Desktop Preview
 

--- a/packaging/windows/QA-CHECKLIST.md
+++ b/packaging/windows/QA-CHECKLIST.md
@@ -28,8 +28,61 @@ Record these values before starting:
 - [ ] Extract the ZIP into a normal user-writable folder such as `Downloads\DOCSight`.
 - [ ] Double-click `DOCSight.exe`.
 - [ ] If SmartScreen appears, confirm the documented flow works: **More info** → **Run anyway** after checksum verification.
+- [ ] A centered DOCSight startup window is visible within **under two seconds** of double-clicking, before slow startup completes.
+- [ ] At 100%, 150%, and 200% display scaling, the startup and expanded recovery layouts remain readable without clipped actions.
+- [ ] The startup window advances through **Prepare local data**, **Start DOCSight**, **Wait for readiness**, and **Open browser**.
+- [ ] The local loopback URL is visible from **Start DOCSight** onward; select **Copy** and paste it into Notepad to verify the exact address.
 - [ ] The default browser opens `http://127.0.0.1:<port>/` without requiring PowerShell, Docker, WSL, or admin setup.
 - [ ] The UI shows the Desktop Preview badge and first-run notice.
+
+## Startup recovery
+
+Run controlled recovery checks from PowerShell in the extracted bundle directory. Use one command block at a time, close the recovery window afterward, and remove the variables before the next normal launch.
+
+**Application-thread failure**
+
+```powershell
+$env:DOCSIGHT_SKIP_BROWSER = "1"
+$env:DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE = "1"
+.\DOCSight.exe
+Remove-Item Env:DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE, Env:DOCSIGHT_SKIP_BROWSER -ErrorAction SilentlyContinue
+```
+
+**No free preview port**
+
+```powershell
+$env:DOCSIGHT_SKIP_BROWSER = "1"
+$env:DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE = "1"
+.\DOCSight.exe
+Remove-Item Env:DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE, Env:DOCSIGHT_SKIP_BROWSER -ErrorAction SilentlyContinue
+```
+
+**Browser-open failure after readiness**
+
+```powershell
+$env:DOCSIGHT_SKIP_BROWSER = "1"
+$env:DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE = "1"
+.\DOCSight.exe
+Remove-Item Env:DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE, Env:DOCSIGHT_SKIP_BROWSER -ErrorAction SilentlyContinue
+```
+
+These switches are ignored unless `DOCSIGHT_SKIP_BROWSER=1` is present.
+
+The release smoke on `windows-latest` separately requires exactly one listener
+on its smoke port and exactly one process-owned IPv4 loopback listener. It also
+requires `runtime.log` without route/import degradation, deletes the successful
+launcher's `launcher.log` before checking fresh injected recovery evidence, and
+requires the recovery process to expose a nonzero main-window handle titled
+exactly `DOCSight`.
+
+- [ ] Capture one screenshot of the normal immediate startup status.
+- [ ] Run the application-thread failure check and capture a screenshot showing readable, plain-language recovery without exception details.
+- [ ] Run the no-port check and verify the address is marked unavailable and **Copy** is disabled. In other error states with a selected port, verify the local URL and **Copy** action still work.
+- [ ] Select **Open log folder** and confirm Explorer opens `%LOCALAPPDATA%\DOCSight\logs` with `launcher.log` and `runtime.log` present.
+- [ ] Treat sanitized `launcher.log` as shareable launcher evidence. Review the separate `runtime.log` diagnostics before sharing them because they may contain instance-specific details.
+- [ ] Select **Retry** and confirm a fresh launcher starts from **Prepare local data** without leaving the prior `DOCSight.exe` process running.
+- [ ] Run the browser-open failure check and verify the recovery window remains visible; copy the URL into a browser and confirm the ready local app is usable.
+- [ ] Select **Close** on an error surface and confirm the launcher process exits.
 
 ## Product click-through
 
@@ -61,6 +114,12 @@ Record these values before starting:
 |---|---|---|
 | Checksum and extraction | | |
 | Double-click startup | | |
+| Immediate status under two seconds | | |
+| Startup phases and URL copy | | |
+| Error screenshot and safe copy | | |
+| Retry and prior-process cleanup | | |
+| Open log folder / `launcher.log` | | |
+| Browser-open failure fallback | | |
 | SmartScreen flow | | |
 | Wizard / Demo Mode | | |
 | Dashboard / glossary / evidence | | |

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -12,8 +12,24 @@ Run from the repository root during development:
 python packaging/windows/docsight_desktop.py
 ```
 
-The launcher prepares a per-user runtime tree, starts DOCSight on loopback, and
-opens the default browser when `/health` is ready.
+The launcher first paints a compact native startup window, then prepares a
+per-user runtime tree, starts DOCSight on loopback, and opens the default
+browser when `/health` is ready. The window shows the current local address
+from **Start DOCSight** onward and provides a copy action.
+
+Startup progresses through four visible phases:
+
+1. **Prepare local data**
+2. **Start DOCSight**
+3. **Wait for readiness**
+4. **Open browser**
+
+If the browser opens successfully, the startup window closes after the open
+attempt. If no port is available, readiness times out, the application thread
+stops, or the browser cannot be opened, the launcher remains visible with
+plain-language recovery guidance, the local URL, **Retry**, **Open log folder**,
+and **Close**. Retry starts a fresh launcher process so a previous local server
+cannot be retained by the same process.
 
 ## Runtime contract
 
@@ -26,7 +42,13 @@ On startup the launcher creates and exports:
 | `WEB_HOST` | `127.0.0.1` |
 | `WEB_PORT` | first available port from `8765` through `8775` |
 | `DOCSIGHT_DESKTOP_MODE` | `1` |
-| log file | `%LOCALAPPDATA%\\DOCSight\\logs\\docsight.log` |
+| privacy-filtered launcher phase/recovery log | `%LOCALAPPDATA%\\DOCSight\\logs\\launcher.log` |
+| application runtime diagnostics | `%LOCALAPPDATA%\\DOCSight\\logs\\runtime.log` |
+
+`launcher.log` is deliberately limited to sanitized launcher events and is
+intended to be shareable. `runtime.log` keeps application diagnostics separate;
+review it before sharing because runtime records may contain instance-specific
+operational details.
 
 If `LOCALAPPDATA` is unavailable, the launcher falls back to
 `Path.home() / "AppData" / "Local"` so the same code path is testable outside
@@ -100,8 +122,24 @@ powershell -ExecutionPolicy Bypass -File packaging/windows/smoke_test.ps1 `
 
 The smoke test launches the packaged executable, uses a temporary
 `LOCALAPPDATA`, skips browser launch via `DOCSIGHT_SKIP_BROWSER=1`, verifies the
-`/health` status and version, checks the listener is bound to `127.0.0.1`, and
-then stops the process.
+`/health` status and version, requires exactly one listener on the smoke port
+and exactly one IPv4 `127.0.0.1` listener owned by the launched process, and
+requires `runtime.log` without packaged route/import failures such as
+`failed to import routes` or `No module named`. It validates a real Reports PDF
+and then stops the process. The deterministic recovery check deletes the first
+process's `launcher.log` before the injected launch, requires the second process
+to write the **Prepare local data** recovery evidence, and confirms a nonzero
+main-window handle whose title is exactly `DOCSight`.
+
+The narrowly scoped `DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE=1`,
+`DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE=1`, and
+`DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE=1` switches are honored only while
+`DOCSIGHT_SKIP_BROWSER=1` is active. They are packaging/manual-QA test
+infrastructure and have no effect during normal interactive startup.
+
+The automated smoke verifies process, window-title, logging, listener, API, and
+recovery contracts. Use `QA-CHECKLIST.md` for visual quality, DPI scaling, and
+interactive action checks.
 
 ## Packaging boundary
 
@@ -116,5 +154,6 @@ Windows packaging tree out of the Docker build context as well.
 ## Non-goals for this slice
 
 - No tray icon, WebView shell, auto-start, updater, installer, MSI, or MSIX.
+- No dedicated shutdown control beyond the launcher recovery surface.
 - No native Windows ICMP/traceroute diagnostics.
 - No code-signing integration while provider onboarding is pending.

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -82,6 +82,11 @@ if (-not (Test-Path $VenvPython)) {
     }
 }
 
+$PointerSize = (& $VenvPython -c "import struct; print(struct.calcsize('P'))").Trim()
+if ($LASTEXITCODE -ne 0 -or $PointerSize -ne "8") {
+    throw "DOCSight Windows builds require a 64-bit Python runtime."
+}
+
 Invoke-Checked $VenvPython -m pip install --upgrade pip
 Invoke-Checked $VenvPython -m pip install --require-hashes -r (Join-Path $ScriptDir "requirements-runtime-windows.txt")
 Invoke-Checked $VenvPython -m pip install --require-hashes -r (Join-Path $ScriptDir "requirements-build.txt")

--- a/packaging/windows/docsight.spec
+++ b/packaging/windows/docsight.spec
@@ -58,6 +58,8 @@ if not VERSION_FILE.exists():
 
 datas = collect_app_datas() + [(str(VERSION_FILE), ".")]
 hiddenimports = collect_app_hiddenimports() + [
+    "tkinter",
+    "tkinter.ttk",
     "waitress",
 ]
 
@@ -72,7 +74,6 @@ a = Analysis(
     hooksconfig={},
     runtime_hooks=[],
     excludes=[
-        "tkinter",
         "pytest",
     ],
     noarchive=False,
@@ -91,7 +92,7 @@ exe = EXE(
     strip=False,
     upx=True,
     console=False,
-    disable_windowed_traceback=False,
+    disable_windowed_traceback=True,
     argv_emulation=False,
     target_arch=None,
     codesign_identity=None,

--- a/packaging/windows/docsight_desktop.py
+++ b/packaging/windows/docsight_desktop.py
@@ -1,9 +1,9 @@
-"""Desktop launcher for local Windows DOCSight preview runs.
+"""Native startup and recovery launcher for DOCSight on Windows.
 
-This entrypoint is intentionally kept under ``packaging/windows`` so the core
-application remains platform-neutral. It prepares per-user runtime paths,
-forces loopback-only binding, handles simple single-instance behavior, and
-opens the user's default browser once the local server is ready.
+Windows-specific behavior stays in ``packaging/windows`` so the core web
+application remains platform-neutral. The launcher paints a small Tk window,
+then prepares per-user paths, selects a loopback port, starts the application,
+and opens the user's browser from a worker thread.
 """
 
 from __future__ import annotations
@@ -11,25 +11,84 @@ from __future__ import annotations
 import json
 import logging
 import os
+import queue
+import re
 import socket
+import subprocess
 import sys
 import threading
 import time
 import urllib.error
 import urllib.request
 import webbrowser
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from enum import Enum
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import MutableMapping
+from typing import Any, Callable, MutableMapping
 
 SOURCE_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
 MAX_PORT = 8775
 HEALTH_TIMEOUT_SECONDS = 30
+EVENT_POLL_MILLISECONDS = 75
+RELAUNCH_HANDLE_OPTION = "--docsight-relaunch-handle="
 
 LOG = logging.getLogger("docsight.desktop")
+
+
+class StartupPhase(str, Enum):
+    PREPARE = "Prepare local data"
+    START = "Start DOCSight"
+    WAIT = "Wait for readiness"
+    OPEN = "Open browser"
+
+
+PHASES = tuple(StartupPhase)
+
+
+class EventKind(str, Enum):
+    PHASE = "phase"
+    READY = "ready"
+    ERROR = "error"
+    EXIT = "exit"
+
+
+class RecoveryCode(str, Enum):
+    NO_PORT = "no_free_port"
+    TIMEOUT = "readiness_timeout"
+    APP_FAILED = "app_thread_failure"
+    BROWSER_FAILED = "browser_open_failure"
+    STARTUP_FAILED = "startup_failure"
+    RELAUNCH_FAILED = "relaunch_failure"
+    HANDOFF_FAILED = "relaunch_handoff_failure"
+
+
+RECOVERY_MESSAGES = {
+    RecoveryCode.NO_PORT: "DOCSight could not find an available local port.",
+    RecoveryCode.TIMEOUT: "DOCSight took too long to become ready.",
+    RecoveryCode.APP_FAILED: "DOCSight stopped unexpectedly during startup.",
+    RecoveryCode.BROWSER_FAILED: (
+        "DOCSight is ready, but the browser could not be opened. "
+        "Use the local address below."
+    ),
+    RecoveryCode.STARTUP_FAILED: "DOCSight could not finish starting.",
+    RecoveryCode.RELAUNCH_FAILED: (
+        "DOCSight could not restart. Close it and start DOCSight again."
+    ),
+    RecoveryCode.HANDOFF_FAILED: (
+        "DOCSight could not safely finish restarting. "
+        "Close it and start DOCSight again."
+    ),
+}
+
+PHASE_MESSAGES = {
+    StartupPhase.PREPARE: "Preparing your local DOCSight data…",
+    StartupPhase.START: "Starting DOCSight on this PC…",
+    StartupPhase.WAIT: "Waiting for the local web app to become ready…",
+    StartupPhase.OPEN: "DOCSight is ready. Opening your browser…",
+}
 
 
 @dataclass(frozen=True)
@@ -41,6 +100,7 @@ class DesktopPaths:
     modules_dir: Path
     logs_dir: Path
     log_file: Path
+    runtime_log_file: Path
 
 
 @dataclass(frozen=True)
@@ -49,6 +109,125 @@ class PortSelection:
 
     port: int
     existing_instance: bool = False
+
+
+@dataclass(frozen=True)
+class LauncherEvent:
+    """Worker-to-UI event. The attempt prevents stale worker updates."""
+
+    attempt: int
+    kind: EventKind
+    phase: StartupPhase | None = None
+    url: str | None = None
+    recovery: RecoveryCode | None = None
+    owns_server: bool = False
+    safe_exception_type: str | None = None
+
+
+@dataclass(frozen=True)
+class LauncherState:
+    """Display-independent state rendered by the Tk view."""
+
+    attempt: int
+    phase: StartupPhase
+    url: str
+    status: str
+    ready: bool = False
+    recovery: RecoveryCode | None = None
+    owns_server: bool = False
+    closed: bool = False
+
+
+@dataclass
+class AppThreadHandle:
+    """Application thread completion state without retaining an exception."""
+
+    thread: threading.Thread | None
+    stopped: threading.Event
+    failure_type: str | None = None
+
+
+class WaitOutcome(str, Enum):
+    READY = "ready"
+    TIMEOUT = "timeout"
+    APP_FAILED = "app_failed"
+
+
+class HandoffOutcome(str, Enum):
+    COMPLETE = "complete"
+    TIMEOUT = "timeout"
+    FAILED = "failed"
+
+
+class LauncherController:
+    """Queue-backed launcher state machine with no dependency on Tk."""
+
+    def __init__(self, initial_url: str) -> None:
+        self.events: queue.Queue[LauncherEvent] = queue.Queue()
+        self.state = LauncherState(
+            attempt=0,
+            phase=StartupPhase.PREPARE,
+            url=initial_url,
+            status=PHASE_MESSAGES[StartupPhase.PREPARE],
+        )
+        self.exit_code = 0
+
+    def begin_attempt(self) -> int:
+        attempt = self.state.attempt + 1
+        self.state = LauncherState(
+            attempt=attempt,
+            phase=StartupPhase.PREPARE,
+            url=self.state.url,
+            status=PHASE_MESSAGES[StartupPhase.PREPARE],
+        )
+        return attempt
+
+    def emit(self, event: LauncherEvent) -> None:
+        """Publish from a worker; this method never touches Tk."""
+        self.events.put(event)
+
+    def drain_events(self) -> bool:
+        """Apply queued events on the UI thread and report whether state changed."""
+        changed = False
+        while True:
+            try:
+                event = self.events.get_nowait()
+            except queue.Empty:
+                return changed
+            if event.attempt != self.state.attempt:
+                continue
+            self._apply(event)
+            changed = True
+
+    def _apply(self, event: LauncherEvent) -> None:
+        url = event.url or self.state.url
+        if event.kind is EventKind.PHASE and event.phase is not None:
+            self.state = replace(
+                self.state,
+                phase=event.phase,
+                url=url,
+                status=PHASE_MESSAGES[event.phase],
+            )
+        elif event.kind is EventKind.READY:
+            self.state = replace(
+                self.state,
+                phase=StartupPhase.OPEN,
+                url=url,
+                status="DOCSight is ready.",
+                ready=True,
+                owns_server=event.owns_server,
+            )
+        elif event.kind is EventKind.ERROR and event.recovery is not None:
+            self.exit_code = 1
+            self.state = replace(
+                self.state,
+                url=event.url,
+                status=RECOVERY_MESSAGES[event.recovery],
+                ready=event.recovery is RecoveryCode.BROWSER_FAILED,
+                recovery=event.recovery,
+            )
+        elif event.kind is EventKind.EXIT:
+            self.state = replace(self.state, closed=True)
 
 
 def _local_app_data(env: MutableMapping[str, str], home: Path | None = None) -> Path:
@@ -73,7 +252,8 @@ def resolve_desktop_paths(
         data_dir=base_dir / "data",
         modules_dir=base_dir / "modules",
         logs_dir=logs_dir,
-        log_file=logs_dir / "docsight.log",
+        log_file=logs_dir / "launcher.log",
+        runtime_log_file=logs_dir / "runtime.log",
     )
 
 
@@ -94,20 +274,101 @@ def configure_desktop_environment(
     return paths
 
 
-def configure_logging(log_file: Path) -> None:
-    """Route launcher/app logs to a small rotating per-user log file."""
-    log_file.parent.mkdir(parents=True, exist_ok=True)
-    handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3, encoding="utf-8")
-    logging.basicConfig(
-        level=getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO),
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        handlers=[handler],
-        force=True,
-    )
+class _LauncherLogFilter(logging.Filter):
+    """Keep traceback-bearing records out of the shareable launcher log."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.exc_info = None
+        record.exc_text = None
+        record.stack_info = None
+        return True
+
+
+_LOGGING_LOCK = threading.Lock()
+_LOGGING_SIGNATURE: tuple[Path, Path] | None = None
+_OWNED_HANDLER_ATTRIBUTE = "_docsight_desktop_handler"
+
+
+def _remove_owned_handlers(logger: logging.Logger) -> None:
+    """Close only handlers installed by this launcher."""
+    for existing_handler in tuple(logger.handlers):
+        if not getattr(existing_handler, _OWNED_HANDLER_ATTRIBUTE, False):
+            continue
+        logger.removeHandler(existing_handler)
+        existing_handler.close()
+
+
+def configure_logging(
+    log_file: Path,
+    runtime_log_file: Path | None = None,
+) -> None:
+    """Configure private launcher and root application diagnostics once."""
+    global _LOGGING_SIGNATURE
+
+    runtime_file = runtime_log_file or log_file.with_name("runtime.log")
+    signature = (log_file.resolve(), runtime_file.resolve())
+    with _LOGGING_LOCK:
+        root_logger = logging.getLogger()
+        if (
+            _LOGGING_SIGNATURE == signature
+            and any(
+                getattr(handler, _OWNED_HANDLER_ATTRIBUTE, False)
+                for handler in LOG.handlers
+            )
+            and any(
+                getattr(handler, _OWNED_HANDLER_ATTRIBUTE, False)
+                for handler in root_logger.handlers
+            )
+        ):
+            return
+
+        _remove_owned_handlers(LOG)
+        _remove_owned_handlers(root_logger)
+
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        runtime_file.parent.mkdir(parents=True, exist_ok=True)
+        formatter = logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+        )
+
+        launcher_handler = RotatingFileHandler(
+            log_file,
+            maxBytes=1_000_000,
+            backupCount=3,
+            encoding="utf-8",
+        )
+        setattr(launcher_handler, _OWNED_HANDLER_ATTRIBUTE, True)
+        launcher_handler.addFilter(_LauncherLogFilter())
+        launcher_handler.setFormatter(formatter)
+        LOG.addHandler(launcher_handler)
+
+        runtime_handler = RotatingFileHandler(
+            runtime_file,
+            maxBytes=5_000_000,
+            backupCount=3,
+            encoding="utf-8",
+        )
+        setattr(runtime_handler, _OWNED_HANDLER_ATTRIBUTE, True)
+        runtime_handler.setFormatter(formatter)
+        root_logger.addHandler(runtime_handler)
+
+        level = getattr(
+            logging,
+            os.environ.get("LOG_LEVEL", "INFO").upper(),
+            logging.INFO,
+        )
+        LOG.setLevel(level)
+        root_logger.setLevel(level)
+        LOG.propagate = False
+        _LOGGING_SIGNATURE = signature
+
+
+def local_url(port: int) -> str:
+    return f"http://{DEFAULT_HOST}:{port}/"
 
 
 def _health_url(port: int) -> str:
-    return f"http://{DEFAULT_HOST}:{port}/health"
+    return f"{local_url(port)}health"
 
 
 def _fetch_health_json(port: int, timeout: float = 0.5) -> dict | None:
@@ -131,10 +392,21 @@ def is_docsight_health_payload(payload: object) -> bool:
     return isinstance(payload, dict) and payload.get("status") == "ok" and "version" in payload
 
 
-def _can_bind_local_port(port: int) -> bool:
+def _can_bind_local_port(
+    port: int,
+    *,
+    platform: str | None = None,
+    socket_factory: Callable[..., Any] = socket.socket,
+) -> bool:
     """Return whether loopback port can be bound by a new DOCSight instance."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    current_platform = platform or sys.platform
+    with socket_factory(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        option = (
+            getattr(socket, "SO_EXCLUSIVEADDRUSE", -5)
+            if current_platform == "win32"
+            else socket.SO_REUSEADDR
+        )
+        sock.setsockopt(socket.SOL_SOCKET, option, 1)
         try:
             sock.bind((DEFAULT_HOST, port))
         except OSError:
@@ -179,7 +451,7 @@ def select_port(
             runtime_env["WEB_PORT"] = str(port)
             return PortSelection(port=port, existing_instance=False)
 
-    raise RuntimeError(f"No free loopback port found in {preferred}-{max_port}")
+    raise RuntimeError("No free loopback port")
 
 
 def get_runtime_root() -> Path:
@@ -195,65 +467,849 @@ def _ensure_repo_on_path() -> None:
         sys.path.insert(0, runtime_root)
 
 
-def _wait_for_ready(port: int, timeout_seconds: float = HEALTH_TIMEOUT_SECONDS) -> bool:
+def _safe_exception_type(exc: BaseException) -> str:
+    """Return a bounded class name suitable for logs and worker events."""
+    name = type(exc).__name__
+    cleaned = re.sub(r"[^A-Za-z0-9_]", "_", name)[:80]
+    return cleaned or "Exception"
+
+
+def _start_app_thread(*, inject_smoke_failure: bool = False) -> AppThreadHandle:
+    """Start the application behind a BaseException-safe completion handle."""
+    stopped = threading.Event()
+    handle = AppThreadHandle(thread=None, stopped=stopped)
+
+    def run_app() -> None:
+        try:
+            if inject_smoke_failure:
+                raise RuntimeError("injected startup failure")
+            _ensure_repo_on_path()
+            from app.main import main as app_main
+
+            app_main()
+        except BaseException as exc:
+            handle.failure_type = _safe_exception_type(exc)
+        finally:
+            stopped.set()
+
+    thread = threading.Thread(target=run_app, name="docsight-app", daemon=True)
+    handle.thread = thread
+    thread.start()
+    return handle
+
+
+def _wait_for_ready(
+    port: int,
+    app_handle: AppThreadHandle | None,
+    timeout_seconds: float = HEALTH_TIMEOUT_SECONDS,
+) -> WaitOutcome:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
+        if app_handle is not None and app_handle.stopped.is_set():
+            return WaitOutcome.APP_FAILED
         if is_docsight_health_payload(_fetch_health_json(port, timeout=1.0)):
-            return True
+            return WaitOutcome.READY
         time.sleep(0.5)
-    return False
+    if app_handle is not None and app_handle.stopped.is_set():
+        return WaitOutcome.APP_FAILED
+    return WaitOutcome.TIMEOUT
 
 
-def open_browser(port: int) -> None:
-    """Open the desktop preview URL in the default browser."""
-    if os.environ.get("DOCSIGHT_SKIP_BROWSER") == "1":
+def open_browser(
+    port: int,
+    env: MutableMapping[str, str] | None = None,
+    browser_open: Callable[[str], object] | None = None,
+    *,
+    platform: str | None = None,
+    com_api: object | None = None,
+) -> bool:
+    """Attempt to open the local URL; browser skipping is a successful no-op."""
+    runtime_env = env if env is not None else os.environ
+    if runtime_env.get("DOCSIGHT_SKIP_BROWSER") == "1":
         LOG.info("Skipping browser launch because DOCSIGHT_SKIP_BROWSER=1")
+        return True
+    if browser_open is not None or (platform or sys.platform) != "win32":
+        opener = browser_open or webbrowser.open
+        return bool(opener(local_url(port)))
+
+    api: Any = com_api
+    if api is None:
+        import ctypes
+
+        api = getattr(ctypes, "windll").ole32
+        api.CoInitializeEx.argtypes = (ctypes.c_void_p, ctypes.c_ulong)
+        api.CoInitializeEx.restype = ctypes.c_long
+        api.CoUninitialize.argtypes = ()
+        api.CoUninitialize.restype = None
+
+    result = int(api.CoInitializeEx(None, 0x2))
+    initialized = result in (0, 1)  # S_OK or S_FALSE.
+    changed_mode = result in (-2147417850, 0x80010106)
+    if not initialized and not changed_mode:
+        raise OSError("COM apartment initialization failed")
+    try:
+        return bool(webbrowser.open(local_url(port)))
+    finally:
+        if initialized:
+            api.CoUninitialize()
+
+
+def copy_local_url(clipboard: object, url: str) -> None:
+    """Copy a local URL using the small clipboard contract exposed by Tk."""
+    clipboard.clipboard_clear()
+    clipboard.clipboard_append(url)
+
+
+def centered_window_geometry(
+    requested_width: int,
+    requested_height: int,
+    screen_width: int,
+    screen_height: int,
+    *,
+    minimum_width: int = 480,
+    minimum_height: int = 300,
+) -> str:
+    """Return a DPI-safe centered geometry string for the launcher window."""
+    width = max(minimum_width, requested_width)
+    height = max(minimum_height, requested_height)
+    x = max(0, (screen_width - width) // 2)
+    y = max(0, (screen_height - height) // 3)
+    return f"{width}x{height}+{x}+{y}"
+
+
+def open_log_folder(
+    logs_dir: Path,
+    *,
+    platform: str | None = None,
+    windows_open: Callable[[str], object] | None = None,
+    process_open: Callable[..., object] | None = None,
+) -> bool:
+    """Open the log directory with the platform shell, using Explorer on Windows."""
+    current_platform = platform or sys.platform
+    if current_platform == "win32":
+        opener = windows_open or getattr(os, "startfile")
+        opener(str(logs_dir))
+        return True
+
+    command = ["open" if current_platform == "darwin" else "xdg-open", str(logs_dir)]
+    launcher = process_open or subprocess.Popen
+    launcher(command)
+    return True
+
+
+def launcher_command(parent_handle: int | None = None) -> list[str]:
+    """Return the command used to start a fresh launcher attempt."""
+    if getattr(sys, "frozen", False):
+        command = [sys.executable]
+    else:
+        command = [sys.executable, str(Path(__file__).resolve())]
+    if parent_handle is not None:
+        command.append(f"{RELAUNCH_HANDLE_OPTION}{parent_handle}")
+    return command
+
+
+def launcher_working_directory() -> Path:
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return SOURCE_ROOT
+
+
+def _windows_process_api() -> object:
+    import ctypes
+    from ctypes import wintypes
+
+    api = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    api.GetCurrentProcess.argtypes = ()
+    api.GetCurrentProcess.restype = wintypes.HANDLE
+    api.DuplicateHandle.argtypes = (
+        wintypes.HANDLE,
+        wintypes.HANDLE,
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.HANDLE),
+        wintypes.DWORD,
+        wintypes.BOOL,
+        wintypes.DWORD,
+    )
+    api.DuplicateHandle.restype = wintypes.BOOL
+    api.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    api.WaitForSingleObject.restype = wintypes.DWORD
+    api.CloseHandle.argtypes = (wintypes.HANDLE,)
+    api.CloseHandle.restype = wintypes.BOOL
+    return api
+
+
+def duplicate_current_process_handle(windows_api: object | None = None) -> int:
+    """Create an inheritable real handle identifying this launcher process."""
+    import ctypes
+    from ctypes import wintypes
+
+    api: Any = windows_api or _windows_process_api()
+    current_process = api.GetCurrentProcess()
+    duplicated = wintypes.HANDLE()
+    succeeded = api.DuplicateHandle(
+        current_process,
+        current_process,
+        current_process,
+        ctypes.byref(duplicated),
+        0x00100000,  # SYNCHRONIZE
+        True,
+        0,
+    )
+    if not succeeded or not duplicated.value:
+        raise OSError("Unable to create launcher handoff handle")
+    return int(duplicated.value)
+
+
+def close_windows_handle(
+    handle: int,
+    windows_api: object | None = None,
+) -> None:
+    api: Any = windows_api or _windows_process_api()
+    api.CloseHandle(handle)
+
+
+def spawn_launcher_process(
+    command: list[str] | None = None,
+    process_factory: Callable[..., object] | None = None,
+    *,
+    platform: str | None = None,
+    duplicate_handle: Callable[[], int] = duplicate_current_process_handle,
+    close_handle: Callable[[int], object] = close_windows_handle,
+    startupinfo_factory: Callable[[], object] | None = None,
+) -> object:
+    """Spawn a fresh launcher process without waiting for it."""
+    launcher = process_factory or subprocess.Popen
+    if command is not None or (platform or sys.platform) != "win32":
+        return launcher(
+            command or launcher_command(),
+            cwd=str(launcher_working_directory()),
+            close_fds=True,
+        )
+
+    parent_handle = duplicate_handle()
+    try:
+        startupinfo = (
+            startupinfo_factory()
+            if startupinfo_factory is not None
+            else subprocess.STARTUPINFO()
+        )
+        startupinfo.lpAttributeList = {"handle_list": [parent_handle]}
+        return launcher(
+            launcher_command(parent_handle=parent_handle),
+            cwd=str(launcher_working_directory()),
+            close_fds=True,
+            startupinfo=startupinfo,
+        )
+    finally:
+        close_handle(parent_handle)
+
+
+def terminate_current_launcher(exit_function: Callable[[int], object] | None = None) -> None:
+    """Terminate this process so its daemon application thread cannot survive."""
+    terminator = exit_function or os._exit
+    terminator(0)
+
+
+def relaunch_launcher(
+    *,
+    spawn: Callable[[], object] = spawn_launcher_process,
+    terminate: Callable[[], object] = terminate_current_launcher,
+) -> None:
+    """Start a normal fresh launcher attempt, then terminate this launcher."""
+    spawn()
+    terminate()
+
+
+def _relaunch_parent_handle(argv: list[str] | None = None) -> int | None:
+    """Read the inherited parent identity handle emitted by the retry helper."""
+    for argument in argv if argv is not None else sys.argv[1:]:
+        if not argument.startswith(RELAUNCH_HANDLE_OPTION):
+            continue
+        raw_handle = argument.removeprefix(RELAUNCH_HANDLE_OPTION)
+        if raw_handle.isdecimal() and int(raw_handle) > 0:
+            return int(raw_handle)
+    return None
+
+
+def wait_for_previous_launcher(
+    parent_handle: int,
+    *,
+    timeout_milliseconds: int = 10_000,
+    windows_api: object | None = None,
+) -> HandoffOutcome:
+    """Wait on the inherited parent identity handle and always close it."""
+    if sys.platform != "win32" and windows_api is None:
+        return HandoffOutcome.COMPLETE
+
+    api: Any = windows_api or _windows_process_api()
+    try:
+        result = int(api.WaitForSingleObject(parent_handle, timeout_milliseconds))
+        if result == 0:
+            return HandoffOutcome.COMPLETE
+        if result == 0x102:
+            return HandoffOutcome.TIMEOUT
+        return HandoffOutcome.FAILED
+    finally:
+        api.CloseHandle(parent_handle)
+
+
+def _phase_event(attempt: int, phase: StartupPhase, url: str) -> LauncherEvent:
+    return LauncherEvent(attempt=attempt, kind=EventKind.PHASE, phase=phase, url=url)
+
+
+class StartupRunner:
+    """Perform slow startup work and communicate only through queued events."""
+
+    def __init__(
+        self,
+        controller: LauncherController,
+        paths: DesktopPaths,
+        env: MutableMapping[str, str] | None = None,
+        *,
+        is_relaunch: bool = False,
+        handoff_outcome: HandoffOutcome = HandoffOutcome.COMPLETE,
+    ) -> None:
+        self.controller = controller
+        self.paths = paths
+        self.env = env if env is not None else os.environ
+        self.is_relaunch = is_relaunch
+        self.handoff_outcome = handoff_outcome
+
+    def _emit_error(
+        self,
+        attempt: int,
+        recovery: RecoveryCode,
+        url: str,
+        failure_type: str,
+    ) -> None:
+        LOG.error(
+            "Recovery available: %s (failure type: %s)",
+            recovery.value,
+            failure_type,
+        )
+        self.controller.emit(
+            LauncherEvent(
+                attempt=attempt,
+                kind=EventKind.ERROR,
+                url=url,
+                recovery=recovery,
+                safe_exception_type=failure_type,
+            )
+        )
+
+    def run(self, attempt: int) -> None:
+        url = self.controller.state.url
+        try:
+            LOG.info("Phase: %s", StartupPhase.PREPARE.value)
+
+            if self.handoff_outcome is not HandoffOutcome.COMPLETE:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.HANDOFF_FAILED,
+                    url,
+                    (
+                        "PreviousLauncherExitTimeout"
+                        if self.handoff_outcome is HandoffOutcome.TIMEOUT
+                        else "PreviousLauncherHandleWaitFailed"
+                    ),
+                )
+                return
+
+            smoke_enabled = (
+                self.env.get("DOCSIGHT_SKIP_BROWSER") == "1"
+                and not self.is_relaunch
+            )
+            if (
+                smoke_enabled
+                and self.env.get("DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE") == "1"
+            ):
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.NO_PORT,
+                    "",
+                    "InjectedNoFreePort",
+                )
+                return
+
+            try:
+                selection = select_port(self.env)
+            except RuntimeError as exc:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.NO_PORT,
+                    "",
+                    _safe_exception_type(exc),
+                )
+                return
+
+            url = local_url(selection.port)
+            self.controller.emit(_phase_event(attempt, StartupPhase.START, url))
+            LOG.info("Phase: %s", StartupPhase.START.value)
+
+            app_handle: AppThreadHandle | None = None
+            if selection.existing_instance:
+                LOG.info("Existing DOCSight instance detected on %s", url)
+            else:
+                LOG.info("Starting DOCSight on %s", url)
+                inject_smoke_failure = (
+                    smoke_enabled
+                    and self.env.get("DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE") == "1"
+                )
+                app_handle = (
+                    _start_app_thread(inject_smoke_failure=True)
+                    if inject_smoke_failure
+                    else _start_app_thread()
+                )
+
+            self.controller.emit(_phase_event(attempt, StartupPhase.WAIT, url))
+            LOG.info("Phase: %s", StartupPhase.WAIT.value)
+            outcome = (
+                WaitOutcome.READY
+                if selection.existing_instance
+                else _wait_for_ready(selection.port, app_handle)
+            )
+            if outcome is WaitOutcome.APP_FAILED:
+                failure_type = (
+                    app_handle.failure_type
+                    if app_handle is not None and app_handle.failure_type
+                    else "ApplicationThreadStopped"
+                )
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.APP_FAILED,
+                    url,
+                    failure_type,
+                )
+                return
+            if outcome is WaitOutcome.TIMEOUT:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.TIMEOUT,
+                    url,
+                    "ReadinessTimeout",
+                )
+                return
+
+            self.controller.emit(_phase_event(attempt, StartupPhase.OPEN, url))
+            LOG.info("Phase: %s", StartupPhase.OPEN.value)
+            LOG.info("DOCSight is ready on %s", url)
+            if (
+                smoke_enabled
+                and self.env.get("DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE") == "1"
+            ):
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.BROWSER_FAILED,
+                    url,
+                    "InjectedBrowserOpenFailure",
+                )
+                return
+            try:
+                browser_opened = open_browser(selection.port, self.env)
+            except BaseException as exc:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.BROWSER_FAILED,
+                    url,
+                    _safe_exception_type(exc),
+                )
+                return
+            if not browser_opened:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.BROWSER_FAILED,
+                    url,
+                    "BrowserOpenReturnedFalse",
+                )
+                return
+
+            self.controller.emit(
+                LauncherEvent(
+                    attempt=attempt,
+                    kind=EventKind.READY,
+                    url=url,
+                    owns_server=not selection.existing_instance,
+                )
+            )
+
+            if app_handle is None:
+                self.controller.emit(LauncherEvent(attempt, EventKind.EXIT))
+                return
+
+            assert app_handle.thread is not None
+            app_handle.thread.join()
+            if app_handle.failure_type:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.APP_FAILED,
+                    url,
+                    app_handle.failure_type,
+                )
+            else:
+                self.controller.emit(LauncherEvent(attempt, EventKind.EXIT))
+        except BaseException as exc:
+            failure_type = _safe_exception_type(exc)
+            if LOG.handlers:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.STARTUP_FAILED,
+                    url,
+                    failure_type,
+                )
+            else:
+                self.controller.emit(
+                    LauncherEvent(
+                        attempt=attempt,
+                        kind=EventKind.ERROR,
+                        url=url,
+                        recovery=RecoveryCode.STARTUP_FAILED,
+                        safe_exception_type=failure_type,
+                    )
+                )
+
+
+class TkLauncher:
+    """Compact native view. All methods are called from the Tk main thread."""
+
+    def __init__(
+        self,
+        root: Any,
+        tk_module: Any,
+        ttk_module: Any,
+        controller: LauncherController,
+        runner: StartupRunner,
+        paths: DesktopPaths,
+    ) -> None:
+        self.root = root
+        self.tk = tk_module
+        self.ttk = ttk_module
+        self.controller = controller
+        self.runner = runner
+        self.paths = paths
+        self._worker: threading.Thread | None = None
+        self.root.report_callback_exception = self._report_callback_exception
+        self._build()
+
+    def _build(self) -> None:
+        self.root.title("DOCSight")
+        self.root.resizable(False, False)
+        self.root.protocol("WM_DELETE_WINDOW", self._close)
+
+        outer = self.ttk.Frame(self.root, padding=(24, 20, 24, 18))
+        outer.grid(row=0, column=0, sticky="nsew")
+        outer.columnconfigure(0, weight=1)
+
+        heading = self.ttk.Label(
+            outer,
+            text="DOCSight",
+            foreground="#1769AA",
+            font=("Segoe UI", 17, "bold"),
+        )
+        heading.grid(row=0, column=0, sticky="w")
+
+        self.status_var = self.tk.StringVar()
+        self.status_label = self.ttk.Label(
+            outer,
+            textvariable=self.status_var,
+            wraplength=420,
+            justify="left",
+        )
+        self.status_label.grid(row=1, column=0, sticky="ew", pady=(7, 14))
+
+        self.phase_labels: list[Any] = []
+        phase_frame = self.ttk.Frame(outer)
+        phase_frame.grid(row=2, column=0, sticky="ew", pady=(0, 14))
+        for row, phase in enumerate(PHASES):
+            label = self.ttk.Label(phase_frame, text=phase.value)
+            label.grid(row=row, column=0, sticky="w", pady=1)
+            self.phase_labels.append(label)
+
+        url_caption = self.ttk.Label(outer, text="Local address")
+        url_caption.grid(row=3, column=0, sticky="w")
+        url_row = self.ttk.Frame(outer)
+        url_row.grid(row=4, column=0, sticky="ew", pady=(4, 12))
+        url_row.columnconfigure(0, weight=1)
+        self.url_var = self.tk.StringVar()
+        self.url_entry = self.ttk.Entry(
+            url_row,
+            textvariable=self.url_var,
+            state="readonly",
+            width=47,
+        )
+        self.url_entry.grid(row=0, column=0, sticky="ew")
+        self.copy_button = self.ttk.Button(
+            url_row,
+            text="Copy",
+            width=8,
+            command=self._copy_url,
+        )
+        self.copy_button.grid(row=0, column=1, padx=(8, 0))
+
+        self.actions = self.ttk.Frame(outer)
+        self.retry_button = self.ttk.Button(
+            self.actions,
+            text="Retry",
+            command=self._retry,
+        )
+        self.retry_button.grid(row=0, column=0)
+        self.log_button = self.ttk.Button(
+            self.actions,
+            text="Open log folder",
+            command=self._open_logs,
+        )
+        self.log_button.grid(row=0, column=1, padx=8)
+        self.close_button = self.ttk.Button(
+            self.actions,
+            text="Close",
+            command=self._close,
+        )
+        self.close_button.grid(row=0, column=2)
+
+        self.render()
+        self.root.update_idletasks()
+        self.root.geometry(
+            centered_window_geometry(
+                self.root.winfo_reqwidth(),
+                self.root.winfo_reqheight(),
+                self.root.winfo_screenwidth(),
+                self.root.winfo_screenheight(),
+            )
+        )
+
+    def start(self) -> None:
+        attempt = self.controller.begin_attempt()
+        self.render()
+        self._worker = threading.Thread(
+            target=self.runner.run,
+            args=(attempt,),
+            name="docsight-startup",
+            daemon=True,
+        )
+        self._worker.start()
+
+    def poll(self) -> None:
+        try:
+            if self.controller.drain_events():
+                self.render()
+            state = self.controller.state
+            if state.closed:
+                self.root.destroy()
+                return
+        except BaseException as exc:
+            self._recover_ui_exception(exc)
+        try:
+            self.root.after(EVENT_POLL_MILLISECONDS, self.poll)
+        except BaseException as exc:
+            self._recover_ui_exception(exc)
+
+    def render(self) -> None:
+        """Render state, retaining a minimal recovery surface on widget failure."""
+        try:
+            self._render_full()
+        except BaseException as exc:
+            self._recover_ui_exception(exc)
+
+    def _render_full(self) -> None:
+        state = self.controller.state
+        self.status_var.set(state.status)
+        self.url_var.set(state.url or "Not available")
+        self.copy_button.configure(state="normal" if state.url else "disabled")
+        current_index = PHASES.index(state.phase)
+        for index, label in enumerate(self.phase_labels):
+            if state.ready or index < current_index:
+                marker = "✓"
+            elif index == current_index:
+                marker = "!" if state.recovery is not None else "→"
+            else:
+                marker = "·"
+            label.configure(text=f"{marker}  {PHASES[index].value}")
+        if state.recovery is not None:
+            self.actions.grid(row=5, column=0, sticky="w")
+            self.root.deiconify()
+            self.root.update_idletasks()
+            self.root.geometry(
+                centered_window_geometry(
+                    self.root.winfo_reqwidth(),
+                    self.root.winfo_reqheight(),
+                    self.root.winfo_screenwidth(),
+                    self.root.winfo_screenheight(),
+                    minimum_height=330,
+                )
+            )
+        else:
+            self.actions.grid_remove()
+        if state.ready and state.recovery is None:
+            if state.owns_server:
+                self.root.withdraw()
+            else:
+                self.root.after(0, self.root.destroy)
+
+    def _report_callback_exception(
+        self,
+        exception_type: type[BaseException],
+        _exception: BaseException,
+        _traceback: object,
+    ) -> None:
+        """Sanitize exceptions escaping Tk callbacks."""
+        name = re.sub(r"[^A-Za-z0-9_]", "_", exception_type.__name__)[:80]
+        self._recover_ui_failure_type(name or "Exception")
+
+    def _recover_ui_exception(self, exc: BaseException) -> None:
+        self._recover_ui_failure_type(_safe_exception_type(exc))
+
+    def _recover_ui_failure_type(self, failure_type: str) -> None:
+        LOG.error(
+            "Recovery available: %s (failure type: %s)",
+            RecoveryCode.STARTUP_FAILED.value,
+            failure_type,
+        )
+        self.controller.exit_code = 1
+        self.controller.state = replace(
+            self.controller.state,
+            status=RECOVERY_MESSAGES[RecoveryCode.STARTUP_FAILED],
+            ready=False,
+            recovery=RecoveryCode.STARTUP_FAILED,
+        )
+        self._render_minimal_recovery()
+
+    def _render_minimal_recovery(self) -> None:
+        """Best-effort fallback that does not recurse through full rendering."""
+        operations = (
+            lambda: self.status_var.set(
+                RECOVERY_MESSAGES[RecoveryCode.STARTUP_FAILED]
+            ),
+            lambda: self.url_var.set(self.controller.state.url or "Not available"),
+            lambda: self.copy_button.configure(
+                state="normal" if self.controller.state.url else "disabled"
+            ),
+            lambda: self.actions.grid(row=5, column=0, sticky="w"),
+            self.root.deiconify,
+        )
+        for operation in operations:
+            try:
+                operation()
+            except BaseException:
+                continue
+
+    def _copy_url(self) -> None:
+        copy_local_url(self.root, self.controller.state.url)
+        self.copy_button.configure(text="Copied")
+        self.root.after(1200, lambda: self.copy_button.configure(text="Copy"))
+
+    def _open_logs(self) -> None:
+        try:
+            open_log_folder(self.paths.logs_dir)
+        except BaseException as exc:
+            LOG.error(
+                "Unable to open launcher log folder (failure type: %s)",
+                _safe_exception_type(exc),
+            )
+            self.status_var.set(
+                "The log folder could not be opened. "
+                "You can find it under your local DOCSight data folder."
+            )
+
+    def _retry(self) -> None:
+        attempt = self.controller.begin_attempt()
+        self.controller.state = replace(
+            self.controller.state,
+            status="Restarting DOCSight…",
+        )
+        self.render()
+        LOG.info("Retry requested; starting a fresh launcher process")
+        try:
+            relaunch_launcher()
+        except BaseException as exc:
+            LOG.error(
+                "Recovery available: %s (failure type: %s)",
+                RecoveryCode.RELAUNCH_FAILED.value,
+                _safe_exception_type(exc),
+            )
+            self.controller.emit(
+                LauncherEvent(
+                    attempt=attempt,
+                    kind=EventKind.ERROR,
+                    recovery=RecoveryCode.RELAUNCH_FAILED,
+                    url=self.controller.state.url,
+                    safe_exception_type=_safe_exception_type(exc),
+                )
+            )
+
+    def _close(self) -> None:
+        self.root.destroy()
+        os._exit(self.controller.exit_code)
+
+
+def show_fatal_startup_message(
+    logs_dir: Path | None,
+    *,
+    message_box: Callable[[object, str, str, int], object] | None = None,
+    env: MutableMapping[str, str] | None = None,
+) -> None:
+    """Show a last-resort Windows message when Tk cannot create the launcher."""
+    runtime_env = env if env is not None else os.environ
+    if runtime_env.get("DOCSIGHT_SKIP_BROWSER") == "1":
         return
-    webbrowser.open(f"http://{DEFAULT_HOST}:{port}/")
+    location = str(logs_dir) if logs_dir is not None else "the local DOCSight data folder"
+    text = (
+        "DOCSight could not open its startup window. Close DOCSight and try again.\n\n"
+        f"Launcher logs: {location}"
+    )
+    try:
+        if message_box is None:
+            if sys.platform != "win32":
+                return
+            import ctypes
 
-
-def _start_app_thread() -> threading.Thread:
-    _ensure_repo_on_path()
-    from app.main import main as app_main
-
-    thread = threading.Thread(target=app_main, name="docsight-app", daemon=True)
-    thread.start()
-    return thread
+            message_box = getattr(ctypes, "windll").user32.MessageBoxW
+        message_box(None, text, "DOCSight", 0x10)
+    except BaseException:
+        return
 
 
 def run_desktop() -> int:
-    """Run the DOCSight desktop preview launcher."""
-    paths = configure_desktop_environment()
-    configure_logging(paths.log_file)
-
+    """Paint the launcher, then run startup work through its event queue."""
+    runtime_env = os.environ
+    paths: DesktopPaths | None = None
     try:
-        selection = select_port()
-    except RuntimeError as exc:
-        LOG.error("%s", exc)
-        print(f"DOCSight Desktop could not find a free local port. See log: {paths.log_file}", file=sys.stderr)
-        return 1
+        paths = configure_desktop_environment(runtime_env)
+        parent_handle = _relaunch_parent_handle()
+        handoff_outcome = (
+            wait_for_previous_launcher(parent_handle)
+            if parent_handle is not None
+            else HandoffOutcome.COMPLETE
+        )
+        configure_logging(paths.log_file, paths.runtime_log_file)
 
-    if selection.existing_instance:
-        LOG.info("Existing DOCSight instance detected on %s:%d", DEFAULT_HOST, selection.port)
-        open_browser(selection.port)
-        return 0
+        import tkinter as tk
+        from tkinter import ttk
 
-    LOG.info("Starting DOCSight Desktop Preview on %s:%d", DEFAULT_HOST, selection.port)
-    app_thread = _start_app_thread()
+        controller = LauncherController("")
+        root = tk.Tk()
+        runner = StartupRunner(
+            controller,
+            paths,
+            runtime_env,
+            is_relaunch=parent_handle is not None,
+            handoff_outcome=handoff_outcome,
+        )
+        view = TkLauncher(root, tk, ttk, controller, runner, paths)
 
-    if _wait_for_ready(selection.port):
-        LOG.info("DOCSight Desktop Preview is ready on %s:%d", DEFAULT_HOST, selection.port)
-        open_browser(selection.port)
+        root.update()
+        root.after(50, view.start)
+        root.after(EVENT_POLL_MILLISECONDS, view.poll)
+        root.mainloop()
+        return controller.exit_code
+    except BaseException as exc:
         try:
-            while app_thread.is_alive():
-                app_thread.join(timeout=60)
-        except KeyboardInterrupt:
-            LOG.info("DOCSight Desktop Preview interrupted by user")
-        return 0
-
-    LOG.error("DOCSight did not become ready within %d seconds", HEALTH_TIMEOUT_SECONDS)
-    print(f"DOCSight Desktop did not become ready. See log: {paths.log_file}", file=sys.stderr)
-    return 1
+            LOG.error(
+                "Recovery unavailable: startup_surface_failure (failure type: %s)",
+                _safe_exception_type(exc),
+            )
+        except BaseException:
+            pass
+        show_fatal_startup_message(paths.logs_dir if paths is not None else None)
+        return 1
 
 
 def main() -> int:

--- a/packaging/windows/smoke_test.ps1
+++ b/packaging/windows/smoke_test.ps1
@@ -23,21 +23,52 @@ $LocalAppData = Join-Path $SmokeRoot "LocalAppData"
 $PreviousLocalAppData = $env:LOCALAPPDATA
 $PreviousWebPort = $env:WEB_PORT
 $PreviousSkipBrowser = $env:DOCSIGHT_SKIP_BROWSER
+$PreviousInjectedStartupFailure = $env:DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE
+$PreviousInjectedBrowserFailure = $env:DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE
+$PreviousInjectedNoPortFailure = $env:DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE
 $Process = $null
 $HttpHandler = $null
 $HttpClient = $null
-$LogFile = Join-Path $LocalAppData "DOCSight\logs\docsight.log"
+$LauncherLogFile = Join-Path $LocalAppData "DOCSight\logs\launcher.log"
+$RuntimeLogFile = Join-Path $LocalAppData "DOCSight\logs\runtime.log"
 $HealthUrl = "http://127.0.0.1:$Port/health"
 $ReportUrl = "http://127.0.0.1:$Port/api/report"
 $ConfigUrl = "http://127.0.0.1:$Port/api/config"
 
 function Write-SmokeLog {
-    if (Test-Path $LogFile) {
-        Write-Host "--- DOCSight Desktop log ---"
-        Get-Content -Path $LogFile -Tail 200 | ForEach-Object { Write-Host $_ }
-        Write-Host "--- end DOCSight Desktop log ---"
+    if (Test-Path -LiteralPath $LauncherLogFile) {
+        Write-Host "--- DOCSight launcher log ---"
+        Get-Content -LiteralPath $LauncherLogFile -Tail 200 | ForEach-Object { Write-Host $_ }
+        Write-Host "--- end DOCSight launcher log ---"
     } else {
-        Write-Host "DOCSight Desktop log not found: $LogFile"
+        Write-Host "DOCSight launcher log not found: $LauncherLogFile"
+    }
+
+    if (Test-Path -LiteralPath $RuntimeLogFile) {
+        Write-Host "--- DOCSight runtime log ---"
+        Get-Content -LiteralPath $RuntimeLogFile -Tail 200 | ForEach-Object { Write-Host $_ }
+        Write-Host "--- end DOCSight runtime log ---"
+    } else {
+        Write-Host "DOCSight runtime log not found: $RuntimeLogFile"
+    }
+}
+
+function Get-PeMachine {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $Stream = [System.IO.File]::OpenRead($Path)
+    $Reader = [System.IO.BinaryReader]::new($Stream)
+    try {
+        $Stream.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $PeOffset = $Reader.ReadInt32()
+        $Stream.Seek($PeOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+        if ($Reader.ReadUInt32() -ne 0x00004550) {
+            throw "DOCSight.exe does not contain a valid PE signature."
+        }
+        return $Reader.ReadUInt16()
+    } finally {
+        $Reader.Dispose()
+        $Stream.Dispose()
     }
 }
 
@@ -89,17 +120,28 @@ try {
     if (-not (Test-Path $Executable)) {
         throw "Copied DOCSight executable not found: $Executable"
     }
+    if ((Get-PeMachine -Path $Executable) -ne 0x8664) {
+        throw "DOCSight.exe is not an AMD64 Windows executable."
+    }
+
+    $ExistingListeners = @(Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue)
+    if ($ExistingListeners.Count -gt 0) {
+        throw "Smoke port $Port is already in use before DOCSight starts."
+    }
 
     $env:LOCALAPPDATA = $LocalAppData
     $env:WEB_PORT = [string]$Port
     $env:DOCSIGHT_SKIP_BROWSER = "1"
+    $env:DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE = $null
+    $env:DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE = $null
+    $env:DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE = $null
 
     $HttpHandler = [System.Net.Http.HttpClientHandler]::new()
     $HttpHandler.UseProxy = $false
     $HttpClient = [System.Net.Http.HttpClient]::new($HttpHandler)
     $HttpClient.Timeout = [TimeSpan]::FromSeconds([Math]::Max(3, $TimeoutSeconds))
 
-    $Process = Start-Process -FilePath $Executable -WorkingDirectory $LaunchBundleDir -PassThru -WindowStyle Hidden
+    $Process = Start-Process -FilePath $Executable -WorkingDirectory $LaunchBundleDir -PassThru
     $Deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     $Payload = $null
 
@@ -135,11 +177,39 @@ try {
         throw "DOCSight /health returned version '$($Payload.version)' instead of '$ExpectedVersion'."
     }
 
-    $Connections = @(Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue)
-    if (-not ($Connections | Where-Object { $_.LocalAddress -eq "127.0.0.1" })) {
-        $Addresses = ($Connections | ForEach-Object { $_.LocalAddress } | Sort-Object -Unique) -join ", "
+    $Process.Refresh()
+    if ($Process.HasExited) {
         Write-SmokeLog
-        throw "DOCSight is not listening on 127.0.0.1:$Port. Observed listener addresses: $Addresses"
+        throw "DOCSight exited after readiness with exit code $($Process.ExitCode)."
+    }
+    $Connections = @(Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue)
+    $OwnedLoopbackListeners = @($Connections | Where-Object {
+        $_.LocalAddress -eq "127.0.0.1" -and $_.OwningProcess -eq $Process.Id
+    })
+    if ($Connections.Count -ne 1) {
+        $ObservedListeners = ($Connections | ForEach-Object {
+            "$($_.LocalAddress) owned by PID $($_.OwningProcess)"
+        }) -join "; "
+        if ([string]::IsNullOrWhiteSpace($ObservedListeners)) {
+            $ObservedListeners = "none"
+        }
+        Write-SmokeLog
+        throw "Expected exactly one listener on smoke port $Port; observed: $ObservedListeners"
+    }
+    if ($OwnedLoopbackListeners.Count -ne 1) {
+        $ObservedListener = "$($Connections[0].LocalAddress) owned by PID $($Connections[0].OwningProcess)"
+        Write-SmokeLog
+        throw "Expected exactly one 127.0.0.1:$Port listener owned by DOCSight process $($Process.Id); observed: $ObservedListener"
+    }
+
+    if (-not (Test-Path -LiteralPath $RuntimeLogFile)) {
+        Write-SmokeLog
+        throw "DOCSight runtime log not found after packaged startup: $RuntimeLogFile"
+    }
+    $RuntimeLogText = Get-Content -LiteralPath $RuntimeLogFile -Raw
+    if ($RuntimeLogText -match "(?i)failed to import routes|No module named") {
+        Write-SmokeLog
+        throw "DOCSight runtime log contains packaged route/import failure diagnostics."
     }
 
     $EmptyReportResponse = Invoke-SmokeHttpRequest -Url $ReportUrl
@@ -210,20 +280,78 @@ try {
         throw "Packaged /api/report response does not begin with %PDF-."
     }
 
-    if (-not (Test-Path $LogFile)) {
-        throw "DOCSight Desktop log not found for post-smoke validation: $LogFile"
-    }
-    $LogText = Get-Content -Path $LogFile -Raw
-    if ($LogText -match "Module 'docsight\.reports': failed to import routes") {
-        Write-SmokeLog
-        throw "DOCSight Desktop log contains a Reports route import failure."
-    }
-    if ($LogText -match "No module named ['`"]unittest['`"]") {
-        Write-SmokeLog
-        throw "DOCSight Desktop log contains a missing unittest import."
+    if (-not (Test-Path -LiteralPath $LauncherLogFile)) {
+        throw "DOCSight launcher log not found for post-smoke validation: $LauncherLogFile"
     }
 
-    Write-Host "DOCSight Desktop smoke passed: copied package path supports spaces/non-ASCII, health/version and loopback listener are valid, Reports route is registered, and /api/report returned application/pdf beginning %PDF-."
+    Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+    $FirstProcessStopped = $Process.WaitForExit(10000)
+    if (-not $FirstProcessStopped) {
+        Write-SmokeLog
+        throw "Successful packaged process did not stop before injected recovery validation."
+    }
+    $Process = $null
+
+    if (Test-Path -LiteralPath $LauncherLogFile) {
+        Remove-Item -LiteralPath $LauncherLogFile -Force
+    }
+    if (Test-Path -LiteralPath $LauncherLogFile) {
+        throw "Unable to clear the first launcher's log before injected recovery validation."
+    }
+
+    # Packaging-only fault injection is honored by the launcher only while the
+    # existing non-interactive browser-skip boundary is active.
+    $env:DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE = "1"
+    $Process = Start-Process -FilePath $Executable -WorkingDirectory $LaunchBundleDir -PassThru
+    $FailureDeadline = (Get-Date).AddSeconds([Math]::Min(20, $TimeoutSeconds))
+    $FailureContractObserved = $false
+    $RecoveryWindowObserved = $false
+    while ((Get-Date) -lt $FailureDeadline) {
+        $Process.Refresh()
+        if ($Process.HasExited) {
+            Write-SmokeLog
+            throw "Injected startup failure exited silently with code $($Process.ExitCode) instead of keeping recovery available."
+        }
+        if (Test-Path -LiteralPath $LauncherLogFile) {
+            $FailureLogText = Get-Content -LiteralPath $LauncherLogFile -Raw
+            if (
+                $FailureLogText -match "Phase: Prepare local data" -and
+                $FailureLogText -match "Recovery available: app_thread_failure" -and
+                $FailureLogText -match "failure type: RuntimeError"
+            ) {
+                $FailureContractObserved = $true
+            }
+        }
+        if (
+            $Process.MainWindowHandle -ne [IntPtr]::Zero -and
+            $Process.MainWindowTitle -ceq "DOCSight"
+        ) {
+            $RecoveryWindowObserved = $true
+        }
+        if ($FailureContractObserved -and $RecoveryWindowObserved) {
+            break
+        }
+        Start-Sleep -Milliseconds 250
+    }
+    if (-not $FailureContractObserved) {
+        Write-SmokeLog
+        throw "Injected startup failure did not produce the expected launcher phase and recovery log contract."
+    }
+    $Process.Refresh()
+    if ($Process.HasExited) {
+        Write-SmokeLog
+        throw "Injected startup failure did not keep the recovery process running."
+    }
+    if ($Process.MainWindowHandle -eq [IntPtr]::Zero) {
+        Write-SmokeLog
+        throw "Injected startup failure did not expose a real main window."
+    }
+    if ($Process.MainWindowTitle -cne "DOCSight") {
+        Write-SmokeLog
+        throw "Injected startup failure main window title was not exactly 'DOCSight'."
+    }
+
+    Write-Host "DOCSight Desktop smoke passed: AMD64 package startup, exactly-one owned loopback listener, runtime imports, Reports PDF, and fresh visible app-thread recovery contracts are valid."
 } catch {
     Write-SmokeLog
     throw
@@ -241,6 +369,9 @@ try {
     $env:LOCALAPPDATA = $PreviousLocalAppData
     $env:WEB_PORT = $PreviousWebPort
     $env:DOCSIGHT_SKIP_BROWSER = $PreviousSkipBrowser
+    $env:DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE = $PreviousInjectedStartupFailure
+    $env:DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE = $PreviousInjectedBrowserFailure
+    $env:DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE = $PreviousInjectedNoPortFailure
 
     if (Test-Path $SmokeRoot) {
         Remove-Item -Recurse -Force $SmokeRoot -ErrorAction SilentlyContinue

--- a/tests/test_desktop_entrypoint.py
+++ b/tests/test_desktop_entrypoint.py
@@ -1,10 +1,13 @@
-"""Tests for the Windows Desktop Preview launcher."""
+"""Linux-friendly tests for the Windows launcher controller and OS boundaries."""
 
 from __future__ import annotations
 
 import importlib.util
+import logging
 import sys
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -19,6 +22,70 @@ sys.modules[spec.name] = desktop
 spec.loader.exec_module(desktop)
 
 
+@pytest.fixture(autouse=True)
+def close_desktop_logging_handlers():
+    """Release module-owned files so Windows temporary directories are removable."""
+    root_logger = logging.getLogger()
+    root_level = root_logger.level
+    launcher_level = desktop.LOG.level
+    launcher_propagate = desktop.LOG.propagate
+    yield
+    desktop._remove_owned_handlers(desktop.LOG)
+    desktop._remove_owned_handlers(root_logger)
+    desktop._LOGGING_SIGNATURE = None
+    root_logger.setLevel(root_level)
+    desktop.LOG.setLevel(launcher_level)
+    desktop.LOG.propagate = launcher_propagate
+
+
+def make_paths(tmp_path: Path) -> object:
+    return desktop.resolve_desktop_paths({"LOCALAPPDATA": str(tmp_path)})
+
+
+def make_controller(port: int = 8765) -> object:
+    controller = desktop.LauncherController(desktop.local_url(port))
+    controller.begin_attempt()
+    return controller
+
+
+def run_runner(monkeypatch, tmp_path, *, selection=None, wait=None, browser=True):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=threading.Event(),
+    )
+    monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
+    monkeypatch.setattr(
+        desktop,
+        "configure_logging",
+        lambda *_args: pytest.fail("StartupRunner must not reconfigure logging"),
+    )
+    monkeypatch.setattr(
+        desktop,
+        "select_port",
+        lambda env: selection or desktop.PortSelection(8765),
+    )
+    monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle: wait or desktop.WaitOutcome.READY,
+    )
+    if isinstance(browser, BaseException):
+        def raise_browser(port, env):
+            raise browser
+
+        monkeypatch.setattr(desktop, "open_browser", raise_browser)
+    else:
+        monkeypatch.setattr(desktop, "open_browser", lambda port, env: browser)
+
+    runner = desktop.StartupRunner(controller, paths, {})
+    runner.run(controller.state.attempt)
+    controller.drain_events()
+    return controller, handle
+
+
 def test_resolve_desktop_paths_uses_localappdata(tmp_path):
     env = {"LOCALAPPDATA": str(tmp_path / "LocalAppData")}
 
@@ -28,7 +95,8 @@ def test_resolve_desktop_paths_uses_localappdata(tmp_path):
     assert paths.data_dir == paths.base_dir / "data"
     assert paths.modules_dir == paths.base_dir / "modules"
     assert paths.logs_dir == paths.base_dir / "logs"
-    assert paths.log_file == paths.logs_dir / "docsight.log"
+    assert paths.log_file == paths.logs_dir / "launcher.log"
+    assert paths.runtime_log_file == paths.logs_dir / "runtime.log"
 
 
 def test_resolve_desktop_paths_falls_back_to_home_localappdata(tmp_path):
@@ -69,7 +137,11 @@ def test_select_port_opens_existing_docsight_instance(monkeypatch):
     env = {"WEB_PORT": "8765"}
 
     monkeypatch.setattr(desktop, "_fetch_health_json", lambda port: {"status": "ok", "version": "dev"})
-    monkeypatch.setattr(desktop, "_can_bind_local_port", lambda port: pytest.fail("existing instance should skip bind probe"))
+    monkeypatch.setattr(
+        desktop,
+        "_can_bind_local_port",
+        lambda port: pytest.fail("existing instance should skip bind probe"),
+    )
 
     selection = desktop.select_port(env)
 
@@ -112,14 +184,624 @@ def test_select_port_raises_when_range_is_unavailable(monkeypatch):
         desktop.select_port(env, max_port=8766)
 
 
+@pytest.mark.parametrize(
+    ("platform", "expected_option"),
+    [
+        ("win32", getattr(desktop.socket, "SO_EXCLUSIVEADDRUSE", -5)),
+        ("linux", desktop.socket.SO_REUSEADDR),
+    ],
+)
+def test_bind_probe_uses_platform_specific_socket_option(platform, expected_option):
+    calls = []
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def setsockopt(self, level, option, value):
+            calls.append(("setsockopt", level, option, value))
+
+        def bind(self, address):
+            calls.append(("bind", address))
+
+    assert desktop._can_bind_local_port(
+        8765,
+        platform=platform,
+        socket_factory=lambda *_args: FakeSocket(),
+    )
+    assert calls == [
+        ("setsockopt", desktop.socket.SOL_SOCKET, expected_option, 1),
+        ("bind", ("127.0.0.1", 8765)),
+    ]
+
+
+def test_bind_probe_returns_false_on_bind_failure():
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def setsockopt(self, *_args):
+            return None
+
+        def bind(self, _address):
+            raise OSError("occupied")
+
+    assert desktop._can_bind_local_port(
+        8765,
+        platform="win32",
+        socket_factory=lambda *_args: FakeSocket(),
+    ) is False
+
+
+def test_controller_applies_phase_transitions_and_ready():
+    controller = make_controller()
+    attempt = controller.state.attempt
+
+    for phase in (
+        desktop.StartupPhase.START,
+        desktop.StartupPhase.WAIT,
+        desktop.StartupPhase.OPEN,
+    ):
+        controller.emit(
+            desktop.LauncherEvent(
+                attempt,
+                desktop.EventKind.PHASE,
+                phase=phase,
+                url=desktop.local_url(8766),
+            )
+        )
+        assert controller.drain_events() is True
+        assert controller.state.phase is phase
+
+    controller.emit(
+        desktop.LauncherEvent(
+            attempt,
+            desktop.EventKind.READY,
+            url=desktop.local_url(8766),
+            owns_server=True,
+        )
+    )
+    controller.drain_events()
+
+    assert controller.state.ready is True
+    assert controller.state.owns_server is True
+    assert controller.state.url == "http://127.0.0.1:8766/"
+
+
+def test_controller_ignores_events_from_stale_attempt():
+    controller = make_controller()
+    stale_attempt = controller.state.attempt
+    active_attempt = controller.begin_attempt()
+
+    controller.emit(
+        desktop.LauncherEvent(
+            stale_attempt,
+            desktop.EventKind.ERROR,
+            recovery=desktop.RecoveryCode.TIMEOUT,
+            url=desktop.local_url(8765),
+        )
+    )
+    controller.emit(
+        desktop.LauncherEvent(
+            active_attempt,
+            desktop.EventKind.PHASE,
+            phase=desktop.StartupPhase.START,
+            url=desktop.local_url(8766),
+        )
+    )
+    controller.drain_events()
+
+    assert controller.state.attempt == active_attempt
+    assert controller.state.phase is desktop.StartupPhase.START
+    assert controller.state.recovery is None
+    assert controller.state.url == "http://127.0.0.1:8766/"
+
+
+def test_startup_runner_reaches_ready_and_emits_all_phases(monkeypatch, tmp_path):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    emitted = []
+    original_emit = controller.emit
+
+    def capture(event):
+        emitted.append(event)
+        original_emit(event)
+
+    controller.emit = capture
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=threading.Event(),
+    )
+    monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8766))
+    monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
+    monkeypatch.setattr(desktop, "_wait_for_ready", lambda port, app_handle: desktop.WaitOutcome.READY)
+    monkeypatch.setattr(desktop, "open_browser", lambda port, env: True)
+
+    desktop.StartupRunner(controller, paths, {}).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert [event.phase for event in emitted if event.kind is desktop.EventKind.PHASE] == [
+        desktop.StartupPhase.START,
+        desktop.StartupPhase.WAIT,
+        desktop.StartupPhase.OPEN,
+    ]
+    assert any(event.kind is desktop.EventKind.READY for event in emitted)
+    assert controller.state.ready is True
+    assert controller.state.closed is True
+
+
+def test_startup_runner_reports_no_free_port(monkeypatch, tmp_path):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
+    monkeypatch.setattr(
+        desktop,
+        "select_port",
+        lambda env: (_ for _ in ()).throw(RuntimeError("occupied by secret service")),
+    )
+
+    desktop.StartupRunner(controller, paths, {}).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is desktop.RecoveryCode.NO_PORT
+    assert controller.state.url == ""
+    assert "secret" not in controller.state.status
+
+
+def test_startup_runner_reports_readiness_timeout(monkeypatch, tmp_path):
+    controller, _ = run_runner(
+        monkeypatch,
+        tmp_path,
+        wait=desktop.WaitOutcome.TIMEOUT,
+    )
+
+    assert controller.state.recovery is desktop.RecoveryCode.TIMEOUT
+    assert controller.state.url == "http://127.0.0.1:8765/"
+
+
+def test_startup_runner_reports_app_thread_system_exit(monkeypatch, tmp_path):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=threading.Event(),
+    )
+    handle.failure_type = "SystemExit"
+    monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
+    monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
+    monkeypatch.setattr(desktop, "_wait_for_ready", lambda port, app_handle: desktop.WaitOutcome.APP_FAILED)
+    desktop.StartupRunner(controller, paths, {}).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is desktop.RecoveryCode.APP_FAILED
+    assert controller.state.status == "DOCSight stopped unexpectedly during startup."
+
+
+@pytest.mark.parametrize(
+    ("browser_result", "failure_type"),
+    [
+        (False, "BrowserOpenReturnedFalse"),
+        (RuntimeError("credential=do-not-show"), "RuntimeError"),
+    ],
+)
+def test_browser_open_failures_keep_ready_recovery_surface(
+    monkeypatch,
+    tmp_path,
+    browser_result,
+    failure_type,
+):
+    controller, _ = run_runner(
+        monkeypatch,
+        tmp_path,
+        browser=browser_result,
+    )
+
+    assert controller.state.recovery is desktop.RecoveryCode.BROWSER_FAILED
+    assert controller.state.ready is True
+    assert controller.state.url == "http://127.0.0.1:8765/"
+    assert failure_type not in controller.state.status
+    assert "credential" not in controller.state.status
+
+
+def test_existing_instance_runs_wait_and_browser_phases_without_app_thread(
+    monkeypatch,
+    tmp_path,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
+    monkeypatch.setattr(
+        desktop,
+        "select_port",
+        lambda env: desktop.PortSelection(8765, existing_instance=True),
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_start_app_thread",
+        lambda: pytest.fail("existing instance must not start an app thread"),
+    )
+    monkeypatch.setattr(desktop, "open_browser", lambda port, env: True)
+
+    desktop.StartupRunner(controller, paths, {}).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.ready is True
+    assert controller.state.owns_server is False
+    assert controller.state.closed is True
+
+
+def test_app_thread_wrapper_captures_baseexception_type_without_message(monkeypatch):
+    from app import main as app_main_module
+
+    monkeypatch.setattr(desktop, "_ensure_repo_on_path", lambda: None)
+    monkeypatch.setattr(
+        app_main_module,
+        "main",
+        lambda: (_ for _ in ()).throw(SystemExit("credential=do-not-retain")),
+    )
+
+    handle = desktop._start_app_thread()
+    assert handle.thread is not None
+    handle.thread.join(timeout=2)
+
+    assert handle.stopped.is_set()
+    assert handle.failure_type == "SystemExit"
+    assert "credential" not in handle.failure_type
+
+
 def test_open_browser_can_be_skipped_for_ci_smoke(monkeypatch):
     calls = []
-    monkeypatch.setenv("DOCSIGHT_SKIP_BROWSER", "1")
-    monkeypatch.setattr(desktop.webbrowser, "open", lambda url: calls.append(url))
 
-    desktop.open_browser(8765)
+    result = desktop.open_browser(
+        8765,
+        {"DOCSIGHT_SKIP_BROWSER": "1"},
+        lambda url: calls.append(url),
+    )
 
+    assert result is True
     assert calls == []
+
+
+def test_open_browser_returns_false_and_uses_loopback_url():
+    calls = []
+
+    result = desktop.open_browser(8766, {}, lambda url: calls.append(url) or False)
+
+    assert result is False
+    assert calls == ["http://127.0.0.1:8766/"]
+
+
+@pytest.mark.parametrize("initialize_result", [0, 1])
+def test_default_windows_browser_balances_successful_com_initialization(
+    monkeypatch,
+    initialize_result,
+):
+    calls = []
+    com_api = SimpleNamespace(
+        CoInitializeEx=lambda reserved, mode: (
+            calls.append(("initialize", reserved, mode)) or initialize_result
+        ),
+        CoUninitialize=lambda: calls.append("uninitialize"),
+    )
+    monkeypatch.setattr(
+        desktop.webbrowser,
+        "open",
+        lambda url: calls.append(("open", url)) or True,
+    )
+
+    assert desktop.open_browser(
+        8765,
+        {},
+        platform="win32",
+        com_api=com_api,
+    ) is True
+    assert calls == [
+        ("initialize", None, 0x2),
+        ("open", "http://127.0.0.1:8765/"),
+        "uninitialize",
+    ]
+
+
+def test_default_windows_browser_handles_changed_com_mode_without_uninitialize(
+    monkeypatch,
+):
+    calls = []
+    com_api = SimpleNamespace(
+        CoInitializeEx=lambda *_args: -2147417850,
+        CoUninitialize=lambda: calls.append("uninitialize"),
+    )
+    monkeypatch.setattr(
+        desktop.webbrowser,
+        "open",
+        lambda url: calls.append(("open", url)) or True,
+    )
+
+    assert desktop.open_browser(
+        8765,
+        {},
+        platform="win32",
+        com_api=com_api,
+    ) is True
+    assert calls == [("open", "http://127.0.0.1:8765/")]
+
+
+def test_custom_windows_browser_callback_does_not_require_com():
+    calls = []
+    com_api = SimpleNamespace(
+        CoInitializeEx=lambda *_args: pytest.fail("custom callback must skip COM"),
+        CoUninitialize=lambda: pytest.fail("custom callback must skip COM"),
+    )
+
+    assert desktop.open_browser(
+        8765,
+        {},
+        lambda url: calls.append(url) or True,
+        platform="win32",
+        com_api=com_api,
+    ) is True
+    assert calls == ["http://127.0.0.1:8765/"]
+
+
+def test_copy_local_url_uses_clipboard_contract():
+    calls = []
+    clipboard = SimpleNamespace(
+        clipboard_clear=lambda: calls.append("clear"),
+        clipboard_append=lambda value: calls.append(("append", value)),
+    )
+
+    desktop.copy_local_url(clipboard, "http://127.0.0.1:8765/")
+
+    assert calls == ["clear", ("append", "http://127.0.0.1:8765/")]
+
+
+@pytest.mark.parametrize(
+    ("requested_width", "requested_height", "expected"),
+    [
+        (420, 260, "480x300+720+200"),
+        (760, 520, "760x520+580+126"),
+    ],
+)
+def test_centered_window_geometry_preserves_scaled_widget_request(
+    requested_width,
+    requested_height,
+    expected,
+):
+    assert desktop.centered_window_geometry(
+        requested_width,
+        requested_height,
+        1920,
+        900,
+    ) == expected
+
+
+def test_open_log_folder_uses_windows_shell_action(tmp_path):
+    calls = []
+
+    result = desktop.open_log_folder(
+        tmp_path,
+        platform="win32",
+        windows_open=lambda path: calls.append(path),
+    )
+
+    assert result is True
+    assert calls == [str(tmp_path)]
+
+
+def test_open_log_folder_is_testable_outside_windows(tmp_path):
+    calls = []
+
+    desktop.open_log_folder(
+        tmp_path,
+        platform="linux",
+        process_open=lambda command: calls.append(command),
+    )
+
+    assert calls == [["xdg-open", str(tmp_path)]]
+
+
+def test_relaunch_spawns_before_terminating_current_process():
+    calls = []
+
+    desktop.relaunch_launcher(
+        spawn=lambda: calls.append("spawn"),
+        terminate=lambda: calls.append("terminate"),
+    )
+
+    assert calls == ["spawn", "terminate"]
+
+
+def test_spawn_launcher_process_is_isolated_for_unit_tests(monkeypatch):
+    calls = []
+    monkeypatch.setattr(desktop, "launcher_working_directory", lambda: ROOT)
+
+    result = desktop.spawn_launcher_process(
+        ["python", "launcher.py"],
+        process_factory=lambda *args, **kwargs: calls.append((args, kwargs)) or "child",
+    )
+
+    assert result == "child"
+    assert calls == [
+        (
+            (["python", "launcher.py"],),
+            {"cwd": str(ROOT), "close_fds": True},
+        )
+    ]
+
+
+def test_windows_spawn_inherits_real_parent_handle_and_closes_local_copy(monkeypatch):
+    calls = []
+    monkeypatch.setattr(desktop, "launcher_working_directory", lambda: ROOT)
+    startupinfo = SimpleNamespace(lpAttributeList=None)
+
+    desktop.spawn_launcher_process(
+        process_factory=lambda *args, **kwargs: calls.append(("spawn", args, kwargs)),
+        platform="win32",
+        duplicate_handle=lambda: calls.append("duplicate") or 4321,
+        close_handle=lambda handle: calls.append(("close", handle)),
+        startupinfo_factory=lambda: startupinfo,
+    )
+
+    assert calls[0] == "duplicate"
+    _, args, kwargs = calls[1]
+    command = args[0]
+    assert command[-1] == "--docsight-relaunch-handle=4321"
+    assert desktop._relaunch_parent_handle(command) == 4321
+    assert kwargs == {
+        "cwd": str(ROOT),
+        "close_fds": True,
+        "startupinfo": startupinfo,
+    }
+    assert startupinfo.lpAttributeList == {"handle_list": [4321]}
+    assert calls[2] == ("close", 4321)
+
+
+def test_windows_parent_handoff_waits_on_inherited_handle_and_closes_it():
+    calls = []
+
+    class FakeWindowsApi:
+        def WaitForSingleObject(self, handle, timeout):
+            calls.append(("wait", handle, timeout))
+            return 0
+
+        def CloseHandle(self, handle):
+            calls.append(("close", handle))
+
+    assert desktop.wait_for_previous_launcher(
+        99,
+        timeout_milliseconds=2500,
+        windows_api=FakeWindowsApi(),
+    ) is desktop.HandoffOutcome.COMPLETE
+    assert calls == [
+        ("wait", 99, 2500),
+        ("close", 99),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("wait_result", "expected"),
+    [
+        (0x102, desktop.HandoffOutcome.TIMEOUT),
+        (0xFFFFFFFF, desktop.HandoffOutcome.FAILED),
+        (17, desktop.HandoffOutcome.FAILED),
+    ],
+)
+def test_windows_parent_handoff_distinguishes_timeout_and_invalid_wait_results(
+    wait_result,
+    expected,
+):
+    closed = []
+    api = SimpleNamespace(
+        WaitForSingleObject=lambda *_args: wait_result,
+        CloseHandle=lambda handle: closed.append(handle),
+    )
+
+    assert desktop.wait_for_previous_launcher(
+        99,
+        windows_api=api,
+    ) is expected
+    assert closed == [99]
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows process handle contract")
+def test_windows_parent_handoff_uses_real_process_handle_api():
+    handle = desktop.duplicate_current_process_handle()
+
+    assert desktop.wait_for_previous_launcher(
+        handle,
+        timeout_milliseconds=1,
+    ) is desktop.HandoffOutcome.TIMEOUT
+
+
+def test_parent_handoff_timeout_stays_on_recovery_before_port_selection(
+    monkeypatch,
+    tmp_path,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    monkeypatch.setattr(
+        desktop,
+        "select_port",
+        lambda env: pytest.fail("port selection must wait for the old launcher"),
+    )
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {},
+        is_relaunch=True,
+        handoff_outcome=desktop.HandoffOutcome.TIMEOUT,
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is desktop.RecoveryCode.HANDOFF_FAILED
+    assert controller.state.status == (
+        "DOCSight could not safely finish restarting. "
+        "Close it and start DOCSight again."
+    )
+
+
+@pytest.mark.parametrize(
+    ("parent_handle", "expected_prefix"),
+    [
+        (None, ["environment", "logging", "tk"]),
+        (99, ["environment", ("wait", 99), "logging", "tk"]),
+    ],
+)
+def test_run_desktop_waits_before_single_logging_configuration(
+    monkeypatch,
+    tmp_path,
+    parent_handle,
+    expected_prefix,
+):
+    calls = []
+    paths = make_paths(tmp_path)
+    fake_tk = SimpleNamespace(
+        ttk=SimpleNamespace(),
+        Tk=lambda: (
+            calls.append("tk")
+            or (_ for _ in ()).throw(RuntimeError("stop after ordering check"))
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "tkinter", fake_tk)
+    monkeypatch.setattr(
+        desktop,
+        "configure_desktop_environment",
+        lambda env: calls.append("environment") or paths,
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_relaunch_parent_handle",
+        lambda: parent_handle,
+    )
+    monkeypatch.setattr(
+        desktop,
+        "wait_for_previous_launcher",
+        lambda handle: calls.append(("wait", handle))
+        or desktop.HandoffOutcome.COMPLETE,
+    )
+    monkeypatch.setattr(
+        desktop,
+        "configure_logging",
+        lambda launcher, runtime: calls.append("logging"),
+    )
+    monkeypatch.setattr(
+        desktop,
+        "show_fatal_startup_message",
+        lambda logs_dir: calls.append("fatal"),
+    )
+
+    assert desktop.run_desktop() == 1
+    assert calls[:-1] == expected_prefix
+    assert calls[-1] == "fatal"
+    assert calls.count("logging") == 1
 
 
 def test_runtime_root_uses_source_checkout_by_default():
@@ -135,24 +817,498 @@ def test_runtime_root_uses_pyinstaller_meipass(monkeypatch, tmp_path):
     assert desktop.get_runtime_root() == bundle_root
 
 
-def test_configure_logging_uses_rotating_file_handler(tmp_path, monkeypatch):
-    log_file = tmp_path / "logs" / "docsight.log"
-    calls = {}
-    created_handlers = []
+def test_configure_logging_installs_private_launcher_and_root_runtime_handlers(
+    tmp_path,
+):
+    log_file = tmp_path / "logs" / "launcher.log"
+    runtime_log_file = tmp_path / "logs" / "runtime.log"
+    foreign_handler = logging.NullHandler()
+    root_logger = logging.getLogger()
+    root_logger.addHandler(foreign_handler)
 
-    class FakeHandler:
-        def __init__(self, *args, **kwargs):
-            self.args = args
-            self.kwargs = kwargs
-            created_handlers.append(self)
+    try:
+        desktop.configure_logging(log_file, runtime_log_file)
 
-    monkeypatch.setattr(desktop, "RotatingFileHandler", FakeHandler)
-    monkeypatch.setattr(desktop.logging, "basicConfig", lambda **kwargs: calls.update(kwargs))
+        assert log_file.parent.is_dir()
+        launcher_handlers = [
+            handler
+            for handler in desktop.LOG.handlers
+            if getattr(handler, desktop._OWNED_HANDLER_ATTRIBUTE, False)
+        ]
+        runtime_handlers = [
+            handler
+            for handler in root_logger.handlers
+            if getattr(handler, desktop._OWNED_HANDLER_ATTRIBUTE, False)
+        ]
+        assert len(launcher_handlers) == 1
+        assert len(runtime_handlers) == 1
+        assert isinstance(launcher_handlers[0], desktop.RotatingFileHandler)
+        assert isinstance(runtime_handlers[0], desktop.RotatingFileHandler)
+        assert launcher_handlers[0].maxBytes == 1_000_000
+        assert runtime_handlers[0].maxBytes == 5_000_000
+        assert foreign_handler in root_logger.handlers
+        assert desktop.LOG.propagate is False
+    finally:
+        root_logger.removeHandler(foreign_handler)
 
-    desktop.configure_logging(log_file)
 
-    assert log_file.parent.is_dir()
-    assert created_handlers[0].args == (log_file,)
-    assert created_handlers[0].kwargs == {"maxBytes": 1_000_000, "backupCount": 3, "encoding": "utf-8"}
-    assert calls["handlers"] == [created_handlers[0]]
-    assert calls["force"] is True
+def test_configure_logging_is_idempotent_for_same_process_paths(tmp_path):
+    paths = make_paths(tmp_path)
+
+    desktop.configure_logging(paths.log_file, paths.runtime_log_file)
+    launcher_handler = next(
+        handler
+        for handler in desktop.LOG.handlers
+        if getattr(handler, desktop._OWNED_HANDLER_ATTRIBUTE, False)
+    )
+    runtime_handler = next(
+        handler
+        for handler in logging.getLogger().handlers
+        if getattr(handler, desktop._OWNED_HANDLER_ATTRIBUTE, False)
+    )
+
+    desktop.configure_logging(paths.log_file, paths.runtime_log_file)
+
+    assert launcher_handler in desktop.LOG.handlers
+    assert runtime_handler in logging.getLogger().handlers
+
+
+def test_launcher_log_excludes_runtime_records_and_tracebacks(tmp_path):
+    log_file = tmp_path / "logs" / "launcher.log"
+    runtime_log_file = tmp_path / "logs" / "runtime.log"
+    desktop.configure_logging(log_file, runtime_log_file)
+
+    desktop.LOG.info("Phase: safe launcher record")
+    logging.getLogger("app.main").error("password=runtime-secret")
+    try:
+        raise RuntimeError("password=launcher-secret")
+    except RuntimeError:
+        desktop.LOG.error("failure type: RuntimeError", exc_info=True)
+    for handler in desktop.LOG.handlers:
+        handler.flush()
+    for handler in logging.getLogger().handlers:
+        if getattr(handler, desktop._OWNED_HANDLER_ATTRIBUTE, False):
+            handler.flush()
+
+    log_text = log_file.read_text(encoding="utf-8")
+    runtime_text = runtime_log_file.read_text(encoding="utf-8")
+    assert "safe launcher record" in log_text
+    assert "failure type: RuntimeError" in log_text
+    assert "runtime-secret" not in log_text
+    assert "launcher-secret" not in log_text
+    assert "Traceback" not in log_text
+    assert "runtime-secret" in runtime_text
+    assert "safe launcher record" not in runtime_text
+
+
+def test_startup_failure_logging_omits_raw_exception_and_traceback(
+    monkeypatch,
+    tmp_path,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    desktop.configure_logging(paths.log_file, paths.runtime_log_file)
+    monkeypatch.setattr(
+        desktop,
+        "select_port",
+        lambda env: (_ for _ in ()).throw(
+            RuntimeError("password=secret request_body=private")
+        ),
+    )
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {"LOCALAPPDATA": str(tmp_path)},
+    ).run(controller.state.attempt)
+    for handler in desktop.LOG.handlers:
+        handler.flush()
+    log_text = paths.log_file.read_text(encoding="utf-8")
+
+    assert "Recovery available: no_free_port" in log_text
+    assert "failure type: RuntimeError" in log_text
+    assert "password=secret" not in log_text
+    assert "request_body" not in log_text
+    assert "Traceback" not in log_text
+
+
+def test_generic_startup_failure_is_recorded_by_private_launcher_log(
+    monkeypatch,
+    tmp_path,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    desktop.configure_logging(paths.log_file, paths.runtime_log_file)
+    monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
+    monkeypatch.setattr(
+        desktop,
+        "_start_app_thread",
+        lambda: (_ for _ in ()).throw(RuntimeError("password=secret")),
+    )
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {"LOCALAPPDATA": str(tmp_path)},
+    ).run(controller.state.attempt)
+    controller.drain_events()
+    for handler in desktop.LOG.handlers:
+        handler.flush()
+    log_text = paths.log_file.read_text(encoding="utf-8")
+
+    assert controller.state.recovery is desktop.RecoveryCode.STARTUP_FAILED
+    assert "Recovery available: startup_failure" in log_text
+    assert "failure type: RuntimeError" in log_text
+    assert "password=secret" not in log_text
+    assert "Traceback" not in log_text
+
+
+def test_smoke_failure_injection_requires_browser_skip_boundary(monkeypatch, tmp_path):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=threading.Event(),
+    )
+    injected = []
+    monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
+
+    def start_app_thread(*, inject_smoke_failure=False):
+        injected.append(inject_smoke_failure)
+        if not inject_smoke_failure:
+            return handle
+        stopped = threading.Event()
+        stopped.set()
+        return desktop.AppThreadHandle(
+            thread=SimpleNamespace(join=lambda: None),
+            stopped=stopped,
+            failure_type="RuntimeError",
+        )
+
+    monkeypatch.setattr(desktop, "_start_app_thread", start_app_thread)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle: (
+            desktop.WaitOutcome.APP_FAILED
+            if app_handle.stopped.is_set()
+            else desktop.WaitOutcome.READY
+        ),
+    )
+    monkeypatch.setattr(desktop, "open_browser", lambda port, env: True)
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {"DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE": "1"},
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is None
+    assert injected == [False]
+
+    controller = make_controller()
+    env = {
+        "DOCSIGHT_SKIP_BROWSER": "1",
+        "DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE": "1",
+    }
+
+    desktop.StartupRunner(controller, paths, env).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is desktop.RecoveryCode.APP_FAILED
+    assert injected == [False, True]
+
+
+def test_relaunch_handle_makes_smoke_failure_injection_one_shot(monkeypatch, tmp_path):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=threading.Event(),
+    )
+    injected = []
+    monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
+
+    def start_app_thread(*, inject_smoke_failure=False):
+        injected.append(inject_smoke_failure)
+        return handle
+
+    monkeypatch.setattr(desktop, "_start_app_thread", start_app_thread)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle: desktop.WaitOutcome.READY,
+    )
+    monkeypatch.setattr(desktop, "open_browser", lambda port, env: True)
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {
+            "DOCSIGHT_SKIP_BROWSER": "1",
+            "DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE": "1",
+        },
+        is_relaunch=True,
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is None
+    assert injected == [False]
+
+
+def test_browser_smoke_injection_reaches_recovery_without_browser(
+    monkeypatch,
+    tmp_path,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=threading.Event(),
+    )
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
+    monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle: desktop.WaitOutcome.READY,
+    )
+    monkeypatch.setattr(
+        desktop,
+        "open_browser",
+        lambda *_args: pytest.fail("browser injection must not invoke a browser"),
+    )
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {
+            "DOCSIGHT_SKIP_BROWSER": "1",
+            "DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE": "1",
+        },
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is desktop.RecoveryCode.BROWSER_FAILED
+    assert controller.state.ready is True
+    assert controller.state.url == "http://127.0.0.1:8765/"
+
+
+def test_no_port_smoke_injection_clears_url_before_port_selection(
+    monkeypatch,
+    tmp_path,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    monkeypatch.setattr(
+        desktop,
+        "select_port",
+        lambda env: pytest.fail("no-port injection must skip selection"),
+    )
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {
+            "DOCSIGHT_SKIP_BROWSER": "1",
+            "DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE": "1",
+        },
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is desktop.RecoveryCode.NO_PORT
+    assert controller.state.url == ""
+
+
+@pytest.mark.parametrize(
+    "injection_name",
+    [
+        "DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE",
+        "DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE",
+    ],
+)
+def test_relaunch_does_not_repeat_new_smoke_injections(
+    monkeypatch,
+    tmp_path,
+    injection_name,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=threading.Event(),
+    )
+    browser_calls = []
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
+    monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle: desktop.WaitOutcome.READY,
+    )
+    monkeypatch.setattr(
+        desktop,
+        "open_browser",
+        lambda port, env: browser_calls.append(port) or True,
+    )
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {
+            "DOCSIGHT_SKIP_BROWSER": "1",
+            injection_name: "1",
+        },
+        is_relaunch=True,
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is None
+    assert controller.state.ready is True
+    assert browser_calls == [8765]
+
+
+def make_minimal_view_for_recovery():
+    values = {"status": [], "url": [], "copy": [], "actions": [], "after": []}
+    view = desktop.TkLauncher.__new__(desktop.TkLauncher)
+    view.controller = make_controller()
+    view.status_var = SimpleNamespace(
+        set=lambda value: values["status"].append(value)
+    )
+    view.url_var = SimpleNamespace(set=lambda value: values["url"].append(value))
+    view.copy_button = SimpleNamespace(
+        configure=lambda **kwargs: values["copy"].append(kwargs)
+    )
+    view.actions = SimpleNamespace(
+        grid=lambda **kwargs: values["actions"].append(kwargs)
+    )
+    view.root = SimpleNamespace(
+        deiconify=lambda: None,
+        after=lambda *args: values["after"].append(args),
+        destroy=lambda: None,
+    )
+    return view, values
+
+
+def test_tk_callback_exception_is_sanitized_and_shows_recovery(tmp_path):
+    view, values = make_minimal_view_for_recovery()
+    paths = make_paths(tmp_path)
+    desktop.configure_logging(paths.log_file, paths.runtime_log_file)
+
+    view._report_callback_exception(
+        RuntimeError,
+        RuntimeError("password=secret"),
+        object(),
+    )
+    for handler in desktop.LOG.handlers:
+        handler.flush()
+    log_text = paths.log_file.read_text(encoding="utf-8")
+
+    assert view.controller.state.recovery is desktop.RecoveryCode.STARTUP_FAILED
+    assert view.controller.exit_code == 1
+    assert view.controller.state.status == "DOCSight could not finish starting."
+    assert all("secret" not in value for value in values["status"])
+    assert values["actions"] == [{"row": 5, "column": 0, "sticky": "w"}]
+    assert "failure type: RuntimeError" in log_text
+    assert "password=secret" not in log_text
+    assert "Traceback" not in log_text
+
+
+def test_render_failure_retains_minimal_recovery_surface():
+    view, values = make_minimal_view_for_recovery()
+    view._render_full = lambda: (_ for _ in ()).throw(
+        RuntimeError("private callback detail")
+    )
+
+    view.render()
+
+    assert view.controller.state.recovery is desktop.RecoveryCode.STARTUP_FAILED
+    assert values["status"][-1] == "DOCSight could not finish starting."
+    assert values["copy"][-1] == {"state": "normal"}
+    assert values["actions"][-1] == {"row": 5, "column": 0, "sticky": "w"}
+
+
+def test_poll_failure_recovers_and_schedules_next_poll():
+    view, values = make_minimal_view_for_recovery()
+    view.controller.drain_events = lambda: (_ for _ in ()).throw(
+        RuntimeError("private poll detail")
+    )
+
+    view.poll()
+
+    assert view.controller.state.recovery is desktop.RecoveryCode.STARTUP_FAILED
+    assert values["after"] == [(desktop.EVENT_POLL_MILLISECONDS, view.poll)]
+
+
+def test_tk_launcher_installs_callback_exception_boundary(monkeypatch, tmp_path):
+    root = SimpleNamespace()
+    monkeypatch.setattr(desktop.TkLauncher, "_build", lambda self: None)
+
+    view = desktop.TkLauncher(
+        root,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        make_controller(),
+        SimpleNamespace(),
+        make_paths(tmp_path),
+    )
+
+    assert root.report_callback_exception == view._report_callback_exception
+
+
+def test_fatal_startup_message_is_sanitized_and_points_to_logs(tmp_path):
+    calls = []
+
+    desktop.show_fatal_startup_message(
+        tmp_path / "logs",
+        message_box=lambda *args: calls.append(args),
+    )
+
+    assert len(calls) == 1
+    assert calls[0][2] == "DOCSight"
+    assert str(tmp_path / "logs") in calls[0][1]
+    assert "Traceback" not in calls[0][1]
+
+
+def test_fatal_startup_message_is_suppressed_in_smoke_mode(tmp_path):
+    calls = []
+
+    desktop.show_fatal_startup_message(
+        tmp_path / "logs",
+        message_box=lambda *args: calls.append(args),
+        env={"DOCSIGHT_SKIP_BROWSER": "1"},
+    )
+
+    assert calls == []
+
+
+def test_pre_ui_failure_returns_error_and_uses_fallback(monkeypatch):
+    calls = []
+
+    def fail_environment(_env):
+        raise RuntimeError("password=secret")
+
+    monkeypatch.setattr(desktop, "configure_desktop_environment", fail_environment)
+    monkeypatch.setattr(
+        desktop,
+        "show_fatal_startup_message",
+        lambda logs_dir: calls.append(logs_dir),
+    )
+
+    assert desktop.run_desktop() == 1
+    assert calls == [None]
+
+
+def test_close_destroys_window_and_terminates_process(monkeypatch):
+    calls = []
+    view = desktop.TkLauncher.__new__(desktop.TkLauncher)
+    view.root = SimpleNamespace(destroy=lambda: calls.append("destroy"))
+    view.controller = SimpleNamespace(exit_code=1)
+    monkeypatch.setattr(desktop.os, "_exit", lambda code: calls.append(("exit", code)))
+
+    view._close()
+
+    assert calls == ["destroy", ("exit", 1)]

--- a/tests/test_windows_desktop_ci.py
+++ b/tests/test_windows_desktop_ci.py
@@ -14,6 +14,9 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "windows-desktop.yml"
 SMOKE_SCRIPT = ROOT / "packaging" / "windows" / "smoke_test.ps1"
+WINDOWS_README = ROOT / "packaging" / "windows" / "README.md"
+WINDOWS_QA_CHECKLIST = ROOT / "packaging" / "windows" / "QA-CHECKLIST.md"
+WINDOWS_PREVIEW_DOC = ROOT / "docs" / "windows-desktop-preview.md"
 
 
 def named_step_block(workflow_text: str, step_name: str) -> str:
@@ -168,6 +171,7 @@ def test_windows_desktop_workflow_triggers_and_permissions():
     assert "release:" in workflow
     assert "types: [published]" in workflow
     assert "permissions:\n  contents: read" in workflow
+    assert "  build:\n    timeout-minutes: 30\n    runs-on: windows-latest" in workflow
     assert "attach-release-assets:" in workflow
     assert "permissions:\n      contents: write" in workflow
 
@@ -527,8 +531,149 @@ def test_smoke_script_launches_built_exe_and_checks_loopback_health():
     assert "$Payload.version -ne $ExpectedVersion" in script
     assert "Get-NetTCPConnection -State Listen -LocalPort $Port" in script
     assert "LocalAddress -eq \"127.0.0.1\"" in script
+    assert "OwningProcess -eq $Process.Id" in script
+    assert "Get-PeMachine -Path $Executable" in script
+    assert "0x8664" in script
+    assert "-WindowStyle Hidden" not in script
     assert "DOCSIGHT_SKIP_BROWSER" in script
+    assert "DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE" in script
+    assert "DOCSight\\logs\\launcher.log" in script
+    assert "DOCSight\\logs\\runtime.log" in script
     assert "python -m app.main" not in script
+
+
+def test_smoke_script_requires_one_owned_ipv4_loopback_listener():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "$Connections.Count -ne 1" in script
+    assert "$OwnedLoopbackListeners.Count -ne 1" in script
+    assert '$_.LocalAddress -eq "127.0.0.1"' in script
+    assert "$_.OwningProcess -eq $Process.Id" in script
+    assert "Expected exactly one listener on smoke port" in script
+    assert "Expected exactly one 127.0.0.1:$Port listener owned by DOCSight" in script
+
+
+def test_smoke_script_prints_both_logs_and_rejects_runtime_import_degradation():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert (
+        '$RuntimeLogFile = Join-Path $LocalAppData "DOCSight\\logs\\runtime.log"'
+        in script
+    )
+    assert "Get-Content -LiteralPath $LauncherLogFile -Tail 200" in script
+    assert "Get-Content -LiteralPath $RuntimeLogFile -Tail 200" in script
+    assert "if (-not (Test-Path -LiteralPath $RuntimeLogFile))" in script
+    assert "Get-Content -LiteralPath $RuntimeLogFile -Raw" in script
+    assert "failed to import routes" in script
+    assert "No module named" in script
+    assert "Write-Host $RuntimeLogText" not in script
+
+
+def test_smoke_script_proves_injected_startup_recovery_without_browser():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert '$env:DOCSIGHT_SKIP_BROWSER = "1"' in script
+    assert '$env:DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE = "1"' in script
+    assert '"Phase: Prepare local data"' in script
+    assert '"Recovery available: app_thread_failure"' in script
+    assert '"failure type: RuntimeError"' in script
+    assert "if ($Process.HasExited)" in script
+    assert "instead of keeping recovery available" in script
+    assert "$Process.Refresh()" in script
+    assert "$Process.MainWindowHandle -eq [IntPtr]::Zero" in script
+    assert '$Process.MainWindowTitle -cne "DOCSight"' in script
+    assert "-WindowStyle Hidden" not in script
+
+
+def test_smoke_script_uses_fresh_launcher_log_for_injected_recovery():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+    launches = [
+        match.start()
+        for match in re.finditer(
+            r"Start-Process -FilePath \$Executable -WorkingDirectory "
+            r"\$LaunchBundleDir -PassThru",
+            script,
+        )
+    ]
+
+    assert len(launches) == 2
+    stop_first_process = script.index(
+        "Stop-Process -Id $Process.Id -Force", launches[0]
+    )
+    wait_for_first_process = script.index(
+        "$FirstProcessStopped = $Process.WaitForExit(10000)", stop_first_process
+    )
+    remove_first_log = script.index(
+        "Remove-Item -LiteralPath $LauncherLogFile -Force", wait_for_first_process
+    )
+    prepare_phase_assertion = script.index('"Phase: Prepare local data"', launches[1])
+    assert (
+        launches[0]
+        < stop_first_process
+        < wait_for_first_process
+        < remove_first_log
+        < launches[1]
+    )
+    assert launches[1] < prepare_phase_assertion
+    assert launches[1] < script.index("$Process.MainWindowHandle", launches[1])
+    assert launches[1] < script.index("$Process.MainWindowTitle", launches[1])
+
+
+def test_smoke_script_restores_all_injection_environment_variables():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+    finally_block = script.rsplit("} finally {", maxsplit=1)[1]
+
+    variables = (
+        ("STARTUP", "Startup"),
+        ("BROWSER", "Browser"),
+        ("NO_PORT", "NoPort"),
+    )
+    for environment_suffix, variable_suffix in variables:
+        environment_name = f"DOCSIGHT_SMOKE_INJECT_{environment_suffix}_FAILURE"
+        assert (
+            f"$PreviousInjected{variable_suffix}Failure = $env:{environment_name}"
+            in script
+        )
+        assert (
+            f"$env:{environment_name} = $PreviousInjected{variable_suffix}Failure"
+            in finally_block
+        )
+
+
+def test_windows_docs_describe_smoke_and_log_sharing_contracts():
+    readme = WINDOWS_README.read_text(encoding="utf-8")
+    qa_checklist = WINDOWS_QA_CHECKLIST.read_text(encoding="utf-8")
+    preview_doc = WINDOWS_PREVIEW_DOC.read_text(encoding="utf-8")
+    combined_docs = "\n".join((readme, qa_checklist, preview_doc))
+
+    assert "from **Start DOCSight** onward" in readme
+    assert "from **Start DOCSight** onward" in qa_checklist
+    assert "from **Start DOCSight** onward" in preview_doc
+    assert "exactly one listener" in combined_docs
+    assert "route/import" in combined_docs
+    assert "fresh **Prepare local data** evidence" in combined_docs
+    assert "nonzero main-window handle" in combined_docs
+    assert "title exactly `DOCSight`" in combined_docs
+    assert "sanitized" in combined_docs
+    assert "shareable" in combined_docs
+    assert "review it before sharing" in combined_docs
+    assert "Linux tests only enforce its\nstatic contract" in preview_doc
+    assert "runs later on `windows-latest`" in preview_doc
+
+
+def test_windows_qa_keeps_all_precise_failure_injection_invocations():
+    qa_checklist = WINDOWS_QA_CHECKLIST.read_text(encoding="utf-8")
+
+    for environment_name in (
+        "DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE",
+        "DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE",
+        "DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE",
+    ):
+        assert f'$env:{environment_name} = "1"' in qa_checklist
+        assert f"Remove-Item Env:{environment_name}," in qa_checklist
+    assert qa_checklist.count('$env:DOCSIGHT_SKIP_BROWSER = "1"') == 3
+    assert qa_checklist.count("Env:DOCSIGHT_SKIP_BROWSER -ErrorAction") == 3
+    assert qa_checklist.count(".\\DOCSight.exe") == 3
 
 
 def test_smoke_script_runs_copied_bundle_from_hostile_temp_path():
@@ -572,14 +717,11 @@ def test_smoke_script_checks_real_pdf_response_from_packaged_process():
     assert script.index("$SetupResponse") < script.index("$PdfResponse")
 
 
-def test_smoke_script_rejects_reports_import_errors_and_preserves_cleanup():
+def test_smoke_script_preserves_cleanup_after_real_reports_route_checks():
     script = SMOKE_SCRIPT.read_text(encoding="utf-8")
 
-    assert "docsight\\.reports" in script
-    assert "failed to import routes" in script
-    assert "No module named" in script
-    assert "unittest" in script
-    assert script.index("$PdfResponse.ContentType") < script.index("$LogText")
+    assert script.index("$EmptyReportResponse") < script.index("$SetupResponse")
+    assert script.index("$SetupResponse") < script.index("$PdfResponse.ContentType")
     assert re.search(
         r"}\s*catch\s*{\s*Write-SmokeLog\s*throw\s*}\s*finally\s*{",
         script,
@@ -587,6 +729,17 @@ def test_smoke_script_rejects_reports_import_errors_and_preserves_cleanup():
     assert "Stop-Process -Id $Process.Id -Force" in script
     assert "$env:LOCALAPPDATA = $PreviousLocalAppData" in script
     assert "Remove-Item -Recurse -Force $SmokeRoot" in script
+
+
+def test_windows_build_and_workflow_require_x64_python():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    build_script = (ROOT / "packaging" / "windows" / "build.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    assert "architecture: x64" in workflow
+    assert "struct.calcsize('P')" in build_script
+    assert 'PointerSize -ne "8"' in build_script
 
 
 def test_step_block_helper_does_not_capture_next_step():

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -51,9 +51,10 @@ def test_pyinstaller_spec_collects_app_tree_and_version_file():
     assert "docsight-traceroute-helper" not in spec_text
 
 
-def test_pyinstaller_spec_keeps_intended_exclusions_without_unittest():
+def test_pyinstaller_spec_bundles_tk_and_keeps_test_exclusion():
     spec_path = WINDOWS_PACKAGING / "docsight.spec"
-    tree = ast.parse(spec_path.read_text(encoding="utf-8"), filename=str(spec_path))
+    spec_text = spec_path.read_text(encoding="utf-8")
+    tree = ast.parse(spec_text, filename=str(spec_path))
     analysis_call = next(
         node
         for node in ast.walk(tree)
@@ -66,9 +67,18 @@ def test_pyinstaller_spec_keeps_intended_exclusions_without_unittest():
     )
     exclusions = ast.literal_eval(excludes_keyword.value)
 
-    assert "tkinter" in exclusions
+    assert '"tkinter"' in spec_text
+    assert '"tkinter.ttk"' in spec_text
+    assert "tkinter" not in exclusions
     assert "pytest" in exclusions
     assert "unittest" not in exclusions
+
+
+def test_pyinstaller_spec_disables_windowed_tracebacks():
+    spec_text = (WINDOWS_PACKAGING / "docsight.spec").read_text(encoding="utf-8")
+
+    assert "disable_windowed_traceback=True" in spec_text
+    assert "disable_windowed_traceback=False" not in spec_text
 
 
 def test_build_script_uses_hash_pinned_requirements_and_creates_zip_hash():

--- a/tests/test_windows_pytest_ci.py
+++ b/tests/test_windows_pytest_ci.py
@@ -126,6 +126,12 @@ def test_manual_qa_checklist_covers_desktop_release_risks():
         "sleep or hibernate",
         "second time",
         "%localappdata%\\docsight",
+        "under two seconds",
+        "copy",
+        "retry",
+        "open log folder",
+        "browser-open failure",
+        "screenshot",
         "uninstall",
     ):
         assert required in lower


### PR DESCRIPTION
## Summary

- add an immediate native Windows startup window with visible Prepare, Start, Readiness, and Browser phases
- keep the selected loopback URL visible and provide plain-language recovery actions for startup, port, readiness, and browser failures
- isolate privacy-filtered launcher events from application runtime diagnostics and make Retry use a fresh process with deterministic Windows handoff
- harden the packaged launcher around Tk callback failures, COM browser opening, exclusive port probing, and windowed traceback suppression
- extend the Windows portable-package smoke test with runtime-import, listener ownership, Reports PDF, fresh recovery-log, and visible-window assertions
- document deterministic manual recovery checks and bound the Windows CI job to 30 minutes

## Testing

- `3135 passed, 2 skipped` in the full non-E2E suite
- `133 passed, 1 skipped` in focused launcher, packaging, workflow, and boundary tests
- real Tk layout check under Xvfb for normal and expanded recovery views
- `git diff --check`

The pull-request Windows workflow remains the authoritative packaged `DOCSight.exe` build and smoke gate on `windows-latest`.
