### PR TITLE
Reuse the running Windows desktop instance

### DIFF
--- a/app/desktop_runtime.py
+++ b/app/desktop_runtime.py
@@ -1,0 +1,59 @@
+"""Loopback and token policy for the desktop-only runtime endpoint."""
+
+from __future__ import annotations
+
+import ipaddress
+import secrets
+from collections.abc import Mapping
+
+from .desktop_runtime_contract import (
+    DESKTOP_MODE_ENV,
+    INSTANCE_TOKEN_ENV,
+    RuntimeState,
+    is_valid_instance_token,
+)
+
+
+def desktop_runtime_payload(
+    *,
+    env: Mapping[str, str],
+    remote_address: str | None,
+    authorization: str | None,
+) -> tuple[dict[str, object], int]:
+    """Return the desktop runtime payload only for an authenticated loopback peer."""
+    if env.get(DESKTOP_MODE_ENV) != "1":
+        return {"status": "not_found"}, 404
+    if not _is_loopback(remote_address):
+        return {"status": "forbidden"}, 403
+
+    token = env.get(INSTANCE_TOKEN_ENV, "")
+    if not is_valid_instance_token(token) or not _authorization_matches(
+        authorization,
+        token,
+    ):
+        return {"status": "not_found"}, 404
+
+    try:
+        state = RuntimeState.from_environment(env)
+    except ValueError:
+        return {"status": "not_found"}, 404
+
+    return {"status": "ok", **state.to_mapping()}, 200
+
+
+def _is_loopback(address: str | None) -> bool:
+    try:
+        return address is not None and ipaddress.ip_address(address).is_loopback
+    except ValueError:
+        return False
+
+
+def _authorization_matches(authorization: str | None, token: str) -> bool:
+    if authorization is None:
+        return False
+    try:
+        observed = authorization.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+    expected = f"Bearer {token}".encode("ascii")
+    return secrets.compare_digest(observed, expected)

--- a/app/desktop_runtime_contract.py
+++ b/app/desktop_runtime_contract.py
@@ -1,0 +1,154 @@
+"""Shared schema and environment contract for the desktop runtime."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+DESKTOP_MODE_ENV = "DOCSIGHT_DESKTOP_MODE"
+INSTANCE_TOKEN_ENV = "DOCSIGHT_DESKTOP_INSTANCE_TOKEN"
+INSTANCE_PID_ENV = "DOCSIGHT_DESKTOP_INSTANCE_PID"
+INSTANCE_START_TIME_ENV = "DOCSIGHT_DESKTOP_PROCESS_START_TIME"
+INSTANCE_VERSION_ENV = "DOCSIGHT_DESKTOP_APP_VERSION"
+WEB_PORT_ENV = "WEB_PORT"
+
+DESKTOP_RUNTIME_ENV_NAMES = (
+    INSTANCE_TOKEN_ENV,
+    INSTANCE_PID_ENV,
+    INSTANCE_START_TIME_ENV,
+    INSTANCE_VERSION_ENV,
+)
+RUNTIME_SCHEMA_VERSION = 1
+RUNTIME_STATE_FIELDS = frozenset(
+    {
+        "schema_version",
+        "pid",
+        "port",
+        "application_version",
+        "process_start_time",
+        "instance_token",
+    }
+)
+
+_TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9_-]{43,128}$")
+_VERSION_PATTERN = re.compile(r"^[^\x00-\x1f\x7f]{1,128}$")
+
+
+@dataclass(frozen=True)
+class RuntimeState:
+    """Strict versioned identity for one running desktop server."""
+
+    schema_version: int
+    pid: int
+    port: int
+    application_version: str
+    process_start_time: int
+    instance_token: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        pid: int,
+        port: int,
+        application_version: str,
+        process_start_time: int,
+        instance_token: str,
+    ) -> RuntimeState:
+        return cls.from_mapping(
+            {
+                "schema_version": RUNTIME_SCHEMA_VERSION,
+                "pid": pid,
+                "port": port,
+                "application_version": application_version,
+                "process_start_time": process_start_time,
+                "instance_token": instance_token,
+            }
+        )
+
+    @classmethod
+    def from_mapping(cls, value: object) -> RuntimeState:
+        if not isinstance(value, dict) or set(value) != RUNTIME_STATE_FIELDS:
+            raise ValueError("runtime state fields are invalid")
+
+        schema_version = _strict_int(value["schema_version"])
+        pid = _strict_int(value["pid"])
+        port = _strict_int(value["port"])
+        process_start_time = _strict_int(value["process_start_time"])
+        application_version = value["application_version"]
+        instance_token = value["instance_token"]
+
+        if schema_version != RUNTIME_SCHEMA_VERSION:
+            raise ValueError("runtime schema version is unsupported")
+        if not 1 <= pid <= 0xFFFFFFFF:
+            raise ValueError("runtime PID is out of range")
+        if not 1 <= port <= 65535:
+            raise ValueError("runtime port is out of range")
+        if not 1 <= process_start_time <= 0xFFFFFFFFFFFFFFFF:
+            raise ValueError("runtime process start time is out of range")
+        if not is_valid_application_version(application_version):
+            raise ValueError("runtime application version is invalid")
+        if not is_valid_instance_token(instance_token):
+            raise ValueError("runtime instance token is invalid")
+
+        return cls(
+            schema_version=schema_version,
+            pid=pid,
+            port=port,
+            application_version=application_version,
+            process_start_time=process_start_time,
+            instance_token=instance_token,
+        )
+
+    @classmethod
+    def from_environment(cls, env: Mapping[str, str]) -> RuntimeState:
+        """Build and validate the exact runtime identity exported by the launcher."""
+        return cls.create(
+            pid=_strict_environment_int(env.get(INSTANCE_PID_ENV)),
+            port=_strict_environment_int(env.get(WEB_PORT_ENV)),
+            application_version=env.get(INSTANCE_VERSION_ENV, ""),
+            process_start_time=_strict_environment_int(
+                env.get(INSTANCE_START_TIME_ENV)
+            ),
+            instance_token=env.get(INSTANCE_TOKEN_ENV, ""),
+        )
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "pid": self.pid,
+            "port": self.port,
+            "application_version": self.application_version,
+            "process_start_time": self.process_start_time,
+            "instance_token": self.instance_token,
+        }
+
+    def export_environment(self) -> dict[str, str]:
+        return {
+            INSTANCE_TOKEN_ENV: self.instance_token,
+            INSTANCE_PID_ENV: str(self.pid),
+            INSTANCE_START_TIME_ENV: str(self.process_start_time),
+            INSTANCE_VERSION_ENV: self.application_version,
+            WEB_PORT_ENV: str(self.port),
+        }
+
+
+def is_valid_instance_token(value: object) -> bool:
+    return isinstance(value, str) and _TOKEN_PATTERN.fullmatch(value) is not None
+
+
+def is_valid_application_version(value: object) -> bool:
+    return isinstance(value, str) and _VERSION_PATTERN.fullmatch(value) is not None
+
+
+def _strict_int(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("runtime integer field is invalid")
+    return value
+
+
+def _strict_environment_int(value: str | None) -> int:
+    if value is None or not value.isdecimal():
+        raise ValueError("invalid desktop runtime integer")
+    return int(value)

--- a/app/main.py
+++ b/app/main.py
@@ -62,6 +62,21 @@ def get_web_host():
     return os.environ.get("WEB_HOST", "0.0.0.0")
 
 
+def _wait_for_web_thread(web_thread, stop_polling):
+    """Keep the process alive until the web server stops, then stop pollers."""
+    try:
+        while web_thread.is_alive():
+            time.sleep(0.25)
+        log.error("Web server stopped unexpectedly")
+    except KeyboardInterrupt:
+        log.info("Shutting down")
+        return
+    finally:
+        stop_polling()
+    if os.environ.get("DOCSIGHT_DESKTOP_MODE", "").strip() != "1":
+        raise RuntimeError("Web server stopped unexpectedly")
+
+
 def _apply_timezone(cfg):
     """Apply the configured timezone where the platform supports TZ reloads."""
     tz = cfg.get("timezone")
@@ -472,14 +487,10 @@ def main():
     else:
         log.info("Not configured yet - open http://localhost:%d for setup", web_port)
 
-    # Keep main thread alive
-    try:
-        while True:
-            time.sleep(60)
-    except KeyboardInterrupt:
-        log.info("Shutting down")
-        if poll_stop:
-            poll_stop.set()
+    # Keep the main thread alive while the web server owns its listener. If the
+    # server thread cannot bind, return so the desktop launcher can perform its
+    # bounded fresh-process recovery instead of waiting for readiness forever.
+    _wait_for_web_thread(web_thread, stop_polling)
 
 
 if __name__ == "__main__":

--- a/app/web.py
+++ b/app/web.py
@@ -24,6 +24,8 @@ from zoneinfo import available_timezones
 from .config import DEFAULTS, MODULE_SECRET_KEYS, PASSWORD_MASK, POLL_MIN, POLL_MAX
 from .analyzer import get_thresholds
 from .docsis_utils import qam_rank
+from .desktop_runtime import desktop_runtime_payload
+from .desktop_runtime_contract import DESKTOP_MODE_ENV
 from .gaming_index import compute_gaming_index
 from .glossary import (
     get_glossary_categories,
@@ -60,7 +62,7 @@ DESKTOP_PREVIEW_DOC_URL = "https://github.com/itsDNNS/docsight/blob/main/docs/wi
 
 def is_desktop_preview_mode() -> bool:
     """Return True when DOCSight runs as the local Desktop Preview build."""
-    return os.environ.get("DOCSIGHT_DESKTOP_MODE") == "1"
+    return os.environ.get(DESKTOP_MODE_ENV) == "1"
 
 
 _THEME_COLLECTIONS = [
@@ -1677,6 +1679,17 @@ def health():
     if _state["analysis"]:
         return {"status": "ok", "docsis_health": _state["analysis"]["summary"]["health"], "version": APP_VERSION}
     return {"status": "ok", "docsis_health": "waiting", "version": APP_VERSION}
+
+
+@app.route("/desktop-runtime")
+def desktop_runtime():
+    """Return authenticated process identity only for desktop loopback clients."""
+    payload, status = desktop_runtime_payload(
+        env=os.environ,
+        remote_address=request.remote_addr,
+        authorization=request.headers.get("Authorization"),
+    )
+    return jsonify(payload), status
 
 
 @app.route("/setup")

--- a/docs/windows-desktop-preview.md
+++ b/docs/windows-desktop-preview.md
@@ -67,6 +67,12 @@ progress while it prepares local data, starts DOCSight, waits for readiness,
 and attempts to open the browser. After DOCSight is ready and the browser-open
 attempt succeeds, the startup window closes.
 
+Starting `DOCSight.exe` again reuses the already-running instance for the same
+Windows user. The later launcher waits for authenticated local readiness, opens
+the exact existing address, and exits without starting another server. This
+also works across multiple signed-in Windows sessions for the same account.
+Different Windows users keep separate instances and data.
+
 If startup cannot finish or the browser cannot be opened, the window stays
 available instead of exiting silently. You can copy the displayed local
 address, choose **Retry** to start a fresh attempt, open the log folder, or
@@ -115,19 +121,38 @@ Typical subfolders:
 | `%LOCALAPPDATA%\DOCSight\data` | Configuration and local monitoring database |
 | `%LOCALAPPDATA%\DOCSight\modules` | Community modules and themes |
 | `%LOCALAPPDATA%\DOCSight\logs` | Privacy-filtered launcher diagnostics in `launcher.log`; separate application diagnostics in `runtime.log` |
+| `%LOCALAPPDATA%\DOCSight\runtime.json` | Versioned single-instance identity; replaced atomically and recovered after crashes |
 
 `launcher.log` contains only sanitized startup/recovery events and is intended
 to be shareable. `runtime.log` contains separate application diagnostics;
 review it before sharing because it can contain instance-specific operational
 details.
 
+`runtime.json` contains the owning PID, selected loopback port, application
+version, process creation time, and a random per-run token. A launcher adopts
+that address only when the Windows process owner and creation time match and a
+token-authenticated loopback endpoint returns the same identity. Stale PIDs,
+reused PIDs, foreign listeners, malformed records, and ordinary `/health`
+responses are rejected. The record is not a LAN-access credential: the
+Desktop Preview remains bound only to `127.0.0.1`.
+
+The per-user mutex uses Windows' machine-visible `Global\` namespace and is
+derived from the account SID, so it coordinates the same user across Windows
+sessions without sharing a server across users. If the direct token lookup
+fails, an independent process-token SID lookup establishes both the current
+owner identity and the same SID-derived mutex name. If both SID lookups fail,
+startup fails safely before mutex creation; the mutex name always remains
+SID-derived.
+
 The release smoke runs later on `windows-latest`; Linux tests only enforce its
-static contract. The Windows run requires exactly one listener on the smoke
-port and exactly one IPv4 loopback listener owned by the launched process,
-requires `runtime.log` without packaged route/import degradation, and deletes
-the first launcher's log before requiring fresh **Prepare local data** evidence
-from the injected recovery process. That recovery process must also have a
-nonzero main-window handle with the title exactly `DOCSight`.
+static contract. The Windows run occupies the preferred port, races two
+launchers, requires one allowed fallback and exactly one IPv4 loopback listener
+owned by the validated runtime PID, and checks authenticated second/third
+launch handoff. It also requires `runtime.log` without packaged route/import
+degradation and deletes the first launcher's log before requiring fresh
+**Prepare local data** evidence from the injected recovery process. That
+recovery process must replace stale runtime state and expose a nonzero
+main-window handle with the title exactly `DOCSight`.
 
 ## Remove the Desktop Preview
 

--- a/packaging/windows/QA-CHECKLIST.md
+++ b/packaging/windows/QA-CHECKLIST.md
@@ -69,11 +69,14 @@ Remove-Item Env:DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE, Env:DOCSIGHT_SKIP_BROWSER
 These switches are ignored unless `DOCSIGHT_SKIP_BROWSER=1` is present.
 
 The release smoke on `windows-latest` separately requires exactly one listener
-on its smoke port and exactly one process-owned IPv4 loopback listener. It also
-requires `runtime.log` without route/import degradation, deletes the successful
-launcher's `launcher.log` before checking fresh injected recovery evidence, and
-requires the recovery process to expose a nonzero main-window handle titled
-exactly `DOCSight`.
+on its selected fallback port and exactly one process-owned IPv4 loopback
+listener. It occupies the preferred port with a foreign listener, races two
+launchers, validates `runtime.json` and its authenticated endpoint, and checks
+that second and third launches exit after handoff. It also requires
+`runtime.log` without route/import degradation, deletes the successful
+launcher's `launcher.log` before checking fresh **Prepare local data** evidence,
+proves stale runtime replacement, and requires the recovery process to expose a
+nonzero main-window handle with the title exactly `DOCSight`.
 
 - [ ] Capture one screenshot of the normal immediate startup status.
 - [ ] Run the application-thread failure check and capture a screenshot showing readable, plain-language recovery without exception details.
@@ -101,7 +104,14 @@ exactly `DOCSight`.
 
 ## Process and data location
 
-- [ ] Launch `DOCSight.exe` a second time while the first instance is running; it should reuse/open the existing local instance instead of starting a conflicting server.
+- [ ] Launch `DOCSight.exe` a second time and a third time while the first instance is running; both should reuse/open the exact existing local port, exit successfully, and start no additional server.
+- [ ] Start two launchers as close together as practical and confirm only one owner/listener remains after readiness.
+- [ ] With a temporary loopback listener occupying port `8765`, start DOCSight and confirm it starts once on an allowed fallback from `8766` through `8775` without adopting the foreign service.
+- [ ] Confirm the only DOCSight listener is IPv4 `127.0.0.1`; no wildcard, LAN, or IPv6 listener is present.
+- [ ] Inspect `%LOCALAPPDATA%\DOCSight\runtime.json` and confirm it has schema version, owner PID, selected port, application version, process start time, and a long random instance token.
+- [ ] End the owner process, leave `runtime.json` in place, and start DOCSight again; confirm the new owner replaces the stale PID, start time, and token.
+- [ ] Replace `runtime.json` with malformed JSON while DOCSight is stopped, then start again and confirm the malformed record is recovered.
+- [ ] If multiple interactive sessions are available for one Windows account, start from the second session and confirm it reuses the same owner. Confirm a different Windows account does not reuse that server.
 - [ ] Verify logs and data are created under `%LOCALAPPDATA%\DOCSight`.
 - [ ] Close DOCSight and confirm the process exits cleanly.
 - [ ] Delete the extracted Desktop Preview folder.

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -42,6 +42,7 @@ On startup the launcher creates and exports:
 | `WEB_HOST` | `127.0.0.1` |
 | `WEB_PORT` | first available port from `8765` through `8775` |
 | `DOCSIGHT_DESKTOP_MODE` | `1` |
+| authenticated desktop runtime record | `%LOCALAPPDATA%\\DOCSight\\runtime.json` |
 | privacy-filtered launcher phase/recovery log | `%LOCALAPPDATA%\\DOCSight\\logs\\launcher.log` |
 | application runtime diagnostics | `%LOCALAPPDATA%\\DOCSight\\logs\\runtime.log` |
 
@@ -56,12 +57,35 @@ Windows.
 
 ## Single-instance behavior
 
-Before starting a new process, the launcher probes the preferred port's
-`/health` endpoint. If the response looks like DOCSight (`status: ok` and a
-`version` field), it opens the browser to that existing instance and exits.
+Before selecting a port or starting the server, the launcher acquires a
+machine-visible Windows named mutex derived from the current user's SID. The
+`Global\` namespace makes the mutex visible across Windows sessions for that
+same user. Different Windows users derive different mutex names and do not
+share a desktop server. If the direct current-user token lookup is unavailable,
+the launcher uses an independent process-token SID lookup against its current
+process and uses that SID for both ownership validation and mutex identity. If
+both SID lookups fail, startup fails safely before creating a mutex. The mutex
+name always remains SID-derived.
+
+The owner holds the mutex for its complete lifetime and atomically replaces
+`%LOCALAPPDATA%\DOCSight\runtime.json`. The versioned record contains the
+process ID, loopback port, application version, Windows process creation time,
+and a cryptographically random per-run token. A later launcher reuses the
+record only after the PID, process owner, creation time, and token-authenticated
+desktop runtime endpoint all match. An ordinary DOCSight-looking `/health`
+response is never enough for handoff.
+
+Second and third launches wait at most 10 seconds while the first owner is
+starting. Once validated, they open the exact running loopback port and exit
+without starting another application server. If an owner crashed, the
+abandoned mutex and stale or malformed runtime record are recovered by a later
+launch. The public runtime cleanup API removes the record on explicit normal
+exit; a future quit control only needs to call that API.
 
 If the preferred port is occupied by another service, the launcher walks the
-portable preview range and starts on the next free port.
+portable preview range and starts once on the next free port. The server always
+binds `127.0.0.1`. If the selected port is lost before the server binds, the
+launcher performs at most one clean retry in a fresh process.
 
 ## Portable ZIP build
 
@@ -120,16 +144,20 @@ powershell -ExecutionPolicy Bypass -File packaging/windows/smoke_test.ps1 `
   -ExpectedVersion v2026-07-09.1
 ```
 
-The smoke test launches the packaged executable, uses a temporary
-`LOCALAPPDATA`, skips browser launch via `DOCSIGHT_SKIP_BROWSER=1`, verifies the
-`/health` status and version, requires exactly one listener on the smoke port
-and exactly one IPv4 `127.0.0.1` listener owned by the launched process, and
-requires `runtime.log` without packaged route/import failures such as
-`failed to import routes` or `No module named`. It validates a real Reports PDF
-and then stops the process. The deterministic recovery check deletes the first
-process's `launcher.log` before the injected launch, requires the second process
-to write the **Prepare local data** recovery evidence, and confirms a nonzero
-main-window handle whose title is exactly `DOCSight`.
+The local smoke uses the real per-user SID mutex and must not run alongside another DOCSight desktop instance for that account.
+
+The smoke test launches the packaged executable from two parallel launchers,
+uses a temporary `LOCALAPPDATA`, and occupies the preferred port with a foreign
+listener. It requires one owner on an allowed fallback, validates the exact
+runtime schema, PID, process start time, random token, authenticated endpoint,
+second/third-launch handoff, and exactly one IPv4 `127.0.0.1` listener owned by
+the runtime PID. It also requires `runtime.log` without packaged route/import
+failures such as `failed to import routes` or `No module named`, validates a
+real Reports PDF, and then stops the process. The deterministic recovery check
+deletes the first process's `launcher.log` before the injected launch, requires
+fresh **Prepare local data** evidence, proves that crash-leftover runtime state
+is replaced, and confirms a nonzero main-window handle whose title is exactly
+`DOCSight`.
 
 The narrowly scoped `DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE=1`,
 `DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE=1`, and

--- a/packaging/windows/desktop_instance.py
+++ b/packaging/windows/desktop_instance.py
@@ -1,0 +1,412 @@
+"""Durable runtime state and owner/follower desktop coordination."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, MutableMapping
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from desktop_platform import (
+    MutexHandle,
+    ProcessIdentity,
+    ProcessInspector,
+    Win32NamedMutex,
+    Win32ProcessInspector,
+    mutex_name_for_user,
+)
+
+from app.desktop_runtime_contract import (
+    DESKTOP_RUNTIME_ENV_NAMES,
+    RuntimeState,
+)
+
+RUNTIME_ENDPOINT_PATH = "/desktop-runtime"
+MAX_COORDINATION_WAIT_SECONDS = 10.0
+_SHARING_VIOLATION_WINERRORS = frozenset({5, 32, 33})
+
+
+class DesktopInstanceError(RuntimeError):
+    """Base error for desktop runtime ownership failures."""
+
+
+class InstanceUnavailableError(DesktopInstanceError):
+    """Raised when another owner never becomes safely reusable."""
+
+
+class RuntimeStateError(DesktopInstanceError):
+    """Raised when durable runtime state cannot be safely maintained."""
+
+
+class RuntimeStateStore:
+    """Strict runtime-state I/O with bounded Windows sharing retries."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        retry_attempts: int = 4,
+        retry_delay_seconds: float = 0.025,
+        sleep: Callable[[float], object] = time.sleep,
+    ) -> None:
+        self.path = path
+        self._retry_attempts = max(1, retry_attempts)
+        self._retry_delay_seconds = max(0.0, retry_delay_seconds)
+        self._sleep = sleep
+
+    def load(self) -> RuntimeState | None:
+        try:
+            raw = self._retry_sharing_violation(
+                lambda: self.path.read_text(encoding="utf-8")
+            )
+        except FileNotFoundError:
+            return None
+        except UnicodeError:
+            return None
+        except OSError as exc:
+            raise RuntimeStateError("unable to read desktop runtime state") from exc
+
+        try:
+            return RuntimeState.from_mapping(json.loads(raw))
+        except (UnicodeError, json.JSONDecodeError, ValueError):
+            return None
+
+    def replace(self, state: RuntimeState) -> None:
+        validated = RuntimeState.from_mapping(state.to_mapping())
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f".{self.path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                temporary_path = Path(handle.name)
+                json.dump(
+                    validated.to_mapping(),
+                    handle,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            self._retry_sharing_violation(
+                lambda: os.replace(temporary_path, self.path)
+            )
+        except OSError as exc:
+            raise RuntimeStateError("unable to replace desktop runtime state") from exc
+        finally:
+            if temporary_path is not None:
+                try:
+                    temporary_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+    def remove(self, *, expected_token: str | None = None) -> None:
+        if expected_token is not None:
+            current = self.load()
+            if current is None or not secrets.compare_digest(
+                current.instance_token.encode("ascii"),
+                expected_token.encode("ascii"),
+            ):
+                return
+        try:
+            self._retry_sharing_violation(
+                lambda: self.path.unlink(missing_ok=True)
+            )
+        except OSError as exc:
+            raise RuntimeStateError("unable to remove desktop runtime state") from exc
+
+    def _retry_sharing_violation(self, operation: Callable[[], Any]) -> Any:
+        for attempt in range(self._retry_attempts):
+            try:
+                return operation()
+            except OSError as exc:
+                if (
+                    getattr(exc, "winerror", None)
+                    not in _SHARING_VIOLATION_WINERRORS
+                    or attempt + 1 >= self._retry_attempts
+                ):
+                    raise
+                self._sleep(self._retry_delay_seconds)
+        raise AssertionError("unreachable sharing retry state")
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject every redirect so the runtime bearer token stays on loopback."""
+
+    def redirect_request(
+        self,
+        req: Any,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        del req, fp, code, msg, headers, newurl
+
+
+def _proxyless_opener() -> Any:
+    """Build an opener that never uses proxies or follows redirects."""
+    return urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        _NoRedirectHandler(),
+    )
+
+
+def probe_runtime_endpoint(
+    state: RuntimeState,
+    *,
+    timeout_seconds: float = 0.75,
+    opener: Any | None = None,
+) -> bool:
+    """Validate the authenticated loopback desktop endpoint against state."""
+    url = f"http://127.0.0.1:{state.port}{RUNTIME_ENDPOINT_PATH}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {state.instance_token}",
+        },
+    )
+    endpoint_opener = opener if opener is not None else _proxyless_opener()
+    try:
+        with endpoint_opener.open(request, timeout=timeout_seconds) as response:
+            if getattr(response, "status", 200) != 200:
+                return False
+            raw = response.read(8192).decode("utf-8")
+    except (
+        OSError,
+        TimeoutError,
+        UnicodeError,
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+    ):
+        return False
+
+    try:
+        payload = json.loads(raw)
+        if not isinstance(payload, dict) or payload.get("status") != "ok":
+            return False
+        runtime_payload = dict(payload)
+        runtime_payload.pop("status")
+        observed = RuntimeState.from_mapping(runtime_payload)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return observed == state
+
+
+class InstanceRole(str, Enum):
+    OWNER = "owner"
+    FOLLOWER = "follower"
+
+
+@dataclass(frozen=True)
+class InstanceDecision:
+    """Result of bounded ownership coordination."""
+
+    role: InstanceRole
+    port: int | None = None
+
+
+class DesktopInstance:
+    """Coordinate one per-user owner and authenticated follower handoff."""
+
+    def __init__(
+        self,
+        *,
+        store: RuntimeStateStore,
+        mutex: MutexHandle,
+        inspector: ProcessInspector,
+        current_user_id: str,
+        env: MutableMapping[str, str],
+        current_pid: int | None = None,
+        token_factory: Callable[[], str] | None = None,
+        endpoint_probe: Callable[[RuntimeState], bool] = probe_runtime_endpoint,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], object] = time.sleep,
+    ) -> None:
+        self.store = store
+        self._mutex = mutex
+        self._inspector = inspector
+        self._current_user_id = current_user_id
+        self._env = env
+        self._current_pid = current_pid if current_pid is not None else os.getpid()
+        self._token_factory = token_factory or (lambda: secrets.token_urlsafe(32))
+        self._endpoint_probe = endpoint_probe
+        self._monotonic = monotonic
+        self._sleep = sleep
+        self._owner = False
+        self._closed = False
+        self._identity: ProcessIdentity | None = None
+        self._state: RuntimeState | None = None
+
+    def coordinate(
+        self,
+        *,
+        wait_seconds: float = MAX_COORDINATION_WAIT_SECONDS,
+        poll_seconds: float = 0.1,
+    ) -> InstanceDecision:
+        """Become owner or return a fully validated existing owner."""
+        if self._closed:
+            raise DesktopInstanceError("desktop instance coordinator is closed")
+        bounded_wait = min(
+            max(0.0, wait_seconds),
+            MAX_COORDINATION_WAIT_SECONDS,
+        )
+        deadline = self._monotonic() + bounded_wait
+        while True:
+            if self._mutex.acquire(0):
+                self._become_owner()
+                return InstanceDecision(InstanceRole.OWNER)
+
+            state = self.store.load()
+            if state is not None and self._is_valid_running_state(state):
+                self._mutex.close()
+                self._closed = True
+                return InstanceDecision(InstanceRole.FOLLOWER, port=state.port)
+
+            now = self._monotonic()
+            if now >= deadline:
+                self._mutex.close()
+                self._closed = True
+                raise InstanceUnavailableError(
+                    "existing desktop instance did not become ready"
+                )
+            self._sleep(min(max(0.01, poll_seconds), deadline - now))
+
+    def publish(self, *, port: int, application_version: str) -> RuntimeState:
+        """Publish this owner's endpoint contract after final port selection."""
+        if not self._owner or self._identity is None or self._closed:
+            raise DesktopInstanceError("desktop runtime is not owned")
+        state = RuntimeState.create(
+            pid=self._identity.pid,
+            port=port,
+            application_version=application_version,
+            process_start_time=self._identity.start_time,
+            instance_token=self._token_factory(),
+        )
+        self._env.update(state.export_environment())
+        try:
+            self.store.replace(state)
+        except BaseException:
+            self._clear_environment()
+            raise
+        self._state = state
+        return state
+
+    def validate_published_runtime(self) -> bool:
+        """Return whether this owner's published endpoint is exactly ready."""
+        return self._state is not None and self._is_valid_running_state(self._state)
+
+    def cleanup(self) -> None:
+        """Remove only this owner's state and release ownership resources."""
+        if self._closed:
+            return
+        cleanup_error: BaseException | None = None
+        try:
+            if self._owner:
+                if self._state is not None:
+                    try:
+                        self.store.remove(
+                            expected_token=self._state.instance_token
+                        )
+                    except Exception as exc:
+                        cleanup_error = exc
+                self._clear_environment()
+        finally:
+            try:
+                self._mutex.close()
+            except Exception as exc:
+                if cleanup_error is None:
+                    cleanup_error = exc
+            self._owner = False
+            self._closed = True
+        if cleanup_error is not None:
+            raise cleanup_error
+
+    def _become_owner(self) -> None:
+        self._owner = True
+        try:
+            self.store.remove()
+            identity = self._inspector.inspect(self._current_pid)
+            if (
+                identity is None
+                or identity.pid != self._current_pid
+                or identity.owner_id != self._current_user_id
+                or identity.start_time <= 0
+            ):
+                raise DesktopInstanceError(
+                    "unable to validate desktop owner process"
+                )
+            self._identity = identity
+        except BaseException:
+            try:
+                self.cleanup()
+            except BaseException:  # noqa: S110 - preserve the owner setup failure
+                pass
+            raise
+
+    def _is_valid_running_state(self, state: RuntimeState) -> bool:
+        observed = self._inspector.inspect(state.pid)
+        if (
+            observed is None
+            or observed.pid != state.pid
+            or observed.owner_id != self._current_user_id
+            or observed.start_time != state.process_start_time
+        ):
+            return False
+        return self._endpoint_probe(state)
+
+    def _clear_environment(self) -> None:
+        for name in DESKTOP_RUNTIME_ENV_NAMES:
+            self._env.pop(name, None)
+
+
+def create_desktop_instance(
+    runtime_path: Path,
+    env: MutableMapping[str, str] | None = None,
+) -> DesktopInstance:
+    """Create the production Windows ownership coordinator."""
+    runtime_env = env if env is not None else os.environ
+    inspector = Win32ProcessInspector()
+    current_pid = os.getpid()
+    try:
+        current_user_id = inspector.current_user_sid()
+    except OSError:
+        current_identity = inspector.inspect(current_pid)
+        if (
+            current_identity is None
+            or current_identity.pid != current_pid
+            or not current_identity.owner_id
+        ):
+            raise DesktopInstanceError(
+                "unable to validate current process ownership"
+            )
+        current_user_id = current_identity.owner_id
+
+    if not current_user_id:
+        raise DesktopInstanceError("unable to validate current process ownership")
+    mutex = Win32NamedMutex(mutex_name_for_user(current_user_id))
+    return DesktopInstance(
+        store=RuntimeStateStore(runtime_path),
+        mutex=mutex,
+        inspector=inspector,
+        current_user_id=current_user_id,
+        env=runtime_env,
+        current_pid=current_pid,
+    )

--- a/packaging/windows/desktop_platform.py
+++ b/packaging/windows/desktop_platform.py
@@ -1,0 +1,407 @@
+"""Windows identity and named-mutex adapters for desktop coordination."""
+
+from __future__ import annotations
+
+import hashlib
+import queue
+import sys
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    """OS identity needed to reject dead, reused, or foreign processes."""
+
+    pid: int
+    owner_id: str
+    start_time: int
+
+
+class ProcessInspector(Protocol):
+    def inspect(self, pid: int) -> ProcessIdentity | None:
+        """Return process identity, or None when it cannot be safely inspected."""
+
+
+class MutexHandle(Protocol):
+    def acquire(self, timeout_milliseconds: int = 0) -> bool:
+        """Acquire ownership, including an abandoned mutex, within the timeout."""
+
+    def release(self) -> None:
+        """Release owned mutex state."""
+
+    def close(self) -> None:
+        """Release ownership and close the underlying handle."""
+
+
+def mutex_name_for_user(user_identity: str) -> str:
+    """Return a machine-visible, per-user mutex name safe for Windows objects."""
+    digest = hashlib.sha256(user_identity.encode("utf-8")).hexdigest()
+    return rf"Global\DOCSight.Desktop.{digest}"
+
+
+class Win32ProcessInspector:
+    """Inspect Windows process owner SID and creation FILETIME via ctypes."""
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    TOKEN_QUERY = 0x0008
+    TOKEN_USER = 1
+
+    def __init__(self, *, kernel32: Any | None = None, advapi32: Any | None = None) -> None:
+        if sys.platform != "win32" and (kernel32 is None or advapi32 is None):
+            raise OSError("Windows process inspection is unavailable")
+        configure_prototypes = kernel32 is None or advapi32 is None
+        if kernel32 is None or advapi32 is None:
+            import ctypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+        self._kernel32 = kernel32
+        self._advapi32 = advapi32
+        if configure_prototypes:
+            self._configure_prototypes()
+
+    def _configure_prototypes(self) -> None:
+        import ctypes
+        from ctypes import wintypes
+
+        self._kernel32.GetCurrentProcess.argtypes = ()
+        self._kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        self._kernel32.OpenProcess.argtypes = (
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        )
+        self._kernel32.OpenProcess.restype = wintypes.HANDLE
+        self._kernel32.GetProcessTimes.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+        )
+        self._kernel32.GetProcessTimes.restype = wintypes.BOOL
+        self._kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        self._kernel32.CloseHandle.restype = wintypes.BOOL
+        self._kernel32.LocalFree.argtypes = (wintypes.HLOCAL,)
+        self._kernel32.LocalFree.restype = wintypes.HLOCAL
+        self._advapi32.OpenProcessToken.argtypes = (
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.HANDLE),
+        )
+        self._advapi32.OpenProcessToken.restype = wintypes.BOOL
+        self._advapi32.GetTokenInformation.argtypes = (
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        )
+        self._advapi32.GetTokenInformation.restype = wintypes.BOOL
+        self._advapi32.ConvertSidToStringSidW.argtypes = (
+            ctypes.c_void_p,
+            ctypes.POINTER(wintypes.LPWSTR),
+        )
+        self._advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
+
+    def current_user_sid(self) -> str:
+        return self._process_owner_sid(self._kernel32.GetCurrentProcess())
+
+    def inspect(self, pid: int) -> ProcessIdentity | None:
+        import ctypes
+        from ctypes import wintypes
+
+        handle = self._kernel32.OpenProcess(
+            self.PROCESS_QUERY_LIMITED_INFORMATION,
+            False,
+            pid,
+        )
+        if not handle:
+            return None
+        try:
+            creation = wintypes.FILETIME()
+            exit_time = wintypes.FILETIME()
+            kernel_time = wintypes.FILETIME()
+            user_time = wintypes.FILETIME()
+            if not self._kernel32.GetProcessTimes(
+                handle,
+                ctypes.byref(creation),
+                ctypes.byref(exit_time),
+                ctypes.byref(kernel_time),
+                ctypes.byref(user_time),
+            ):
+                return None
+            start_time = (int(creation.dwHighDateTime) << 32) | int(
+                creation.dwLowDateTime
+            )
+            try:
+                owner_id = self._process_owner_sid(handle)
+            except OSError:
+                return None
+            return ProcessIdentity(pid=pid, owner_id=owner_id, start_time=start_time)
+        finally:
+            self._kernel32.CloseHandle(handle)
+
+    def _process_owner_sid(self, process_handle: Any) -> str:
+        import ctypes
+        from ctypes import wintypes
+
+        token = wintypes.HANDLE()
+        if not self._advapi32.OpenProcessToken(
+            process_handle,
+            self.TOKEN_QUERY,
+            ctypes.byref(token),
+        ):
+            raise OSError("unable to open process token")
+        try:
+            required = wintypes.DWORD()
+            self._advapi32.GetTokenInformation(
+                token,
+                self.TOKEN_USER,
+                None,
+                0,
+                ctypes.byref(required),
+            )
+            if required.value == 0:
+                raise OSError("unable to size process token")
+            buffer = ctypes.create_string_buffer(required.value)
+            if not self._advapi32.GetTokenInformation(
+                token,
+                self.TOKEN_USER,
+                buffer,
+                required,
+                ctypes.byref(required),
+            ):
+                raise OSError("unable to read process token")
+            sid_pointer = ctypes.cast(
+                buffer,
+                ctypes.POINTER(ctypes.c_void_p),
+            ).contents.value
+            sid_text = wintypes.LPWSTR()
+            if not self._advapi32.ConvertSidToStringSidW(
+                sid_pointer,
+                ctypes.byref(sid_text),
+            ):
+                raise OSError("unable to format process SID")
+            try:
+                return str(sid_text.value)
+            finally:
+                self._kernel32.LocalFree(sid_text)
+        finally:
+            self._kernel32.CloseHandle(token)
+
+
+@dataclass
+class _MutexCommand:
+    operation: str
+    timeout_milliseconds: int = 0
+    completed: threading.Event = field(default_factory=threading.Event)
+    result: bool | None = None
+    error: Exception | None = None
+
+
+class Win32NamedMutex:
+    """Named mutex whose ownership is parked on one dedicated OS thread."""
+
+    COMMAND_TIMEOUT_SECONDS = 5.0
+    WAIT_OBJECT_0 = 0
+    WAIT_ABANDONED = 0x80
+    WAIT_TIMEOUT = 0x102
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        kernel32: Any | None = None,
+        command_timeout_seconds: float = COMMAND_TIMEOUT_SECONDS,
+    ) -> None:
+        if sys.platform != "win32" and kernel32 is None:
+            raise OSError("Windows named mutexes are unavailable")
+        configure_prototypes = kernel32 is None
+        if kernel32 is None:
+            import ctypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        if configure_prototypes:
+            from ctypes import wintypes
+
+            kernel32.CreateMutexW.argtypes = (
+                wintypes.LPVOID,
+                wintypes.BOOL,
+                wintypes.LPCWSTR,
+            )
+            kernel32.CreateMutexW.restype = wintypes.HANDLE
+            kernel32.WaitForSingleObject.argtypes = (
+                wintypes.HANDLE,
+                wintypes.DWORD,
+            )
+            kernel32.WaitForSingleObject.restype = wintypes.DWORD
+            kernel32.ReleaseMutex.argtypes = (wintypes.HANDLE,)
+            kernel32.ReleaseMutex.restype = wintypes.BOOL
+            kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+            kernel32.CloseHandle.restype = wintypes.BOOL
+
+        self._kernel32 = kernel32
+        self._name = name
+        self._commands: queue.Queue[_MutexCommand] = queue.Queue()
+        self._ready = threading.Event()
+        self._startup_error: Exception | None = None
+        self._command_timeout_seconds = max(0.0, command_timeout_seconds)
+        self._closed = False
+        self._call_lock = threading.Lock()
+        self._thread = threading.Thread(
+            target=self._ownership_loop,
+            name="docsight-mutex-owner",
+            daemon=True,
+        )
+        self._thread.start()
+        if not self._ready.wait(self.COMMAND_TIMEOUT_SECONDS):
+            raise TimeoutError("desktop mutex ownership thread did not initialize")
+        if self._startup_error is not None:
+            self._thread.join()
+            raise self._startup_error
+
+    def acquire(self, timeout_milliseconds: int = 0) -> bool:
+        command = self._submit(
+            _MutexCommand(
+                "acquire",
+                timeout_milliseconds=max(0, timeout_milliseconds),
+            )
+        )
+        return bool(command.result)
+
+    def release(self) -> None:
+        with self._call_lock:
+            if self._closed:
+                return
+            command = _MutexCommand("release")
+            self._commands.put(command)
+            self._wait_for_command(command)
+        if command.error is not None:
+            raise command.error
+
+    def close(self) -> None:
+        wait_error: Exception | None = None
+        with self._call_lock:
+            if self._closed:
+                return
+            command = _MutexCommand("close")
+            self._commands.put(command)
+            try:
+                self._wait_for_command(command)
+            except Exception as exc:
+                wait_error = exc
+            finally:
+                self._closed = True
+        self._thread.join(timeout=0)
+        if wait_error is not None:
+            raise wait_error
+        if command.error is not None:
+            raise command.error
+
+    def _submit(self, command: _MutexCommand) -> _MutexCommand:
+        with self._call_lock:
+            if self._closed:
+                raise RuntimeError("desktop ownership mutex is closed")
+            self._commands.put(command)
+            self._wait_for_command(command)
+        if command.error is not None:
+            raise command.error
+        return command
+
+    def _wait_for_command(self, command: _MutexCommand) -> None:
+        if command.completed.is_set():
+            return
+        if not self._thread.is_alive():
+            raise RuntimeError("desktop mutex ownership thread stopped unexpectedly")
+        if command.completed.wait(self._command_timeout_seconds):
+            return
+        if not self._thread.is_alive():
+            raise RuntimeError("desktop mutex ownership thread stopped unexpectedly")
+        raise TimeoutError(
+            f"desktop mutex {command.operation} command timed out"
+        )
+
+    def _ownership_loop(self) -> None:
+        try:
+            handle = self._kernel32.CreateMutexW(None, False, self._name)
+            if not handle:
+                raise OSError("unable to create desktop ownership mutex")
+        except Exception as exc:
+            self._startup_error = exc
+            self._ready.set()
+            return
+
+        owned = False
+        self._ready.set()
+        while True:
+            command = self._commands.get()
+            should_exit = False
+            try:
+                if command.operation == "acquire":
+                    if owned:
+                        command.result = True
+                    else:
+                        result = int(
+                            self._kernel32.WaitForSingleObject(
+                                handle,
+                                command.timeout_milliseconds,
+                            )
+                        )
+                        if result in (self.WAIT_OBJECT_0, self.WAIT_ABANDONED):
+                            owned = True
+                            command.result = True
+                        elif result == self.WAIT_TIMEOUT:
+                            command.result = False
+                        else:
+                            raise OSError(
+                                "unable to wait for desktop ownership mutex"
+                            )
+                elif command.operation == "release":
+                    if owned:
+                        if not self._kernel32.ReleaseMutex(handle):
+                            raise OSError(
+                                "unable to release desktop ownership mutex"
+                            )
+                        owned = False
+                elif command.operation == "close":
+                    release_error: Exception | None = None
+                    if owned:
+                        try:
+                            if not self._kernel32.ReleaseMutex(handle):
+                                raise OSError(
+                                    "unable to release desktop ownership mutex"
+                                )
+                            owned = False
+                        except Exception as exc:
+                            release_error = exc
+                    try:
+                        if not self._kernel32.CloseHandle(handle):
+                            raise OSError(
+                                "unable to close desktop ownership mutex"
+                            )
+                    except Exception as exc:
+                        if release_error is None:
+                            release_error = exc
+                    if release_error is not None:
+                        raise release_error
+                    should_exit = True
+                else:
+                    raise RuntimeError("unknown desktop mutex command")
+            except BaseException as exc:
+                if isinstance(exc, Exception):
+                    command.error = exc
+                else:
+                    command.error = RuntimeError(
+                        "desktop mutex ownership thread stopped unexpectedly"
+                    )
+                    command.error.__cause__ = exc
+                    should_exit = True
+                if command.operation == "close":
+                    should_exit = True
+            finally:
+                command.completed.set()
+            if should_exit:
+                return

--- a/packaging/windows/docsight.spec
+++ b/packaging/windows/docsight.spec
@@ -58,6 +58,8 @@ if not VERSION_FILE.exists():
 
 datas = collect_app_datas() + [(str(VERSION_FILE), ".")]
 hiddenimports = collect_app_hiddenimports() + [
+    "desktop_instance",
+    "desktop_platform",
     "tkinter",
     "tkinter.ttk",
     "waitress",

--- a/packaging/windows/docsight_desktop.py
+++ b/packaging/windows/docsight_desktop.py
@@ -8,7 +8,6 @@ and opens the user's browser from a worker thread.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import queue
@@ -18,8 +17,6 @@ import subprocess
 import sys
 import threading
 import time
-import urllib.error
-import urllib.request
 import webbrowser
 from dataclasses import dataclass, replace
 from enum import Enum
@@ -27,13 +24,30 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Callable, MutableMapping
 
+WINDOWS_PACKAGING_DIR = Path(__file__).resolve().parent
 SOURCE_ROOT = Path(__file__).resolve().parents[2]
+for import_root in (SOURCE_ROOT, WINDOWS_PACKAGING_DIR):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+
+from app.desktop_runtime_contract import (  # noqa: E402
+    DESKTOP_MODE_ENV,
+    WEB_PORT_ENV,
+)
+from desktop_instance import (  # noqa: E402
+    DesktopInstance,
+    DesktopInstanceError,
+    InstanceRole,
+    InstanceUnavailableError,
+    create_desktop_instance,
+)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
 MAX_PORT = 8775
 HEALTH_TIMEOUT_SECONDS = 30
 EVENT_POLL_MILLISECONDS = 75
 RELAUNCH_HANDLE_OPTION = "--docsight-relaunch-handle="
+BIND_RETRY_ENV = "DOCSIGHT_DESKTOP_BIND_RETRY"
 
 LOG = logging.getLogger("docsight.desktop")
 
@@ -101,14 +115,14 @@ class DesktopPaths:
     logs_dir: Path
     log_file: Path
     runtime_log_file: Path
+    runtime_file: Path
 
 
 @dataclass(frozen=True)
 class PortSelection:
-    """Selected local web port and whether an existing instance owns it."""
+    """Selected free local web port for a new owner."""
 
     port: int
-    existing_instance: bool = False
 
 
 @dataclass(frozen=True)
@@ -254,6 +268,7 @@ def resolve_desktop_paths(
         logs_dir=logs_dir,
         log_file=logs_dir / "launcher.log",
         runtime_log_file=logs_dir / "runtime.log",
+        runtime_file=base_dir / "runtime.json",
     )
 
 
@@ -270,7 +285,7 @@ def configure_desktop_environment(
     runtime_env["DATA_DIR"] = str(paths.data_dir)
     runtime_env["MODULES_DIR"] = str(paths.modules_dir)
     runtime_env["WEB_HOST"] = DEFAULT_HOST
-    runtime_env["DOCSIGHT_DESKTOP_MODE"] = "1"
+    runtime_env[DESKTOP_MODE_ENV] = "1"
     return paths
 
 
@@ -367,31 +382,6 @@ def local_url(port: int) -> str:
     return f"http://{DEFAULT_HOST}:{port}/"
 
 
-def _health_url(port: int) -> str:
-    return f"{local_url(port)}health"
-
-
-def _fetch_health_json(port: int, timeout: float = 0.5) -> dict | None:
-    """Fetch and parse a local DOCSight health response, returning None on miss."""
-    request = urllib.request.Request(_health_url(port), headers={"Accept": "application/json"})
-    try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            raw = response.read(4096).decode("utf-8")
-    except (OSError, urllib.error.URLError, TimeoutError):
-        return None
-
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    return payload if isinstance(payload, dict) else None
-
-
-def is_docsight_health_payload(payload: object) -> bool:
-    """Return True when a health payload looks like a DOCSight instance."""
-    return isinstance(payload, dict) and payload.get("status") == "ok" and "version" in payload
-
-
 def _can_bind_local_port(
     port: int,
     *,
@@ -415,7 +405,7 @@ def _can_bind_local_port(
 
 
 def _preferred_port(env: MutableMapping[str, str]) -> int:
-    raw = env.get("WEB_PORT", str(DEFAULT_PORT))
+    raw = env.get(WEB_PORT_ENV, str(DEFAULT_PORT))
     try:
         port = int(raw)
     except (TypeError, ValueError):
@@ -428,19 +418,16 @@ def select_port(
     *,
     max_port: int = MAX_PORT,
 ) -> PortSelection:
-    """Select a loopback port or detect an already-running DOCSight instance."""
+    """Select a free loopback port for the mutex-owning desktop instance."""
     runtime_env = env if env is not None else os.environ
     preferred = _preferred_port(runtime_env)
 
-    existing_payload = _fetch_health_json(preferred)
-    if is_docsight_health_payload(existing_payload):
-        return PortSelection(port=preferred, existing_instance=True)
-
     candidates = [preferred]
-    if preferred <= max_port:
-        candidates.extend(port for port in range(max(DEFAULT_PORT, preferred + 1), max_port + 1))
-    else:
-        candidates.extend(range(DEFAULT_PORT, max_port + 1))
+    candidates.extend(
+        port
+        for port in range(DEFAULT_PORT, max_port + 1)
+        if port != preferred
+    )
 
     seen: set[int] = set()
     for port in candidates:
@@ -448,8 +435,8 @@ def select_port(
             continue
         seen.add(port)
         if _can_bind_local_port(port):
-            runtime_env["WEB_PORT"] = str(port)
-            return PortSelection(port=port, existing_instance=False)
+            runtime_env[WEB_PORT_ENV] = str(port)
+            return PortSelection(port=port)
 
     raise RuntimeError("No free loopback port")
 
@@ -502,12 +489,14 @@ def _wait_for_ready(
     port: int,
     app_handle: AppThreadHandle | None,
     timeout_seconds: float = HEALTH_TIMEOUT_SECONDS,
+    *,
+    readiness_probe: Callable[[], bool],
 ) -> WaitOutcome:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         if app_handle is not None and app_handle.stopped.is_set():
             return WaitOutcome.APP_FAILED
-        if is_docsight_health_payload(_fetch_health_json(port, timeout=1.0)):
+        if readiness_probe():
             return WaitOutcome.READY
         time.sleep(0.5)
     if app_handle is not None and app_handle.stopped.is_set():
@@ -713,11 +702,24 @@ def terminate_current_launcher(exit_function: Callable[[int], object] | None = N
 def relaunch_launcher(
     *,
     spawn: Callable[[], object] = spawn_launcher_process,
+    cleanup: Callable[[], object] | None = None,
     terminate: Callable[[], object] = terminate_current_launcher,
 ) -> None:
     """Start a normal fresh launcher attempt, then terminate this launcher."""
     spawn()
+    cleanup_error: BaseException | None = None
+    if cleanup is not None:
+        try:
+            cleanup()
+        except BaseException as exc:
+            cleanup_error = exc
+            LOG.error(
+                "Runtime cleanup failed during relaunch (failure type: %s)",
+                _safe_exception_type(exc),
+            )
     terminate()
+    if cleanup_error is not None:
+        raise cleanup_error
 
 
 def _relaunch_parent_handle(argv: list[str] | None = None) -> int | None:
@@ -766,11 +768,13 @@ class StartupRunner:
         paths: DesktopPaths,
         env: MutableMapping[str, str] | None = None,
         *,
+        desktop_instance: DesktopInstance,
         is_relaunch: bool = False,
         handoff_outcome: HandoffOutcome = HandoffOutcome.COMPLETE,
     ) -> None:
         self.controller = controller
         self.paths = paths
+        self.desktop_instance = desktop_instance
         self.env = env if env is not None else os.environ
         self.is_relaunch = is_relaunch
         self.handoff_outcome = handoff_outcome
@@ -815,6 +819,25 @@ class StartupRunner:
                 )
                 return
 
+            try:
+                instance_decision = self.desktop_instance.coordinate()
+            except InstanceUnavailableError as exc:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.TIMEOUT,
+                    "",
+                    _safe_exception_type(exc),
+                )
+                return
+            except DesktopInstanceError as exc:
+                self._emit_error(
+                    attempt,
+                    RecoveryCode.STARTUP_FAILED,
+                    "",
+                    _safe_exception_type(exc),
+                )
+                return
+
             smoke_enabled = (
                 self.env.get("DOCSIGHT_SKIP_BROWSER") == "1"
                 and not self.is_relaunch
@@ -831,24 +854,46 @@ class StartupRunner:
                 )
                 return
 
-            try:
-                selection = select_port(self.env)
-            except RuntimeError as exc:
-                self._emit_error(
-                    attempt,
-                    RecoveryCode.NO_PORT,
-                    "",
-                    _safe_exception_type(exc),
-                )
-                return
+            if instance_decision.role is InstanceRole.FOLLOWER:
+                assert instance_decision.port is not None
+                selection = PortSelection(instance_decision.port)
+                owns_server = False
+            else:
+                owns_server = True
+                try:
+                    selection = select_port(self.env)
+                except RuntimeError as exc:
+                    self._emit_error(
+                        attempt,
+                        RecoveryCode.NO_PORT,
+                        "",
+                        _safe_exception_type(exc),
+                    )
+                    return
+                try:
+                    _ensure_repo_on_path()
+                    from app.version import get_app_version
+
+                    self.desktop_instance.publish(
+                        port=selection.port,
+                        application_version=get_app_version(),
+                    )
+                except BaseException as exc:
+                    self._emit_error(
+                        attempt,
+                        RecoveryCode.STARTUP_FAILED,
+                        url,
+                        _safe_exception_type(exc),
+                    )
+                    return
 
             url = local_url(selection.port)
             self.controller.emit(_phase_event(attempt, StartupPhase.START, url))
             LOG.info("Phase: %s", StartupPhase.START.value)
 
             app_handle: AppThreadHandle | None = None
-            if selection.existing_instance:
-                LOG.info("Existing DOCSight instance detected on %s", url)
+            if not owns_server:
+                LOG.info("Validated existing DOCSight desktop instance on %s", url)
             else:
                 LOG.info("Starting DOCSight on %s", url)
                 inject_smoke_failure = (
@@ -865,10 +910,37 @@ class StartupRunner:
             LOG.info("Phase: %s", StartupPhase.WAIT.value)
             outcome = (
                 WaitOutcome.READY
-                if selection.existing_instance
-                else _wait_for_ready(selection.port, app_handle)
+                if not owns_server
+                else _wait_for_ready(
+                    selection.port,
+                    app_handle,
+                    readiness_probe=self.desktop_instance.validate_published_runtime,
+                )
             )
             if outcome is WaitOutcome.APP_FAILED:
+                if (
+                    owns_server
+                    and app_handle is not None
+                    and app_handle.failure_type is None
+                    and self.env.get(BIND_RETRY_ENV) != "1"
+                    and not _can_bind_local_port(selection.port)
+                ):
+                    LOG.warning(
+                        "Selected loopback port was lost before readiness; "
+                        "starting one fresh launcher attempt"
+                    )
+                    self.env[BIND_RETRY_ENV] = "1"
+                    try:
+                        relaunch_launcher(cleanup=self.desktop_instance.cleanup)
+                    except BaseException as exc:
+                        self.env.pop(BIND_RETRY_ENV, None)
+                        self._emit_error(
+                            attempt,
+                            RecoveryCode.RELAUNCH_FAILED,
+                            url,
+                            _safe_exception_type(exc),
+                        )
+                    return
                 failure_type = (
                     app_handle.failure_type
                     if app_handle is not None and app_handle.failure_type
@@ -893,6 +965,7 @@ class StartupRunner:
             self.controller.emit(_phase_event(attempt, StartupPhase.OPEN, url))
             LOG.info("Phase: %s", StartupPhase.OPEN.value)
             LOG.info("DOCSight is ready on %s", url)
+            self.env.pop(BIND_RETRY_ENV, None)
             if (
                 smoke_enabled
                 and self.env.get("DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE") == "1"
@@ -928,7 +1001,7 @@ class StartupRunner:
                     attempt=attempt,
                     kind=EventKind.READY,
                     url=url,
-                    owns_server=not selection.existing_instance,
+                    owns_server=owns_server,
                 )
             )
 
@@ -979,6 +1052,7 @@ class TkLauncher:
         controller: LauncherController,
         runner: StartupRunner,
         paths: DesktopPaths,
+        desktop_instance: DesktopInstance,
     ) -> None:
         self.root = root
         self.tk = tk_module
@@ -986,6 +1060,7 @@ class TkLauncher:
         self.controller = controller
         self.runner = runner
         self.paths = paths
+        self.desktop_instance = desktop_instance
         self._worker: threading.Thread | None = None
         self.root.report_callback_exception = self._report_callback_exception
         self._build()
@@ -1138,11 +1213,8 @@ class TkLauncher:
             )
         else:
             self.actions.grid_remove()
-        if state.ready and state.recovery is None:
-            if state.owns_server:
-                self.root.withdraw()
-            else:
-                self.root.after(0, self.root.destroy)
+        if state.ready and state.recovery is None and state.owns_server:
+            self.root.withdraw()
 
     def _report_callback_exception(
         self,
@@ -1217,8 +1289,9 @@ class TkLauncher:
         )
         self.render()
         LOG.info("Retry requested; starting a fresh launcher process")
+        self.runner.env.pop(BIND_RETRY_ENV, None)
         try:
-            relaunch_launcher()
+            relaunch_launcher(cleanup=self.desktop_instance.cleanup)
         except BaseException as exc:
             LOG.error(
                 "Recovery available: %s (failure type: %s)",
@@ -1237,6 +1310,10 @@ class TkLauncher:
 
     def _close(self) -> None:
         self.root.destroy()
+        try:
+            self.desktop_instance.cleanup()
+        except BaseException:
+            pass
         os._exit(self.controller.exit_code)
 
 
@@ -1271,6 +1348,7 @@ def run_desktop() -> int:
     """Paint the launcher, then run startup work through its event queue."""
     runtime_env = os.environ
     paths: DesktopPaths | None = None
+    desktop_instance: DesktopInstance | None = None
     try:
         paths = configure_desktop_environment(runtime_env)
         parent_handle = _relaunch_parent_handle()
@@ -1280,6 +1358,7 @@ def run_desktop() -> int:
             else HandoffOutcome.COMPLETE
         )
         configure_logging(paths.log_file, paths.runtime_log_file)
+        desktop_instance = create_desktop_instance(paths.runtime_file, runtime_env)
 
         import tkinter as tk
         from tkinter import ttk
@@ -1290,17 +1369,40 @@ def run_desktop() -> int:
             controller,
             paths,
             runtime_env,
+            desktop_instance=desktop_instance,
             is_relaunch=parent_handle is not None,
             handoff_outcome=handoff_outcome,
         )
-        view = TkLauncher(root, tk, ttk, controller, runner, paths)
+        view = TkLauncher(
+            root,
+            tk,
+            ttk,
+            controller,
+            runner,
+            paths,
+            desktop_instance,
+        )
 
         root.update()
         root.after(50, view.start)
         root.after(EVENT_POLL_MILLISECONDS, view.poll)
         root.mainloop()
+        try:
+            desktop_instance.cleanup()
+        except BaseException as exc:
+            LOG.error(
+                "Runtime cleanup failed after launcher mainloop exit "
+                "(failure type: %s)",
+                _safe_exception_type(exc),
+            )
+            return 1
         return controller.exit_code
     except BaseException as exc:
+        if desktop_instance is not None:
+            try:
+                desktop_instance.cleanup()
+            except BaseException:
+                pass
         try:
             LOG.error(
                 "Recovery unavailable: startup_surface_failure (failure type: %s)",

--- a/packaging/windows/smoke_test.ps1
+++ b/packaging/windows/smoke_test.ps1
@@ -27,13 +27,20 @@ $PreviousInjectedStartupFailure = $env:DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE
 $PreviousInjectedBrowserFailure = $env:DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE
 $PreviousInjectedNoPortFailure = $env:DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE
 $Process = $null
+$LaunchOne = $null
+$LaunchTwo = $null
+$FollowerProcess = $null
+$ThirdProcess = $null
+$ForeignListener = $null
 $HttpHandler = $null
 $HttpClient = $null
 $LauncherLogFile = Join-Path $LocalAppData "DOCSight\logs\launcher.log"
 $RuntimeLogFile = Join-Path $LocalAppData "DOCSight\logs\runtime.log"
-$HealthUrl = "http://127.0.0.1:$Port/health"
-$ReportUrl = "http://127.0.0.1:$Port/api/report"
-$ConfigUrl = "http://127.0.0.1:$Port/api/config"
+$RuntimeStateFile = Join-Path $LocalAppData "DOCSight\runtime.json"
+$HealthUrl = $null
+$ReportUrl = $null
+$ConfigUrl = $null
+$DesktopRuntimeUrl = $null
 
 function Write-SmokeLog {
     if (Test-Path -LiteralPath $LauncherLogFile) {
@@ -76,7 +83,8 @@ function Invoke-SmokeHttpRequest {
     param(
         [Parameter(Mandatory = $true)][string]$Url,
         [ValidateSet("GET", "POST")][string]$Method = "GET",
-        [string]$JsonBody
+        [string]$JsonBody,
+        [string]$BearerToken
     )
 
     $Request = [System.Net.Http.HttpRequestMessage]::new(
@@ -84,6 +92,12 @@ function Invoke-SmokeHttpRequest {
         [System.Uri]::new($Url)
     )
     try {
+        if ($PSBoundParameters.ContainsKey("BearerToken")) {
+            $Request.Headers.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::new(
+                "Bearer",
+                $BearerToken
+            )
+        }
         if ($PSBoundParameters.ContainsKey("JsonBody")) {
             $Request.Content = [System.Net.Http.StringContent]::new(
                 $JsonBody,
@@ -128,6 +142,11 @@ try {
     if ($ExistingListeners.Count -gt 0) {
         throw "Smoke port $Port is already in use before DOCSight starts."
     }
+    $ForeignListener = [System.Net.Sockets.TcpListener]::new(
+        [System.Net.IPAddress]::Loopback,
+        $Port
+    )
+    $ForeignListener.Start()
 
     $env:LOCALAPPDATA = $LocalAppData
     $env:WEB_PORT = [string]$Port
@@ -141,20 +160,45 @@ try {
     $HttpClient = [System.Net.Http.HttpClient]::new($HttpHandler)
     $HttpClient.Timeout = [TimeSpan]::FromSeconds([Math]::Max(3, $TimeoutSeconds))
 
-    $Process = Start-Process -FilePath $Executable -WorkingDirectory $LaunchBundleDir -PassThru
+    # Start two launchers back-to-back while a foreign listener owns the
+    # preferred port. Exactly one launcher must become the fallback-port owner.
+    $LaunchOne = Start-Process -FilePath $Executable -WorkingDirectory $LaunchBundleDir -PassThru
+    $LaunchTwo = Start-Process -FilePath $Executable -WorkingDirectory $LaunchBundleDir -PassThru
     $Deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     $Payload = $null
+    $RuntimeState = $null
+    $DesktopRuntimePayload = $null
 
     while ((Get-Date) -lt $Deadline) {
-        if ($Process.HasExited) {
+        $LaunchOne.Refresh()
+        $LaunchTwo.Refresh()
+        if ($LaunchOne.HasExited -and $LaunchTwo.HasExited) {
             Write-SmokeLog
-            throw "DOCSight exited before /health became ready with exit code $($Process.ExitCode)."
+            throw "Both parallel DOCSight launchers exited before runtime readiness."
         }
 
         try {
-            $Payload = Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3
-            if ($Payload.status -eq "ok") {
-                break
+            if (Test-Path -LiteralPath $RuntimeStateFile) {
+                $RuntimeState = Get-Content -LiteralPath $RuntimeStateFile -Raw | ConvertFrom-Json
+                $RuntimePort = [int]$RuntimeState.port
+                $HealthUrl = "http://127.0.0.1:$RuntimePort/health"
+                $ReportUrl = "http://127.0.0.1:$RuntimePort/api/report"
+                $ConfigUrl = "http://127.0.0.1:$RuntimePort/api/config"
+                $DesktopRuntimeUrl = "http://127.0.0.1:$RuntimePort/desktop-runtime"
+                $Payload = Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3
+                $DesktopRuntimeResponse = Invoke-SmokeHttpRequest `
+                    -Url $DesktopRuntimeUrl `
+                    -BearerToken ([string]$RuntimeState.instance_token)
+                if ($DesktopRuntimeResponse.StatusCode -eq 200) {
+                    $DesktopRuntimePayload = $DesktopRuntimeResponse.Body | ConvertFrom-Json
+                }
+                if (
+                    $Payload.status -eq "ok" -and
+                    $null -ne $DesktopRuntimePayload -and
+                    $DesktopRuntimePayload.status -eq "ok"
+                ) {
+                    break
+                }
             }
         } catch {
             Start-Sleep -Milliseconds 500
@@ -164,9 +208,13 @@ try {
         Start-Sleep -Milliseconds 500
     }
 
-    if ($null -eq $Payload) {
+    if ($null -eq $RuntimeState) {
         Write-SmokeLog
-        throw "DOCSight /health did not respond within $TimeoutSeconds seconds."
+        throw "DOCSight did not publish runtime.json within $TimeoutSeconds seconds."
+    }
+    if ($null -eq $Payload -or $null -eq $DesktopRuntimePayload) {
+        Write-SmokeLog
+        throw "DOCSight runtime endpoints did not become ready within $TimeoutSeconds seconds."
     }
     if ($Payload.status -ne "ok") {
         Write-SmokeLog
@@ -177,12 +225,99 @@ try {
         throw "DOCSight /health returned version '$($Payload.version)' instead of '$ExpectedVersion'."
     }
 
+    $RuntimeFields = @($RuntimeState.PSObject.Properties.Name | Sort-Object)
+    $ExpectedRuntimeFields = @(
+        "application_version",
+        "instance_token",
+        "pid",
+        "port",
+        "process_start_time",
+        "schema_version"
+    ) | Sort-Object
+    $RuntimeFieldDifference = @(Compare-Object $RuntimeFields $ExpectedRuntimeFields)
+    if ($RuntimeFieldDifference.Count -ne 0) {
+        Write-SmokeLog
+        throw "runtime.json does not contain the exact versioned desktop runtime schema."
+    }
+    if ([int]$RuntimeState.schema_version -ne 1) {
+        throw "runtime.json schema_version is not 1."
+    }
+    if ([int]$RuntimeState.port -eq $Port) {
+        throw "DOCSight adopted the foreign listener on preferred port $Port."
+    }
+    if ([int]$RuntimeState.port -lt 8765 -or [int]$RuntimeState.port -gt 8775) {
+        throw "DOCSight selected fallback port '$($RuntimeState.port)' outside 8765-8775."
+    }
+    if ([string]$RuntimeState.application_version -ne $ExpectedVersion) {
+        throw "runtime.json application version does not match the packaged build."
+    }
+    if ([string]$RuntimeState.instance_token -notmatch "^[A-Za-z0-9_-]{43,128}$") {
+        throw "runtime.json instance token is malformed."
+    }
+
+    $ParallelLaunches = @($LaunchOne, $LaunchTwo)
+    $OwnerCandidates = @($ParallelLaunches | Where-Object {
+        $_.Id -eq [int]$RuntimeState.pid
+    })
+    if ($OwnerCandidates.Count -ne 1) {
+        Write-SmokeLog
+        throw "runtime.json PID does not identify exactly one parallel launcher."
+    }
+    $Process = $OwnerCandidates[0]
+    $FollowerProcess = @($ParallelLaunches | Where-Object {
+        $_.Id -ne $Process.Id
+    })[0]
     $Process.Refresh()
     if ($Process.HasExited) {
         Write-SmokeLog
         throw "DOCSight exited after readiness with exit code $($Process.ExitCode)."
     }
-    $Connections = @(Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue)
+    $ExpectedStartTime = $Process.StartTime.ToUniversalTime().ToFileTimeUtc()
+    if ([int64]$RuntimeState.process_start_time -ne $ExpectedStartTime) {
+        throw "runtime.json process start time does not match its owner process."
+    }
+    if (
+        [int]$DesktopRuntimePayload.pid -ne $Process.Id -or
+        [int]$DesktopRuntimePayload.port -ne [int]$RuntimeState.port -or
+        [int64]$DesktopRuntimePayload.process_start_time -ne $ExpectedStartTime -or
+        [string]$DesktopRuntimePayload.instance_token -cne [string]$RuntimeState.instance_token -or
+        [string]$DesktopRuntimePayload.application_version -cne $ExpectedVersion
+    ) {
+        throw "Authenticated desktop runtime payload does not exactly match runtime.json."
+    }
+
+    $RejectedTokenResponse = Invoke-SmokeHttpRequest `
+        -Url $DesktopRuntimeUrl `
+        -BearerToken (("B" * 43) -join "")
+    if ($RejectedTokenResponse.StatusCode -ne 404) {
+        throw "Desktop runtime endpoint accepted the wrong instance token."
+    }
+
+    if (-not $FollowerProcess.WaitForExit(15000)) {
+        throw "The non-owner parallel launcher did not hand off and exit."
+    }
+    if ($FollowerProcess.ExitCode -ne 0) {
+        throw "The non-owner parallel launcher exited with code $($FollowerProcess.ExitCode)."
+    }
+
+    $ThirdProcess = Start-Process -FilePath $Executable -WorkingDirectory $LaunchBundleDir -PassThru
+    if (-not $ThirdProcess.WaitForExit(15000)) {
+        throw "The third launcher did not reuse the running desktop instance."
+    }
+    if ($ThirdProcess.ExitCode -ne 0) {
+        throw "The third launcher exited with code $($ThirdProcess.ExitCode)."
+    }
+    $StateAfterHandoffs = Get-Content -LiteralPath $RuntimeStateFile -Raw | ConvertFrom-Json
+    if (
+        [int]$StateAfterHandoffs.pid -ne $Process.Id -or
+        [int]$StateAfterHandoffs.port -ne [int]$RuntimeState.port -or
+        [string]$StateAfterHandoffs.instance_token -cne [string]$RuntimeState.instance_token
+    ) {
+        throw "Second or third launch replaced the existing owner's runtime state."
+    }
+
+    $RuntimePort = [int]$RuntimeState.port
+    $Connections = @(Get-NetTCPConnection -State Listen -LocalPort $RuntimePort -ErrorAction SilentlyContinue)
     $OwnedLoopbackListeners = @($Connections | Where-Object {
         $_.LocalAddress -eq "127.0.0.1" -and $_.OwningProcess -eq $Process.Id
     })
@@ -194,12 +329,12 @@ try {
             $ObservedListeners = "none"
         }
         Write-SmokeLog
-        throw "Expected exactly one listener on smoke port $Port; observed: $ObservedListeners"
+        throw "Expected exactly one listener on runtime port $RuntimePort; observed: $ObservedListeners"
     }
     if ($OwnedLoopbackListeners.Count -ne 1) {
         $ObservedListener = "$($Connections[0].LocalAddress) owned by PID $($Connections[0].OwningProcess)"
         Write-SmokeLog
-        throw "Expected exactly one 127.0.0.1:$Port listener owned by DOCSight process $($Process.Id); observed: $ObservedListener"
+        throw "Expected exactly one 127.0.0.1:$RuntimePort listener owned by DOCSight process $($Process.Id); observed: $ObservedListener"
     }
 
     if (-not (Test-Path -LiteralPath $RuntimeLogFile)) {
@@ -284,6 +419,7 @@ try {
         throw "DOCSight launcher log not found for post-smoke validation: $LauncherLogFile"
     }
 
+    $PreviousRuntimeToken = [string]$RuntimeState.instance_token
     Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
     $FirstProcessStopped = $Process.WaitForExit(10000)
     if (-not $FirstProcessStopped) {
@@ -306,6 +442,7 @@ try {
     $FailureDeadline = (Get-Date).AddSeconds([Math]::Min(20, $TimeoutSeconds))
     $FailureContractObserved = $false
     $RecoveryWindowObserved = $false
+    $StaleRuntimeRecovered = $false
     while ((Get-Date) -lt $FailureDeadline) {
         $Process.Refresh()
         if ($Process.HasExited) {
@@ -328,7 +465,24 @@ try {
         ) {
             $RecoveryWindowObserved = $true
         }
-        if ($FailureContractObserved -and $RecoveryWindowObserved) {
+        if (Test-Path -LiteralPath $RuntimeStateFile) {
+            try {
+                $RecoveryRuntimeState = Get-Content -LiteralPath $RuntimeStateFile -Raw | ConvertFrom-Json
+                if (
+                    [int]$RecoveryRuntimeState.pid -eq $Process.Id -and
+                    [string]$RecoveryRuntimeState.instance_token -cne $PreviousRuntimeToken
+                ) {
+                    $StaleRuntimeRecovered = $true
+                }
+            } catch {
+                $StaleRuntimeRecovered = $false
+            }
+        }
+        if (
+            $FailureContractObserved -and
+            $RecoveryWindowObserved -and
+            $StaleRuntimeRecovered
+        ) {
             break
         }
         Start-Sleep -Milliseconds 250
@@ -336,6 +490,10 @@ try {
     if (-not $FailureContractObserved) {
         Write-SmokeLog
         throw "Injected startup failure did not produce the expected launcher phase and recovery log contract."
+    }
+    if (-not $StaleRuntimeRecovered) {
+        Write-SmokeLog
+        throw "A crash-leftover runtime record was not replaced by the next owner."
     }
     $Process.Refresh()
     if ($Process.HasExited) {
@@ -351,14 +509,27 @@ try {
         throw "Injected startup failure main window title was not exactly 'DOCSight'."
     }
 
-    Write-Host "DOCSight Desktop smoke passed: AMD64 package startup, exactly-one owned loopback listener, runtime imports, Reports PDF, and fresh visible app-thread recovery contracts are valid."
+    Write-Host "DOCSight Desktop smoke passed: foreign-port fallback, parallel single ownership, authenticated second/third-launch handoff, loopback binding, packaged routes, and stale-state recovery are valid."
 } catch {
     Write-SmokeLog
     throw
 } finally {
-    if ($null -ne $Process -and -not $Process.HasExited) {
-        Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
-        $Process.WaitForExit(10000) | Out-Null
+    $CleanupProcesses = @(
+        $Process,
+        $LaunchOne,
+        $LaunchTwo,
+        $FollowerProcess,
+        $ThirdProcess
+    ) | Where-Object { $null -ne $_ } | Sort-Object Id -Unique
+    foreach ($CleanupProcess in $CleanupProcesses) {
+        $CleanupProcess.Refresh()
+        if (-not $CleanupProcess.HasExited) {
+            Stop-Process -Id $CleanupProcess.Id -Force -ErrorAction SilentlyContinue
+            $CleanupProcess.WaitForExit(10000) | Out-Null
+        }
+    }
+    if ($null -ne $ForeignListener) {
+        $ForeignListener.Stop()
     }
     if ($null -ne $HttpClient) {
         $HttpClient.Dispose()

--- a/tests/test_desktop_entrypoint.py
+++ b/tests/test_desktop_entrypoint.py
@@ -48,6 +48,29 @@ def make_controller(port: int = 8765) -> object:
     return controller
 
 
+class FakeDesktopInstance:
+    def __init__(self, *, role=None, port=None, coordinate_error=None):
+        self.role = role or desktop.InstanceRole.OWNER
+        self.port = port
+        self.coordinate_error = coordinate_error
+        self.published = []
+        self.cleanup_calls = 0
+
+    def coordinate(self):
+        if self.coordinate_error is not None:
+            raise self.coordinate_error
+        return SimpleNamespace(role=self.role, port=self.port)
+
+    def publish(self, *, port, application_version):
+        self.published.append((port, application_version))
+
+    def validate_published_runtime(self):
+        return True
+
+    def cleanup(self):
+        self.cleanup_calls += 1
+
+
 def run_runner(monkeypatch, tmp_path, *, selection=None, wait=None, browser=True):
     controller = make_controller()
     paths = make_paths(tmp_path)
@@ -70,7 +93,7 @@ def run_runner(monkeypatch, tmp_path, *, selection=None, wait=None, browser=True
     monkeypatch.setattr(
         desktop,
         "_wait_for_ready",
-        lambda port, app_handle: wait or desktop.WaitOutcome.READY,
+        lambda port, app_handle, **_kwargs: wait or desktop.WaitOutcome.READY,
     )
     if isinstance(browser, BaseException):
         def raise_browser(port, env):
@@ -80,7 +103,12 @@ def run_runner(monkeypatch, tmp_path, *, selection=None, wait=None, browser=True
     else:
         monkeypatch.setattr(desktop, "open_browser", lambda port, env: browser)
 
-    runner = desktop.StartupRunner(controller, paths, {})
+    runner = desktop.StartupRunner(
+        controller,
+        paths,
+        {},
+        desktop_instance=FakeDesktopInstance(),
+    )
     runner.run(controller.state.attempt)
     controller.drain_events()
     return controller, handle
@@ -97,6 +125,7 @@ def test_resolve_desktop_paths_uses_localappdata(tmp_path):
     assert paths.logs_dir == paths.base_dir / "logs"
     assert paths.log_file == paths.logs_dir / "launcher.log"
     assert paths.runtime_log_file == paths.logs_dir / "runtime.log"
+    assert paths.runtime_file == paths.base_dir / "runtime.json"
 
 
 def test_resolve_desktop_paths_falls_back_to_home_localappdata(tmp_path):
@@ -119,69 +148,65 @@ def test_configure_desktop_environment_creates_paths_and_exports_contract(tmp_pa
     assert env["DOCSIGHT_DESKTOP_MODE"] == "1"
 
 
-@pytest.mark.parametrize(
-    ("payload", "expected"),
-    [
-        ({"status": "ok", "version": "v2026-07-05.1", "docsis_health": "waiting"}, True),
-        ({"status": "ok", "docsis_health": "waiting"}, False),
-        ({"status": "error", "version": "v2026-07-05.1"}, False),
-        (None, False),
-        (["not", "a", "dict"], False),
-    ],
-)
-def test_detects_docsight_health_payload(payload, expected):
-    assert desktop.is_docsight_health_payload(payload) is expected
-
-
-def test_select_port_opens_existing_docsight_instance(monkeypatch):
+def test_select_port_never_adopts_docsight_looking_foreign_listener(monkeypatch):
     env = {"WEB_PORT": "8765"}
+    bind_results = {8765: False, 8766: True}
 
-    monkeypatch.setattr(desktop, "_fetch_health_json", lambda port: {"status": "ok", "version": "dev"})
-    monkeypatch.setattr(
-        desktop,
-        "_can_bind_local_port",
-        lambda port: pytest.fail("existing instance should skip bind probe"),
-    )
+    monkeypatch.setattr(desktop, "_can_bind_local_port", lambda port: bind_results[port])
 
-    selection = desktop.select_port(env)
+    selection = desktop.select_port(env, max_port=8766)
 
-    assert selection == desktop.PortSelection(port=8765, existing_instance=True)
-    assert "WEB_PORT" in env
+    assert selection == desktop.PortSelection(port=8766)
+    assert env["WEB_PORT"] == "8766"
 
 
 def test_select_port_walks_when_preferred_port_has_non_docsight_service(monkeypatch):
     env = {"WEB_PORT": "8765"}
     bind_results = {8765: False, 8766: True}
 
-    monkeypatch.setattr(desktop, "_fetch_health_json", lambda port: {"status": "ok", "service": "other"})
     monkeypatch.setattr(desktop, "_can_bind_local_port", lambda port: bind_results[port])
 
     selection = desktop.select_port(env, max_port=8766)
 
-    assert selection == desktop.PortSelection(port=8766, existing_instance=False)
+    assert selection == desktop.PortSelection(port=8766)
     assert env["WEB_PORT"] == "8766"
 
 
 def test_select_port_uses_default_when_web_port_is_invalid(monkeypatch):
     env = {"WEB_PORT": "not-a-port"}
 
-    monkeypatch.setattr(desktop, "_fetch_health_json", lambda port: None)
     monkeypatch.setattr(desktop, "_can_bind_local_port", lambda port: port == 8765)
 
     selection = desktop.select_port(env, max_port=8765)
 
-    assert selection == desktop.PortSelection(port=8765, existing_instance=False)
+    assert selection == desktop.PortSelection(port=8765)
     assert env["WEB_PORT"] == "8765"
 
 
 def test_select_port_raises_when_range_is_unavailable(monkeypatch):
     env = {"WEB_PORT": "8765"}
 
-    monkeypatch.setattr(desktop, "_fetch_health_json", lambda port: None)
     monkeypatch.setattr(desktop, "_can_bind_local_port", lambda port: False)
 
     with pytest.raises(RuntimeError, match="No free loopback port"):
         desktop.select_port(env, max_port=8766)
+
+
+def test_select_port_reconsiders_full_range_after_inherited_preference(
+    monkeypatch,
+):
+    env = {"WEB_PORT": "8770"}
+    attempted = []
+
+    def can_bind(port):
+        attempted.append(port)
+        return port == 8766
+
+    monkeypatch.setattr(desktop, "_can_bind_local_port", can_bind)
+
+    assert desktop.select_port(env) == desktop.PortSelection(8766)
+    assert attempted == [8770, 8765, 8766]
+    assert env["WEB_PORT"] == "8766"
 
 
 @pytest.mark.parametrize(
@@ -321,10 +346,19 @@ def test_startup_runner_reaches_ready_and_emits_all_phases(monkeypatch, tmp_path
     monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
     monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8766))
     monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
-    monkeypatch.setattr(desktop, "_wait_for_ready", lambda port, app_handle: desktop.WaitOutcome.READY)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle, **_kwargs: desktop.WaitOutcome.READY,
+    )
     monkeypatch.setattr(desktop, "open_browser", lambda port, env: True)
 
-    desktop.StartupRunner(controller, paths, {}).run(controller.state.attempt)
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {},
+        desktop_instance=FakeDesktopInstance(),
+    ).run(controller.state.attempt)
     controller.drain_events()
 
     assert [event.phase for event in emitted if event.kind is desktop.EventKind.PHASE] == [
@@ -347,7 +381,12 @@ def test_startup_runner_reports_no_free_port(monkeypatch, tmp_path):
         lambda env: (_ for _ in ()).throw(RuntimeError("occupied by secret service")),
     )
 
-    desktop.StartupRunner(controller, paths, {}).run(controller.state.attempt)
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {},
+        desktop_instance=FakeDesktopInstance(),
+    ).run(controller.state.attempt)
     controller.drain_events()
 
     assert controller.state.recovery is desktop.RecoveryCode.NO_PORT
@@ -377,12 +416,108 @@ def test_startup_runner_reports_app_thread_system_exit(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop, "configure_desktop_environment", lambda env: paths)
     monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
     monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
-    monkeypatch.setattr(desktop, "_wait_for_ready", lambda port, app_handle: desktop.WaitOutcome.APP_FAILED)
-    desktop.StartupRunner(controller, paths, {}).run(controller.state.attempt)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle, **_kwargs: desktop.WaitOutcome.APP_FAILED,
+    )
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {},
+        desktop_instance=FakeDesktopInstance(),
+    ).run(controller.state.attempt)
     controller.drain_events()
 
     assert controller.state.recovery is desktop.RecoveryCode.APP_FAILED
     assert controller.state.status == "DOCSight stopped unexpectedly during startup."
+
+
+def test_bind_loss_uses_one_fresh_process_retry_and_cleans_runtime(
+    monkeypatch,
+    tmp_path,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    env = {}
+    instance = FakeDesktopInstance()
+    stopped = threading.Event()
+    stopped.set()
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=stopped,
+    )
+    calls = []
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
+    monkeypatch.setattr(
+        desktop,
+        "_start_app_thread",
+        lambda: calls.append("start_app") or handle,
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle, **_kwargs: desktop.WaitOutcome.APP_FAILED,
+    )
+    monkeypatch.setattr(desktop, "_can_bind_local_port", lambda port: False)
+
+    def relaunch(*, cleanup):
+        calls.append("spawn")
+        cleanup()
+        calls.append("terminate")
+
+    monkeypatch.setattr(desktop, "relaunch_launcher", relaunch)
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        env,
+        desktop_instance=instance,
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert calls == ["start_app", "spawn", "terminate"]
+    assert instance.cleanup_calls == 1
+    assert env[desktop.BIND_RETRY_ENV] == "1"
+    assert controller.state.recovery is None
+
+
+def test_bind_loss_retry_is_bounded_across_fresh_launcher_process(
+    monkeypatch,
+    tmp_path,
+):
+    controller = make_controller()
+    paths = make_paths(tmp_path)
+    env = {desktop.BIND_RETRY_ENV: "1"}
+    stopped = threading.Event()
+    stopped.set()
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=stopped,
+    )
+    monkeypatch.setattr(desktop, "select_port", lambda env: desktop.PortSelection(8765))
+    monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda port, app_handle, **_kwargs: desktop.WaitOutcome.APP_FAILED,
+    )
+    monkeypatch.setattr(desktop, "_can_bind_local_port", lambda port: False)
+    monkeypatch.setattr(
+        desktop,
+        "relaunch_launcher",
+        lambda **_kwargs: pytest.fail("the clean bind retry must happen only once"),
+    )
+
+    desktop.StartupRunner(
+        controller,
+        paths,
+        env,
+        desktop_instance=FakeDesktopInstance(),
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is desktop.RecoveryCode.APP_FAILED
 
 
 @pytest.mark.parametrize(
@@ -411,6 +546,81 @@ def test_browser_open_failures_keep_ready_recovery_surface(
     assert "credential" not in controller.state.status
 
 
+def test_browser_failure_retains_mutex_until_main_thread_cleanup(
+    monkeypatch,
+    tmp_path,
+):
+    from desktop_platform import Win32NamedMutex
+
+    api_calls = []
+    api = SimpleNamespace(
+        CreateMutexW=lambda *_args: 55,
+        WaitForSingleObject=lambda *_args: (
+            api_calls.append(("wait", threading.get_ident())) or 0
+        ),
+        ReleaseMutex=lambda *_args: (
+            api_calls.append(("release", threading.get_ident())) or True
+        ),
+        CloseHandle=lambda *_args: (
+            api_calls.append(("close", threading.get_ident())) or True
+        ),
+    )
+    mutex = Win32NamedMutex("Global\\browser-failure", kernel32=api)
+
+    class RetainingInstance:
+        def coordinate(self):
+            assert mutex.acquire()
+            return SimpleNamespace(role=desktop.InstanceRole.OWNER, port=None)
+
+        def publish(self, **_kwargs):
+            return None
+
+        def validate_published_runtime(self):
+            return True
+
+        def cleanup(self):
+            mutex.close()
+
+    handle = desktop.AppThreadHandle(
+        thread=SimpleNamespace(join=lambda: None),
+        stopped=threading.Event(),
+    )
+    monkeypatch.setattr(desktop, "select_port", lambda _env: desktop.PortSelection(8765))
+    monkeypatch.setattr(desktop, "_start_app_thread", lambda: handle)
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_ready",
+        lambda *_args, **_kwargs: desktop.WaitOutcome.READY,
+    )
+    monkeypatch.setattr(desktop, "open_browser", lambda *_args: False)
+    controller = make_controller()
+    instance = RetainingInstance()
+    runner = desktop.StartupRunner(
+        controller,
+        make_paths(tmp_path),
+        {},
+        desktop_instance=instance,
+    )
+    worker = threading.Thread(target=runner.run, args=(controller.state.attempt,))
+    worker.start()
+    worker.join()
+    controller.drain_events()
+
+    assert controller.state.recovery is desktop.RecoveryCode.BROWSER_FAILED
+    assert [name for name, _thread_id in api_calls] == ["wait"]
+
+    caller_thread = threading.get_ident()
+    instance.cleanup()
+
+    assert [name for name, _thread_id in api_calls] == [
+        "wait",
+        "release",
+        "close",
+    ]
+    assert len({thread_id for _name, thread_id in api_calls}) == 1
+    assert api_calls[0][1] != caller_thread
+
+
 def test_existing_instance_runs_wait_and_browser_phases_without_app_thread(
     monkeypatch,
     tmp_path,
@@ -421,7 +631,7 @@ def test_existing_instance_runs_wait_and_browser_phases_without_app_thread(
     monkeypatch.setattr(
         desktop,
         "select_port",
-        lambda env: desktop.PortSelection(8765, existing_instance=True),
+        lambda env: pytest.fail("a validated follower must use runtime state"),
     )
     monkeypatch.setattr(
         desktop,
@@ -430,12 +640,52 @@ def test_existing_instance_runs_wait_and_browser_phases_without_app_thread(
     )
     monkeypatch.setattr(desktop, "open_browser", lambda port, env: True)
 
-    desktop.StartupRunner(controller, paths, {}).run(controller.state.attempt)
+    desktop.StartupRunner(
+        controller,
+        paths,
+        {},
+        desktop_instance=FakeDesktopInstance(
+            role=desktop.InstanceRole.FOLLOWER,
+            port=8765,
+        ),
+    ).run(controller.state.attempt)
     controller.drain_events()
 
     assert controller.state.ready is True
     assert controller.state.owns_server is False
     assert controller.state.closed is True
+    assert controller.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    ("error", "recovery"),
+    [
+        (
+            desktop.InstanceUnavailableError("not ready"),
+            desktop.RecoveryCode.TIMEOUT,
+        ),
+        (
+            desktop.DesktopInstanceError("unsafe owner"),
+            desktop.RecoveryCode.STARTUP_FAILED,
+        ),
+    ],
+)
+def test_instance_coordination_errors_map_to_safe_recovery(
+    tmp_path,
+    error,
+    recovery,
+):
+    controller = make_controller()
+    desktop.StartupRunner(
+        controller,
+        make_paths(tmp_path),
+        {},
+        desktop_instance=FakeDesktopInstance(coordinate_error=error),
+    ).run(controller.state.attempt)
+    controller.drain_events()
+
+    assert controller.state.recovery is recovery
+    assert type(error).__name__ not in controller.state.status
 
 
 def test_app_thread_wrapper_captures_baseexception_type_without_message(monkeypatch):
@@ -618,6 +868,36 @@ def test_relaunch_spawns_before_terminating_current_process():
     assert calls == ["spawn", "terminate"]
 
 
+def test_relaunch_cleans_runtime_after_spawn_before_terminating():
+    calls = []
+
+    desktop.relaunch_launcher(
+        spawn=lambda: calls.append("spawn"),
+        cleanup=lambda: calls.append("cleanup"),
+        terminate=lambda: calls.append("terminate"),
+    )
+
+    assert calls == ["spawn", "cleanup", "terminate"]
+
+
+def test_relaunch_still_terminates_when_cleanup_fails():
+    calls = []
+    failure = RuntimeError("cleanup failed")
+
+    def cleanup():
+        calls.append("cleanup")
+        raise failure
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        desktop.relaunch_launcher(
+            spawn=lambda: calls.append("spawn"),
+            cleanup=cleanup,
+            terminate=lambda: calls.append("terminate"),
+        )
+
+    assert calls == ["spawn", "cleanup", "terminate"]
+
+
 def test_spawn_launcher_process_is_isolated_for_unit_tests(monkeypatch):
     calls = []
     monkeypatch.setattr(desktop, "launcher_working_directory", lambda: ROOT)
@@ -736,6 +1016,7 @@ def test_parent_handoff_timeout_stays_on_recovery_before_port_selection(
         controller,
         paths,
         {},
+        desktop_instance=FakeDesktopInstance(),
         is_relaunch=True,
         handoff_outcome=desktop.HandoffOutcome.TIMEOUT,
     ).run(controller.state.attempt)
@@ -794,6 +1075,11 @@ def test_run_desktop_waits_before_single_logging_configuration(
     )
     monkeypatch.setattr(
         desktop,
+        "create_desktop_instance",
+        lambda runtime_file, env: FakeDesktopInstance(),
+    )
+    monkeypatch.setattr(
+        desktop,
         "show_fatal_startup_message",
         lambda logs_dir: calls.append("fatal"),
     )
@@ -802,6 +1088,103 @@ def test_run_desktop_waits_before_single_logging_configuration(
     assert calls[:-1] == expected_prefix
     assert calls[-1] == "fatal"
     assert calls.count("logging") == 1
+
+
+def test_run_desktop_normal_mainloop_exit_cleans_owner_runtime(
+    monkeypatch,
+    tmp_path,
+):
+    calls = []
+    paths = make_paths(tmp_path)
+    instance = FakeDesktopInstance()
+    root = SimpleNamespace(
+        update=lambda: calls.append("update"),
+        after=lambda *_args: calls.append("after"),
+        mainloop=lambda: calls.append("mainloop"),
+    )
+    fake_tk = SimpleNamespace(ttk=SimpleNamespace(), Tk=lambda: root)
+    monkeypatch.setitem(sys.modules, "tkinter", fake_tk)
+    monkeypatch.setattr(
+        desktop,
+        "configure_desktop_environment",
+        lambda _env: paths,
+    )
+    monkeypatch.setattr(desktop, "_relaunch_parent_handle", lambda: None)
+    monkeypatch.setattr(desktop, "configure_logging", lambda *_args: None)
+    monkeypatch.setattr(
+        desktop,
+        "create_desktop_instance",
+        lambda *_args: instance,
+    )
+    monkeypatch.setattr(desktop, "TkLauncher", lambda *_args: SimpleNamespace(
+        start=lambda: None,
+        poll=lambda: None,
+    ))
+
+    assert desktop.run_desktop() == 0
+    assert calls == ["update", "after", "after", "mainloop"]
+    assert instance.cleanup_calls == 1
+
+
+def test_run_desktop_mainloop_cleanup_failure_is_not_startup_surface_failure(
+    monkeypatch,
+    tmp_path,
+):
+    calls = []
+    logged = []
+    paths = make_paths(tmp_path)
+
+    class CleanupFailureInstance(FakeDesktopInstance):
+        def cleanup(self):
+            self.cleanup_calls += 1
+            raise RuntimeError("cleanup secret")
+
+    instance = CleanupFailureInstance()
+    root = SimpleNamespace(
+        update=lambda: None,
+        after=lambda *_args: None,
+        mainloop=lambda: calls.append("mainloop"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tkinter",
+        SimpleNamespace(ttk=SimpleNamespace(), Tk=lambda: root),
+    )
+    monkeypatch.setattr(
+        desktop,
+        "configure_desktop_environment",
+        lambda _env: paths,
+    )
+    monkeypatch.setattr(desktop, "_relaunch_parent_handle", lambda: None)
+    monkeypatch.setattr(desktop, "configure_logging", lambda *_args: None)
+    monkeypatch.setattr(
+        desktop,
+        "create_desktop_instance",
+        lambda *_args: instance,
+    )
+    monkeypatch.setattr(
+        desktop,
+        "TkLauncher",
+        lambda *_args: SimpleNamespace(start=lambda: None, poll=lambda: None),
+    )
+    monkeypatch.setattr(
+        desktop,
+        "show_fatal_startup_message",
+        lambda _logs_dir: calls.append("fatal"),
+    )
+    monkeypatch.setattr(
+        desktop.LOG,
+        "error",
+        lambda message, *args: logged.append(message % args),
+    )
+
+    assert desktop.run_desktop() == 1
+    assert calls == ["mainloop"]
+    assert instance.cleanup_calls == 1
+    assert logged == [
+        "Runtime cleanup failed after launcher mainloop exit "
+        "(failure type: RuntimeError)"
+    ]
 
 
 def test_runtime_root_uses_source_checkout_by_default():
@@ -920,6 +1303,7 @@ def test_startup_failure_logging_omits_raw_exception_and_traceback(
         controller,
         paths,
         {"LOCALAPPDATA": str(tmp_path)},
+        desktop_instance=FakeDesktopInstance(),
     ).run(controller.state.attempt)
     for handler in desktop.LOG.handlers:
         handler.flush()
@@ -951,6 +1335,7 @@ def test_generic_startup_failure_is_recorded_by_private_launcher_log(
         controller,
         paths,
         {"LOCALAPPDATA": str(tmp_path)},
+        desktop_instance=FakeDesktopInstance(),
     ).run(controller.state.attempt)
     controller.drain_events()
     for handler in desktop.LOG.handlers:
@@ -991,7 +1376,7 @@ def test_smoke_failure_injection_requires_browser_skip_boundary(monkeypatch, tmp
     monkeypatch.setattr(
         desktop,
         "_wait_for_ready",
-        lambda port, app_handle: (
+        lambda port, app_handle, **_kwargs: (
             desktop.WaitOutcome.APP_FAILED
             if app_handle.stopped.is_set()
             else desktop.WaitOutcome.READY
@@ -1002,6 +1387,7 @@ def test_smoke_failure_injection_requires_browser_skip_boundary(monkeypatch, tmp
         controller,
         paths,
         {"DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE": "1"},
+        desktop_instance=FakeDesktopInstance(),
     ).run(controller.state.attempt)
     controller.drain_events()
 
@@ -1014,7 +1400,12 @@ def test_smoke_failure_injection_requires_browser_skip_boundary(monkeypatch, tmp
         "DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE": "1",
     }
 
-    desktop.StartupRunner(controller, paths, env).run(controller.state.attempt)
+    desktop.StartupRunner(
+        controller,
+        paths,
+        env,
+        desktop_instance=FakeDesktopInstance(),
+    ).run(controller.state.attempt)
     controller.drain_events()
 
     assert controller.state.recovery is desktop.RecoveryCode.APP_FAILED
@@ -1040,7 +1431,7 @@ def test_relaunch_handle_makes_smoke_failure_injection_one_shot(monkeypatch, tmp
     monkeypatch.setattr(
         desktop,
         "_wait_for_ready",
-        lambda port, app_handle: desktop.WaitOutcome.READY,
+        lambda port, app_handle, **_kwargs: desktop.WaitOutcome.READY,
     )
     monkeypatch.setattr(desktop, "open_browser", lambda port, env: True)
 
@@ -1051,6 +1442,7 @@ def test_relaunch_handle_makes_smoke_failure_injection_one_shot(monkeypatch, tmp
             "DOCSIGHT_SKIP_BROWSER": "1",
             "DOCSIGHT_SMOKE_INJECT_STARTUP_FAILURE": "1",
         },
+        desktop_instance=FakeDesktopInstance(),
         is_relaunch=True,
     ).run(controller.state.attempt)
     controller.drain_events()
@@ -1074,7 +1466,7 @@ def test_browser_smoke_injection_reaches_recovery_without_browser(
     monkeypatch.setattr(
         desktop,
         "_wait_for_ready",
-        lambda port, app_handle: desktop.WaitOutcome.READY,
+        lambda port, app_handle, **_kwargs: desktop.WaitOutcome.READY,
     )
     monkeypatch.setattr(
         desktop,
@@ -1089,6 +1481,7 @@ def test_browser_smoke_injection_reaches_recovery_without_browser(
             "DOCSIGHT_SKIP_BROWSER": "1",
             "DOCSIGHT_SMOKE_INJECT_BROWSER_FAILURE": "1",
         },
+        desktop_instance=FakeDesktopInstance(),
     ).run(controller.state.attempt)
     controller.drain_events()
 
@@ -1116,6 +1509,7 @@ def test_no_port_smoke_injection_clears_url_before_port_selection(
             "DOCSIGHT_SKIP_BROWSER": "1",
             "DOCSIGHT_SMOKE_INJECT_NO_PORT_FAILURE": "1",
         },
+        desktop_instance=FakeDesktopInstance(),
     ).run(controller.state.attempt)
     controller.drain_events()
 
@@ -1147,7 +1541,7 @@ def test_relaunch_does_not_repeat_new_smoke_injections(
     monkeypatch.setattr(
         desktop,
         "_wait_for_ready",
-        lambda port, app_handle: desktop.WaitOutcome.READY,
+        lambda port, app_handle, **_kwargs: desktop.WaitOutcome.READY,
     )
     monkeypatch.setattr(
         desktop,
@@ -1162,6 +1556,7 @@ def test_relaunch_does_not_repeat_new_smoke_injections(
             "DOCSIGHT_SKIP_BROWSER": "1",
             injection_name: "1",
         },
+        desktop_instance=FakeDesktopInstance(),
         is_relaunch=True,
     ).run(controller.state.attempt)
     controller.drain_events()
@@ -1243,6 +1638,39 @@ def test_poll_failure_recovers_and_schedules_next_poll():
     assert values["after"] == [(desktop.EVENT_POLL_MILLISECONDS, view.poll)]
 
 
+def test_follower_window_is_destroyed_once_by_poll_path():
+    calls = []
+    controller = make_controller()
+    controller.state = desktop.replace(
+        controller.state,
+        phase=desktop.StartupPhase.OPEN,
+        ready=True,
+        owns_server=False,
+        closed=True,
+    )
+    controller.drain_events = lambda: False
+    view = desktop.TkLauncher.__new__(desktop.TkLauncher)
+    view.controller = controller
+    view.status_var = SimpleNamespace(set=lambda _value: None)
+    view.url_var = SimpleNamespace(set=lambda _value: None)
+    view.copy_button = SimpleNamespace(configure=lambda **_kwargs: None)
+    view.phase_labels = [
+        SimpleNamespace(configure=lambda **_kwargs: None)
+        for _phase in desktop.PHASES
+    ]
+    view.actions = SimpleNamespace(grid_remove=lambda: None)
+    view.root = SimpleNamespace(
+        withdraw=lambda: calls.append("withdraw"),
+        destroy=lambda: calls.append("destroy"),
+        after=lambda *_args: calls.append("after"),
+    )
+
+    view._render_full()
+    view.poll()
+
+    assert calls == ["destroy"]
+
+
 def test_tk_launcher_installs_callback_exception_boundary(monkeypatch, tmp_path):
     root = SimpleNamespace()
     monkeypatch.setattr(desktop.TkLauncher, "_build", lambda self: None)
@@ -1254,6 +1682,7 @@ def test_tk_launcher_installs_callback_exception_boundary(monkeypatch, tmp_path)
         make_controller(),
         SimpleNamespace(),
         make_paths(tmp_path),
+        FakeDesktopInstance(),
     )
 
     assert root.report_callback_exception == view._report_callback_exception
@@ -1307,6 +1736,7 @@ def test_close_destroys_window_and_terminates_process(monkeypatch):
     view = desktop.TkLauncher.__new__(desktop.TkLauncher)
     view.root = SimpleNamespace(destroy=lambda: calls.append("destroy"))
     view.controller = SimpleNamespace(exit_code=1)
+    view.desktop_instance = FakeDesktopInstance()
     monkeypatch.setattr(desktop.os, "_exit", lambda code: calls.append(("exit", code)))
 
     view._close()

--- a/tests/test_desktop_instance.py
+++ b/tests/test_desktop_instance.py
@@ -1,0 +1,866 @@
+"""Focused tests for Windows desktop runtime ownership."""
+
+from __future__ import annotations
+
+import email.message
+import importlib.util
+import io
+import json
+import os
+import sys
+import threading
+import urllib.request
+import urllib.response
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app import desktop_runtime_contract as contract
+
+ROOT = Path(__file__).resolve().parents[1]
+WINDOWS_DIR = ROOT / "packaging" / "windows"
+MODULE_PATH = WINDOWS_DIR / "desktop_instance.py"
+if str(WINDOWS_DIR) not in sys.path:
+    sys.path.insert(0, str(WINDOWS_DIR))
+
+spec = importlib.util.spec_from_file_location("docsight_desktop_instance", MODULE_PATH)
+assert spec is not None
+assert spec.loader is not None
+runtime = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = runtime
+spec.loader.exec_module(runtime)
+
+TOKEN = "A" * 43
+OTHER_TOKEN = "B" * 43
+OWNER = "S-1-5-21-1000"
+PID = 4242
+START_TIME = 133700000
+
+
+def make_state(**overrides):
+    values = {
+        "pid": PID,
+        "port": 8765,
+        "application_version": "v1.2.3",
+        "process_start_time": START_TIME,
+        "instance_token": TOKEN,
+    }
+    values.update(overrides)
+    return runtime.RuntimeState.create(**values)
+
+
+class FakeMutex:
+    def __init__(self, acquire_results):
+        self.acquire_results = list(acquire_results)
+        self.owned = False
+        self.closed = False
+        self.release_calls = 0
+
+    def acquire(self, timeout_milliseconds=0):
+        del timeout_milliseconds
+        result = self.acquire_results.pop(0) if self.acquire_results else False
+        self.owned = result
+        return result
+
+    def release(self):
+        if self.owned:
+            self.release_calls += 1
+            self.owned = False
+
+    def close(self):
+        self.release()
+        self.closed = True
+
+
+class FakeInspector:
+    def __init__(self, identities):
+        self.identities = identities
+        self.calls = []
+
+    def inspect(self, pid):
+        self.calls.append(pid)
+        return self.identities.get(pid)
+
+
+def make_coordinator(
+    tmp_path,
+    *,
+    mutex=None,
+    inspector=None,
+    endpoint_probe=lambda state: True,
+    env=None,
+    token=TOKEN,
+    monotonic=None,
+    sleep=None,
+):
+    identity = runtime.ProcessIdentity(PID, OWNER, START_TIME)
+    return runtime.DesktopInstance(
+        store=runtime.RuntimeStateStore(tmp_path / "runtime.json"),
+        mutex=mutex or FakeMutex([True]),
+        inspector=inspector or FakeInspector({PID: identity}),
+        current_user_id=OWNER,
+        env=env if env is not None else {},
+        current_pid=PID,
+        token_factory=lambda: token,
+        endpoint_probe=endpoint_probe,
+        monotonic=monotonic or (lambda: 0.0),
+        sleep=sleep or (lambda _seconds: None),
+    )
+
+
+def test_runtime_state_round_trips_with_exact_schema():
+    state = make_state()
+
+    assert runtime.RuntimeState.from_mapping(state.to_mapping()) == state
+    assert state.to_mapping() == {
+        "schema_version": 1,
+        "pid": PID,
+        "port": 8765,
+        "application_version": "v1.2.3",
+        "process_start_time": START_TIME,
+        "instance_token": TOKEN,
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", 2),
+        ("schema_version", True),
+        ("pid", 0),
+        ("pid", "4242"),
+        ("port", 0),
+        ("port", 65536),
+        ("process_start_time", -1),
+        ("application_version", ""),
+        ("application_version", "bad\nversion"),
+        ("instance_token", "guessable"),
+        ("instance_token", 123),
+    ],
+)
+def test_runtime_state_rejects_invalid_types_and_ranges(field, value):
+    mapping = make_state().to_mapping()
+    mapping[field] = value
+
+    with pytest.raises(ValueError):
+        runtime.RuntimeState.from_mapping(mapping)
+
+
+def test_runtime_state_rejects_missing_and_extra_fields():
+    mapping = make_state().to_mapping()
+    mapping["unexpected"] = True
+
+    with pytest.raises(ValueError):
+        runtime.RuntimeState.from_mapping(mapping)
+
+    mapping.pop("unexpected")
+    mapping.pop("pid")
+    with pytest.raises(ValueError):
+        runtime.RuntimeState.from_mapping(mapping)
+
+
+def test_runtime_store_atomically_replaces_existing_state(monkeypatch, tmp_path):
+    path = tmp_path / "runtime.json"
+    path.write_text("old-state", encoding="utf-8")
+    store = runtime.RuntimeStateStore(path)
+    real_replace = os.replace
+    calls = []
+
+    def checked_replace(source, destination):
+        assert Path(destination).read_text(encoding="utf-8") == "old-state"
+        assert Path(source).parent == path.parent
+        calls.append((Path(source), Path(destination)))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(runtime.os, "replace", checked_replace)
+
+    store.replace(make_state())
+
+    assert len(calls) == 1
+    assert store.load() == make_state()
+    assert list(tmp_path.glob(".runtime.json.*.tmp")) == []
+
+
+def sharing_error(winerror):
+    error = OSError("sharing failure")
+    error.winerror = winerror
+    return error
+
+
+def test_runtime_store_retries_read_sharing_violations(monkeypatch, tmp_path):
+    path = tmp_path / "runtime.json"
+    path.write_text(json.dumps(make_state().to_mapping()), encoding="utf-8")
+    real_read_text = Path.read_text
+    attempts = []
+    sleeps = []
+
+    def flaky_read_text(target, *args, **kwargs):
+        if target == path:
+            attempts.append(target)
+            if len(attempts) < 3:
+                raise sharing_error(32)
+        return real_read_text(target, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+    store = runtime.RuntimeStateStore(path, sleep=sleeps.append)
+
+    assert store.load() == make_state()
+    assert len(attempts) == 3
+    assert sleeps == [0.025, 0.025]
+
+
+def test_runtime_store_retries_replace_and_remove_sharing_violations(
+    monkeypatch,
+    tmp_path,
+):
+    path = tmp_path / "runtime.json"
+    real_replace = os.replace
+    real_unlink = Path.unlink
+    replace_attempts = []
+    unlink_attempts = []
+    sleeps = []
+
+    def flaky_replace(source, destination):
+        replace_attempts.append((source, destination))
+        if len(replace_attempts) == 1:
+            raise sharing_error(5)
+        return real_replace(source, destination)
+
+    def flaky_unlink(target, *args, **kwargs):
+        if target == path:
+            unlink_attempts.append(target)
+            if len(unlink_attempts) == 1:
+                raise sharing_error(33)
+        return real_unlink(target, *args, **kwargs)
+
+    monkeypatch.setattr(runtime.os, "replace", flaky_replace)
+    store = runtime.RuntimeStateStore(path, sleep=sleeps.append)
+    store.replace(make_state())
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+    store.remove()
+
+    assert len(replace_attempts) == 2
+    assert len(unlink_attempts) == 2
+    assert sleeps == [0.025, 0.025]
+    assert not path.exists()
+
+
+def test_runtime_store_does_not_retry_unrelated_os_errors(monkeypatch, tmp_path):
+    path = tmp_path / "runtime.json"
+    attempts = []
+    sleeps = []
+
+    def failed_read_text(*_args, **_kwargs):
+        attempts.append(True)
+        raise sharing_error(87)
+
+    monkeypatch.setattr(Path, "read_text", failed_read_text)
+    store = runtime.RuntimeStateStore(path, sleep=sleeps.append)
+
+    with pytest.raises(runtime.RuntimeStateError):
+        store.load()
+    assert attempts == [True]
+    assert sleeps == []
+
+
+@pytest.mark.parametrize("contents", ["{", "[]", '{"schema_version":1}', "\udcff"])
+def test_runtime_store_treats_malformed_state_as_unusable(tmp_path, contents):
+    path = tmp_path / "runtime.json"
+    if contents == "\udcff":
+        path.write_bytes(b"\xff")
+    else:
+        path.write_text(contents, encoding="utf-8")
+
+    assert runtime.RuntimeStateStore(path).load() is None
+
+
+def test_runtime_store_cleanup_does_not_remove_a_newer_owner(tmp_path):
+    store = runtime.RuntimeStateStore(tmp_path / "runtime.json")
+    store.replace(make_state(instance_token=OTHER_TOKEN))
+
+    store.remove(expected_token=TOKEN)
+
+    assert store.load() == make_state(instance_token=OTHER_TOKEN)
+
+
+def test_sid_mutex_name_is_machine_visible_and_per_user():
+    first = runtime.mutex_name_for_user("S-1-5-21-1000")
+    same = runtime.mutex_name_for_user("S-1-5-21-1000")
+    other = runtime.mutex_name_for_user("S-1-5-21-2000")
+
+    assert first.startswith("Global\\DOCSight.Desktop.")
+    assert first == same
+    assert first != other
+    assert "Local\\" not in first
+
+
+def test_factory_uses_same_sid_mutex_for_direct_and_independent_lookup(
+    monkeypatch,
+    tmp_path,
+):
+    current_pid = os.getpid()
+    captured_names = []
+
+    class Inspector:
+        def __init__(self, *, direct_sid):
+            self.direct_sid = direct_sid
+
+        def current_user_sid(self):
+            if not self.direct_sid:
+                raise OSError("SID unavailable")
+            return OWNER
+
+        def inspect(self, pid):
+            return runtime.ProcessIdentity(pid, OWNER, START_TIME)
+
+    class Mutex(FakeMutex):
+        def __init__(self, name):
+            captured_names.append(name)
+            super().__init__([True])
+
+    inspectors = iter((Inspector(direct_sid=True), Inspector(direct_sid=False)))
+    monkeypatch.setattr(runtime, "Win32ProcessInspector", lambda: next(inspectors))
+    monkeypatch.setattr(runtime, "Win32NamedMutex", Mutex)
+
+    direct = runtime.create_desktop_instance(tmp_path / "direct.json", {})
+    independent = runtime.create_desktop_instance(tmp_path / "independent.json", {})
+
+    assert captured_names == [
+        runtime.mutex_name_for_user(OWNER),
+        runtime.mutex_name_for_user(OWNER),
+    ]
+    assert independent.coordinate().role is runtime.InstanceRole.OWNER
+    independent.publish(port=8765, application_version="v1")
+    assert runtime.RuntimeStateStore(tmp_path / "independent.json").load().pid == (
+        current_pid
+    )
+    direct.cleanup()
+    independent.cleanup()
+
+
+def test_factory_fails_safe_before_mutex_when_both_sid_paths_fail(
+    monkeypatch,
+    tmp_path,
+):
+    class Inspector:
+        def current_user_sid(self):
+            raise OSError("SID unavailable")
+
+        def inspect(self, _pid):
+            return None
+
+    monkeypatch.setattr(runtime, "Win32ProcessInspector", Inspector)
+    monkeypatch.setattr(
+        runtime,
+        "Win32NamedMutex",
+        lambda _name: pytest.fail("mutex must not be created without a SID"),
+    )
+
+    with pytest.raises(
+        runtime.DesktopInstanceError,
+        match="validate current process ownership",
+    ):
+        runtime.create_desktop_instance(tmp_path / "runtime.json", {})
+
+
+@pytest.mark.parametrize("wait_result", [0, 0x80])
+def test_named_mutex_owns_abandoned_or_signaled_handle_and_balances_close(wait_result):
+    calls = []
+    api = SimpleNamespace(
+        CreateMutexW=lambda *_args: 55,
+        WaitForSingleObject=lambda handle, timeout: (
+            calls.append(("wait", handle, timeout)) or wait_result
+        ),
+        ReleaseMutex=lambda handle: calls.append(("release", handle)) or True,
+        CloseHandle=lambda handle: calls.append(("close", handle)) or True,
+    )
+    mutex = runtime.Win32NamedMutex("Global\\test", kernel32=api)
+
+    assert mutex.acquire() is True
+    mutex.close()
+    mutex.close()
+
+    assert calls == [("wait", 55, 0), ("release", 55), ("close", 55)]
+
+
+def test_owner_publishes_environment_and_explicit_cleanup(tmp_path):
+    env = {}
+    mutex = FakeMutex([True])
+    coordinator = make_coordinator(tmp_path, mutex=mutex, env=env)
+
+    assert coordinator.coordinate().role is runtime.InstanceRole.OWNER
+    state = coordinator.publish(port=8766, application_version="v2")
+
+    assert state == make_state(port=8766, application_version="v2")
+    assert runtime.RuntimeStateStore(tmp_path / "runtime.json").load() == state
+    assert env[contract.INSTANCE_TOKEN_ENV] == TOKEN
+    assert env[contract.INSTANCE_PID_ENV] == str(PID)
+    assert env[contract.INSTANCE_START_TIME_ENV] == str(START_TIME)
+    assert env[contract.INSTANCE_VERSION_ENV] == "v2"
+    assert env["WEB_PORT"] == "8766"
+
+    coordinator.cleanup()
+    coordinator.cleanup()
+
+    assert not (tmp_path / "runtime.json").exists()
+    assert contract.INSTANCE_TOKEN_ENV not in env
+    assert mutex.release_calls == 1
+    assert mutex.closed is True
+
+
+def test_explicit_owner_cleanup_does_not_remove_unverifiable_runtime_state(tmp_path):
+    coordinator = make_coordinator(tmp_path)
+    coordinator.coordinate()
+    coordinator.publish(port=8765, application_version="v1")
+    (tmp_path / "runtime.json").write_text("{malformed", encoding="utf-8")
+
+    coordinator.cleanup()
+
+    assert (tmp_path / "runtime.json").read_text(encoding="utf-8") == "{malformed"
+
+
+def test_owner_cleanup_does_not_remove_newer_owner_state(tmp_path):
+    coordinator = make_coordinator(tmp_path)
+    coordinator.coordinate()
+    coordinator.publish(port=8765, application_version="v1")
+    store = runtime.RuntimeStateStore(tmp_path / "runtime.json")
+    newer_state = make_state(instance_token=OTHER_TOKEN)
+    store.replace(newer_state)
+
+    coordinator.cleanup()
+
+    assert store.load() == newer_state
+
+
+def test_owner_that_never_published_does_not_remove_later_runtime_state(tmp_path):
+    coordinator = make_coordinator(tmp_path)
+    coordinator.coordinate()
+    later_state = make_state(instance_token=OTHER_TOKEN)
+    runtime.RuntimeStateStore(tmp_path / "runtime.json").replace(later_state)
+
+    coordinator.cleanup()
+
+    assert runtime.RuntimeStateStore(tmp_path / "runtime.json").load() == later_state
+
+
+def test_follower_reuses_only_fully_validated_runtime_state(tmp_path):
+    store = runtime.RuntimeStateStore(tmp_path / "runtime.json")
+    state = make_state(port=8770)
+    store.replace(state)
+    mutex = FakeMutex([False])
+    inspector = FakeInspector(
+        {PID: runtime.ProcessIdentity(PID, OWNER, START_TIME)}
+    )
+    probes = []
+    coordinator = make_coordinator(
+        tmp_path,
+        mutex=mutex,
+        inspector=inspector,
+        endpoint_probe=lambda observed: probes.append(observed) or True,
+    )
+
+    decision = coordinator.coordinate(wait_seconds=0)
+
+    assert decision == runtime.InstanceDecision(runtime.InstanceRole.FOLLOWER, 8770)
+    assert probes == [state]
+    assert mutex.closed is True
+
+
+def test_follower_cleanup_preserves_owner_runtime_state(tmp_path):
+    store = runtime.RuntimeStateStore(tmp_path / "runtime.json")
+    state = make_state(port=8770)
+    store.replace(state)
+    coordinator = make_coordinator(
+        tmp_path,
+        mutex=FakeMutex([False]),
+        inspector=FakeInspector(
+            {PID: runtime.ProcessIdentity(PID, OWNER, START_TIME)}
+        ),
+    )
+
+    assert coordinator.coordinate(wait_seconds=0).role is runtime.InstanceRole.FOLLOWER
+    coordinator.cleanup()
+
+    assert store.load() == state
+
+
+def test_owner_coordination_raises_desktop_instance_error_for_unverified_self(
+    tmp_path,
+):
+    mutex = FakeMutex([True])
+    coordinator = make_coordinator(
+        tmp_path,
+        mutex=mutex,
+        inspector=FakeInspector({}),
+    )
+
+    with pytest.raises(
+        runtime.DesktopInstanceError,
+        match="validate desktop owner process",
+    ):
+        coordinator.coordinate()
+    assert mutex.closed is True
+    assert mutex.release_calls == 1
+
+
+def test_owner_setup_remove_failure_releases_mutex_for_immediate_competitor(
+    tmp_path,
+):
+    shared = SimpleNamespace(held=False)
+
+    class SharedMutex:
+        def __init__(self):
+            self.owned = False
+            self.closed = False
+
+        def acquire(self, _timeout_milliseconds=0):
+            if shared.held:
+                return False
+            shared.held = True
+            self.owned = True
+            return True
+
+        def release(self):
+            if self.owned:
+                shared.held = False
+                self.owned = False
+
+        def close(self):
+            self.release()
+            self.closed = True
+
+    class FailingStore(runtime.RuntimeStateStore):
+        def remove(self, *, expected_token=None):
+            del expected_token
+            raise runtime.RuntimeStateError("injected remove failure")
+
+    first_mutex = SharedMutex()
+    first = runtime.DesktopInstance(
+        store=FailingStore(tmp_path / "runtime.json"),
+        mutex=first_mutex,
+        inspector=FakeInspector(
+            {PID: runtime.ProcessIdentity(PID, OWNER, START_TIME)}
+        ),
+        current_user_id=OWNER,
+        env={},
+        current_pid=PID,
+    )
+
+    with pytest.raises(runtime.RuntimeStateError, match="injected remove failure"):
+        first.coordinate(wait_seconds=10)
+
+    assert first_mutex.closed is True
+    assert shared.held is False
+
+    second = make_coordinator(
+        tmp_path,
+        mutex=SharedMutex(),
+        sleep=lambda _seconds: pytest.fail("competitor must not enter wait loop"),
+    )
+    assert second.coordinate(wait_seconds=10).role is runtime.InstanceRole.OWNER
+    second.cleanup()
+
+
+@pytest.mark.parametrize(
+    ("observed_identity", "endpoint_valid"),
+    [
+        (None, True),
+        (runtime.ProcessIdentity(PID, "S-1-5-21-OTHER", START_TIME), True),
+        (runtime.ProcessIdentity(PID, OWNER, START_TIME + 1), True),
+        (runtime.ProcessIdentity(PID, OWNER, START_TIME), False),
+    ],
+)
+def test_dead_reused_foreign_or_wrong_token_runtime_is_rejected(
+    tmp_path,
+    observed_identity,
+    endpoint_valid,
+):
+    runtime.RuntimeStateStore(tmp_path / "runtime.json").replace(make_state())
+    clock = [0.0]
+
+    def advance(seconds):
+        clock[0] += seconds
+
+    coordinator = make_coordinator(
+        tmp_path,
+        mutex=FakeMutex([False, False, False]),
+        inspector=FakeInspector(
+            {PID: observed_identity} if observed_identity is not None else {}
+        ),
+        endpoint_probe=lambda state: endpoint_valid,
+        monotonic=lambda: clock[0],
+        sleep=advance,
+    )
+
+    with pytest.raises(runtime.InstanceUnavailableError):
+        coordinator.coordinate(wait_seconds=0.02, poll_seconds=0.01)
+
+
+def test_stale_or_malformed_state_is_cleaned_during_takeover(tmp_path):
+    path = tmp_path / "runtime.json"
+    path.write_text("{malformed", encoding="utf-8")
+    mutex = FakeMutex([False, True])
+    clock = [0.0]
+    coordinator = make_coordinator(
+        tmp_path,
+        mutex=mutex,
+        monotonic=lambda: clock[0],
+        sleep=lambda seconds: clock.__setitem__(0, clock[0] + seconds),
+    )
+
+    decision = coordinator.coordinate(wait_seconds=1, poll_seconds=0.01)
+
+    assert decision.role is runtime.InstanceRole.OWNER
+    assert not path.exists()
+    coordinator.cleanup()
+
+
+def test_coordination_wait_is_capped_at_ten_seconds(tmp_path):
+    clock = [0.0]
+    sleeps = []
+
+    def advance(seconds):
+        sleeps.append(seconds)
+        clock[0] += seconds
+
+    coordinator = make_coordinator(
+        tmp_path,
+        mutex=FakeMutex([]),
+        monotonic=lambda: clock[0],
+        sleep=advance,
+    )
+
+    with pytest.raises(runtime.InstanceUnavailableError):
+        coordinator.coordinate(wait_seconds=30, poll_seconds=6)
+
+    assert clock == [10.0]
+    assert sleeps == [6, 4.0]
+
+
+def test_probe_sends_token_and_requires_exact_runtime_payload():
+    state = make_state()
+    requests = []
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit):
+            payload = {"status": "ok", **state.to_mapping()}
+            return json.dumps(payload).encode("utf-8")
+
+    def urlopen(request, timeout):
+        requests.append((request, timeout))
+        return Response()
+
+    assert runtime.probe_runtime_endpoint(
+        state,
+        opener=SimpleNamespace(open=urlopen),
+    ) is True
+    request, timeout = requests[0]
+    assert request.full_url == "http://127.0.0.1:8765/desktop-runtime"
+    assert request.get_header("Authorization") == f"Bearer {TOKEN}"
+    assert timeout == 0.75
+
+
+def test_probe_builds_proxyless_opener_even_with_proxy_environment(
+    monkeypatch,
+):
+    state = make_state()
+    calls = []
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit):
+            return json.dumps(
+                {"status": "ok", **state.to_mapping()}
+            ).encode("utf-8")
+
+    class Opener:
+        def open(self, request, timeout):
+            calls.append(("open", request.full_url, timeout))
+            return Response()
+
+    def proxy_handler(proxies):
+        calls.append(("proxy_handler", proxies))
+        return "proxy-handler"
+
+    def build_opener(*handlers):
+        calls.append(("build_opener", handlers))
+        return Opener()
+
+    monkeypatch.setenv("HTTP_PROXY", "http://192.0.2.1:8080")
+    monkeypatch.setenv("ALL_PROXY", "http://192.0.2.2:8080")
+    monkeypatch.setattr(runtime.urllib.request, "ProxyHandler", proxy_handler)
+    monkeypatch.setattr(runtime.urllib.request, "build_opener", build_opener)
+
+    assert runtime.probe_runtime_endpoint(state) is True
+    assert calls[:1] == [("proxy_handler", {})]
+    assert calls[1][0] == "build_opener"
+    assert calls[1][1][0] == "proxy-handler"
+    assert isinstance(calls[1][1][1], runtime._NoRedirectHandler)
+    assert calls[2:] == [
+        ("open", "http://127.0.0.1:8765/desktop-runtime", 0.75),
+    ]
+
+
+def test_proxyless_probe_refuses_non_loopback_redirect_without_following():
+    requests = []
+
+    class RedirectTransport(urllib.request.HTTPHandler):
+        def http_open(self, request):
+            requests.append(
+                (request.full_url, request.get_header("Authorization"))
+            )
+            if request.full_url != "http://127.0.0.1:8765/desktop-runtime":
+                pytest.fail("runtime probe followed a redirect off loopback")
+            headers = email.message.Message()
+            headers["Location"] = "http://192.0.2.1/token-capture"
+            response = urllib.response.addinfourl(
+                io.BytesIO(b""),
+                headers,
+                request.full_url,
+                code=302,
+            )
+            response.msg = "Found"
+            return response
+
+    state = make_state()
+    opener = urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        runtime._NoRedirectHandler(),
+        RedirectTransport(),
+    )
+    assert runtime.probe_runtime_endpoint(state, opener=opener) is False
+    assert requests == [
+        (
+            "http://127.0.0.1:8765/desktop-runtime",
+            f"Bearer {state.instance_token}",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"status": "ok", "version": "v1.2.3"},
+        {"status": "ok", **make_state(instance_token=OTHER_TOKEN).to_mapping()},
+        {"status": "ok", **make_state(process_start_time=START_TIME + 1).to_mapping()},
+        ["not", "an", "object"],
+    ],
+)
+def test_probe_rejects_health_lookalikes_and_identity_mismatches(payload):
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit):
+            return json.dumps(payload).encode("utf-8")
+
+    assert runtime.probe_runtime_endpoint(
+        make_state(),
+        opener=SimpleNamespace(open=lambda *_args, **_kwargs: Response()),
+    ) is False
+
+
+def test_parallel_coordination_produces_one_owner_and_one_follower(tmp_path):
+    class SharedState:
+        def __init__(self):
+            self.lock = threading.Lock()
+            self.held = False
+
+    class SharedMutex:
+        def __init__(self, shared):
+            self.shared = shared
+            self.owned = False
+            self.closed = False
+
+        def acquire(self, _timeout=0):
+            with self.shared.lock:
+                if self.shared.held:
+                    return False
+                self.shared.held = True
+                self.owned = True
+                return True
+
+        def release(self):
+            with self.shared.lock:
+                if self.owned:
+                    self.shared.held = False
+                    self.owned = False
+
+        def close(self):
+            self.release()
+            self.closed = True
+
+    shared = SharedState()
+    store = runtime.RuntimeStateStore(tmp_path / "runtime.json")
+    inspector = FakeInspector(
+        {PID: runtime.ProcessIdentity(PID, OWNER, START_TIME)}
+    )
+    barrier = threading.Barrier(2)
+    owner_done = threading.Event()
+    results = []
+    errors = []
+
+    def worker(token):
+        clock = [0.0]
+        coordinator = runtime.DesktopInstance(
+            store=store,
+            mutex=SharedMutex(shared),
+            inspector=inspector,
+            current_user_id=OWNER,
+            env={},
+            current_pid=PID,
+            token_factory=lambda: token,
+            endpoint_probe=lambda state: store.load() == state,
+            monotonic=lambda: clock[0],
+            sleep=lambda seconds: (
+                clock.__setitem__(0, clock[0] + seconds),
+                threading.Event().wait(0.001),
+            ),
+        )
+        try:
+            barrier.wait()
+            decision = coordinator.coordinate(wait_seconds=2, poll_seconds=0.01)
+            results.append(decision.role)
+            if decision.role is runtime.InstanceRole.OWNER:
+                coordinator.publish(port=8765, application_version="v1")
+                owner_done.wait(2)
+                coordinator.cleanup()
+            else:
+                owner_done.set()
+        except Exception as exc:
+            errors.append(exc)
+            owner_done.set()
+
+    first = threading.Thread(target=worker, args=(TOKEN,))
+    second = threading.Thread(target=worker, args=(OTHER_TOKEN,))
+    first.start()
+    second.start()
+    first.join(timeout=3)
+    second.join(timeout=3)
+
+    assert errors == []
+    assert sorted(results) == [
+        runtime.InstanceRole.FOLLOWER,
+        runtime.InstanceRole.OWNER,
+    ]

--- a/tests/test_desktop_platform.py
+++ b/tests/test_desktop_platform.py
@@ -1,0 +1,233 @@
+"""Focused tests for the Windows identity and mutex platform adapter."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WINDOWS_DIR = ROOT / "packaging" / "windows"
+if str(WINDOWS_DIR) not in sys.path:
+    sys.path.insert(0, str(WINDOWS_DIR))
+
+platform_adapter = importlib.import_module("desktop_platform")
+
+
+@pytest.mark.parametrize("wait_result", [0, 0x80])
+def test_named_mutex_parks_wait_release_and_close_on_one_thread(wait_result):
+    api_calls = []
+    caller_threads = []
+
+    def record(name, result):
+        def call(*args):
+            api_calls.append((name, threading.get_ident(), args))
+            return result
+
+        return call
+
+    api = SimpleNamespace(
+        CreateMutexW=record("create", 55),
+        WaitForSingleObject=record("wait", wait_result),
+        ReleaseMutex=record("release", True),
+        CloseHandle=record("close", True),
+    )
+    mutex = platform_adapter.Win32NamedMutex("Global\\test", kernel32=api)
+
+    def acquire_from_startup_worker():
+        caller_threads.append(threading.get_ident())
+        assert mutex.acquire() is True
+
+    worker = threading.Thread(target=acquire_from_startup_worker)
+    worker.start()
+    worker.join()
+    caller_threads.append(threading.get_ident())
+    mutex.close()
+
+    ownership_calls = [
+        call for call in api_calls if call[0] in {"wait", "release", "close"}
+    ]
+    assert [call[0] for call in ownership_calls] == ["wait", "release", "close"]
+    assert len({call[1] for call in ownership_calls}) == 1
+    assert ownership_calls[0][1] not in caller_threads
+
+
+def test_named_mutex_release_and_reacquire_are_safe_from_retry_thread():
+    api_calls = []
+    api = SimpleNamespace(
+        CreateMutexW=lambda *_args: 55,
+        WaitForSingleObject=lambda *_args: (
+            api_calls.append(("wait", threading.get_ident())) or 0
+        ),
+        ReleaseMutex=lambda *_args: (
+            api_calls.append(("release", threading.get_ident())) or True
+        ),
+        CloseHandle=lambda *_args: (
+            api_calls.append(("close", threading.get_ident())) or True
+        ),
+    )
+    mutex = platform_adapter.Win32NamedMutex("Global\\test", kernel32=api)
+    assert mutex.acquire()
+    retry_caller = []
+
+    def retry():
+        retry_caller.append(threading.get_ident())
+        mutex.release()
+        assert mutex.acquire()
+
+    worker = threading.Thread(target=retry)
+    worker.start()
+    worker.join()
+    mutex.close()
+
+    assert [name for name, _thread_id in api_calls] == [
+        "wait",
+        "release",
+        "wait",
+        "release",
+        "close",
+    ]
+    assert len({thread_id for _name, thread_id in api_calls}) == 1
+    assert api_calls[0][1] != retry_caller[0]
+
+
+def test_named_mutex_timeout_does_not_release_unowned_handle():
+    calls = []
+    api = SimpleNamespace(
+        CreateMutexW=lambda *_args: 55,
+        WaitForSingleObject=lambda *_args: 0x102,
+        ReleaseMutex=lambda *_args: calls.append("release") or True,
+        CloseHandle=lambda *_args: calls.append("close") or True,
+    )
+    mutex = platform_adapter.Win32NamedMutex("Global\\test", kernel32=api)
+
+    assert mutex.acquire(25) is False
+    mutex.close()
+
+    assert calls == ["close"]
+
+
+def test_named_mutex_acquire_fails_boundedly_when_owner_thread_stalls():
+    entered = threading.Event()
+    resume = threading.Event()
+    finished = threading.Event()
+
+    def stalled_wait(*_args):
+        entered.set()
+        assert resume.wait(timeout=1)
+        finished.set()
+        return 0
+
+    api = SimpleNamespace(
+        CreateMutexW=lambda *_args: 55,
+        WaitForSingleObject=stalled_wait,
+        ReleaseMutex=lambda *_args: True,
+        CloseHandle=lambda *_args: True,
+    )
+    mutex = platform_adapter.Win32NamedMutex(
+        "Global\\test",
+        kernel32=api,
+        command_timeout_seconds=0.01,
+    )
+
+    with pytest.raises(TimeoutError, match="acquire"):
+        mutex.acquire()
+
+    assert entered.is_set()
+    resume.set()
+    assert finished.wait(timeout=1)
+    mutex._command_timeout_seconds = 1
+    mutex.close()
+
+
+def test_named_mutex_worker_death_fails_commands_and_close_is_idempotent():
+    api = SimpleNamespace(
+        CreateMutexW=lambda *_args: 55,
+        WaitForSingleObject=lambda *_args: (_ for _ in ()).throw(SystemExit()),
+        ReleaseMutex=lambda *_args: True,
+        CloseHandle=lambda *_args: True,
+    )
+    mutex = platform_adapter.Win32NamedMutex("Global\\test", kernel32=api)
+
+    with pytest.raises(RuntimeError, match="ownership thread stopped"):
+        mutex.acquire()
+    mutex._thread.join(timeout=1)
+    assert not mutex._thread.is_alive()
+
+    with pytest.raises(RuntimeError, match="ownership thread stopped"):
+        mutex.release()
+    with pytest.raises(RuntimeError, match="ownership thread stopped"):
+        mutex.close()
+    mutex.close()
+
+
+def test_process_inspector_uses_limited_query_and_closes_process_handle(
+    monkeypatch,
+):
+    calls = []
+
+    class Kernel32:
+        def OpenProcess(self, access, inherit, pid):
+            calls.append(("open", access, inherit, pid))
+            return 77
+
+        def GetProcessTimes(
+            self,
+            handle,
+            creation,
+            _exit_time,
+            _kernel_time,
+            _user_time,
+        ):
+            calls.append(("times", handle))
+            creation._obj.dwLowDateTime = 0x89ABCDEF
+            creation._obj.dwHighDateTime = 0x01234567
+            return True
+
+        def CloseHandle(self, handle):
+            calls.append(("close", handle))
+            return True
+
+    inspector = platform_adapter.Win32ProcessInspector(
+        kernel32=Kernel32(),
+        advapi32=object(),
+    )
+    monkeypatch.setattr(inspector, "_process_owner_sid", lambda handle: "S-1-test")
+
+    identity = inspector.inspect(4242)
+
+    assert identity == platform_adapter.ProcessIdentity(
+        4242,
+        "S-1-test",
+        0x0123456789ABCDEF,
+    )
+    assert calls == [
+        (
+            "open",
+            platform_adapter.Win32ProcessInspector.PROCESS_QUERY_LIMITED_INFORMATION,
+            False,
+            4242,
+        ),
+        ("times", 77),
+        ("close", 77),
+    ]
+
+
+def test_process_inspector_closes_handle_when_process_times_are_unavailable():
+    calls = []
+    kernel32 = SimpleNamespace(
+        OpenProcess=lambda *_args: 77,
+        GetProcessTimes=lambda *_args: False,
+        CloseHandle=lambda handle: calls.append(handle) or True,
+    )
+    inspector = platform_adapter.Win32ProcessInspector(
+        kernel32=kernel32,
+        advapi32=object(),
+    )
+
+    assert inspector.inspect(4242) is None
+    assert calls == [77]

--- a/tests/test_desktop_runtime_contract.py
+++ b/tests/test_desktop_runtime_contract.py
@@ -1,0 +1,62 @@
+"""Focused tests for the shared desktop runtime contract boundary."""
+
+from pathlib import Path
+
+import pytest
+
+from app import desktop_runtime_contract as contract
+
+TOKEN = "A" * 43
+
+
+def test_runtime_contract_round_trips_exact_environment_and_fields():
+    state = contract.RuntimeState.create(
+        pid=4242,
+        port=8765,
+        application_version="v1.2.3",
+        process_start_time=133700000,
+        instance_token=TOKEN,
+    )
+
+    assert contract.RuntimeState.from_environment(
+        state.export_environment()
+    ) == state
+    assert set(state.to_mapping()) == contract.RUNTIME_STATE_FIELDS
+    assert tuple(state.export_environment()) == (
+        contract.INSTANCE_TOKEN_ENV,
+        contract.INSTANCE_PID_ENV,
+        contract.INSTANCE_START_TIME_ENV,
+        contract.INSTANCE_VERSION_ENV,
+        contract.WEB_PORT_ENV,
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        (contract.INSTANCE_PID_ENV, "true"),
+        (contract.INSTANCE_START_TIME_ENV, "0"),
+        (contract.WEB_PORT_ENV, "65536"),
+        (contract.INSTANCE_VERSION_ENV, "bad\nversion"),
+        (contract.INSTANCE_TOKEN_ENV, "short"),
+    ],
+)
+def test_runtime_contract_rejects_invalid_environment(name, value):
+    env = contract.RuntimeState.create(
+        pid=4242,
+        port=8765,
+        application_version="v1.2.3",
+        process_start_time=133700000,
+        instance_token=TOKEN,
+    ).export_environment()
+    env[name] = value
+
+    with pytest.raises(ValueError):
+        contract.RuntimeState.from_environment(env)
+
+
+def test_shared_app_runtime_modules_never_import_packaging():
+    app_dir = Path(__file__).resolve().parents[1] / "app"
+
+    for name in ("desktop_runtime.py", "desktop_runtime_contract.py"):
+        assert "packaging" not in (app_dir / name).read_text(encoding="utf-8")

--- a/tests/test_main_lifecycle.py
+++ b/tests/test_main_lifecycle.py
@@ -1,0 +1,49 @@
+"""Focused lifecycle checks for the application entrypoint."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app import main
+
+
+def test_web_thread_exit_returns_normally_in_desktop_mode(monkeypatch):
+    calls = []
+    stopped_thread = SimpleNamespace(is_alive=lambda: False)
+    monkeypatch.setenv("DOCSIGHT_DESKTOP_MODE", "1")
+
+    main._wait_for_web_thread(
+        stopped_thread,
+        lambda: calls.append("stop_polling"),
+    )
+
+    assert calls == ["stop_polling"]
+
+
+def test_web_thread_exit_raises_after_stopping_polling_in_server_mode(monkeypatch):
+    calls = []
+    stopped_thread = SimpleNamespace(is_alive=lambda: False)
+    monkeypatch.delenv("DOCSIGHT_DESKTOP_MODE", raising=False)
+
+    with pytest.raises(RuntimeError, match="Web server stopped unexpectedly"):
+        main._wait_for_web_thread(
+            stopped_thread,
+            lambda: calls.append("stop_polling"),
+        )
+
+    assert calls == ["stop_polling"]
+
+
+def test_keyboard_shutdown_stops_polling_resources(monkeypatch):
+    calls = []
+    monkeypatch.delenv("DOCSIGHT_DESKTOP_MODE", raising=False)
+
+    def interrupted():
+        raise KeyboardInterrupt
+
+    main._wait_for_web_thread(
+        SimpleNamespace(is_alive=interrupted),
+        lambda: calls.append("stop_polling"),
+    )
+
+    assert calls == ["stop_polling"]

--- a/tests/test_windows_desktop_ci.py
+++ b/tests/test_windows_desktop_ci.py
@@ -14,6 +14,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "windows-desktop.yml"
 SMOKE_SCRIPT = ROOT / "packaging" / "windows" / "smoke_test.ps1"
+PYINSTALLER_SPEC = ROOT / "packaging" / "windows" / "docsight.spec"
 WINDOWS_README = ROOT / "packaging" / "windows" / "README.md"
 WINDOWS_QA_CHECKLIST = ROOT / "packaging" / "windows" / "QA-CHECKLIST.md"
 WINDOWS_PREVIEW_DOC = ROOT / "docs" / "windows-desktop-preview.md"
@@ -542,6 +543,43 @@ def test_smoke_script_launches_built_exe_and_checks_loopback_health():
     assert "python -m app.main" not in script
 
 
+def test_pyinstaller_collects_desktop_runtime_ownership_modules():
+    spec_text = PYINSTALLER_SPEC.read_text(encoding="utf-8")
+    launcher = (ROOT / "packaging" / "windows" / "docsight_desktop.py").read_text(
+        encoding="utf-8"
+    )
+    instance = (ROOT / "packaging" / "windows" / "desktop_instance.py").read_text(
+        encoding="utf-8"
+    )
+    platform = (ROOT / "packaging" / "windows" / "desktop_platform.py").read_text(
+        encoding="utf-8"
+    )
+    endpoint = (ROOT / "app" / "desktop_runtime.py").read_text(encoding="utf-8")
+
+    assert '"desktop_instance"' in spec_text
+    assert '"desktop_platform"' in spec_text
+    assert "from desktop_instance import" in launcher
+    assert "collect_app_hiddenimports()" in spec_text
+    assert (ROOT / "app" / "desktop_runtime.py").is_file()
+    assert (ROOT / "app" / "desktop_runtime_contract.py").is_file()
+    assert "from app.desktop_runtime_contract import" in instance
+    assert "from desktop_platform import" in instance
+    assert "desktop_instance" not in platform
+    assert "packaging" not in endpoint
+
+
+def test_launcher_normal_mainloop_exit_runs_runtime_cleanup():
+    launcher = (ROOT / "packaging" / "windows" / "docsight_desktop.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "root.mainloop()\n        try:\n            desktop_instance.cleanup()"
+        in launcher
+    )
+    assert "Runtime cleanup failed after launcher mainloop exit" in launcher
+
+
 def test_smoke_script_requires_one_owned_ipv4_loopback_listener():
     script = SMOKE_SCRIPT.read_text(encoding="utf-8")
 
@@ -549,8 +587,29 @@ def test_smoke_script_requires_one_owned_ipv4_loopback_listener():
     assert "$OwnedLoopbackListeners.Count -ne 1" in script
     assert '$_.LocalAddress -eq "127.0.0.1"' in script
     assert "$_.OwningProcess -eq $Process.Id" in script
-    assert "Expected exactly one listener on smoke port" in script
-    assert "Expected exactly one 127.0.0.1:$Port listener owned by DOCSight" in script
+    assert "Expected exactly one listener on runtime port" in script
+    assert "Expected exactly one 127.0.0.1:$RuntimePort listener owned by DOCSight" in script
+
+
+def test_smoke_script_executes_single_instance_runtime_handoff_scenarios():
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "[System.Net.Sockets.TcpListener]::new" in script
+    assert "$ForeignListener.Start()" in script
+    assert '$RuntimeStateFile = Join-Path $LocalAppData "DOCSight\\runtime.json"' in script
+    assert "$LaunchOne = Start-Process" in script
+    assert "$LaunchTwo = Start-Process" in script
+    assert "$ThirdProcess = Start-Process" in script
+    assert "did not hand off and exit" in script
+    assert "did not reuse the running desktop instance" in script
+    assert "adopted the foreign listener" in script
+    assert "outside 8765-8775" in script
+    assert "-BearerToken ([string]$RuntimeState.instance_token)" in script
+    assert "accepted the wrong instance token" in script
+    assert "$Process.StartTime.ToUniversalTime().ToFileTimeUtc()" in script
+    assert "process start time does not match" in script
+    assert "Second or third launch replaced" in script
+    assert "crash-leftover runtime record was not replaced" in script
 
 
 def test_smoke_script_prints_both_logs_and_rejects_runtime_import_degradation():
@@ -596,9 +655,9 @@ def test_smoke_script_uses_fresh_launcher_log_for_injected_recovery():
         )
     ]
 
-    assert len(launches) == 2
+    assert len(launches) == 4
     stop_first_process = script.index(
-        "Stop-Process -Id $Process.Id -Force", launches[0]
+        "Stop-Process -Id $Process.Id -Force", launches[2]
     )
     wait_for_first_process = script.index(
         "$FirstProcessStopped = $Process.WaitForExit(10000)", stop_first_process
@@ -606,17 +665,17 @@ def test_smoke_script_uses_fresh_launcher_log_for_injected_recovery():
     remove_first_log = script.index(
         "Remove-Item -LiteralPath $LauncherLogFile -Force", wait_for_first_process
     )
-    prepare_phase_assertion = script.index('"Phase: Prepare local data"', launches[1])
+    prepare_phase_assertion = script.index('"Phase: Prepare local data"', launches[3])
     assert (
         launches[0]
         < stop_first_process
         < wait_for_first_process
         < remove_first_log
-        < launches[1]
+        < launches[3]
     )
-    assert launches[1] < prepare_phase_assertion
-    assert launches[1] < script.index("$Process.MainWindowHandle", launches[1])
-    assert launches[1] < script.index("$Process.MainWindowTitle", launches[1])
+    assert launches[3] < prepare_phase_assertion
+    assert launches[3] < script.index("$Process.MainWindowHandle", launches[3])
+    assert launches[3] < script.index("$Process.MainWindowTitle", launches[3])
 
 
 def test_smoke_script_restores_all_injection_environment_variables():
@@ -645,6 +704,7 @@ def test_windows_docs_describe_smoke_and_log_sharing_contracts():
     qa_checklist = WINDOWS_QA_CHECKLIST.read_text(encoding="utf-8")
     preview_doc = WINDOWS_PREVIEW_DOC.read_text(encoding="utf-8")
     combined_docs = "\n".join((readme, qa_checklist, preview_doc))
+    normalized_docs = " ".join(combined_docs.split())
 
     assert "from **Start DOCSight** onward" in readme
     assert "from **Start DOCSight** onward" in qa_checklist
@@ -659,6 +719,18 @@ def test_windows_docs_describe_smoke_and_log_sharing_contracts():
     assert "review it before sharing" in combined_docs
     assert "Linux tests only enforce its\nstatic contract" in preview_doc
     assert "runs later on `windows-latest`" in preview_doc
+    assert "`Global\\` namespace" in combined_docs
+    assert "current user's SID" in combined_docs
+    assert "independent process-token SID lookup" in normalized_docs
+    assert "both SID lookups fail, startup fails safely" in normalized_docs
+    assert "mutex name always remains SID-derived" in normalized_docs
+    assert "Different Windows users" in combined_docs
+    assert "process creation time" in combined_docs
+    assert "token-authenticated" in combined_docs
+    assert "second/third-launch handoff" in combined_docs
+    assert "ordinary `/health`" in combined_docs
+    assert "`127.0.0.1`" in combined_docs
+    assert "must not run alongside another DOCSight desktop instance" in readme
 
 
 def test_windows_qa_keeps_all_precise_failure_injection_invocations():

--- a/tests/web/test_desktop_runtime.py
+++ b/tests/web/test_desktop_runtime.py
@@ -1,0 +1,120 @@
+"""Desktop runtime endpoint mode, loopback, and token policy."""
+
+from __future__ import annotations
+
+TOKEN = "A" * 43
+RUNTIME_ENV = {
+    "DOCSIGHT_DESKTOP_MODE": "1",
+    "DOCSIGHT_DESKTOP_INSTANCE_TOKEN": TOKEN,
+    "DOCSIGHT_DESKTOP_INSTANCE_PID": "4242",
+    "DOCSIGHT_DESKTOP_PROCESS_START_TIME": "133700000",
+    "DOCSIGHT_DESKTOP_APP_VERSION": "v1.2.3",
+    "WEB_PORT": "8765",
+}
+
+
+def set_runtime_environment(monkeypatch):
+    for key, value in RUNTIME_ENV.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_desktop_runtime_endpoint_is_unavailable_outside_desktop_mode(
+    client,
+    monkeypatch,
+):
+    for key in RUNTIME_ENV:
+        monkeypatch.delenv(key, raising=False)
+
+    response = client.get(
+        "/desktop-runtime",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_desktop_runtime_endpoint_rejects_non_loopback_client(client, monkeypatch):
+    set_runtime_environment(monkeypatch)
+
+    response = client.get(
+        "/desktop-runtime",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+        environ_base={"REMOTE_ADDR": "192.0.2.10"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_desktop_runtime_endpoint_rejects_missing_or_wrong_token(
+    client,
+    monkeypatch,
+):
+    set_runtime_environment(monkeypatch)
+
+    assert client.get("/desktop-runtime").status_code == 404
+    assert client.get(
+        "/desktop-runtime",
+        headers={"Authorization": f"Bearer {'B' * 43}"},
+    ).status_code == 404
+
+
+def test_desktop_runtime_endpoint_rejects_non_ascii_authorization(
+    client,
+    monkeypatch,
+):
+    set_runtime_environment(monkeypatch)
+
+    response = client.get(
+        "/desktop-runtime",
+        headers={"Authorization": "Bearer \N{SNOWMAN}"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_desktop_runtime_endpoint_returns_exact_identity_on_loopback(
+    client,
+    monkeypatch,
+):
+    set_runtime_environment(monkeypatch)
+
+    response = client.get(
+        "/desktop-runtime",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+        environ_base={"REMOTE_ADDR": "::1"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "ok",
+        "schema_version": 1,
+        "pid": 4242,
+        "port": 8765,
+        "application_version": "v1.2.3",
+        "process_start_time": 133700000,
+        "instance_token": TOKEN,
+    }
+
+
+def test_desktop_runtime_endpoint_rejects_malformed_process_contract(
+    client,
+    monkeypatch,
+):
+    set_runtime_environment(monkeypatch)
+    monkeypatch.setenv("DOCSIGHT_DESKTOP_INSTANCE_PID", "true")
+
+    response = client.get(
+        "/desktop-runtime",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_ordinary_health_does_not_expose_desktop_token(client, monkeypatch):
+    set_runtime_environment(monkeypatch)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert "instance_token" not in response.get_json()

--- a/tests/web/test_route_auth_coverage.py
+++ b/tests/web/test_route_auth_coverage.py
@@ -14,6 +14,7 @@ from app.web import app, init_config, init_storage
 # routes must make an explicit choice: require authentication or extend this
 # allowlist with a product reason.
 PUBLIC_ENDPOINT_METHODS = {
+    "desktop_runtime": {"GET"},  # desktop-mode loopback token authentication
     "health": {"GET"},  # container/runtime health probe
     "metrics_bp.metrics": {"GET"},  # Prometheus scrape endpoint
     "login": {"GET", "POST"},  # authentication entrypoint
@@ -135,6 +136,7 @@ def test_public_route_allowlist_matches_current_route_surface():
     )
 
     assert public_rules == [
+        ("desktop_runtime", "/desktop-runtime", ("GET",)),
         ("health", "/health", ("GET",)),
         ("login", "/login", ("GET", "POST")),
         ("metrics_bp.metrics", "/metrics", ("GET",)),


### PR DESCRIPTION
## Summary

- reuse one authenticated DOCSight desktop runtime per Windows user, including across interactive sessions
- validate the existing process by owner SID, creation time, exact runtime schema, and per-run token before handoff
- isolate the shared runtime contract, Windows platform primitives, and owner/follower coordination behind focused module boundaries
- recover stale state, occupied ports, and one bind race without adopting foreign listeners
- extend the packaged Windows smoke and manual QA contract for parallel launches and clean shutdown

## Verification

- `python -m pytest -q tests/test_desktop_instance.py tests/test_desktop_platform.py tests/test_desktop_runtime_contract.py tests/test_main_lifecycle.py tests/web/test_desktop_runtime.py tests/test_desktop_entrypoint.py tests/test_windows_desktop_ci.py`
  - 191 passed, 1 skipped
- `python -m pytest -q --ignore=tests/e2e`
  - 3218 passed, 2 skipped
- focused Ruff checks for new modules and tests
- Python compile checks for changed runtime and launcher modules
- `git diff --check`

The pull-request Windows workflow builds the portable artifact and runs the process-level package smoke on `windows-latest`.
