### PR TITLE
Fix Connection Monitor KPI formatting

### DIFF
--- a/app/modules/connection_monitor/static/js/connection-monitor-card.js
+++ b/app/modules/connection_monitor/static/js/connection-monitor-card.js
@@ -133,13 +133,14 @@
                 var stats = collectStats(enabled);
 
                 if (stats.avgLatency != null) {
-                    setText(elements.latency, fmtNumber(stats.avgLatency, 1) + ' ms ' + translate('metric_average_label', 'avg').toLowerCase());
+                    setText(elements.latency, fmtNumber(stats.avgLatency, 1));
+                    appendText(elements.latency, 'ms', 'unit');
                 } else {
                     setText(elements.latency, '–');
                 }
                 if (elements.latency) elements.latency.style.color = 'var(--' + health.key + ')';
 
-                setText(elements.avg, ok.length + '/' + enabled.length + ' OK');
+                setText(elements.avg, translate('metric_average_label', 'Avg') + ' · ' + ok.length + '/' + enabled.length + ' OK');
                 setText(elements.badge, health.badge);
                 if (elements.badge) elements.badge.className = 'badge badge-' + health.key;
 

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v77';
+var CACHE_VERSION = 'v78';
 var SHELL_CACHE = 'docsight-shell-' + CACHE_VERSION;
 var STATIC_CACHE = 'docsight-static-' + CACHE_VERSION;
 var OFFLINE_SHELL_HEADERS = {

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -3,6 +3,7 @@
 import re
 
 import pytest
+from playwright.sync_api import expect
 
 
 class TestDashboardLoad:
@@ -261,6 +262,59 @@ class TestDashboardSections:
         assert card.count() == 1
         assert card.get_attribute("role") == "button"
         assert card.get_attribute("tabindex") == "0"
+
+    def test_enabled_connection_monitor_card_uses_standard_kpi_anatomy(self, demo_page):
+        demo_page.route(
+            "**/api/connection-monitor/summary",
+            lambda route: route.fulfill(
+                json={
+                    "1": {
+                        "label": "Cloudflare",
+                        "host": "1.1.1.1",
+                        "enabled": True,
+                        "avg_latency_ms": 39.9,
+                        "min_latency_ms": 37.2,
+                        "max_latency_ms": 43.6,
+                        "packet_loss_pct": 0,
+                    }
+                }
+            ),
+        )
+        demo_page.reload(wait_until="networkidle")
+
+        latency = demo_page.locator("#cm-card-latency")
+        average = demo_page.locator("#cm-card-avg")
+        badge = demo_page.locator("#cm-card-badge")
+        expect(average).to_have_text("Avg · 1/1 OK")
+
+        assert latency.text_content() == "39.9ms"
+        assert latency.locator(":scope > .unit").count() == 1
+        assert latency.locator(":scope > .unit").text_content() == "ms"
+        assert "Avg" not in latency.text_content()
+        assert average.text_content() == "Avg · 1/1 OK"
+        assert badge.text_content() == "Good"
+
+        structure = demo_page.evaluate(
+            """
+            () => {
+                const latency = document.querySelector('#cm-card-latency');
+                const average = document.querySelector('#cm-card-avg');
+                const averageRow = average && average.closest('.metric-average-row');
+                return {
+                    primaryText: latency && latency.firstChild && latency.firstChild.nodeValue,
+                    unitParentIsPrimary: latency && latency.querySelector(':scope > .unit')?.parentElement === latency,
+                    averageParentIsSecondaryRow: averageRow?.contains(average) === true,
+                    primaryContainsAverage: latency?.contains(average) === true,
+                };
+            }
+            """
+        )
+        assert structure == {
+            "primaryText": "39.9",
+            "unitParentIsPrimary": True,
+            "averageParentIsSecondaryRow": True,
+            "primaryContainsAverage": False,
+        }
 
     def test_disabled_connection_monitor_card_shows_no_data_state(self, demo_page):
         status = demo_page.locator("#cm-card-latency")


### PR DESCRIPTION
## Summary
- render Connection Monitor latency with the shared KPI unit treatment
- move the localized average label into the standard secondary row
- cover the enabled card structure with a Playwright regression test
- refresh the service-worker cache version for the updated module asset

## Testing
- `tests/e2e/test_dashboard.py`: 26 passed
- static and PWA contract tests: 26 passed
- non-E2E suite: 3258 passed, 2 skipped
- visual browser check: no wrapping, overlap, or console errors

Fixes #765
