### PR TITLE
Add Netgear CM1000 modem support

### DIFF
--- a/.github/ISSUE_TEMPLATE/modem_support.yml
+++ b/.github/ISSUE_TEMPLATE/modem_support.yml
@@ -27,7 +27,7 @@ body:
     attributes:
       label: "Model Number"
       description: "Full model number (check the label on the device)"
-      placeholder: "e.g., Arris TG3442DE, Netgear CM1000"
+      placeholder: "e.g., Arris TG3442DE, Motorola MB8611"
     validations:
       required: true
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -408,6 +408,7 @@ class ModemDriver(ABC):
 | `cm3500` | `cm3500.py` | Arris CM3500B | Form POST (IP-based session) |
 | `connectbox` | `connectbox.py` | Unitymedia Connect Box (CH7465) | Session cookie |
 | `vodafone_station` | `vodafone_station.py` | CGA6444VF, CGA4322DE, TG3442DE | Auto-detected (see below) |
+| `cm1000` | `cm1000.py` | Netgear CM1000 | HTTP Basic or local Genie form |
 | `cm3000` | `cm3000.py` | Netgear CM3000 | HTTP Basic Auth |
 | `surfboard` | `surfboard.py` | Arris SURFboard S33/S34/SB8200 | HNAP1 HMAC-SHA256 |
 | `sb6183` | `sb6183.py` | Arris SB6183 | None (HTTP status pages) |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 </p>
 
 <p align="center">
-  <strong>Self-hosted</strong> • <strong>Local data</strong> • <strong>Demo</strong> • <strong>Reports</strong> • <strong>19 modem families</strong> • <strong>MIT</strong>
+  <strong>Self-hosted</strong> • <strong>Local data</strong> • <strong>Demo</strong> • <strong>Reports</strong> • <strong>20 modem families</strong> • <strong>MIT</strong>
 </p>
 
 <p align="center">
@@ -281,7 +281,7 @@ More views from the product:
 
 ## Supported Hardware
 
-DOCSight supports **19 modem families** out of the box and also offers **Generic Router mode** for fiber, DSL, and satellite connections.
+DOCSight supports **20 modem families** out of the box and also offers **Generic Router mode** for fiber, DSL, and satellite connections.
 
 ### Common setups
 
@@ -296,6 +296,7 @@ DOCSight supports **19 modem families** out of the box and also offers **Generic
 - **Arris SB6183:** HTTP status pages, no authentication required
 - **Hitron CODA-56 and CODA-4680**
 - **Netgear CM3000**
+- **Netgear CM1000**
 - **Generic Router mode:** no DOCSIS signal pages, but still supports speed tracking, latency monitoring, incident logging, reports, and modules
 
 [See the full compatibility and setup docs in the wiki →](https://github.com/itsDNNS/docsight/wiki)

--- a/app/drivers/__init__.py
+++ b/app/drivers/__init__.py
@@ -20,6 +20,8 @@ driver_registry.register_builtin("ch7465_play", "app.drivers.ch7465.CH7465Driver
                                  init_kwargs={"play_firmware": True})
 driver_registry.register_builtin("cm3000", "app.drivers.cm3000.CM3000Driver", "Netgear CM3000",
                                  hints={"default_url": "http://192.168.100.1", "default_user": "admin"})
+driver_registry.register_builtin("cm1000", "app.drivers.cm1000.CM1000Driver", "Netgear CM1000",
+                                 hints={"default_url": "http://192.168.100.1", "default_user": "admin"})
 driver_registry.register_builtin("cm3500", "app.drivers.cm3500.CM3500Driver", "Arris CM3500B",
                                  hints={"default_url": "https://192.168.100.1", "default_user": "admin"})
 driver_registry.register_builtin("surfboard", "app.drivers.surfboard.SurfboardDriver",

--- a/app/drivers/cm1000.py
+++ b/app/drivers/cm1000.py
@@ -1,0 +1,432 @@
+"""Netgear CM1000 driver for DOCSight.
+
+The CM1000 exposes server-rendered DOCSIS channel tables on
+``/DocsisStatus.asp``. Firmware variants use either HTTP Basic auth or a
+Netgear Genie form login with a per-page ``webToken``. The driver supports
+both authentication styles and maps table columns by header name so layouts
+with or without an ``Unerrored Codewords`` column are handled correctly.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+from .base import ModemDriver
+from .utils import hz_to_mhz, normalize_modulation
+from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
+
+log = logging.getLogger("docsis.driver.cm1000")
+
+_STATUS_PATH = "/DocsisStatus.asp"
+_LOGIN_PATH = "/GenieLogin.asp"
+_LOGIN_ACTION = "/goform/GenieLogin"
+_TABLE_IDS = ("dsTable", "usTable", "d31dsTable", "d31usTable")
+_NUMBER_RE = re.compile(r"[-+]?\d+(?:\.\d+)?")
+_HEADER_RE = re.compile(r"[^a-z0-9]+")
+
+# CM1000 downstream SC-QAM channels use the North American 6 MHz
+# ITU-T J.83 Annex B profiles. The modem status page does not expose symbol
+# rate, so provide the standardized kSym/s value for DOCSight capacity math.
+_ANNEX_B_DOWNSTREAM_SYMBOL_RATES = {
+    "64QAM": 5057,
+    "256QAM": 5361,
+}
+
+_ALIASES = {
+    "channel": {"channel", "channelnumber", "channelno"},
+    "lock": {"lockstatus", "status"},
+    "modulation": {
+        "modulation",
+        "channeltype",
+        "uschanneltype",
+        "profile",
+        "profiles",
+        "profileid",
+        "profileids",
+        "profilemodulation",
+    },
+    "channel_id": {"channelid", "id"},
+    "frequency": {"frequency", "frequencyhz"},
+    "power": {"power", "powerlevel", "powerdbmv"},
+    "snr": {"snr", "mer", "snrmer"},
+    "symbol_rate": {"symbolrate", "symbolrateksymsec"},
+    "corr": {
+        "correctables",
+        "correctable",
+        "correctablecodewords",
+        "corrected",
+        "correctedcodewords",
+    },
+    "uncorr": {
+        "uncorrectables",
+        "uncorrectable",
+        "uncorrectablecodewords",
+        "uncorrected",
+        "uncorrectedcodewords",
+    },
+}
+
+
+class CM1000Driver(ModemDriver):
+    """Driver for the Netgear CM1000 DOCSIS 3.1 cable modem."""
+
+    def __init__(self, url: str, user: str, password: str):
+        super().__init__(url.rstrip("/"), user, password)
+        self._session = self._new_session()
+        self._status_html: str | None = None
+
+    def _new_session(self) -> requests.Session:
+        session = requests.Session()
+        session.auth = (self._user, self._password)
+        return session
+
+    def login(self) -> None:
+        """Authenticate and cache a validated ``DocsisStatus.asp`` page.
+
+        A direct Basic-auth request is attempted first because some CM1000
+        firmware exposes the page that way. If it does not return a status
+        page, the driver performs the Genie token/form login and retries.
+        """
+        self._status_html = None
+        for attempt in range(2):
+            try:
+                direct = self._session.get(self._url + _STATUS_PATH, timeout=30)
+                if direct.status_code == 200 and self._is_status_page(direct.text):
+                    self._status_html = direct.text
+                    log.info("CM1000 auth OK via direct status access")
+                    return
+
+                # A 401/403 or a 200 login wrapper is expected on form-login
+                # firmware. Other HTTP errors should still be surfaced.
+                if direct.status_code not in (200, 401, 403):
+                    direct.raise_for_status()
+
+                # Do not send a stale/preemptive Basic Authorization header to
+                # the form-login firmware. The authenticated cookie established
+                # below is sufficient for the status-page request.
+                self._session.auth = None
+                self._login_via_form()
+                status = self._session.get(self._url + _STATUS_PATH, timeout=30)
+                status.raise_for_status()
+                self._ensure_status_page(status.text)
+                self._status_html = status.text
+                log.info("CM1000 auth OK via Genie form login")
+                return
+            except requests.ConnectionError as exc:
+                if attempt == 0:
+                    log.warning("CM1000 connection lost, retrying with fresh session")
+                    self._session.close()
+                    self._session = self._new_session()
+                    continue
+                raise RuntimeError(
+                    "CM1000 authentication failed: connection refused after retry"
+                ) from exc
+            except requests.RequestException as exc:
+                raise RuntimeError(f"CM1000 authentication failed: {exc}") from exc
+            except RuntimeError:
+                raise
+
+    def get_docsis_data(self) -> DocsisData:
+        html = self._fetch_status_page()
+        soup = BeautifulSoup(html, "html.parser")
+
+        ds30 = self._parse_downstream_table(soup, "dsTable", docsis31=False)
+        us30 = self._parse_upstream_table(soup, "usTable", docsis31=False)
+        ds31 = self._parse_downstream_table(soup, "d31dsTable", docsis31=True)
+        us31 = self._parse_upstream_table(soup, "d31usTable", docsis31=True)
+
+        if not any((ds30, us30, ds31, us31)):
+            log.warning("CM1000 parsed 0 locked channels from DocsisStatus.asp")
+
+        return {
+            "channelDs": {"docsis30": ds30, "docsis31": ds31},
+            "channelUs": {"docsis30": us30, "docsis31": us31},
+        }
+
+    def get_device_info(self) -> DeviceInfo:
+        return {"manufacturer": "Netgear", "model": "CM1000", "sw_version": ""}
+
+    def get_connection_info(self) -> ConnectionInfo:
+        return {}
+
+    def _fetch_status_page(self) -> str:
+        if self._status_html is not None:
+            return self._status_html
+        try:
+            response = self._session.get(self._url + _STATUS_PATH, timeout=30)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise RuntimeError(f"CM1000 status page retrieval failed: {exc}") from exc
+        self._ensure_status_page(response.text)
+        return response.text
+
+    def _login_via_form(self) -> None:
+        login_url = self._url + _LOGIN_PATH
+        response = self._session.get(login_url, timeout=30)
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        form = soup.find("form", action=re.compile(r"GenieLogin", re.IGNORECASE))
+        if form is None:
+            form = soup.find("form")
+        if form is None:
+            raise RuntimeError("CM1000 login page did not contain a login form")
+
+        payload: dict[str, str] = {}
+        for field in form.find_all("input"):
+            name = field.get("name")
+            if not name:
+                continue
+            field_type = str(field.get("type", "")).lower()
+            if field_type in {"submit", "button", "image"}:
+                continue
+            payload[str(name)] = str(field.get("value", ""))
+
+        # A few firmware revisions render webToken outside the form. Preserve
+        # it when present so the same login path covers both page variants.
+        if "webToken" not in payload:
+            token = soup.find("input", attrs={"name": "webToken"})
+            if token is not None:
+                payload["webToken"] = str(token.get("value", ""))
+
+        payload["loginUsername"] = self._user
+        payload["loginPassword"] = self._password
+        payload.setdefault("login", "1")
+
+        action = str(form.get("action") or _LOGIN_ACTION)
+        post_url = urljoin(self._url + "/", action.lstrip("/"))
+        submit = self._session.post(post_url, data=payload, timeout=30)
+        submit.raise_for_status()
+
+    @staticmethod
+    def _is_status_page(html: str) -> bool:
+        if not html:
+            return False
+        soup = BeautifulSoup(html, "html.parser")
+        return any(soup.find("table", id=table_id) is not None for table_id in _TABLE_IDS)
+
+    @staticmethod
+    def _ensure_status_page(html: str) -> None:
+        if not html:
+            raise RuntimeError("CM1000 returned an empty status page")
+        if not CM1000Driver._is_status_page(html):
+            raise RuntimeError(
+                "CM1000 authentication failed: modem did not return DocsisStatus.asp"
+            )
+
+    @staticmethod
+    def _normalize_header(value: str) -> str:
+        return _HEADER_RE.sub("", value.lower())
+
+    @classmethod
+    def _table_rows(cls, soup: BeautifulSoup, table_id: str) -> list[dict[str, str]]:
+        table = soup.find("table", id=table_id)
+        if table is None:
+            return []
+
+        headers: list[str] = []
+        result: list[dict[str, str]] = []
+        for row in table.find_all("tr"):
+            cells = row.find_all(["th", "td"], recursive=False)
+            if not cells:
+                cells = row.find_all(["th", "td"])
+            values = [cell.get_text(" ", strip=True) for cell in cells]
+            if not values:
+                continue
+
+            normalized = [cls._normalize_header(value) for value in values]
+            if not headers and cls._looks_like_header(normalized):
+                headers = normalized
+                continue
+
+            if headers:
+                # Ignore malformed/placeholder rows rather than shifting cells.
+                if len(values) < len(headers):
+                    continue
+                result.append(dict(zip(headers, values)))
+            else:
+                result.append({str(index): value for index, value in enumerate(values)})
+        return result
+
+    @staticmethod
+    def _looks_like_header(values: list[str]) -> bool:
+        known = set().union(*_ALIASES.values())
+        return "channel" in values and any(value in known for value in values[1:])
+
+    @staticmethod
+    def _get(row: dict[str, str], field: str, default: str = "") -> str:
+        for alias in _ALIASES[field]:
+            if alias in row:
+                return row[alias]
+        return default
+
+    @classmethod
+    def _is_locked(cls, row: dict[str, str]) -> bool:
+        status = cls._get(row, "lock")
+        if not status and "1" in row:
+            status = row["1"]
+        return status.strip().lower() == "locked"
+
+    @classmethod
+    def _channel_id(cls, row: dict[str, str]) -> int | None:
+        value = cls._get(row, "channel_id")
+        if not value:
+            value = cls._get(row, "channel") or row.get("0", "")
+        return cls._parse_int(value)
+
+    @classmethod
+    def _parse_downstream_table(
+        cls, soup: BeautifulSoup, table_id: str, *, docsis31: bool
+    ) -> list[RawChannel]:
+        result: list[RawChannel] = []
+        for row in cls._table_rows(soup, table_id):
+            if not cls._is_locked(row):
+                continue
+
+            positional = not any(key.isalpha() for key in row)
+            if positional:
+                row = cls._map_downstream_positional(row)
+
+            channel_id = cls._channel_id(row)
+            if channel_id is None:
+                continue
+            frequency = cls._get(row, "frequency")
+            power = cls._parse_float(cls._get(row, "power"))
+            snr = cls._parse_float(cls._get(row, "snr"))
+            modulation_raw = cls._get(row, "modulation")
+            corr = cls._parse_int(cls._get(row, "corr"))
+            uncorr = cls._parse_int(cls._get(row, "uncorr"))
+
+            if docsis31:
+                channel: RawChannel = {
+                    "channelID": channel_id,
+                    "type": "OFDM",
+                    "frequency": hz_to_mhz(frequency),
+                    "powerLevel": power,
+                    "mer": snr,
+                    "mse": None,
+                    "modulation": "OFDM",
+                    "corrErrors": corr,
+                    "nonCorrErrors": uncorr,
+                }
+            else:
+                modulation = normalize_modulation(modulation_raw)
+                channel = {
+                    "channelID": channel_id,
+                    "frequency": hz_to_mhz(frequency),
+                    "powerLevel": power,
+                    "mer": snr,
+                    "mse": -snr if snr is not None else None,
+                    "modulation": modulation,
+                    "corrErrors": corr,
+                    "nonCorrErrors": uncorr,
+                }
+                symbol_rate = _ANNEX_B_DOWNSTREAM_SYMBOL_RATES.get(modulation)
+                if symbol_rate is not None:
+                    channel["symbolRate"] = symbol_rate
+            result.append(channel)
+        return result
+
+    @classmethod
+    def _parse_upstream_table(
+        cls, soup: BeautifulSoup, table_id: str, *, docsis31: bool
+    ) -> list[RawChannel]:
+        result: list[RawChannel] = []
+        for row in cls._table_rows(soup, table_id):
+            if not cls._is_locked(row):
+                continue
+
+            positional = not any(key.isalpha() for key in row)
+            if positional:
+                row = cls._map_upstream_positional(row)
+
+            channel_id = cls._channel_id(row)
+            if channel_id is None:
+                continue
+            frequency = cls._get(row, "frequency")
+            power = cls._parse_float(cls._get(row, "power"))
+            modulation_raw = cls._get(row, "modulation")
+            modulation = normalize_modulation(modulation_raw)
+
+            if docsis31:
+                channel: RawChannel = {
+                    "channelID": channel_id,
+                    "type": "OFDMA",
+                    "frequency": hz_to_mhz(frequency),
+                    "powerLevel": power,
+                    "modulation": "OFDMA",
+                    "multiplex": "",
+                }
+            else:
+                channel = {
+                    "channelID": channel_id,
+                    "frequency": hz_to_mhz(frequency),
+                    "powerLevel": power,
+                    "modulation": modulation,
+                    "multiplex": modulation,
+                }
+                symbol_rate = cls._parse_int(cls._get(row, "symbol_rate"))
+                if symbol_rate is not None:
+                    channel["symbolRate"] = symbol_rate
+            result.append(channel)
+        return result
+
+    @classmethod
+    def _map_downstream_positional(cls, row: dict[str, str]) -> dict[str, str]:
+        values = [row[str(index)] for index in range(len(row))]
+        if len(values) < 9:
+            return row
+        mapped = {
+            "channel": values[0],
+            "lockstatus": values[1],
+            "modulation": values[2],
+            "channelid": values[3],
+            "frequency": values[4],
+            "power": values[5],
+            "snr": values[6],
+        }
+        # Ten/eleven-column layouts include Unerrored before Correctables.
+        if len(values) >= 10:
+            mapped["correctables"] = values[-2]
+            mapped["uncorrectables"] = values[-1]
+        else:
+            mapped["correctables"] = values[7]
+            mapped["uncorrectables"] = values[8]
+        return mapped
+
+    @staticmethod
+    def _map_upstream_positional(row: dict[str, str]) -> dict[str, str]:
+        values = [row[str(index)] for index in range(len(row))]
+        if len(values) < 6:
+            return row
+        mapped = {
+            "channel": values[0],
+            "lockstatus": values[1],
+            "modulation": values[2],
+            "channelid": values[3],
+        }
+        if len(values) >= 7:
+            mapped["symbolrate"] = values[4]
+            mapped["frequency"] = values[5]
+            mapped["power"] = values[6]
+        else:
+            mapped["frequency"] = values[4]
+            mapped["power"] = values[5]
+        return mapped
+
+    @staticmethod
+    def _parse_float(value: str) -> float | None:
+        if not value:
+            return None
+        match = _NUMBER_RE.search(value.replace(",", ""))
+        return float(match.group(0)) if match else None
+
+    @classmethod
+    def _parse_int(cls, value: str) -> int | None:
+        number = cls._parse_float(value)
+        return int(number) if number is not None else None

--- a/app/drivers/cm1000.py
+++ b/app/drivers/cm1000.py
@@ -1,24 +1,23 @@
 """Netgear CM1000 driver for DOCSight.
 
-The CM1000 exposes server-rendered DOCSIS channel tables on
-``/DocsisStatus.asp``. Firmware variants use either HTTP Basic auth or a
-Netgear Genie form login with a per-page ``webToken``. The driver supports
-both authentication styles and maps table columns by header name so layouts
-with or without an ``Unerrored Codewords`` column are handled correctly.
+The CM1000 exposes DOCSIS channel data on ``/DocsisStatus.asp``. Firmware
+variants use either pipe-delimited JavaScript values or server-rendered
+tables, and authenticate with HTTP Basic auth or a Netgear Genie form login
+with a per-page ``webToken``. Table columns are mapped by header name so
+layouts with or without an ``Unerrored Codewords`` column remain compatible.
 """
 
 from __future__ import annotations
 
 import logging
 import re
-from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
 
+from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
 from .base import ModemDriver
 from .utils import hz_to_mhz, normalize_modulation
-from ..types import ConnectionInfo, DeviceInfo, DocsisData, RawChannel
 
 log = logging.getLogger("docsis.driver.cm1000")
 
@@ -28,6 +27,17 @@ _LOGIN_ACTION = "/goform/GenieLogin"
 _TABLE_IDS = ("dsTable", "usTable", "d31dsTable", "d31usTable")
 _NUMBER_RE = re.compile(r"[-+]?\d+(?:\.\d+)?")
 _HEADER_RE = re.compile(r"[^a-z0-9]+")
+_FUNCTION_START_RE = re.compile(r"function\s+(?P<name>\w+)\s*\(\)\s*\{")
+_TAG_VALUE_ASSIGNMENT_RE = re.compile(
+    r"\bvar\s+tagValueList\s*=\s*(?P<value>.*?);", re.DOTALL
+)
+_STRING_LITERAL_RE = re.compile(
+    r"'(?P<single>(?:\\.|[^'\\])*)'|\"(?P<double>(?:\\.|[^\"\\])*)\"",
+    re.DOTALL,
+)
+_DS_TAG_VALUE_FUNCTION = "InitDsTableTagValue"
+_US_TAG_VALUE_FUNCTION = "InitUsTableTagValue"
+_TAG_VALUE_FIELDS_PER_ROW = 7
 
 # CM1000 downstream SC-QAM channels use the North American 6 MHz
 # ITU-T J.83 Annex B profiles. The modem status page does not expose symbol
@@ -128,15 +138,23 @@ class CM1000Driver(ModemDriver):
                 ) from exc
             except requests.RequestException as exc:
                 raise RuntimeError(f"CM1000 authentication failed: {exc}") from exc
-            except RuntimeError:
-                raise
 
     def get_docsis_data(self) -> DocsisData:
         html = self._fetch_status_page()
         soup = BeautifulSoup(html, "html.parser")
 
-        ds30 = self._parse_downstream_table(soup, "dsTable", docsis31=False)
-        us30 = self._parse_upstream_table(soup, "usTable", docsis31=False)
+        ds_tag_values = self._extract_tag_value_list(html, _DS_TAG_VALUE_FUNCTION)
+        if ds_tag_values is not None:
+            ds30 = self._parse_downstream_tag_values(ds_tag_values)
+        else:
+            ds30 = self._parse_downstream_table(soup, "dsTable", docsis31=False)
+
+        us_tag_values = self._extract_tag_value_list(html, _US_TAG_VALUE_FUNCTION)
+        if us_tag_values is not None:
+            us30 = self._parse_upstream_tag_values(us_tag_values)
+        else:
+            us30 = self._parse_upstream_table(soup, "usTable", docsis31=False)
+
         ds31 = self._parse_downstream_table(soup, "d31dsTable", docsis31=True)
         us31 = self._parse_upstream_table(soup, "d31usTable", docsis31=True)
 
@@ -198,9 +216,10 @@ class CM1000Driver(ModemDriver):
         payload["loginPassword"] = self._password
         payload.setdefault("login", "1")
 
-        action = str(form.get("action") or _LOGIN_ACTION)
-        post_url = urljoin(self._url + "/", action.lstrip("/"))
-        submit = self._session.post(post_url, data=payload, timeout=30)
+        post_url = self._url + _LOGIN_ACTION
+        submit = self._session.post(
+            post_url, data=payload, timeout=30, allow_redirects=False
+        )
         submit.raise_for_status()
 
     @staticmethod
@@ -208,7 +227,12 @@ class CM1000Driver(ModemDriver):
         if not html:
             return False
         soup = BeautifulSoup(html, "html.parser")
-        return any(soup.find("table", id=table_id) is not None for table_id in _TABLE_IDS)
+        if any(soup.find("table", id=table_id) is not None for table_id in _TABLE_IDS):
+            return True
+        return any(
+            CM1000Driver._extract_tag_value_list(html, function_name) is not None
+            for function_name in (_DS_TAG_VALUE_FUNCTION, _US_TAG_VALUE_FUNCTION)
+        )
 
     @staticmethod
     def _ensure_status_page(html: str) -> None:
@@ -278,6 +302,184 @@ class CM1000Driver(ModemDriver):
         if not value:
             value = cls._get(row, "channel") or row.get("0", "")
         return cls._parse_int(value)
+
+    @classmethod
+    def _parse_downstream_tag_values(cls, raw: str) -> list[RawChannel]:
+        """Parse seven-field DOCSIS 3.0 downstream JavaScript rows."""
+        rows = cls._split_tag_value_rows(raw)
+        if rows is None:
+            return []
+
+        result: list[RawChannel] = []
+        for row in rows:
+            if row[1].strip().lower() != "locked":
+                continue
+
+            channel_id = cls._parse_int(row[3])
+            if channel_id is None:
+                continue
+            snr = cls._parse_float(row[6])
+            modulation = normalize_modulation(row[2])
+            channel: RawChannel = {
+                "channelID": channel_id,
+                "frequency": hz_to_mhz(row[4]),
+                "powerLevel": cls._parse_float(row[5]),
+                "mer": snr,
+                "mse": -snr if snr is not None else None,
+                "modulation": modulation,
+                "corrErrors": None,
+                "nonCorrErrors": None,
+            }
+            symbol_rate = _ANNEX_B_DOWNSTREAM_SYMBOL_RATES.get(modulation)
+            if symbol_rate is not None:
+                channel["symbolRate"] = symbol_rate
+            result.append(channel)
+        return result
+
+    @classmethod
+    def _parse_upstream_tag_values(cls, raw: str) -> list[RawChannel]:
+        """Parse seven-field DOCSIS 3.0 upstream JavaScript rows."""
+        rows = cls._split_tag_value_rows(raw)
+        if rows is None:
+            return []
+
+        result: list[RawChannel] = []
+        for row in rows:
+            if row[1].strip().lower() != "locked":
+                continue
+
+            channel_id = cls._parse_int(row[3])
+            if channel_id is None:
+                continue
+            modulation = normalize_modulation(row[2])
+            channel: RawChannel = {
+                "channelID": channel_id,
+                "frequency": hz_to_mhz(row[5]),
+                "powerLevel": cls._parse_float(row[6]),
+                "modulation": modulation,
+                "multiplex": modulation,
+            }
+            symbol_rate = cls._parse_int(row[4])
+            if symbol_rate is not None:
+                channel["symbolRate"] = symbol_rate
+            result.append(channel)
+        return result
+
+    @staticmethod
+    def _extract_function_body(html: str, function_name: str) -> str | None:
+        """Return the body of a named no-argument JavaScript function."""
+        for match in _FUNCTION_START_RE.finditer(html):
+            if match.group("name") != function_name:
+                continue
+
+            body_start = match.end()
+            depth = 1
+            index = body_start
+            while index < len(html) and depth:
+                if html[index] == "{":
+                    depth += 1
+                elif html[index] == "}":
+                    depth -= 1
+                index += 1
+
+            if depth == 0:
+                return html[body_start : index - 1]
+            return None
+        return None
+
+    @staticmethod
+    def _strip_javascript_comments(source: str) -> str:
+        """Remove JavaScript comments while preserving quoted string contents."""
+        result: list[str] = []
+        index = 0
+        quote: str | None = None
+
+        while index < len(source):
+            char = source[index]
+            if quote is not None:
+                result.append(char)
+                if char == "\\" and index + 1 < len(source):
+                    index += 1
+                    result.append(source[index])
+                elif char == quote:
+                    quote = None
+                index += 1
+                continue
+
+            if char in {"'", '"'}:
+                quote = char
+                result.append(char)
+                index += 1
+                continue
+
+            if source.startswith("//", index):
+                newline = source.find("\n", index + 2)
+                if newline == -1:
+                    break
+                result.append("\n")
+                index = newline + 1
+                continue
+
+            if source.startswith("/*", index):
+                comment_end = source.find("*/", index + 2)
+                if comment_end == -1:
+                    break
+                result.append(" ")
+                index = comment_end + 2
+                continue
+
+            result.append(char)
+            index += 1
+
+        return "".join(result)
+
+    @classmethod
+    def _extract_tag_value_list(cls, html: str, function_name: str) -> str | None:
+        """Extract the live, possibly concatenated tagValueList assignment."""
+        body = cls._extract_function_body(html, function_name)
+        if body is None:
+            return None
+
+        body = cls._strip_javascript_comments(body)
+        assignment = _TAG_VALUE_ASSIGNMENT_RE.search(body)
+        if assignment is None:
+            return None
+
+        literals: list[str] = []
+        for match in _STRING_LITERAL_RE.finditer(assignment.group("value")):
+            value = match.group("single")
+            if value is None:
+                value = match.group("double")
+            literals.append(
+                value.replace(r"\'", "'")
+                .replace(r'\"', '"')
+                .replace(r"\\", "\\")
+            )
+        if not literals:
+            return None
+
+        payload = "".join(literals)
+        return payload if cls._split_tag_value_rows(payload) is not None else None
+
+    @staticmethod
+    def _split_tag_value_rows(raw: str) -> list[list[str]] | None:
+        """Validate and split a leading-count tagValueList into seven-field rows."""
+        parts = raw.split("|")
+        count_prefix = parts[0].strip()
+        if not count_prefix.isdecimal():
+            return None
+
+        row_count = int(count_prefix)
+        values = parts[1:]
+        if values and not values[-1]:
+            values.pop()
+        if len(values) != row_count * _TAG_VALUE_FIELDS_PER_ROW:
+            return None
+
+        return [
+            values[index : index + _TAG_VALUE_FIELDS_PER_ROW]
+            for index in range(0, len(values), _TAG_VALUE_FIELDS_PER_ROW)
+        ]
 
     @classmethod
     def _parse_downstream_table(

--- a/docs/index.html
+++ b/docs/index.html
@@ -219,7 +219,7 @@
             <li>Local data</li>
             <li>Demo mode</li>
             <li>Reports</li>
-            <li>19 modem families</li>
+            <li>20 modem families</li>
             <li>MIT licensed</li>
           </ul>
           <div class="trust-promise" aria-label="Local-first trust promise">

--- a/tests/fixtures/cm1000/DocsisStatus.asp.html
+++ b/tests/fixtures/cm1000/DocsisStatus.asp.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+    <title>NETGEAR Modem CM1000v2</title>
+    <script type="text/javascript">
+        function InitUsTableTagValue()
+        {
+            /*
+              Channel (text) | Lock Status (text) | US Channel Type (text) | Channel ID (text) | Symbol Rate (text) | Frequency (text) | Power (text)
+            */
+            /*
+                var tagValueList = "4" +
+                    "|1|Not Locked|Unknown|0|0|0|0.0" +
+                    "|2|Not Locked|Unknown|0|0|0|0.0" +
+                    "|3|Not Locked|Unknown|0|0|0|0.0" +
+                    "|4|Not Locked|Unknown|0|0|0|0.0";
+            */
+            var tagValueList = '4|1|Locked|TDMA|1|2560|33000000 Hz|34.8|2|Not Locked|Unknown|0|0|0 Hz|0.0|3|Not Locked|Unknown|0|0|0 Hz|0.0|4|Not Locked|Unknown|0|0|0 Hz|0.0';
+
+            return tagValueList.split("|");
+        }
+
+        function InitDsTableTagValue()
+        {
+            /*
+              Channel (text) | Lock Status (text) | Modulation (text) | Channel ID (text) | Frequency (text) | Power (text) | SNR (text)
+            */
+            /*
+                var tagValueList = "8" +
+                    "|1|Locked|Unknown|0|809500000|-61.6|0.0" +
+                    "|2|Not Locked|Unknown|0|0|0.0|0.0" +
+                    "|3|Not Locked|Unknown|0|0|0.0|0.0" +
+                    "|4|Not Locked|Unknown|0|0|0.0|0.0" +
+                    "|5|Not Locked|Unknown|0|0|0.0|0.0" +
+                    "|6|Not Locked|Unknown|0|0|0.0|0.0" +
+                    "|7|Not Locked|Unknown|0|0|0.0|0.0" +
+                    "|8|Not Locked|Unknown|0|0|0.0|0.0";
+            */
+            var tagValueList = '8|1|Locked|QAM64|143|453000000 Hz|-2.5|48.5|2|Not Locked|Unknown|0|0 Hz|0.0|0.0|3|Not Locked|Unknown|0|0 Hz|0.0|0.0|4|Not Locked|Unknown|0|0 Hz|0.0|0.0|5|Not Locked|Unknown|0|0 Hz|0.0|0.0|6|Not Locked|Unknown|0|0 Hz|0.0|0.0|7|Not Locked|Unknown|0|0 Hz|0.0|0.0|8|Not Locked|Unknown|0|0 Hz|0.0|0.0';
+
+            return tagValueList.split("|");
+        }
+    </script>
+</head>
+<body></body>
+</html>

--- a/tests/test_cm1000_driver.py
+++ b/tests/test_cm1000_driver.py
@@ -1,9 +1,14 @@
+from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 import requests
 
 from app.drivers.cm1000 import CM1000Driver
+
+CM1000_JS_HTML = (
+    Path(__file__).parent / "fixtures" / "cm1000" / "DocsisStatus.asp.html"
+).read_text(encoding="utf-8")
 
 STATUS_HTML = """
 <html><head><title>NETGEAR Cable Modem CM1000</title></head><body>
@@ -104,8 +109,66 @@ def test_login_uses_genie_webtoken_form_flow(driver):
             "loginPassword": "secret",
         },
         timeout=30,
+        allow_redirects=False,
     )
     assert driver._status_html == STATUS_HTML
+
+
+@pytest.mark.parametrize(
+    "hostile_action",
+    ["https://attacker.invalid/collect", "//attacker.invalid/collect"],
+)
+def test_form_login_never_posts_credentials_to_form_action(driver, hostile_action):
+    hostile_login_html = LOGIN_HTML.replace(
+        'action="/goform/GenieLogin"', f'action="{hostile_action}"'
+    )
+
+    with patch.object(
+        driver._session, "get", return_value=response(hostile_login_html)
+    ), patch.object(driver._session, "post", return_value=response("ok")) as post:
+        driver._login_via_form()
+
+    post.assert_called_once_with(
+        "http://192.168.100.1/goform/GenieLogin",
+        data={
+            "webToken": "abc123",
+            "login": "1",
+            "loginUsername": "admin",
+            "loginPassword": "secret",
+        },
+        timeout=30,
+        allow_redirects=False,
+    )
+    assert hostile_action not in [args[0] for args, _kwargs in post.call_args_list]
+
+
+def test_form_login_disables_redirects(driver):
+    with patch.object(
+        driver._session, "get", return_value=response(LOGIN_HTML)
+    ), patch.object(driver._session, "post", return_value=response("", 302)) as post:
+        driver._login_via_form()
+
+    assert post.call_args.kwargs["allow_redirects"] is False
+
+
+def test_login_clears_basic_auth_before_form_post_and_retries_status_page(driver):
+    auth_during_post = []
+
+    def submit(*_args, **_kwargs):
+        auth_during_post.append(driver._session.auth)
+        return response("", 302)
+
+    with patch.object(
+        driver._session,
+        "get",
+        side_effect=[response("login", 401), response(LOGIN_HTML), response(STATUS_HTML)],
+    ) as get, patch.object(driver._session, "post", side_effect=submit):
+        driver.login()
+
+    assert auth_during_post == [None]
+    assert get.call_args_list[-1] == call(
+        "http://192.168.100.1/DocsisStatus.asp", timeout=30
+    )
 
 
 def test_login_rejects_non_status_page_after_form_login(driver):
@@ -113,9 +176,10 @@ def test_login_rejects_non_status_page_after_form_login(driver):
         driver._session,
         "get",
         side_effect=[response("login", 401), response(LOGIN_HTML), response("still login")],
-    ), patch.object(driver._session, "post", return_value=response("ok")):
-        with pytest.raises(RuntimeError, match="did not return DocsisStatus.asp"):
-            driver.login()
+    ), patch.object(
+        driver._session, "post", return_value=response("ok")
+    ), pytest.raises(RuntimeError, match="did not return DocsisStatus.asp"):
+        driver.login()
 
 
 def test_login_retries_once_on_connection_reset(driver):
@@ -177,6 +241,133 @@ def test_parses_all_four_channel_families(driver):
         "modulation": "OFDMA",
         "multiplex": "",
     }]
+
+
+def test_real_javascript_fixture_is_recognized_and_parsed(driver):
+    assert driver._is_status_page(CM1000_JS_HTML)
+    driver._status_html = CM1000_JS_HTML
+
+    data = driver.get_docsis_data()
+
+    assert data["channelDs"]["docsis30"] == [{
+        "channelID": 143,
+        "frequency": "453 MHz",
+        "powerLevel": -2.5,
+        "mer": 48.5,
+        "mse": -48.5,
+        "modulation": "64QAM",
+        "symbolRate": 5057,
+        "corrErrors": None,
+        "nonCorrErrors": None,
+    }]
+    assert data["channelUs"]["docsis30"] == [{
+        "channelID": 1,
+        "frequency": "33 MHz",
+        "powerLevel": 34.8,
+        "modulation": "TDMA",
+        "multiplex": "TDMA",
+        "symbolRate": 2560,
+    }]
+    assert data["channelDs"]["docsis31"] == []
+    assert data["channelUs"]["docsis31"] == []
+
+
+def test_javascript_families_take_precedence_and_docsis31_tables_remain_fallback(driver):
+    driver._status_html = CM1000_JS_HTML + STATUS_HTML
+
+    data = driver.get_docsis_data()
+
+    assert [channel["channelID"] for channel in data["channelDs"]["docsis30"]] == [143]
+    assert [channel["channelID"] for channel in data["channelUs"]["docsis30"]] == [1]
+    assert [channel["channelID"] for channel in data["channelDs"]["docsis31"]] == [159]
+    assert [channel["channelID"] for channel in data["channelUs"]["docsis31"]] == [41]
+
+
+def test_malformed_javascript_function_falls_back_to_downstream_table(driver):
+    driver._status_html = """
+    <script>
+    function InitDsTableTagValue()
+    {
+        /* var tagValueList = '1|comment-only'; */
+        return [];
+    }
+    </script>
+    """ + SIXTY_FOUR_QAM_HTML
+
+    channels = driver.get_docsis_data()["channelDs"]["docsis30"]
+
+    assert [channel["channelID"] for channel in channels] == [2]
+
+
+def test_empty_javascript_payload_falls_back_to_downstream_table(driver):
+    javascript = """
+    <script>
+    function InitDsTableTagValue()
+    {
+        var tagValueList = "";
+        return tagValueList.split("|");
+    }
+    </script>
+    """
+    assert not driver._is_status_page(javascript)
+    driver._status_html = javascript + SIXTY_FOUR_QAM_HTML
+
+    channels = driver.get_docsis_data()["channelDs"]["docsis30"]
+
+    assert [channel["channelID"] for channel in channels] == [2]
+
+
+def test_mismatched_javascript_count_falls_back_to_downstream_table(driver):
+    javascript = """
+    <script>
+    function InitDsTableTagValue()
+    {
+        var tagValueList = "2|1|Locked|256QAM|99|591000000|-2.5|40.0";
+        return tagValueList.split("|");
+    }
+    </script>
+    """
+    assert not driver._is_status_page(javascript)
+    driver._status_html = javascript + SIXTY_FOUR_QAM_HTML
+
+    channels = driver.get_docsis_data()["channelDs"]["docsis30"]
+
+    assert [channel["channelID"] for channel in channels] == [2]
+
+
+def test_valid_zero_row_javascript_payload_suppresses_table_fallback(driver):
+    javascript = """
+    <script>
+    function InitDsTableTagValue()
+    {
+        var tagValueList = "0";
+        return tagValueList.split("|");
+    }
+    </script>
+    """
+    assert driver._is_status_page(javascript)
+    driver._status_html = javascript + SIXTY_FOUR_QAM_HTML
+
+    channels = driver.get_docsis_data()["channelDs"]["docsis30"]
+
+    assert channels == []
+
+
+def test_line_commented_placeholder_is_ignored_before_live_assignment(driver):
+    driver._status_html = """
+    <script>
+    function InitDsTableTagValue()
+    {
+        // var tagValueList = "1|placeholder|Locked|256QAM|98|591000000|0|40";
+        var tagValueList = "1|http://modem/status|Locked|64QAM|99|453000000|-2.5|48.5";
+        return tagValueList.split("|");
+    }
+    </script>
+    """ + SIXTY_FOUR_QAM_HTML
+
+    channels = driver.get_docsis_data()["channelDs"]["docsis30"]
+
+    assert [channel["channelID"] for channel in channels] == [99]
 
 
 def test_header_mapping_supports_layout_without_unerrored_column(driver):

--- a/tests/test_cm1000_driver.py
+++ b/tests/test_cm1000_driver.py
@@ -1,0 +1,217 @@
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import requests
+
+from app.drivers.cm1000 import CM1000Driver
+
+STATUS_HTML = """
+<html><head><title>NETGEAR Cable Modem CM1000</title></head><body>
+<table id="dsTable">
+<tr><td><span class="thead">Channel</span></td><td><span class="thead">Lock Status</span></td><td><span class="thead">Modulation</span></td><td><span class="thead">Channel ID</span></td><td><span class="thead">Frequency</span></td><td><span class="thead">Power</span></td><td><span class="thead">SNR/MER</span></td><td><span class="thead">Unerrored Codewords</span></td><td><span class="thead">Correctable Codewords</span></td><td><span class="thead">Uncorrectable Codewords</span></td></tr>
+<tr><td>1</td><td>Locked</td><td>256QAM</td><td>7</td><td>591000000 Hz</td><td>-2.5 dBmV</td><td>40.0 dB</td><td>1,000,000</td><td>1,234</td><td>5</td></tr>
+<tr><td>2</td><td>Not Locked</td><td>256QAM</td><td>8</td><td>597000000 Hz</td><td>0.0 dBmV</td><td>0.0 dB</td><td>0</td><td>999</td><td>999</td></tr>
+</table>
+<table id="usTable">
+<tr><th>Channel</th><th>Lock Status</th><th>Channel Type</th><th>Channel ID</th><th>Frequency</th><th>Power</th></tr>
+<tr><td>1</td><td>Locked</td><td>ATDMA</td><td>3</td><td>29200000 Hz</td><td>43.5 dBmV</td></tr>
+</table>
+<table id="d31dsTable">
+<tr><th>Channel</th><th>Lock Status</th><th>Modulation</th><th>Channel ID</th><th>Frequency</th><th>Power</th><th>SNR/MER</th><th>Active Subcarrier Number Range</th><th>Unerrored Codewords</th><th>Correctables</th><th>UnCorrectables</th></tr>
+<tr><td>1</td><td>Locked</td><td>OFDM PLC</td><td>159</td><td>960000000 Hz</td><td>6.0 dBmV</td><td>41.2 dB</td><td>148 ~ 3947</td><td>999999</td><td>1,148</td><td>12</td></tr>
+</table>
+<table id="d31usTable">
+<tr><th>Channel</th><th>Lock Status</th><th>Modulation</th><th>Channel ID</th><th>Frequency</th><th>Power</th></tr>
+<tr><td>1</td><td>Locked</td><td>OFDMA Profile 12</td><td>41</td><td>36200000 Hz</td><td>36.5 dBmV</td></tr>
+</table>
+</body></html>
+"""
+
+NINE_COLUMN_HTML = """
+<table id="dsTable">
+<tr><td>Channel</td><td>Lock Status</td><td>Modulation</td><td>Channel ID</td><td>Frequency</td><td>Power</td><td>SNR</td><td>Correctables</td><td>UnCorrectables</td></tr>
+<tr><td>1</td><td>Locked</td><td>QAM 256</td><td>1</td><td>387000000 Hz</td><td>5.8 dBmV</td><td>40.9 dB</td><td>7</td><td>2</td></tr>
+</table>
+"""
+
+SIXTY_FOUR_QAM_HTML = """
+<table id="dsTable">
+<tr><th>Channel</th><th>Lock Status</th><th>Modulation</th><th>Channel ID</th><th>Frequency</th><th>Power</th><th>SNR</th><th>Correctables</th><th>UnCorrectables</th></tr>
+<tr><td>1</td><td>Locked</td><td>64QAM</td><td>2</td><td>393000000 Hz</td><td>1.0 dBmV</td><td>35.0 dB</td><td>0</td><td>0</td></tr>
+</table>
+"""
+
+LOGIN_HTML = """
+<html><body><form name="login" action="/goform/GenieLogin">
+<input type="hidden" name="webToken" value="abc123">
+<input type="hidden" name="login" value="1">
+<input type="text" name="loginUsername" value="">
+<input type="password" name="loginPassword" value="">
+<input type="submit" value="Log In">
+</form></body></html>
+"""
+
+@pytest.fixture
+def driver():
+    return CM1000Driver("http://192.168.100.1/", "admin", "secret")
+
+
+def response(text="", status=200):
+    result = MagicMock()
+    result.text = text
+    result.status_code = status
+    result.raise_for_status.side_effect = (
+        requests.HTTPError(f"HTTP {status}") if status >= 400 else None
+    )
+    return result
+
+
+def test_init_normalizes_url_and_sets_basic_auth(driver):
+    assert driver._url == "http://192.168.100.1"
+    assert driver._session.auth == ("admin", "secret")
+
+
+def test_login_accepts_direct_basic_auth_status_page(driver):
+    status = response(STATUS_HTML)
+    with patch.object(driver._session, "get", return_value=status) as get:
+        driver.login()
+    get.assert_called_once_with("http://192.168.100.1/DocsisStatus.asp", timeout=30)
+    assert driver._status_html == STATUS_HTML
+
+
+def test_login_uses_genie_webtoken_form_flow(driver):
+    wrapper = response("<html>login required</html>", status=401)
+    login = response(LOGIN_HTML)
+    submitted = response("ok")
+    status = response(STATUS_HTML)
+
+    with patch.object(driver._session, "get", side_effect=[wrapper, login, status]) as get, patch.object(
+        driver._session, "post", return_value=submitted
+    ) as post:
+        driver.login()
+
+    assert get.call_args_list == [
+        call("http://192.168.100.1/DocsisStatus.asp", timeout=30),
+        call("http://192.168.100.1/GenieLogin.asp", timeout=30),
+        call("http://192.168.100.1/DocsisStatus.asp", timeout=30),
+    ]
+    post.assert_called_once_with(
+        "http://192.168.100.1/goform/GenieLogin",
+        data={
+            "webToken": "abc123",
+            "login": "1",
+            "loginUsername": "admin",
+            "loginPassword": "secret",
+        },
+        timeout=30,
+    )
+    assert driver._status_html == STATUS_HTML
+
+
+def test_login_rejects_non_status_page_after_form_login(driver):
+    with patch.object(
+        driver._session,
+        "get",
+        side_effect=[response("login", 401), response(LOGIN_HTML), response("still login")],
+    ), patch.object(driver._session, "post", return_value=response("ok")):
+        with pytest.raises(RuntimeError, match="did not return DocsisStatus.asp"):
+            driver.login()
+
+
+def test_login_retries_once_on_connection_reset(driver):
+    new_session = MagicMock()
+    new_session.auth = ("admin", "secret")
+    new_session.get.return_value = response(STATUS_HTML)
+
+    with patch.object(driver._session, "get", side_effect=requests.ConnectionError("reset")), patch(
+        "app.drivers.cm1000.requests.Session", return_value=new_session
+    ):
+        driver.login()
+
+    assert driver._status_html == STATUS_HTML
+
+
+def test_parses_all_four_channel_families(driver):
+    driver._status_html = STATUS_HTML
+    data = driver.get_docsis_data()
+
+    ds30 = data["channelDs"]["docsis30"]
+    us30 = data["channelUs"]["docsis30"]
+    ds31 = data["channelDs"]["docsis31"]
+    us31 = data["channelUs"]["docsis31"]
+
+    assert ds30 == [{
+        "channelID": 7,
+        "frequency": "591 MHz",
+        "powerLevel": -2.5,
+        "mer": 40.0,
+        "mse": -40.0,
+        "modulation": "256QAM",
+        "symbolRate": 5361,
+        "corrErrors": 1234,
+        "nonCorrErrors": 5,
+    }]
+    assert us30 == [{
+        "channelID": 3,
+        "frequency": "29.2 MHz",
+        "powerLevel": 43.5,
+        "modulation": "ATDMA",
+        "multiplex": "ATDMA",
+    }]
+    assert ds31 == [{
+        "channelID": 159,
+        "type": "OFDM",
+        "frequency": "960 MHz",
+        "powerLevel": 6.0,
+        "mer": 41.2,
+        "mse": None,
+        "modulation": "OFDM",
+        "corrErrors": 1148,
+        "nonCorrErrors": 12,
+    }]
+    assert us31 == [{
+        "channelID": 41,
+        "type": "OFDMA",
+        "frequency": "36.2 MHz",
+        "powerLevel": 36.5,
+        "modulation": "OFDMA",
+        "multiplex": "",
+    }]
+
+
+def test_header_mapping_supports_layout_without_unerrored_column(driver):
+    driver._status_html = NINE_COLUMN_HTML
+    channel = driver.get_docsis_data()["channelDs"]["docsis30"][0]
+    assert channel["corrErrors"] == 7
+    assert channel["nonCorrErrors"] == 2
+    assert channel["modulation"] == "256QAM"
+    assert channel["symbolRate"] == 5361
+
+
+def test_sets_annex_b_symbol_rate_for_64qam_downstream(driver):
+    driver._status_html = SIXTY_FOUR_QAM_HTML
+    channel = driver.get_docsis_data()["channelDs"]["docsis30"][0]
+    assert channel["modulation"] == "64QAM"
+    assert channel["symbolRate"] == 5057
+
+
+def test_status_html_is_reused_for_entire_collection_cycle(driver):
+    driver._status_html = STATUS_HTML
+    with patch.object(driver._session, "get") as get:
+        driver.get_docsis_data()
+        driver.get_device_info()
+    get.assert_not_called()
+
+
+def test_device_and_connection_info(driver):
+    assert driver.get_device_info() == {
+        "manufacturer": "Netgear",
+        "model": "CM1000",
+        "sw_version": "",
+    }
+    assert driver.get_connection_info() == {}
+
+def test_load_via_registry():
+    from app.drivers import load_driver
+    loaded = load_driver("cm1000", "http://192.168.100.1", "admin", "secret")
+    assert isinstance(loaded, CM1000Driver)


### PR DESCRIPTION
## Summary

Adds dedicated Netgear CM1000 support based on the capture and hardware evidence in #771.

- registers `cm1000` as a built-in modem type with the standard `http://192.168.100.1` default
- supports HTTP Basic authentication and the local Netgear Genie login flow
- confines form credentials to the fixed local login endpoint and disables login redirects
- parses capture-backed DOCSIS 3.0 JavaScript channel data with strict validation and HTML-table fallback
- preserves DOCSIS 3.1 table parsing and Annex B downstream symbol rates
- reports unsupported channel error counters as unavailable instead of measured zero
- adds a scrubbed capture-derived fixture, regression tests, architecture documentation, and public support updates

Fixes #771

## Validation

- CM1000 and CM3000 focused tests: 72 passed
- non-E2E suite: 3355 passed, 2 skipped
- full UTC browser E2E batch: 517 passed
- Ruff on changed Python files: passed
- `git diff --check`: passed
- fixture sensitivity scan: no credentials, tokens, MAC addresses, serial numbers, URLs, hostnames, or private IP addresses

## Hardware evidence

The original contributor validated Netgear CM1000v2 firmware V10.01.07 against a physical modem, including repeated authenticated polling and DOCSIS 3.0/3.1 channel collection. The public fixture retains the scrubbed downstream and upstream expressions from the issue capture.
