### PR TITLE
Fix duplicate channel selection

### DIFF
--- a/app/blueprints/analysis_bp.py
+++ b/app/blueprints/analysis_bp.py
@@ -146,22 +146,26 @@ def _channel_history_window_args():
 @require_auth
 def api_channel_history():
     """Return per-channel time series data.
-    ?channel_id=X&direction=ds|us&range=1h|6h|1d|2d|3d|7d|30d|90d
-    Legacy ?days=N remains supported."""
+    ?selector=X selects an exact channel identity; legacy ?channel_id=N remains
+    supported for IDs that uniquely identify a channel. ?days=N also remains
+    supported as a legacy time window."""
     _storage = get_storage()
     if not _storage:
         return jsonify([])
+    selector = request.args.get("selector")
     channel_id = request.args.get("channel_id", type=int)
     direction = request.args.get("direction", "ds")
     window_args, range_error = _channel_history_window_args()
     if range_error:
         return range_error
     assert window_args is not None
-    if channel_id is None:
-        return jsonify({"error": "channel_id is required"}), 400
+    if selector is None and channel_id is None:
+        return jsonify({"error": "channel_id or selector is required"}), 400
     if direction not in ("ds", "us"):
         return jsonify({"error": "direction must be 'ds' or 'us'"}), 400
-    data = _storage.get_channel_history(channel_id, direction, **window_args)
+    data = _storage.get_channel_history(
+        channel_id, direction, selector=selector, **window_args
+    )
     _localize_timestamps(data)
     return jsonify(data)
 
@@ -170,30 +174,37 @@ def api_channel_history():
 @require_auth
 def api_channel_compare():
     """Return per-channel time series for multiple channels.
-    ?channels=1,2,3&direction=ds|us&range=1h|6h|1d|2d|3d|7d|30d|90d
-    Legacy ?days=N remains supported."""
+    ?selectors=X,Y selects exact channel identities; legacy ?channels=1,2,3
+    remains supported for unique IDs. ?days=N also remains supported."""
     _storage = get_storage()
     if not _storage:
         return jsonify({})
     channels_param = request.args.get("channels", "")
+    selectors_param = request.args.get("selectors", "")
     direction = request.args.get("direction", "ds")
     window_args, range_error = _channel_history_window_args()
     if range_error:
         return range_error
     assert window_args is not None
-    if not channels_param:
-        return jsonify({"error": "channels parameter is required"}), 400
+    if not channels_param and not selectors_param:
+        return jsonify({"error": "channels or selectors parameter is required"}), 400
     if direction not in ("ds", "us"):
         return jsonify({"error": "direction must be 'ds' or 'us'"}), 400
-    try:
-        channel_ids = [int(c.strip()) for c in channels_param.split(",") if c.strip()]
-    except ValueError:
-        return jsonify({"error": "channels must be comma-separated integers"}), 400
-    if len(channel_ids) > 64:
+    selectors = [item.strip() for item in selectors_param.split(",") if item.strip()]
+    channel_ids = []
+    if not selectors:
+        try:
+            channel_ids = [int(c.strip()) for c in channels_param.split(",") if c.strip()]
+        except ValueError:
+            return jsonify({"error": "channels must be comma-separated integers"}), 400
+    requested_count = len(selectors) if selectors else len(channel_ids)
+    if requested_count > 64:
         return jsonify({"error": "maximum 64 channels"}), 400
-    if not channel_ids:
+    if requested_count == 0:
         return jsonify({"error": "at least one channel required"}), 400
-    result = _storage.get_multi_channel_history(channel_ids, direction, **window_args)
+    result = _storage.get_multi_channel_history(
+        channel_ids, direction, selectors=selectors, **window_args
+    )
     # Convert int keys to strings for JSON
     return jsonify({str(k): v for k, v in result.items()})
 

--- a/app/channel_selector.py
+++ b/app/channel_selector.py
@@ -1,0 +1,137 @@
+"""Stable channel identity and exact selector matching for channel history views."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from collections import Counter, defaultdict
+from decimal import Decimal, InvalidOperation
+
+
+_FREQUENCY_RE = re.compile(
+    r"^([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*(hz|khz|mhz)?$",
+    re.IGNORECASE,
+)
+
+
+def _canonical_decimal(value: Decimal) -> str:
+    if not value.is_finite():
+        raise InvalidOperation
+    normalized = format(value.normalize(), "f")
+    return "0" if normalized in ("-0", "") else normalized
+
+
+def normalize_channel_id(value) -> str:
+    """Normalize numeric IDs across int/float/string storage representations."""
+    if value is None or isinstance(value, bool):
+        return "z:"
+    text = str(value).strip()
+    try:
+        return "n:" + _canonical_decimal(Decimal(text))
+    except (InvalidOperation, ValueError):
+        return "t:" + text
+
+
+def legacy_channel_id(value) -> int | None:
+    """Return the legacy integer ID representation, or None when invalid."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = Decimal(str(value).strip())
+    except (InvalidOperation, ValueError):
+        return None
+    if not parsed.is_finite() or parsed != parsed.to_integral_value():
+        return None
+    return int(parsed)
+
+
+def normalize_frequency(value) -> str:
+    """Normalize stored numeric and unit-bearing frequency forms to MHz."""
+    if value is None or isinstance(value, bool):
+        return "z:"
+    text = str(value).strip()
+    match = _FREQUENCY_RE.fullmatch(text)
+    if match:
+        try:
+            frequency = Decimal(match.group(1))
+            unit = (match.group(2) or "mhz").lower()
+            if unit == "hz":
+                frequency /= Decimal(1_000_000)
+            elif unit == "khz":
+                frequency /= Decimal(1_000)
+            return "n:" + _canonical_decimal(frequency)
+        except (InvalidOperation, ValueError):
+            pass
+    return "t:" + " ".join(text.lower().split())
+
+
+def channel_selector(channel: dict) -> str:
+    """Build an opaque, stable selector from modem ID and channel frequency."""
+    identity = [
+        normalize_channel_id(channel.get("channel_id")),
+        normalize_frequency(channel.get("frequency")),
+    ]
+    payload = json.dumps(identity, ensure_ascii=False, separators=(",", ":"))
+    digest = hashlib.sha256(payload.encode("utf-8")).digest()[:18]
+    encoded = base64.urlsafe_b64encode(digest).decode("ascii")
+    return "c1_" + encoded.rstrip("=")
+
+
+def attach_channel_selectors(channels: list[dict]) -> list[dict]:
+    """Copy current channel rows and add selector metadata for frontend use."""
+    id_counts = Counter(
+        normalize_channel_id(channel.get("channel_id")) for channel in channels
+    )
+    result = []
+    for channel in channels:
+        row = dict(channel)
+        normalized_id = normalize_channel_id(channel.get("channel_id"))
+        legacy_id = legacy_channel_id(channel.get("channel_id"))
+        row["selector"] = channel_selector(channel)
+        row["selector_required"] = legacy_id is None or id_counts[normalized_id] > 1
+        if legacy_id is not None:
+            row["legacy_channel_id"] = legacy_id
+        result.append(row)
+    return result
+
+
+def match_channel(
+    channels: list[dict], *, selector: str | None = None, channel_id=None
+) -> dict | None:
+    """Return exactly one matching row; unmatched or ambiguous matches return None."""
+    requested = [selector] if selector is not None else [channel_id]
+    matches = match_channels(
+        channels,
+        selectors=requested if selector is not None else None,
+        channel_ids=requested if selector is None else None,
+    )
+    return matches.get(requested[0])
+
+
+def match_channels(
+    channels: list[dict], *, selectors=None, channel_ids=None
+) -> dict:
+    """Match multiple identities after indexing each snapshot channel once."""
+    selectors = list(selectors or [])
+    requested = selectors if selectors else list(channel_ids or [])
+    if not requested:
+        return {}
+
+    grouped = defaultdict(list)
+    if selectors:
+        for channel in channels:
+            grouped[channel_selector(channel)].append(channel)
+    else:
+        for channel in channels:
+            normalized_id = legacy_channel_id(channel.get("channel_id"))
+            if normalized_id is not None:
+                grouped[normalized_id].append(channel)
+
+    result = {}
+    for identity in requested:
+        key = identity if selectors else legacy_channel_id(identity)
+        matches = grouped.get(key, [])
+        result[identity] = matches[0] if len(matches) == 1 else None
+    return result

--- a/app/drivers/tc4400.py
+++ b/app/drivers/tc4400.py
@@ -261,7 +261,9 @@ class TC4400Driver(ModemDriver):
         }
 
         for i, h in enumerate(headers):
-            if "channel" in h and ("id" in h or "index" in h):
+            if "channel" in h and "id" in h:
+                col["channel_id"] = i
+            elif "channel" in h and "index" in h and col["channel_id"] is None:
                 col["channel_id"] = i
             elif "lock" in h:
                 col["lock_status"] = i

--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -5,7 +5,9 @@
 
 /* ── Channel State URL Persistence ── */
 /* Hash format: #channels?mode=timeline&dir=ds&channel=42&range=1d
+   Exact:       #channels?mode=timeline&dir=ds&selector=<opaque>&range=1d
    Compare:     #channels?mode=compare&dir=us&range=30d&channels=1,2,3
+   Exact:       #channels?mode=compare&dir=ds&range=7d&selectors=<opaque>,<opaque>
    Preset:      #channels?mode=compare&dir=ds&range=7d&preset=all */
 
 function _channelRangeHours(range) {
@@ -28,6 +30,65 @@ function _normalizeChannelRangeValue(value) {
     return allowed.indexOf(raw) !== -1 ? raw : '1d';
 }
 
+function _channelReference(ch) {
+    var id = String(ch.channel_id);
+    var legacyId = ch.legacy_channel_id !== undefined
+        ? String(ch.legacy_channel_id)
+        : id;
+    var selector = ch.selector || '';
+    var usesSelector = !!ch.selector_required;
+    return {
+        id: id,
+        legacyId: legacyId,
+        selector: selector,
+        usesSelector: usesSelector,
+        key: usesSelector ? 'selector:' + selector : 'id:' + legacyId
+    };
+}
+
+function _channelOptionValue(direction, ref) {
+    return ref.usesSelector
+        ? direction + '-selector-' + ref.selector
+        : direction + '-' + ref.legacyId;
+}
+
+function _readChannelSelection(select) {
+    if (!select || !select.value || select.selectedIndex < 0) return null;
+    var option = select.options[select.selectedIndex];
+    if (!option || option.dataset.channelId === undefined) return null;
+    var usesSelector = option.dataset.selectorRequired === 'true';
+    return {
+        direction: option.dataset.direction,
+        id: option.dataset.channelId,
+        legacyId: option.dataset.legacyChannelId,
+        selector: option.dataset.selector || '',
+        usesSelector: usesSelector,
+        key: usesSelector ? 'selector:' + (option.dataset.selector || '') : 'id:' + option.dataset.legacyChannelId,
+        option: option
+    };
+}
+
+function _findChannelOption(select, direction, field, value) {
+    if (!select) return null;
+    var found = null;
+    for (var i = 0; i < select.options.length; i++) {
+        var option = select.options[i];
+        if (option.dataset.direction === direction && option.dataset[field] === String(value)) {
+            if (found) return null;
+            found = option;
+        }
+    }
+    return found;
+}
+
+function _compareUsesSelectors() {
+    return _compareChannels.some(function(ch) { return ch.usesSelector; });
+}
+
+function _compareDataKey(ch, usesSelectors) {
+    return usesSelectors ? ch.selector : String(ch.legacyId);
+}
+
 function parseChannelHash() {
     var hash = location.hash.replace('#', '');
     var qIdx = hash.indexOf('?');
@@ -46,11 +107,11 @@ function writeChannelHash() {
     var params = ['mode=' + mode];
     if (mode === 'timeline') {
         var sel = document.getElementById('channel-select');
-        var val = sel ? sel.value : '';
-        if (val) {
-            var parts = val.split('-');
-            params.push('dir=' + parts[0]);
-            params.push('channel=' + parts[1]);
+        var ref = _readChannelSelection(sel);
+        if (ref) {
+            params.push('dir=' + ref.direction);
+            if (ref.usesSelector) params.push('selector=' + encodeURIComponent(ref.selector));
+            else params.push('channel=' + encodeURIComponent(ref.legacyId));
         }
         params.push('range=' + encodeURIComponent(getPillValue('channel-time-tabs') || '1d'));
     } else {
@@ -59,10 +120,15 @@ function writeChannelHash() {
         if (_comparePreset === 'all') {
             params.push('preset=all');
         } else if (_compareChannels.length > 0) {
-            var ids = _compareChannels.map(function(c) { return c.id; });
-            ids.sort(function(a, b) { return a - b; });
-            ids = ids.filter(function(v, i, a) { return i === 0 || a[i - 1] !== v; });
-            params.push('channels=' + ids.join(','));
+            if (_compareUsesSelectors()) {
+                var selectors = _compareChannels.map(function(c) { return c.selector; });
+                params.push('selectors=' + encodeURIComponent(selectors.join(',')));
+            } else {
+                var ids = _compareChannels.map(function(c) { return c.legacyId; });
+                ids.sort(function(a, b) { return Number(a) - Number(b); });
+                ids = ids.filter(function(v, i, a) { return i === 0 || a[i - 1] !== v; });
+                params.push('channels=' + ids.join(','));
+            }
         }
     }
     history.replaceState(null, '', '#channels?' + params.join('&'));
@@ -101,9 +167,15 @@ function initChannelView() {
         if (params.mode === 'timeline') {
             setPillByValue('channel-time-tabs', _normalizeChannelRangeValue(params.range || params.days || '1d'));
             var sel = document.getElementById('channel-select');
-            if (params.dir && params.channel) {
-                sel.value = params.dir + '-' + params.channel;
-                if (sel.value === params.dir + '-' + params.channel) {
+            var restoredOption = null;
+            if (params.dir && params.selector) {
+                restoredOption = _findChannelOption(sel, params.dir, 'selector', params.selector);
+            } else if (params.dir && params.channel) {
+                restoredOption = _findChannelOption(sel, params.dir, 'legacyChannelId', params.channel);
+            }
+            if (restoredOption) {
+                sel.value = restoredOption.value;
+                if (sel.value === restoredOption.value) {
                     loadChannelTimeline();
                     return;
                 }
@@ -123,20 +195,26 @@ function initChannelView() {
             updateCompareActionLabels();
             if (params.preset === 'all') {
                 addAllCompareChannels();
-            } else if (params.channels) {
-                var channelIds = params.channels.split(',').map(function(s) { return parseInt(s); });
+            } else if (params.selectors || params.channels) {
+                var selectorKeys = params.selectors ? params.selectors.split(',') : [];
+                var channelIds = params.channels ? params.channels.split(',') : [];
                 var dir = params.dir || 'ds';
                 fetch('/api/channels')
                     .then(function(r) { return r.json(); })
                     .then(function(data) {
                         var available = dir === 'ds' ? (data.ds_channels || []) : (data.us_channels || []);
                         _compareChannels = [];
-                        channelIds.forEach(function(id) {
+                        var requested = selectorKeys.length ? selectorKeys : channelIds;
+                        requested.forEach(function(value) {
+                            var matched = [];
                             for (var i = 0; i < available.length; i++) {
-                                if (available[i].channel_id === id) {
-                                    _compareChannels.push(buildCompareChannelEntry(available[i], _compareChannels.length, dir));
-                                    break;
-                                }
+                                var matches = selectorKeys.length
+                                    ? available[i].selector === value
+                                    : _channelReference(available[i]).legacyId === String(value);
+                                if (matches) matched.push(available[i]);
+                            }
+                            if (matched.length === 1) {
+                                _compareChannels.push(buildCompareChannelEntry(matched[0], _compareChannels.length, dir));
                             }
                         });
                         renderCompareChips();
@@ -195,8 +273,7 @@ function switchChannelMode() {
             document.getElementById('channel-no-data').style.display = 'none';
         } else {
             // Restore info bar for already-selected channel
-            var cparts = sel.value.split('-');
-            _updateChannelInfoBar(cparts[0], cparts[1]);
+            _updateChannelInfoBar(_readChannelSelection(sel));
         }
     }
     _updateChannelSelectionControls();
@@ -220,8 +297,14 @@ function loadChannelList(callback) {
                 var grp = document.createElement('optgroup');
                 grp.label = T.downstream_channels || 'Downstream Channels';
                 ds.forEach(function(ch) {
+                    var ref = _channelReference(ch);
                     var opt = document.createElement('option');
-                    opt.value = 'ds-' + ch.channel_id;
+                    opt.value = _channelOptionValue('ds', ref);
+                    opt.dataset.direction = 'ds';
+                    opt.dataset.channelId = ref.id;
+                    opt.dataset.legacyChannelId = ref.legacyId;
+                    opt.dataset.selector = ref.selector;
+                    opt.dataset.selectorRequired = ref.usesSelector ? 'true' : 'false';
                     opt.dataset.docsis = ch.docsis_version || '3.0';
                     opt.textContent = 'DS ' + ch.channel_id + ' (' + (ch.frequency || '') + ')';
                     grp.appendChild(opt);
@@ -232,8 +315,14 @@ function loadChannelList(callback) {
                 var grp2 = document.createElement('optgroup');
                 grp2.label = T.upstream_channels || 'Upstream Channels';
                 us.forEach(function(ch) {
+                    var ref = _channelReference(ch);
                     var opt = document.createElement('option');
-                    opt.value = 'us-' + ch.channel_id;
+                    opt.value = _channelOptionValue('us', ref);
+                    opt.dataset.direction = 'us';
+                    opt.dataset.channelId = ref.id;
+                    opt.dataset.legacyChannelId = ref.legacyId;
+                    opt.dataset.selector = ref.selector;
+                    opt.dataset.selectorRequired = ref.usesSelector ? 'true' : 'false';
                     opt.dataset.docsis = ch.docsis_version || '3.0';
                     opt.textContent = 'US ' + ch.channel_id + ' (' + (ch.frequency || '') + ')';
                     grp2.appendChild(opt);
@@ -414,24 +503,25 @@ function toggleCompareTempOverlay() {
 }
 window.toggleCompareTempOverlay = toggleCompareTempOverlay;
 
-function _updateChannelInfoBar(direction, channelId) {
+function _updateChannelInfoBar(ref) {
     var bar = document.getElementById('channel-info-bar');
     if (!bar) return;
-    if (!_cachedChannelData) { bar.style.display = 'none'; return; }
-    var channels = direction === 'ds'
+    if (!_cachedChannelData || !ref) { bar.style.display = 'none'; return; }
+    var channels = ref.direction === 'ds'
         ? (_cachedChannelData.ds_channels || [])
         : (_cachedChannelData.us_channels || []);
     var ch = null;
     for (var i = 0; i < channels.length; i++) {
-        if (String(channels[i].channel_id) === String(channelId)) { ch = channels[i]; break; }
+        var candidate = _channelReference(channels[i]);
+        if (candidate.key === ref.key) { ch = channels[i]; break; }
     }
     if (!ch) { bar.style.display = 'none'; return; }
     while (bar.firstChild) bar.removeChild(bar.firstChild);
-    var dir = direction.toUpperCase();
+    var dir = ref.direction.toUpperCase();
     var health = ch.health || 'unknown';
     var healthLabel = T['health_' + health] || health;
 
-    bar.appendChild(_makeInfoItem(dir + ' ' + channelId, true));
+    bar.appendChild(_makeInfoItem(dir + ' ' + ref.id, true));
     bar.appendChild(_makeInfoSep());
     if (ch.frequency) {
         var freqStr = String(ch.frequency);
@@ -558,11 +648,15 @@ function loadChannelTimeline() {
         writeChannelHash();
         return;
     }
-    var parts = val.split('-');
+    var ref = _readChannelSelection(sel);
+    if (!ref) {
+        sel.value = '';
+        loadChannelTimeline();
+        return;
+    }
     _updateChannelSelectionControls();
-    var direction = parts[0];
-    var channelId = parts[1];
-    var selectedOpt = sel.options[sel.selectedIndex];
+    var direction = ref.direction;
+    var selectedOpt = ref.option;
     var docsisVersion = selectedOpt ? selectedOpt.dataset.docsis || '3.0' : '3.0';
     var days = getPillValue('channel-time-tabs') || '1d';
     writeChannelHash();
@@ -572,9 +666,12 @@ function loadChannelTimeline() {
     chartsEl.style.display = 'none';
     emptyEl.style.display = 'none';
     noDataEl.style.display = 'none';
-    _updateChannelInfoBar(direction, channelId);
+    _updateChannelInfoBar(ref);
 
-    fetch('/api/channel-history?channel_id=' + channelId + '&direction=' + direction + '&range=' + encodeURIComponent(days))
+    var identityParam = ref.usesSelector
+        ? 'selector=' + encodeURIComponent(ref.selector)
+        : 'channel_id=' + encodeURIComponent(ref.legacyId);
+    fetch('/api/channel-history?' + identityParam + '&direction=' + direction + '&range=' + encodeURIComponent(days))
         .then(function(r) { return r.json(); })
         .then(function(data) {
             if (requestId !== _channelTimelineRequestSeq) return;
@@ -642,8 +739,13 @@ function getComparePresetLabel(dir) {
 
 function buildCompareChannelEntry(ch, index, dir) {
     var prefix = dir === 'ds' ? 'DS' : 'US';
+    var ref = _channelReference(ch);
     return {
-        id: ch.channel_id,
+        id: ref.id,
+        legacyId: ref.legacyId,
+        selector: ref.selector,
+        usesSelector: ref.usesSelector,
+        key: ref.key,
         label: prefix + ' ' + ch.channel_id + ' (' + (ch.frequency || '') + ')',
         color: compareColor(index),
         docsis: ch.docsis_version || '3.0'
@@ -685,10 +787,15 @@ function populateCompareChannelList(data) {
     sel.innerHTML = '<option value="">' + (T.select_channel || 'Select Channel') + '</option>';
     var channels = dir === 'ds' ? (data.ds_channels || []) : (data.us_channels || []);
     channels.forEach(function(ch) {
-        var already = _compareChannels.some(function(c) { return c.id === ch.channel_id; });
+        var ref = _channelReference(ch);
+        var already = _compareChannels.some(function(c) { return c.key === ref.key; });
         if (already) return;
         var opt = document.createElement('option');
-        opt.value = ch.channel_id;
+        opt.value = ref.key;
+        opt.dataset.channelId = ref.id;
+        opt.dataset.legacyChannelId = ref.legacyId;
+        opt.dataset.selector = ref.selector;
+        opt.dataset.selectorRequired = ref.usesSelector ? 'true' : 'false';
         opt.dataset.docsis = ch.docsis_version || '3.0';
         opt.dataset.freq = ch.frequency || '';
         var prefix = dir === 'ds' ? 'DS' : 'US';
@@ -745,13 +852,23 @@ function addCompareChannel() {
         return;
     }
     _comparePreset = null;
-    var id = parseInt(opt.value);
-    if (_compareChannels.some(function(c) { return c.id === id; })) return;
+    var ref = {
+        id: opt.dataset.channelId,
+        legacyId: opt.dataset.legacyChannelId,
+        selector: opt.dataset.selector || '',
+        usesSelector: opt.dataset.selectorRequired === 'true',
+        key: opt.value
+    };
+    if (_compareChannels.some(function(c) { return c.key === ref.key; })) return;
     var dir = getCompareDirection();
     var prefix = dir === 'ds' ? 'DS' : 'US';
     _compareChannels.push({
-        id: id,
-        label: prefix + ' ' + id + ' (' + (opt.dataset.freq || '') + ')',
+        id: ref.id,
+        legacyId: ref.legacyId,
+        selector: ref.selector,
+        usesSelector: ref.usesSelector,
+        key: ref.key,
+        label: prefix + ' ' + ref.id + ' (' + (opt.dataset.freq || '') + ')',
         color: compareColor(_compareChannels.length),
         docsis: opt.dataset.docsis || '3.0'
     });
@@ -804,9 +921,9 @@ function clearCompareChannels() {
 }
 window.clearCompareChannels = clearCompareChannels;
 
-function removeCompareChannel(id) {
+function removeCompareChannel(key) {
     _comparePreset = null;
-    _compareChannels = _compareChannels.filter(function(c) { return c.id !== id; });
+    _compareChannels = _compareChannels.filter(function(c) { return c.key !== key; });
     // Re-assign colors sequentially
     _compareChannels.forEach(function(c, i) { c.color = compareColor(i); });
     renderCompareChips();
@@ -837,7 +954,12 @@ function renderCompareChips() {
         var chip = document.createElement('span');
         chip.className = 'compare-chip';
         chip.style.backgroundColor = ch.color;
-        chip.innerHTML = escapeHtml(ch.label) + ' <button class="compare-chip-remove" onclick="removeCompareChannel(' + ch.id + ')">&times;</button>';
+        chip.textContent = ch.label + ' ';
+        var remove = document.createElement('button');
+        remove.className = 'compare-chip-remove';
+        remove.innerHTML = '&times;';
+        remove.onclick = function() { removeCompareChannel(ch.key); };
+        chip.appendChild(remove);
         container.appendChild(chip);
     });
 }
@@ -851,20 +973,22 @@ function _renderCompareCharts() {
     var dir = ctx.dir || getCompareDirection();
     var xLabels = docsightFormatXAxisLabels(timestamps, days);
     var tempOpts = _channelWeatherHasData(_lastCompareWeather) ? { tempData: _lastCompareWeather } : null;
+    var usesSelectors = !!ctx.usesSelectors;
 
     // Build lookup maps per channel: timestamp -> data point
     var lookups = {};
     _compareChannels.forEach(function(ch) {
         var map = {};
-        (data[String(ch.id)] || []).forEach(function(d) { map[d.timestamp] = d; });
-        lookups[ch.id] = map;
+        var dataKey = _compareDataKey(ch, usesSelectors);
+        (data[dataKey] || []).forEach(function(d) { map[d.timestamp] = d; });
+        lookups[ch.key] = map;
     });
 
     // Power Chart
     var powerDatasets = _compareChannels.map(function(ch) {
         return {
             label: 'CH ' + ch.id,
-            data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.power : null; }),
+            data: timestamps.map(function(ts) { var d = lookups[ch.key][ts]; return d ? d.power : null; }),
             color: ch.color,
             showPoints: false
         };
@@ -879,7 +1003,7 @@ function _renderCompareCharts() {
         var snrDatasets = _compareChannels.map(function(ch) {
             return {
                 label: 'CH ' + ch.id,
-                data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d ? d.snr : null; }),
+                data: timestamps.map(function(ts) { var d = lookups[ch.key][ts]; return d ? d.snr : null; }),
                 color: ch.color,
                 showPoints: false
             };
@@ -892,7 +1016,7 @@ function _renderCompareCharts() {
     // Errors Chart (DS only, lines not bars)
     if (dir === 'ds') {
         var compareHasErrors = _compareChannels.some(function(ch) {
-            return _hasChannelDocsisErrorSeries(data[String(ch.id)] || []);
+            return _hasChannelDocsisErrorSeries(data[_compareDataKey(ch, usesSelectors)] || []);
         });
         _setChartCardVisible('compare-errors-card', 'chart-cmp-errors', compareHasErrors);
         if (compareHasErrors) {
@@ -900,13 +1024,13 @@ function _renderCompareCharts() {
             _compareChannels.forEach(function(ch) {
                 errorDatasets.push({
                     label: 'CH ' + ch.id + ' ' + (T.uncorrectable || 'Uncorr.'),
-                    data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.uncorrectable_errors != null ? d.uncorrectable_errors : null; }),
+                    data: timestamps.map(function(ts) { var d = lookups[ch.key][ts]; return d && d.uncorrectable_errors != null ? d.uncorrectable_errors : null; }),
                     color: ch.color,
                     showPoints: false
                 });
                 errorDatasets.push({
                     label: 'CH ' + ch.id + ' ' + (T.correctable || 'Corr.'),
-                    data: timestamps.map(function(ts) { var d = lookups[ch.id][ts]; return d && d.correctable_errors != null ? d.correctable_errors : null; }),
+                    data: timestamps.map(function(ts) { var d = lookups[ch.key][ts]; return d && d.correctable_errors != null ? d.correctable_errors : null; }),
                     color: ch.color,
                     dashed: true,
                     showPoints: false
@@ -922,7 +1046,7 @@ function _renderCompareCharts() {
     var modCard = document.getElementById('compare-modulation-card');
     var hasMod = false;
     _compareChannels.forEach(function(ch) {
-        var chData = data[String(ch.id)] || [];
+        var chData = data[_compareDataKey(ch, usesSelectors)] || [];
         if (chData.some(function(d) { return d.modulation; })) hasMod = true;
     });
     if (!hasMod) {
@@ -932,7 +1056,7 @@ function _renderCompareCharts() {
         // Collect all unique QAM values
         var allQam = {};
         _compareChannels.forEach(function(ch) {
-            (data[String(ch.id)] || []).forEach(function(d) {
+            (data[_compareDataKey(ch, usesSelectors)] || []).forEach(function(d) {
                 if (d.modulation) allQam[d.modulation] = true;
             });
         });
@@ -949,7 +1073,7 @@ function _renderCompareCharts() {
             return {
                 label: 'CH ' + ch.id,
                 data: timestamps.map(function(ts) {
-                    var d = lookups[ch.id][ts];
+                    var d = lookups[ch.key][ts];
                     if (!d || !d.modulation) return null;
                     return qamMap[d.modulation] !== undefined ? qamMap[d.modulation] : null;
                 }),
@@ -994,7 +1118,11 @@ function loadCompareCharts() {
     }
     var dir = getCompareDirection();
     var days = getPillValue('compare-time-tabs') || '1d';
-    var ids = _compareChannels.map(function(c) { return c.id; }).join(',');
+    var usesSelectors = _compareUsesSelectors();
+    var identityName = usesSelectors ? 'selectors' : 'channels';
+    var identities = _compareChannels.map(function(c) {
+        return usesSelectors ? c.selector : c.legacyId;
+    }).join(',');
     writeChannelHash();
     var requestId = ++_compareRequestSeq;
 
@@ -1002,7 +1130,7 @@ function loadCompareCharts() {
     chartsEl.style.display = 'none';
     emptyEl.style.display = 'none';
 
-    fetch('/api/channel-compare?channels=' + ids + '&direction=' + dir + '&range=' + encodeURIComponent(days))
+    fetch('/api/channel-compare?' + identityName + '=' + encodeURIComponent(identities) + '&direction=' + dir + '&range=' + encodeURIComponent(days))
         .then(function(r) { return r.json(); })
         .then(function(data) {
             if (requestId !== _compareRequestSeq) return;
@@ -1012,7 +1140,7 @@ function loadCompareCharts() {
             // Build unified timestamp list from all channels
             var tsSet = {};
             _compareChannels.forEach(function(ch) {
-                var chData = data[String(ch.id)] || [];
+                var chData = data[_compareDataKey(ch, usesSelectors)] || [];
                 chData.forEach(function(d) { tsSet[d.timestamp] = true; });
             });
             var timestamps = Object.keys(tsSet).sort();
@@ -1030,7 +1158,8 @@ function loadCompareCharts() {
                 data: data,
                 timestamps: timestamps,
                 days: days,
-                dir: dir
+                dir: dir,
+                usesSelectors: usesSelectors
             };
             _lastCompareWeather = null;
             _updateCompareTempToggle();

--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -3,11 +3,29 @@
 import json
 import sqlite3
 
+from app.channel_selector import match_channel, match_channels
+
 from ..tz import utc_cutoff
 from .error_counters import unwrap_uint32_counter_series
 
 
 _CHANNEL_ERROR_KEYS = ("correctable_errors", "uncorrectable_errors")
+
+
+def _history_row(timestamp, channel, *, include_frequency=False):
+    row = {
+        "timestamp": timestamp,
+        "power": channel.get("power"),
+        "snr": channel.get("snr"),
+        "correctable_errors": channel.get("correctable_errors"),
+        "uncorrectable_errors": channel.get("uncorrectable_errors"),
+        "modulation": channel.get("modulation", ""),
+    }
+    if include_frequency:
+        row["frequency"] = channel.get("frequency", "")
+    else:
+        row["health"] = channel.get("health", "")
+    return row
 
 
 class AnalysisMethods:
@@ -168,11 +186,13 @@ class AnalysisMethods:
         timeline.sort(key=lambda x: x["timestamp"])
         return timeline
 
-    def get_channel_history(self, channel_id, direction, days=7, hours=None):
+    def get_channel_history(
+        self, channel_id, direction, days=7, hours=None, selector=None
+    ):
         """Return time series for a single channel over the selected window.
+        An exact selector takes precedence over the legacy unique channel_id.
         direction: 'ds' or 'us'. Returns list of dicts with timestamp + channel fields."""
         _COL_MAP = {"ds": "ds_channels_json", "us": "us_channels_json"}
-        channel_id = int(channel_id)
         _COL_MAP[direction]  # validated in web.py to be 'ds' or 'us'
         cutoff = utc_cutoff(hours=hours) if hours is not None else utc_cutoff(days=days)
         with self._connect() as conn:
@@ -189,30 +209,27 @@ class AnalysisMethods:
         results = []
         for ts, channels_json in rows:
             channels = json.loads(channels_json)
-            for ch in channels:
-                try:
-                    stored_id = int(float(ch.get("channel_id", 0)))
-                except (ValueError, TypeError):
-                    stored_id = ch.get("channel_id")
-                if stored_id == channel_id:
-                    results.append({
-                        "timestamp": ts,
-                        "power": ch.get("power"),
-                        "snr": ch.get("snr"),
-                        "correctable_errors": ch.get("correctable_errors"),
-                        "uncorrectable_errors": ch.get("uncorrectable_errors"),
-                        "modulation": ch.get("modulation", ""),
-                        "health": ch.get("health", ""),
-                    })
-                    break
+            channel = match_channel(
+                channels, selector=selector, channel_id=channel_id
+            )
+            if channel is not None:
+                results.append(_history_row(ts, channel))
         unwrap_uint32_counter_series(results, _CHANNEL_ERROR_KEYS)
         return results
 
-    def get_multi_channel_history(self, channel_ids, direction, days=7, hours=None):
+    def get_multi_channel_history(
+        self, channel_ids, direction, days=7, hours=None, selectors=None
+    ):
         """Return time series for multiple channels over the selected window.
-        direction: 'ds' or 'us'. Returns dict {channel_id: [{timestamp, power, snr, ...}, ...]}"""
+        Exact selectors take precedence over legacy unique channel IDs.
+        direction: 'ds' or 'us'. Returns keyed lists of channel history rows."""
+        selectors = list(selectors or [])
         channel_ids = [int(c) for c in channel_ids]
-        channel_set = set(channel_ids)
+        targets = (
+            [(selector, {"selector": selector}) for selector in selectors]
+            if selectors
+            else [(channel_id, {"channel_id": channel_id}) for channel_id in channel_ids]
+        )
         cutoff = utc_cutoff(hours=hours) if hours is not None else utc_cutoff(days=days)
         col = "ds_channels_json" if direction == "ds" else "us_channels_json"
         with self._connect() as conn:
@@ -220,24 +237,20 @@ class AnalysisMethods:
                 f"SELECT timestamp, {col} FROM snapshots WHERE timestamp >= ? ORDER BY timestamp",
                 (cutoff,),
             ).fetchall()
-        results = {cid: [] for cid in channel_ids}
+        results = {key: [] for key, _match_args in targets}
         for ts, channels_json in rows:
             channels = json.loads(channels_json)
-            for ch in channels:
-                try:
-                    cid = int(float(ch.get("channel_id", 0)))
-                except (ValueError, TypeError):
-                    cid = ch.get("channel_id")
-                if cid in channel_set:
-                    results[cid].append({
-                        "timestamp": ts,
-                        "power": ch.get("power"),
-                        "snr": ch.get("snr"),
-                        "correctable_errors": ch.get("correctable_errors"),
-                        "uncorrectable_errors": ch.get("uncorrectable_errors"),
-                        "modulation": ch.get("modulation", ""),
-                        "frequency": ch.get("frequency", ""),
-                    })
+            matches = match_channels(
+                channels,
+                selectors=selectors if selectors else None,
+                channel_ids=channel_ids if not selectors else None,
+            )
+            for key, _match_args in targets:
+                channel = matches.get(key)
+                if channel is not None:
+                    results[key].append(
+                        _history_row(ts, channel, include_frequency=True)
+                    )
         for rows_for_channel in results.values():
             unwrap_uint32_counter_series(rows_for_channel, _CHANNEL_ERROR_KEYS)
         return results

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -361,6 +361,8 @@ class SnapshotMethods:
 
     def get_current_channels(self):
         """Return DS and US channels from the latest snapshot."""
+        from app.channel_selector import attach_channel_selectors
+
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT ds_channels_json, us_channels_json FROM snapshots ORDER BY timestamp DESC LIMIT 1"
@@ -368,6 +370,6 @@ class SnapshotMethods:
         if not row:
             return {"ds_channels": [], "us_channels": []}
         return {
-            "ds_channels": json.loads(row[0]),
-            "us_channels": json.loads(row[1]),
+            "ds_channels": attach_channel_selectors(json.loads(row[0])),
+            "us_channels": attach_channel_selectors(json.loads(row[1])),
         }

--- a/tests/drivers/test_modulation_normalization.py
+++ b/tests/drivers/test_modulation_normalization.py
@@ -98,6 +98,23 @@ def test_tc4400_downstream_sc_qam_type_is_canonical():
     assert channels[0]["mse"] == -39.5
 
 
+@pytest.mark.parametrize(
+    ("headers", "expected_index"),
+    [
+        (["Channel ID", "Channel Index", "Lock Status", "Frequency"], 0),
+        (["Channel Index", "Channel ID", "Lock Status", "Frequency"], 1),
+    ],
+)
+def test_tc4400_column_mapping_always_prefers_explicit_channel_id(
+    headers, expected_index
+):
+    driver = TC4400Driver("http://192.168.100.1", "user", "pass")
+
+    columns = driver._map_columns([header.lower() for header in headers])
+
+    assert columns["channel_id"] == expected_index
+
+
 def test_vodafone_cga_docsis31_types_are_uppercase():
     class Response:
         def json(self):

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -255,6 +255,54 @@ class TestChartZoom:
 class TestChannelCharts:
     """Charts in the Channels > Timeline view."""
 
+    def test_duplicate_id_timeline_restores_exact_selector_and_requests_same_channel(self, demo_page):
+        selectors = {"634": "selector634", "738": "selector738"}
+        history_requests = []
+        demo_page.route(
+            "**/api/channels",
+            lambda route: route.fulfill(json={
+                "ds_channels": [
+                    {"channel_id": 0, "frequency": "634 MHz", "power": 4.8,
+                     "snr": 38.1, "docsis_version": "3.0", "health": "good",
+                     "selector": selectors["634"], "selector_required": True},
+                    {"channel_id": 0, "frequency": "738 MHz", "power": -1.7,
+                     "snr": 41.2, "docsis_version": "3.1", "health": "warning",
+                     "selector": selectors["738"], "selector_required": True},
+                ],
+                "us_channels": [],
+            }),
+        )
+
+        def history_route(route):
+            history_requests.append(route.request.url)
+            power = -1.7 if "selector=selector738" in route.request.url else 4.8
+            route.fulfill(json=[{
+                "timestamp": "2026-05-01T12:00:00",
+                "power": power,
+                "snr": 41.2,
+                "modulation": "OFDM",
+                "correctable_errors": 20,
+                "uncorrectable_errors": 3,
+            }])
+
+        demo_page.route("**/api/channel-history**", history_route)
+        base_url = demo_page.url.split("#", 1)[0]
+        demo_page.goto(
+            base_url + "#channels?mode=timeline&dir=ds&selector=selector738&range=1d"
+        )
+        wait_for_uplot(demo_page, "chart-ch-power")
+
+        select = demo_page.locator("#channel-select")
+        assert select.locator("option:checked").text_content() == "DS 0 (738 MHz)"
+        assert "738 MHz" in demo_page.locator("#channel-info-bar").text_content()
+        assert "Power -1.7 dBmV" in demo_page.locator("#channel-info-bar").text_content()
+        assert "selector=selector738" in demo_page.url
+        assert history_requests and "selector=selector738" in history_requests[-1]
+        assert "channel_id=" not in history_requests[-1]
+        assert demo_page.evaluate(
+            "window.charts['chart-ch-power'].data[1][0]"
+        ) == -1.7
+
     def test_channel_unused_controls_follow_selection_state(self, demo_page):
         """Range and clear controls should only show after a usable channel selection."""
         navigate_to_channels(demo_page)
@@ -420,6 +468,55 @@ class TestChannelCharts:
 
 class TestCompareCharts:
     """Charts in the Channels > Compare view."""
+
+    def test_duplicate_id_channels_coexist_with_distinct_compare_data(self, demo_page):
+        compare_requests = []
+        demo_page.route(
+            "**/api/channels",
+            lambda route: route.fulfill(json={
+                "ds_channels": [
+                    {"channel_id": 0, "frequency": "634 MHz", "docsis_version": "3.0",
+                     "selector": "selector634", "selector_required": True},
+                    {"channel_id": 0, "frequency": "738 MHz", "docsis_version": "3.1",
+                     "selector": "selector738", "selector_required": True},
+                ],
+                "us_channels": [],
+            }),
+        )
+
+        def compare_route(route):
+            compare_requests.append(route.request.url)
+            route.fulfill(json={
+                "selector634": [{"timestamp": "2026-05-01T12:00:00", "power": 4.8,
+                                   "snr": 38.1, "modulation": "256QAM"}],
+                "selector738": [{"timestamp": "2026-05-01T12:00:00", "power": -1.7,
+                                   "snr": 41.2, "modulation": "OFDM"}],
+            })
+
+        demo_page.route("**/api/channel-compare**", compare_route)
+        navigate_to_channels(demo_page)
+        demo_page.locator('.trend-tab[data-value="compare"]').click()
+
+        compare_select = demo_page.locator("#compare-channel-select")
+        compare_select.select_option(label="DS 0 (634 MHz)")
+        demo_page.locator("#compare-add-btn").click()
+        expect(demo_page.locator("#compare-chips .compare-chip")).to_have_count(1)
+        expect(
+            compare_select.locator('option', has_text="DS 0 (634 MHz)")
+        ).to_have_count(0)
+        compare_select.select_option(label="DS 0 (738 MHz)")
+        demo_page.locator("#compare-add-btn").click()
+        wait_for_uplot(demo_page, "chart-cmp-power")
+
+        chips = demo_page.locator("#compare-chips .compare-chip")
+        assert chips.count() == 2
+        assert "634 MHz" in chips.nth(0).text_content()
+        assert "738 MHz" in chips.nth(1).text_content()
+        assert "selectors=selector634%2Cselector738" in demo_page.url
+        assert "selectors=selector634%2Cselector738" in compare_requests[-1]
+        assert demo_page.evaluate(
+            "window.charts['chart-cmp-power'].data.slice(1, 3).map(series => series[0])"
+        ) == [4.8, -1.7]
 
     def test_compare_mode_renders_power_chart(self, demo_page):
         """Compare mode with channels should render power overlay chart."""

--- a/tests/test_channel_selector_static_contract.py
+++ b/tests/test_channel_selector_static_contract.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHANNELS_JS = ROOT / "app" / "static" / "js" / "channels.js"
+
+
+def test_channel_frontend_has_one_selector_reference_decoder():
+    source = CHANNELS_JS.read_text(encoding="utf-8")
+
+    assert source.count("function _readChannelSelection(") == 1
+    assert "selector=" in source
+    assert "selectors=" in source
+    assert "dataset.selector" in source
+
+
+def test_compare_identity_is_not_deduplicated_by_modem_channel_id():
+    source = CHANNELS_JS.read_text(encoding="utf-8")
+
+    assert "c.key === ref.key" in source
+    assert "removeCompareChannel(ch.key)" in source

--- a/tests/test_channel_timeline.py
+++ b/tests/test_channel_timeline.py
@@ -56,6 +56,19 @@ def _make_analysis(ds_channels=None, us_channels=None):
     }
 
 
+def _duplicate_id_analysis(first_frequency="634 MHz", second_frequency="738 MHz"):
+    return _make_analysis(ds_channels=[
+        {"channel_id": 0, "frequency": first_frequency, "power": 4.8,
+         "modulation": "256QAM", "snr": 38.1, "correctable_errors": 10,
+         "uncorrectable_errors": 2, "docsis_version": "3.0",
+         "health": "good", "health_detail": ""},
+        {"channel_id": 0, "frequency": second_frequency, "power": -1.7,
+         "modulation": "OFDM", "snr": 41.2, "correctable_errors": 20,
+         "uncorrectable_errors": 3, "docsis_version": "3.1",
+         "health": "warning", "health_detail": "power warning low"},
+    ])
+
+
 @pytest.fixture
 def storage(tmp_path):
     db_path = str(tmp_path / "test.db")
@@ -305,6 +318,107 @@ class TestGetChannelHistory:
         assert len(result[1]) == 1
         assert result[1][0]["power"] == 5.2
 
+    def test_ambiguous_legacy_id_returns_no_unrelated_first_match(self, storage):
+        storage.save_snapshot(_duplicate_id_analysis())
+
+        assert storage.get_channel_history(0, "ds", days=7) == []
+
+    def test_selector_keeps_duplicate_ids_independent_and_normalizes_frequency(self, storage):
+        older = _duplicate_id_analysis(634, "738.0 MHz")
+        newer = _duplicate_id_analysis("634.0 MHz", 738)
+        newer["ds_channels"][0]["power"] = 5.1
+        newer["ds_channels"][1]["power"] = -2.0
+        _insert_snapshot(storage, older, _utc_ts(timedelta(minutes=2)))
+        _insert_snapshot(storage, newer, _utc_ts(timedelta(minutes=1)))
+        current = storage.get_current_channels()["ds_channels"]
+        first_selector = current[0]["selector"]
+        second_selector = current[1]["selector"]
+
+        first = storage.get_channel_history(
+            0, "ds", days=7, selector=first_selector
+        )
+        second = storage.get_channel_history(
+            0, "ds", days=7, selector=second_selector
+        )
+
+        assert [row["power"] for row in first] == [4.8, 5.1]
+        assert [row["power"] for row in second] == [-1.7, -2.0]
+
+    def test_selector_supports_duplicate_invalid_ids(self, storage):
+        analysis = _duplicate_id_analysis()
+        analysis["ds_channels"][0]["channel_id"] = None
+        analysis["ds_channels"][1]["channel_id"] = None
+        storage.save_snapshot(analysis)
+        current = storage.get_current_channels()["ds_channels"]
+
+        first = storage.get_channel_history(
+            None, "ds", days=7, selector=current[0]["selector"]
+        )
+        second = storage.get_channel_history(
+            None, "ds", days=7, selector=current[1]["selector"]
+        )
+
+        assert first[0]["power"] == 4.8
+        assert second[0]["power"] == -1.7
+
+    def test_explicit_unmatched_selector_returns_empty(self, storage):
+        storage.save_snapshot(_duplicate_id_analysis())
+
+        assert storage.get_channel_history(
+            0, "ds", days=7, selector="not-a-channel"
+        ) == []
+
+    def test_ambiguous_selector_returns_empty(self, storage):
+        storage.save_snapshot(_duplicate_id_analysis("634 MHz", 634.0))
+        selector = storage.get_current_channels()["ds_channels"][0]["selector"]
+
+        assert storage.get_channel_history(
+            0, "ds", days=7, selector=selector
+        ) == []
+
+    def test_multi_selector_history_does_not_merge_duplicate_ids(self, storage):
+        storage.save_snapshot(_duplicate_id_analysis())
+        current = storage.get_current_channels()["ds_channels"]
+        selectors = [channel["selector"] for channel in current]
+
+        result = storage.get_multi_channel_history(
+            [], "ds", days=7, selectors=selectors
+        )
+
+        assert result[selectors[0]][0]["power"] == 4.8
+        assert result[selectors[1]][0]["power"] == -1.7
+
+    def test_multi_selector_history_indexes_each_snapshot_channel_once(
+        self, storage, monkeypatch
+    ):
+        analysis = _make_analysis(ds_channels=[
+            {"channel_id": 0, "frequency": f"{600 + index} MHz", "power": index}
+            for index in range(32)
+        ])
+        storage.save_snapshot(analysis)
+        selectors = [
+            channel["selector"]
+            for channel in storage.get_current_channels()["ds_channels"]
+        ]
+        from app import channel_selector as selector_module
+
+        original = selector_module.channel_selector
+        calls = 0
+
+        def counted_selector(channel):
+            nonlocal calls
+            calls += 1
+            return original(channel)
+
+        monkeypatch.setattr(selector_module, "channel_selector", counted_selector)
+
+        result = storage.get_multi_channel_history(
+            [], "ds", days=7, selectors=selectors
+        )
+
+        assert all(len(result[selector]) == 1 for selector in selectors)
+        assert calls == 32
+
 
 class TestGetCurrentChannels:
     def test_returns_channels(self, storage):
@@ -317,6 +431,15 @@ class TestGetCurrentChannels:
     def test_empty_storage(self, storage):
         result = storage.get_current_channels()
         assert result == {"ds_channels": [], "us_channels": []}
+
+    def test_exposes_stable_distinct_selectors_for_duplicate_ids(self, storage):
+        storage.save_snapshot(_duplicate_id_analysis())
+
+        result = storage.get_current_channels()["ds_channels"]
+
+        assert result[0]["selector"] != result[1]["selector"]
+        assert result[0]["selector_required"] is True
+        assert result[1]["selector_required"] is True
 
 
 # ── API Tests ──
@@ -411,6 +534,39 @@ class TestChannelHistoryEndpoint:
 
         assert resp.status_code == 400
 
+    def test_selector_returns_exact_duplicate_channel(self, client):
+        c, s = client
+        s.save_snapshot(_duplicate_id_analysis())
+        selector = json.loads(c.get("/api/channels").data)["ds_channels"][1]["selector"]
+
+        resp = c.get(
+            "/api/channel-history",
+            query_string={"selector": selector, "direction": "ds", "range": "1d"},
+        )
+
+        assert resp.status_code == 200
+        assert json.loads(resp.data)[0]["power"] == -1.7
+
+    def test_ambiguous_legacy_api_request_returns_empty(self, client):
+        c, s = client
+        s.save_snapshot(_duplicate_id_analysis())
+
+        resp = c.get("/api/channel-history?channel_id=0&direction=ds&range=1d")
+
+        assert resp.status_code == 200
+        assert json.loads(resp.data) == []
+
+    def test_explicit_unmatched_api_selector_returns_empty(self, client):
+        c, s = client
+        s.save_snapshot(_duplicate_id_analysis())
+
+        resp = c.get(
+            "/api/channel-history?selector=not-a-channel&direction=ds&range=1d"
+        )
+
+        assert resp.status_code == 200
+        assert json.loads(resp.data) == []
+
 
 class TestChannelCompareEndpoint:
     def test_returns_multiple_channels(self, client):
@@ -457,3 +613,23 @@ class TestChannelCompareEndpoint:
         assert resp.status_code == 400
         data = json.loads(resp.data)
         assert data["error"] == "maximum 64 channels"
+
+    def test_selectors_keep_duplicate_id_channels_separate(self, client):
+        c, s = client
+        s.save_snapshot(_duplicate_id_analysis())
+        channels = json.loads(c.get("/api/channels").data)["ds_channels"]
+        selectors = [channel["selector"] for channel in channels]
+
+        resp = c.get(
+            "/api/channel-compare",
+            query_string={
+                "selectors": ",".join(selectors),
+                "direction": "ds",
+                "range": "1d",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data[selectors[0]][0]["power"] == 4.8
+        assert data[selectors[1]][0]["power"] == -1.7


### PR DESCRIPTION
## Summary

- add an exact channel selector based on normalized modem channel ID and frequency
- keep duplicate TC4400 channel IDs independently selectable in Timeline and Compare
- prefer the TC4400 `Channel ID` column over `Channel Index` in either header order
- retain legacy integer-ID API and URL behavior when a channel ID is unambiguous
- return empty history for ambiguous or unmatched identities instead of unrelated first-channel data

## Implementation

`/api/channels` now exposes an opaque selector for each current channel. Timeline and Compare use that selector whenever the modem ID is duplicated or invalid. Historical snapshots remain unchanged; selectors are matched against their existing ID and frequency fields at query time.

Multi-channel history builds one identity index per snapshot so 90-day Compare requests remain linear in the number of stored channels rather than multiplying channels by selected identities.

## Verification

- regression tests against the old implementation: 14 expected failures
- focused parser, storage, API, and static contract tests: 70 passed
- full non-browser suite: 3320 passed, 2 skipped
- Chromium regressions for exact Timeline restoration and duplicate-ID Compare: 2 passed
- 90-day benchmark with 32 duplicate-ID channels and 8,641 snapshots: 1.452 seconds locally; 1.599 seconds in independent review
- JavaScript syntax, Python compilation, and diff checks passed

Closes #773
