### PR TITLE
Document error counter coverage

### DIFF
--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -6,7 +6,7 @@ This page keeps public positioning honest by separating shipped capabilities fro
 
 | Area | Status | Notes |
 |---|---|---|
-| DOCSIS signal monitoring | Shipped | Signal health, channels, modulation, SNR and power history for supported modem families. |
+| DOCSIS signal monitoring | Shipped | Signal health, channels, modulation, SNR, power history, raw error counters and comparable-channel error coverage for supported modem families. |
 | Generic Router mode | Shipped | Useful for non-cable connections, but strongest DOCSIS evidence needs cable signal data. |
 | Demo mode | Shipped | Generates realistic synthetic history for evaluation without a modem. |
 | Correlation analysis | Shipped | Combines signal, speed, latency, events and notes into one investigation view. |


### PR DESCRIPTION
## Summary

- document raw DOCSIS error counters in the public feature matrix
- clarify that error coverage is scoped to comparable channels

## Verification

- `uv run --with-requirements requirements.txt --with-requirements requirements-test.txt python -m pytest -q tests/test_public_launch_surface.py --tb=short`
- `git diff --check`