### PR TITLE
Harden correlation interaction E2E synchronization

### DIFF
--- a/tests/e2e/test_correlation_ui.py
+++ b/tests/e2e/test_correlation_ui.py
@@ -677,7 +677,9 @@ def test_reachability_legend_tooltip_and_mouse_keyboard_drilldown(demo_page):
     page.wait_for_selector("#view-correlation.active")
     page.wait_for_selector("#correlation-chart-container", state="visible")
     overlay = page.locator("#correlation-overlay")
+    expect(overlay).to_be_visible()
     box = overlay.bounding_box()
+    assert box is not None, "Correlation overlay should have a bounding box"
     lane_point = page.evaluate(
         "() => ({ x: window._corrChartState.pad.left + 2, y: window._corrChartState.reachabilityLane.y + 2 })"
     )

--- a/tests/e2e/test_segment_utilization.py
+++ b/tests/e2e/test_segment_utilization.py
@@ -477,19 +477,48 @@ class TestSegmentCorrelation:
         box = overlay.bounding_box()
         assert box, "Correlation overlay should be present for hover interactions"
 
-        modem_row = fritzbox_page.locator('#correlation-tbody tr[data-src="modem"]').first
-        row_ts = modem_row.get_attribute("data-ts")
-        assert row_ts, "Correlation table should include at least one modem transition row"
-        hover_x = fritzbox_page.evaluate(
+        modem_point = fritzbox_page.evaluate(
             """
-            (rowTs) => {
+            () => {
                 const st = window._corrChartState;
-                return st.xScale(new Date(rowTs).getTime());
+                const timelineTimestamps = new Set(
+                    Array.from(
+                        document.querySelectorAll(
+                            '#correlation-tbody tr[data-src="modem"]'
+                        )
+                    ).map((row) => row.getAttribute('data-ts'))
+                );
+                const point = st.modem.find((item) => {
+                    const timestamp = new Date(item.timestamp).getTime();
+                    return timestamp >= st.tMin && timestamp <= st.tMax
+                        && timelineTimestamps.has(item.timestamp);
+                });
+                if (!point) return null;
+                const timestamp = new Date(point.timestamp).getTime();
+                return {
+                    timestamp: point.timestamp,
+                    x: Math.max(
+                        st.pad.left + 1,
+                        Math.min(st.pad.left + st.plotW - 1, st.xScale(timestamp))
+                    ),
+                };
             }
             """,
-            row_ts,
         )
-        fritzbox_page.mouse.move(box["x"] + hover_x, box["y"] + box["height"] * 0.45)
+        assert modem_point, "Correlation chart should include an in-range modem point"
+
+        modem_row = fritzbox_page.locator(
+            f'#correlation-tbody tr[data-src="modem"][data-ts="{modem_point["timestamp"]}"]'
+        )
+        assert modem_row.count() > 0, (
+            "Correlation timeline should include a modem row matching the selected "
+            f'chart point timestamp {modem_point["timestamp"]}'
+        )
+        modem_row = modem_row.first
+
+        fritzbox_page.mouse.move(
+            box["x"] + modem_point["x"], box["y"] + box["height"] * 0.45
+        )
         fritzbox_page.wait_for_timeout(400)
 
         tooltip = fritzbox_page.locator("#correlation-tooltip")


### PR DESCRIPTION
## Summary

- select a modem sample that is both inside the active correlation chart range and represented in the timeline
- hover a coordinate kept inside the chart interaction area and continue asserting the exact corresponding row is highlighted
- wait for the correlation overlay to become visible before reading its bounding box after repeated view switches

These changes remove two correlation interaction timing failures without changing production behavior.

## Validation

- reproduced the off-range hover failure on unmodified `origin/main`
- segment hover test passed three consecutive runs under `TZ=UTC`
- full `tests/e2e/test_segment_utilization.py`: 54 passed
- full local E2E batch: 517 passed
- GitHub's first full-E2E run exposed the separate overlay timing failure with 516 passed and 1 failed
- overlay drilldown test passed three consecutive runs after synchronization
- full `tests/e2e/test_correlation_ui.py`: 32 passed
- `git diff --check`: passed
