### PR TITLE
Stabilize correlation lane click E2E

### DIFF
--- a/tests/e2e/test_correlation_ui.py
+++ b/tests/e2e/test_correlation_ui.py
@@ -678,12 +678,10 @@ def test_reachability_legend_tooltip_and_mouse_keyboard_drilldown(demo_page):
     page.wait_for_selector("#correlation-chart-container", state="visible")
     overlay = page.locator("#correlation-overlay")
     expect(overlay).to_be_visible()
-    box = overlay.bounding_box()
-    assert box is not None, "Correlation overlay should have a bounding box"
     lane_point = page.evaluate(
         "() => ({ x: window._corrChartState.pad.left + 2, y: window._corrChartState.reachabilityLane.y + 2 })"
     )
-    page.mouse.click(box["x"] + lane_point["x"], box["y"] + lane_point["y"])
+    overlay.click(position=lane_point)
     expect(page.locator("#view-connection-monitor.active")).to_be_visible()
     expect(destination_title).to_be_focused()
 


### PR DESCRIPTION
## Summary

- use the correlation overlay's locator-relative click for the reachability-lane drilldown
- preserve the existing lane coordinates, destination visibility check, and focus-transfer assertion
- avoid a race between a successful visibility check and a separate bounding-box lookup

## Validation

- affected drilldown test passed three consecutive runs
- full correlation browser suite: 32 passed
- Python compile and diff checks passed
