### PR TITLE
Confine module static file paths

### DIFF
--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, cast
 
-from flask import send_from_directory, url_for
+from flask import abort, send_file, url_for
 
 from app import analyzer as _analyzer
 from app import config as _cfg
@@ -716,10 +716,20 @@ def setup_module_static(app, module_id: str, module_path: str, static_subdir: st
         log.debug("Module '%s': no static directory at %s", module_id, static_dir)
         return
 
+    static_root = os.path.realpath(static_dir)
+    static_prefix = static_root + os.sep
     route = f"/modules/{module_id}/static/<path:filename>"
 
-    def serve_static(filename, _dir=static_dir):
-        return send_from_directory(_dir, filename)
+    def serve_static(filename, _root=static_root, _prefix=static_prefix):
+        try:
+            candidate = os.path.realpath(os.path.join(_root, filename))
+        except (OSError, TypeError, ValueError):
+            return abort(404)
+        if candidate.startswith(_prefix):
+            if not os.path.isfile(candidate):
+                return abort(404)
+            return send_file(candidate)
+        return abort(404)
 
     # Use a unique endpoint name per module
     endpoint = module_static_endpoint(module_id)

--- a/tests/module_loader/test_loading_core.py
+++ b/tests/module_loader/test_loading_core.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 from flask import Flask
+from werkzeug.exceptions import NotFound
 import app.module_loader as module_loader
 from app.module_loader import ModuleInfo, validate_manifest, ManifestError, discover_modules, register_module_config, merge_module_i18n, load_module_routes, load_module_collector, load_module_publisher, setup_module_static, setup_module_templates, ModuleLoader
 
@@ -390,6 +391,38 @@ class TestStaticAndTemplates:
                 assert resp.status_code == 200
                 assert b"console.log" in resp.data
                 resp.close()
+
+    def test_static_route_rejects_traversal_and_symlink_escape(self, tmp_path):
+        app = Flask(__name__)
+        module_dir = tmp_path / "testmod"
+        static_dir = module_dir / "static"
+        nested_dir = static_dir / "nested"
+        nested_dir.mkdir(parents=True)
+        (nested_dir / "ok.js").write_text("safe", encoding="utf-8")
+        outside_dir = module_dir / "static-outside"
+        outside_dir.mkdir()
+        outside_file = outside_dir / "secret.js"
+        outside_file.write_text("secret", encoding="utf-8")
+        symlink = static_dir / "escape.js"
+        try:
+            symlink.symlink_to(outside_file)
+        except OSError:
+            pytest.skip("symlinks are unavailable in this environment")
+
+        setup_module_static(app, "test.mod", str(module_dir), "static/")
+        view = app.view_functions[module_loader.module_static_endpoint("test.mod")]
+
+        with app.test_request_context("/"):
+            with pytest.raises(NotFound):
+                view("../static-outside/secret.js")
+            with pytest.raises(NotFound):
+                view("escape.js")
+
+        with app.test_client() as client:
+            response = client.get("/modules/test.mod/static/nested/ok.js")
+            assert response.status_code == 200
+            assert response.data == b"safe"
+            response.close()
 
     def test_module_static_endpoint_and_url_helper_share_prefix_aware_contract(self):
         endpoint = module_loader.module_static_endpoint("test.mod")


### PR DESCRIPTION
## Summary

- resolve module static-file requests against the canonical registered static root
- reject traversal, symlink escapes, and missing targets with `404`
- preserve nested module asset delivery and prefix-aware endpoint behavior

## Validation

- complete non-E2E suite: `3534 passed, 2 skipped`
- Python compile and diff checks passed
- built-in registry, Windows smoke test, and PE verification contracts remain unchanged
