### PR TITLE
Refactor Flask startup into a deterministic application factory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,6 +25,35 @@ Supervisor app information and set an explicit `BASE_PATH` before starting
 DOCSight, but the wrapper owns that platform integration. Core continues to
 use its own authentication and generic reverse-proxy contract.
 
+### Application factory
+
+`app.app_factory.create_app()` is the single production construction path for
+the Flask application. Importing `app.web` defines the core HTTP surface and
+its accessor facade, but does not construct an application. Factory creation
+has a fixed order: configure Flask, establish the durable signing key, attach
+runtime state, synchronize authentication state, register core routes,
+register core blueprints, load module contributions and templates, install
+base-path handling, then apply reverse-proxy handling as the outer WSGI layer.
+
+Each application owns a typed `DocsightRuntime` at
+`app.extensions["docsight"]`. It contains the configuration manager, storage,
+authentication state, rate limiter, update checker, module loader, collector
+references, derived-storage cache, and lock-protected dashboard state. Route
+and module code reaches the current application through the accessors in
+`app.web`; it must not retain app-specific values in module globals.
+
+Collector threads receive the same runtime explicitly through the existing
+`web=` duck-type parameter. The runtime implements `update_state()`,
+`clear_speedtest_latest()`, `get_state()`, `get_module_loader()`, and the
+read-only `_state` snapshot expected by existing collectors, without requiring
+a Flask request or application context.
+
+Module schema registries in `app.config`, analyzer threshold selection,
+translation catalogs, driver/theme registries, and dynamic Python imports are
+process-wide. Per-application configuration values, storage paths, signing and
+authentication state, rate-limit buckets, update caches, module loader,
+templates, collectors, and derived storages remain isolated.
+
 ---
 
 ## System Architecture
@@ -216,7 +245,9 @@ All shared state is protected by locks:
 |------|----------|----------|
 | `_lock` | `Collector` base | Scheduling state (`_last_poll`, `_consecutive_failures`) |
 | `_collect_lock` | `Collector` base | Prevents concurrent `collect()` (manual poll vs auto-poll) |
-| `_state_lock` | `web.py` | Shared `_state` dict (written by collectors, read by Flask) |
+| `RuntimeState._lock` | `runtime.py` | Per-application dashboard state (written by collectors, read by Flask) |
+| `LoginRateLimiter._lock` | `runtime.py` | Per-application login failure buckets |
+| `UpdateChecker._lock` | `runtime.py` | Per-application update-check state |
 | `_lock` | `EventDetector` | Previous snapshot comparison (`_prev`) |
 
 SQLite uses **WAL mode** (`PRAGMA journal_mode=WAL`) for concurrent reads during writes.
@@ -257,7 +288,7 @@ Driver.get_docsis_data()
     → event_detector.check()
       → storage.save_snapshot()
         → mqtt_pub.publish_data()
-          → web.update_state()
+          → runtime.update_state()
 ```
 
 **Output:** `CollectorResult` with channel health assessment
@@ -287,7 +318,7 @@ _generate_data() (base channels + variation)
     → event_detector.check()
       → storage.save_snapshot()
         → mqtt_pub.publish_data()
-          → web.update_state()
+          → runtime.update_state()
 ```
 
 **Features:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Collector Registry → Base Collector (Fail-Safe) → Analyzer/Storage → Web U
 - New modem types must implement the `ModemDriver` base class (`app/drivers/base.py`)
 - Collectors run in **parallel threads** via `ThreadPoolExecutor`. Protect shared state with locks.
 - Use the collector pattern for automatic fail-safe and health monitoring
+- Construct applications only with `app.app_factory.create_app()`. Importing `app.web` must remain free of application construction and app-specific globals.
 
 See [`ARCHITECTURE.md`](ARCHITECTURE.md) for detailed technical documentation and data flow diagrams.
 
@@ -70,8 +71,10 @@ Open `http://localhost:8765` to access the setup wizard.
 
 ```
 app/
+  app_factory.py     - Deterministic Flask application construction
   main.py            - Entrypoint, ThreadPoolExecutor polling loop
-  web.py             - Flask routes and API endpoints (thread-safe state)
+  runtime.py         - Typed per-application runtime state and locks
+  web.py             - Core routes, filters, auth, and runtime accessors
   analyzer.py        - DOCSIS channel health analysis
   threshold_profiles.py - Built-in analyzer threshold profiles
   event_detector.py  - Signal anomaly detection (thread-safe)
@@ -126,6 +129,14 @@ We prefer new languages to be contributed by people who actually use the tool in
 ## Building Modules
 
 DOCSight supports community modules that extend functionality without modifying core code. Modules can add API endpoints, data collectors, settings panels, dashboard tabs, and more.
+
+Server-side module code should import the established accessors it needs from
+`app.web`, such as `get_config_manager()`, `get_storage()`, `get_state()`, or
+`get_module_loader()`. These accessors resolve the active application's typed
+runtime. Do not import or create a module-level Flask application, and do not
+cache app-derived storage or mutable request/runtime state in module globals.
+Collectors receive their runtime-facing `web` object explicitly and must keep
+working without a Flask application context.
 
 ### Browser URL contract
 

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -1,0 +1,148 @@
+"""Deterministic Flask application construction for DOCSight."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Mapping, Sequence
+from datetime import timedelta
+from typing import Any
+
+from flask import Flask
+from jinja2 import ChoiceLoader, FileSystemLoader
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+from . import web
+from .base_path import configure_base_path
+from .blueprints import register_blueprints
+from .module_loader import ModuleLoader
+from .runtime import (
+    AuthStateStore,
+    DocsightRuntime,
+    LoginRateLimiter,
+    UpdateChecker,
+    attach_runtime,
+)
+
+
+LOG = logging.getLogger("docsis.web")
+ModuleLoaderFactory = Callable[[Flask], Any | None]
+
+
+def default_module_loader_factory(
+    config_manager,
+    *,
+    builtin_base_path: str | None = None,
+    search_paths: Sequence[str] | None = None,
+) -> ModuleLoaderFactory:
+    """Build a per-app module loader using this configuration's enabled set."""
+    builtin_path = builtin_base_path or os.path.join(os.path.dirname(__file__), "modules")
+    module_paths = list(search_paths or ())
+
+    def build(app: Flask):
+        disabled_raw = config_manager.get("disabled_modules", "")
+        disabled_ids = {item.strip() for item in disabled_raw.split(",") if item.strip()}
+        loader = ModuleLoader(
+            app,
+            builtin_base_path=builtin_path,
+            search_paths=module_paths,
+            disabled_ids=disabled_ids,
+        )
+        loader.load_all()
+        return loader
+
+    return build
+
+
+def install_module_template_loader(app: Flask, module_loader) -> None:
+    """Add enabled module template directories to this app's Jinja loader."""
+    if module_loader is None:
+        return
+    loaders = [app.jinja_loader]
+    for module in module_loader.get_enabled_modules():
+        template_dir = os.path.join(module.path, "templates")
+        if os.path.isdir(template_dir):
+            loaders.append(FileSystemLoader(template_dir))
+    if len(loaders) > 1:
+        app.jinja_loader = ChoiceLoader(loaders)
+
+
+def apply_reverse_proxy(app: Flask, environ: Mapping[str, str]) -> None:
+    """Install trusted reverse-proxy handling as the outer WSGI layer."""
+    reverse_proxy = environ.get("REVERSE_PROXY", "").strip()
+    if not reverse_proxy:
+        return
+    num_proxies = int(reverse_proxy) if reverse_proxy.isdigit() else 1
+    app.wsgi_app = ProxyFix(
+        app.wsgi_app,
+        x_for=num_proxies,
+        x_proto=num_proxies,
+        x_host=0,
+        x_prefix=0,
+    )
+    app.config["SESSION_COOKIE_SECURE"] = True
+    LOG.info(
+        "Reverse proxy mode: trusting %d hop(s), secure cookies enabled",
+        num_proxies,
+    )
+
+
+def create_app(
+    *,
+    config_manager,
+    storage=None,
+    on_config_changed: Callable[[], None] | None = None,
+    module_loader_factory: ModuleLoaderFactory | None = None,
+    environ: Mapping[str, str] | None = None,
+    testing: bool = False,
+) -> Flask:
+    """Create one fully isolated DOCSight application in a fixed order.
+
+    Construction configures Flask, attaches runtime state, initializes auth,
+    registers core and blueprint routes, loads modules and templates, then
+    installs base-path and reverse-proxy middleware.
+    """
+    if config_manager is None:
+        raise TypeError("config_manager is required")
+    env = os.environ if environ is None else environ
+
+    app = Flask("app.web", template_folder="templates")
+    app.config.update(
+        SESSION_COOKIE_HTTPONLY=True,
+        SESSION_COOKIE_SAMESITE="Lax",
+        PERMANENT_SESSION_LIFETIME=timedelta(days=web._session_lifetime_days(env)),
+        SESSION_REFRESH_EACH_REQUEST=True,
+        TESTING=testing,
+    )
+
+    auth_state = AuthStateStore(config_manager.data_dir)
+    app.secret_key = auth_state.load_or_create_session_key()
+    enabled_check = getattr(config_manager, "is_update_check_enabled", None)
+    runtime = DocsightRuntime(
+        config_manager=config_manager,
+        storage=storage,
+        on_config_changed=on_config_changed,
+        auth_state=auth_state,
+        login_rate_limiter=LoginRateLimiter(
+            max_attempts=web._LOGIN_MAX_ATTEMPTS,
+            window=web._LOGIN_WINDOW,
+            lockout_base=web._LOGIN_LOCKOUT_BASE,
+            max_tracked_ips=web._LOGIN_MAX_TRACKED_IPS,
+        ),
+        update_checker=UpdateChecker(
+            app_version=web.APP_VERSION,
+            is_enabled=enabled_check if callable(enabled_check) else lambda: False,
+            ttl=web._UPDATE_CACHE_TTL,
+        ),
+    )
+    attach_runtime(app, runtime)
+    web.bootstrap_auth_state(app, runtime)
+    web.register_core_routes(app)
+    register_blueprints(app)
+
+    loader = module_loader_factory(app) if module_loader_factory else None
+    runtime.module_loader = loader
+    install_module_template_loader(app, loader)
+    configure_base_path(app, env)
+    apply_reverse_proxy(app, env)
+    return app

--- a/app/base_path.py
+++ b/app/base_path.py
@@ -183,3 +183,12 @@ def configure_base_path(
         trusted_hops=trusted_hops,
     )
     app.session_interface = RequestScopedCookieSessionInterface()
+
+
+def validate_base_path_configuration(
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Validate base-path environment values without constructing an app."""
+    env = os.environ if environ is None else environ
+    normalize_base_path(env.get("BASE_PATH"))
+    parse_trusted_prefix_hops(env.get("REVERSE_PROXY_PREFIX"))

--- a/app/blueprints/metrics_bp.py
+++ b/app/blueprints/metrics_bp.py
@@ -2,7 +2,7 @@
 
 from flask import Blueprint, Response, request
 
-from app.web import get_state, get_modem_collector
+from app.web import get_state, get_modem_collector, get_config_manager, get_storage
 from app.prometheus import format_metrics
 
 metrics_bp = Blueprint("metrics_bp", __name__)
@@ -10,17 +10,13 @@ metrics_bp = Blueprint("metrics_bp", __name__)
 
 def _metrics_token_required() -> bool:
     """Return whether /metrics should require a Bearer API token."""
-    from app import web as _web
-
-    config = getattr(_web, "_config_manager", None)
+    config = get_config_manager()
     return bool(config and config.get("metrics_require_token", False))
 
 
 def _has_valid_bearer_token() -> bool:
     """Validate the request's Bearer token through DOCSight token storage."""
-    from app import web as _web
-
-    storage = getattr(_web, "_storage", None)
+    storage = get_storage()
     auth_header = request.headers.get("Authorization", "")
     if not storage or not auth_header.startswith("Bearer "):
         return False

--- a/app/blueprints/segment_bp.py
+++ b/app/blueprints/segment_bp.py
@@ -8,13 +8,11 @@ from flask import Blueprint, jsonify, request
 from app.i18n import get_translations
 from app.storage.segment_utilization import SegmentUtilizationStorage
 from app.web import get_config_manager, get_storage, require_auth
+from app.runtime import current_runtime
 
 log = logging.getLogger("docsis.web.segment")
 
 segment_bp = Blueprint("segment_bp", __name__)
-
-_storage_instance = None
-
 
 def _get_lang():
     return request.cookies.get("lang", "en")
@@ -22,12 +20,12 @@ def _get_lang():
 
 def _get_storage():
     """Lazy-init segment storage using core DB path."""
-    global _storage_instance
-    if _storage_instance is None:
-        storage = get_storage()
-        if storage:
-            _storage_instance = SegmentUtilizationStorage(storage.db_path)
-    return _storage_instance
+    storage = get_storage()
+    if not storage:
+        return None
+    return current_runtime().derived_storage.get(
+        "segment_utilization", lambda: SegmentUtilizationStorage(storage.db_path)
+    )
 
 
 RANGE_HOURS = {"24h": 24, "7d": 168, "30d": 720, "all": 0}

--- a/app/collectors/demo.py
+++ b/app/collectors/demo.py
@@ -1,6 +1,7 @@
 """Demo collector — generates realistic DOCSIS data for testing without a real modem."""
 
 import copy
+import functools
 import json
 import logging
 import math
@@ -62,17 +63,12 @@ DEMO_TRACEROUTE_TRACE_CONFIGS = (
 )
 
 _FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "..", "fixtures")
-_BASE_DATA = None
-
-
+@functools.lru_cache(maxsize=1)
 def _load_base_data():
     """Load channel definitions from demo_channels.json (once)."""
-    global _BASE_DATA
-    if _BASE_DATA is None:
-        path = os.path.join(_FIXTURES_DIR, "demo_channels.json")
-        with open(path) as f:
-            _BASE_DATA = json.load(f)
-    return _BASE_DATA
+    path = os.path.join(_FIXTURES_DIR, "demo_channels.json")
+    with open(path) as handle:
+        return json.load(handle)
 
 
 class DemoCollector(Collector):
@@ -218,7 +214,7 @@ class DemoCollector(Collector):
                 )
                 self._discovery_published = True
                 time.sleep(1)
-            speedtest = self._web._state.get("speedtest_latest")
+            speedtest = self._web.get_state().get("speedtest_latest")
             gi = compute_gaming_index(analysis, speedtest)
             self._mqtt_pub.publish_data(analysis, gaming_index=gi)
 

--- a/app/collectors/modem.py
+++ b/app/collectors/modem.py
@@ -200,7 +200,7 @@ class ModemCollector(Collector):
                 )
                 self._discovery_published = True
                 time.sleep(1)
-            speedtest = self._web._state.get("speedtest_latest")
+            speedtest = self._web.get_state().get("speedtest_latest")
             gi = compute_gaming_index(analysis, speedtest)
             self._mqtt_pub.publish_data(analysis, gaming_index=gi)
 

--- a/app/main.py
+++ b/app/main.py
@@ -8,10 +8,12 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 from . import analyzer, web
-from .base_path import configure_base_path
+from .app_factory import create_app, default_module_loader_factory
+from .base_path import validate_base_path_configuration
 from .config import ConfigManager
 from .event_detector import EventDetector
 from .module_paths import get_modules_dir
+from .runtime import DocsightRuntime, get_runtime
 from .server_lifecycle import ServerLifecycleController
 from .storage import SnapshotStorage
 from .tz import guess_iana_timezone, utc_cutoff
@@ -54,6 +56,7 @@ if os.environ.get("DOCSIGHT_AUDIT_JSON", "").strip() == "1":
 
 
 def run_web(
+    application,
     port: int,
     server_lifecycle: ServerLifecycleController | None = None,
 ) -> None:
@@ -63,7 +66,7 @@ def run_web(
     host = get_web_host()
     server = WaitressServerAdapter(
         create_server(
-            web.app,
+            application,
             host=host,
             port=port,
             threads=4,
@@ -131,7 +134,7 @@ def _get_modem_config_key(config_mgr):
     )
 
 
-def polling_loop(config_mgr, storage, stop_event):
+def polling_loop(config_mgr, storage, stop_event, runtime: DocsightRuntime):
     """Flat orchestrator: tick every second, let each collector decide when to poll."""
     config = config_mgr.get_all()
 
@@ -141,7 +144,7 @@ def polling_loop(config_mgr, storage, stop_event):
     # Connect MQTT (optional, loaded from module if available)
     mqtt_pub = None
     mqtt_cls = None
-    module_loader = web.get_module_loader() if hasattr(web, 'get_module_loader') else None
+    module_loader = runtime.get_module_loader()
     if module_loader:
         for mod in module_loader.get_enabled_modules():
             if mod.publisher_class and mod.id == 'docsight.mqtt':
@@ -216,11 +219,11 @@ def polling_loop(config_mgr, storage, stop_event):
     ))
     log.info("Smart Capture: registered %d trigger(s)", len(smart_capture.triggers))
 
-    web.update_state(poll_interval=config["poll_interval"])
+    runtime.update_state(poll_interval=config["poll_interval"])
 
     event_detector = EventDetector(hysteresis=config_mgr.get("health_hysteresis", 0))
     collectors = discover_collectors(
-        config_mgr, storage, event_detector, mqtt_pub, web, analyzer,
+        config_mgr, storage, event_detector, mqtt_pub, runtime, analyzer,
         notifier=notifier, smart_capture=smart_capture,
     )
 
@@ -243,8 +246,8 @@ def polling_loop(config_mgr, storage, stop_event):
     # Inject collectors into web layer for manual polling and status endpoint
     modem_collector = next((c for c in collectors if c.name in ("modem", "demo")), None)
     if modem_collector:
-        web.init_collector(modem_collector)
-    web.init_collectors(collectors)
+        runtime.modem_collector = modem_collector
+    runtime.collectors = collectors
 
     # Track modem config for driver hot-swap detection
     modem_config_key = (
@@ -315,7 +318,7 @@ def polling_loop(config_mgr, storage, stop_event):
                 collector.record_failure()
                 log.error("%s error: %s", collector.name, e)
                 if collector.name in ("modem", "demo"):
-                    web.update_state(error=e)
+                    runtime.update_state(error=e)
 
     try:
         while not stop_event.is_set():
@@ -338,7 +341,7 @@ def polling_loop(config_mgr, storage, stop_event):
                         event_detector=event_detector,
                         storage=storage,
                         mqtt_pub=mqtt_pub,
-                        web=web,
+                        web=runtime,
                         poll_interval=config_mgr.get("poll_interval", 900),
                         notifier=notifier,
                         smart_capture=smart_capture,
@@ -348,9 +351,9 @@ def polling_loop(config_mgr, storage, stop_event):
                         for c in collectors
                     ]
                     modem_collector = new_modem
-                    web.init_collector(new_modem)
-                    web.init_collectors(collectors)
-                    web.reset_modem_state()
+                    runtime.modem_collector = new_modem
+                    runtime.collectors = collectors
+                    runtime.reset_modem_state()
                     modem_config_key = new_key
                     log.info("Driver hot-swapped to %s", new_key[0])
 
@@ -377,11 +380,10 @@ def polling_loop(config_mgr, storage, stop_event):
 
             # ── Smart Capture expiry check (every 60s) ──
             if smart_capture:
-                if not hasattr(polling_loop, '_sc_expiry_counter'):
-                    polling_loop._sc_expiry_counter = 0
-                polling_loop._sc_expiry_counter += 1
-                if polling_loop._sc_expiry_counter >= 60:
-                    polling_loop._sc_expiry_counter = 0
+                expiry_counter = runtime.derived_storage.value("smart_capture_expiry_counter", 0) + 1
+                runtime.derived_storage.set_value("smart_capture_expiry_counter", expiry_counter)
+                if expiry_counter >= 60:
+                    runtime.derived_storage.set_value("smart_capture_expiry_counter", 0)
                     match_window = config_mgr.get("sc_speedtest_match_window", 900)
                     try:
                         expiry_minutes = max(10, int(match_window) // 60 + 5)
@@ -418,8 +420,7 @@ def polling_loop(config_mgr, storage, stop_event):
 
 
 def main(server_lifecycle: ServerLifecycleController | None = None):
-    configure_base_path(web.app)
-
+    validate_base_path_configuration(os.environ)
     data_dir = os.environ.get("DATA_DIR", "/data")
     config_mgr = ConfigManager(data_dir)
     _apply_timezone(config_mgr)
@@ -434,11 +435,10 @@ def main(server_lifecycle: ServerLifecycleController | None = None):
     storage.migrate_to_utc(tz_name)
     storage.set_timezone(tz_name)
 
-    web.init_storage(storage)
-
     # Polling thread management
     poll_thread = None
     poll_stop = None
+    runtime = None
 
     def stop_polling():
         nonlocal poll_thread, poll_stop
@@ -451,10 +451,10 @@ def main(server_lifecycle: ServerLifecycleController | None = None):
     def start_polling():
         nonlocal poll_thread, poll_stop
         stop_polling()
-        web.reset_modem_state()
+        runtime.reset_modem_state()
         poll_stop = threading.Event()
         poll_thread = threading.Thread(
-            target=polling_loop, args=(config_mgr, storage, poll_stop), daemon=True
+            target=polling_loop, args=(config_mgr, storage, poll_stop, runtime), daemon=True
         )
         poll_thread.start()
         log.info("Polling loop started")
@@ -463,42 +463,20 @@ def main(server_lifecycle: ServerLifecycleController | None = None):
         """Called when config is saved via web UI."""
         _handle_config_changed(config_mgr, storage, stop_polling, start_polling)
 
-    web.init_config(config_mgr, on_config_changed)
-
-    # Module system
-    from .module_loader import ModuleLoader
-
     builtin_path = os.path.join(os.path.dirname(__file__), "modules")
     community_path = get_modules_dir()
-    disabled_raw = config_mgr.get("disabled_modules", "")
-    disabled_ids = {s.strip() for s in disabled_raw.split(",") if s.strip()}
-
-    module_loader = ModuleLoader(
-        web.app,
-        builtin_base_path=builtin_path,
-        search_paths=[community_path],
-        disabled_ids=disabled_ids,
+    application = create_app(
+        config_manager=config_mgr,
+        storage=storage,
+        on_config_changed=on_config_changed,
+        module_loader_factory=default_module_loader_factory(
+            config_mgr,
+            builtin_base_path=builtin_path,
+            search_paths=[community_path],
+        ),
+        environ=os.environ,
     )
-    module_loader.load_all()
-    web.init_modules(module_loader)
-    web.setup_module_templates(module_loader)
-
-    # Reverse proxy support: REVERSE_PROXY=1 (or number of proxy hops)
-    # rewrites request.remote_addr from X-Forwarded-For so rate limiting
-    # and audit logs see the real client IP, not the proxy IP.
-    reverse_proxy = os.environ.get("REVERSE_PROXY", "").strip()
-    if reverse_proxy:
-        from werkzeug.middleware.proxy_fix import ProxyFix
-        num_proxies = int(reverse_proxy) if reverse_proxy.isdigit() else 1
-        web.app.wsgi_app = ProxyFix(
-            web.app.wsgi_app,
-            x_for=num_proxies,
-            x_proto=num_proxies,
-            x_host=0,
-            x_prefix=0,
-        )
-        web.app.config["SESSION_COOKIE_SECURE"] = True
-        log.info("Reverse proxy mode: trusting %d hop(s), secure cookies enabled", num_proxies)
+    runtime = get_runtime(application)
 
     # Start Flask
     web_port = config_mgr.get("web_port", 8765)
@@ -506,7 +484,7 @@ def main(server_lifecycle: ServerLifecycleController | None = None):
     lifecycle = server_lifecycle or ServerLifecycleController()
     web_thread = threading.Thread(
         target=run_web,
-        args=(web_port, lifecycle),
+        args=(application, web_port, lifecycle),
         daemon=True,
     )
     web_thread.start()

--- a/app/modules/backup/routes.py
+++ b/app/modules/backup/routes.py
@@ -15,6 +15,7 @@ from app.web import (
     get_config_manager, get_on_config_changed,
     _get_client_ip,
 )
+from app.runtime import current_runtime
 
 from werkzeug.utils import secure_filename
 
@@ -28,24 +29,28 @@ log = logging.getLogger("docsis.web")
 
 bp = Blueprint("backup_bp", __name__)
 
-# Rate-limit unauthenticated restore attempts (setup-race mitigation)
-_restore_attempts: dict[str, list[float]] = defaultdict(list)
 _RESTORE_MAX_ATTEMPTS = 5
 _RESTORE_WINDOW = 3600  # 1 hour
 
 
 def _check_restore_rate_limit() -> bool:
     """Return True if the client has exceeded the restore rate limit."""
+    restore_attempts = current_runtime().derived_storage.get(
+        "backup_restore_attempts", lambda: defaultdict(list)
+    )
     ip = _get_client_ip()
     now = time.time()
-    attempts = _restore_attempts[ip]
-    _restore_attempts[ip] = [t for t in attempts if now - t < _RESTORE_WINDOW]
-    return len(_restore_attempts[ip]) >= _RESTORE_MAX_ATTEMPTS
+    attempts = restore_attempts[ip]
+    restore_attempts[ip] = [t for t in attempts if now - t < _RESTORE_WINDOW]
+    return len(restore_attempts[ip]) >= _RESTORE_MAX_ATTEMPTS
 
 
 def _record_restore_attempt():
     """Record a restore attempt for the current client IP."""
-    _restore_attempts[_get_client_ip()].append(time.time())
+    restore_attempts = current_runtime().derived_storage.get(
+        "backup_restore_attempts", lambda: defaultdict(list)
+    )
+    restore_attempts[_get_client_ip()].append(time.time())
 
 
 def _int_config(config_mgr, key, default):

--- a/app/modules/bnetz/routes.py
+++ b/app/modules/bnetz/routes.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from flask import Blueprint, request, jsonify, send_file
 
 from app.web import require_auth, get_storage, _get_client_ip, _get_lang
+from app.runtime import current_runtime
 from app.storage import MAX_ATTACHMENT_SIZE
 from app.i18n import get_translations
 from .csv_parser import parse_bnetz_csv
@@ -17,17 +18,13 @@ log = logging.getLogger("docsis.web.bnetz")
 
 bp = Blueprint("bnetz_module", __name__)
 
-# Lazy-initialized module-local storage
-_storage = None
-
-
 def _get_bnetz_storage():
-    global _storage
-    if _storage is None:
-        core_storage = get_storage()
-        if core_storage:
-            _storage = BnetzStorage(core_storage.db_path)
-    return _storage
+    core_storage = get_storage()
+    if not core_storage:
+        return None
+    return current_runtime().derived_storage.get(
+        "bnetz", lambda: BnetzStorage(core_storage.db_path)
+    )
 
 
 @bp.route("/api/bnetz/upload", methods=["POST"])

--- a/app/modules/bqm/routes.py
+++ b/app/modules/bqm/routes.py
@@ -10,6 +10,7 @@ from app.web import (
     require_auth,
     get_storage, get_config_manager, _valid_date, _get_client_ip, _get_tz_name,
 )
+from app.runtime import current_runtime
 from app.tz import local_today, utc_now
 
 from .auth import extract_share_id, validate_share_id, ThinkBroadbandBatchAbort, fetch_share_csv, is_csv_url
@@ -25,17 +26,13 @@ bp = Blueprint("bqm_module", __name__)
 _TBB_SHARE_PATH = "/broadband/monitoring/quality/share/"
 _TBB_HOSTS = {"thinkbroadband.com", "www.thinkbroadband.com"}
 
-# Lazy-initialized module-local storage
-_storage = None
-
-
 def _get_bqm_storage():
-    global _storage
-    if _storage is None:
-        core_storage = get_storage()
-        if core_storage:
-            _storage = BqmStorage(core_storage.db_path)
-    return _storage
+    core_storage = get_storage()
+    if not core_storage:
+        return None
+    return current_runtime().derived_storage.get(
+        "bqm", lambda: BqmStorage(core_storage.db_path)
+    )
 
 
 def _rows_to_columns(rows):

--- a/app/modules/connection_monitor/routes.py
+++ b/app/modules/connection_monitor/routes.py
@@ -14,6 +14,7 @@ from flask import Blueprint, jsonify, request, Response
 
 from app.tz import local_date_to_utc_range, local_today, to_local_display, _parse_utc
 from app.web import get_config_manager, require_auth, _get_tz_name
+from app.runtime import current_runtime
 
 from .probe import ProbeEngine
 from .storage import ConnectionMonitorStorage
@@ -32,18 +33,14 @@ def _no_cache_api(response):
     return response
 
 
-# Lazy-initialized storage
-_storage = None
-
-
 def _get_cm_storage():
     """Get ConnectionMonitorStorage. Uses DATA_DIR like collector."""
-    global _storage
-    if _storage is None:
-        data_dir = os.environ.get("DATA_DIR", "/data")
-        db_path = os.path.join(data_dir, "connection_monitor.db")
-        _storage = ConnectionMonitorStorage(db_path)
-    return _storage
+    config_manager = get_config_manager()
+    data_dir = config_manager.data_dir if config_manager else os.environ.get("DATA_DIR", "/data")
+    db_path = os.path.join(data_dir, "connection_monitor.db")
+    return current_runtime().derived_storage.get(
+        f"connection_monitor:{db_path}", lambda: ConnectionMonitorStorage(db_path)
+    )
 
 
 def _get_probe_engine():
@@ -53,14 +50,10 @@ def _get_probe_engine():
     return ProbeEngine(method=method)
 
 
-_traceroute_probe = None
-
-
 def _get_traceroute_probe():
-    global _traceroute_probe
-    if _traceroute_probe is None:
-        _traceroute_probe = TracerouteProbe()
-    return _traceroute_probe
+    return current_runtime().derived_storage.get(
+        "connection_monitor_traceroute_probe", TracerouteProbe
+    )
 
 
 def _epoch_to_iso(ts):

--- a/app/modules/speedtest/routes.py
+++ b/app/modules/speedtest/routes.py
@@ -8,6 +8,7 @@ from flask import Blueprint, request, jsonify
 
 from app.config import parse_config_bool
 from app.web import require_auth, get_config_manager, get_state, get_storage, clear_speedtest_latest
+from app.runtime import current_runtime
 from app.i18n import get_translations
 from app.storage.sqlite import connect_sqlite
 
@@ -18,21 +19,16 @@ log = logging.getLogger("docsis.web.speedtest")
 
 bp = Blueprint("speedtest_module", __name__)
 
-# Lazy-initialized module-local storage
-_storage = None
-
-# Rate-limit: track last manual trigger timestamp
-_last_trigger_ts = 0
 _TRIGGER_COOLDOWN = 60  # seconds
 
 
 def _get_speedtest_storage():
-    global _storage
-    if _storage is None:
-        core_storage = get_storage()
-        if core_storage:
-            _storage = SpeedtestStorage(core_storage.db_path)
-    return _storage
+    core_storage = get_storage()
+    if not core_storage:
+        return None
+    return current_runtime().derived_storage.get(
+        "speedtest", lambda: SpeedtestStorage(core_storage.db_path)
+    )
 
 
 def _classify_speed(actual, booked):
@@ -231,7 +227,6 @@ def api_speedtest_signal(result_id):
 @require_auth
 def api_speedtest_run():
     """Trigger a speedtest run via the Speedtest Tracker API."""
-    global _last_trigger_ts
     _config_manager = get_config_manager()
     if not _config_manager or not _config_manager.is_speedtest_configured():
         return jsonify({"success": False, "error": "Speedtest Tracker not configured"}), 400
@@ -240,8 +235,10 @@ def api_speedtest_run():
         return jsonify({"success": False, "error": "Not available in demo mode"}), 400
 
     now = time.time()
-    if now - _last_trigger_ts < _TRIGGER_COOLDOWN:
-        remaining = int(_TRIGGER_COOLDOWN - (now - _last_trigger_ts))
+    runtime = current_runtime()
+    last_trigger_ts = runtime.derived_storage.value("speedtest_last_trigger", 0.0)
+    if now - last_trigger_ts < _TRIGGER_COOLDOWN:
+        remaining = int(_TRIGGER_COOLDOWN - (now - last_trigger_ts))
         return jsonify({"success": False, "error": f"Rate limited, retry in {remaining}s"}), 429
 
     url = _config_manager.get("speedtest_tracker_url", "").rstrip("/")
@@ -257,7 +254,7 @@ def api_speedtest_run():
             verify=not tls_insecure,
         )
         if resp.status_code == 201:
-            _last_trigger_ts = now
+            runtime.derived_storage.set_value("speedtest_last_trigger", now)
             log.info("Speedtest manually triggered via UI")
             return jsonify({"success": True})
         else:

--- a/app/modules/weather/routes.py
+++ b/app/modules/weather/routes.py
@@ -5,23 +5,20 @@ import logging
 from flask import Blueprint, request, jsonify
 
 from app.web import require_auth, get_config_manager, get_state, get_storage
+from app.runtime import current_runtime
 from .storage import WeatherStorage
 
 log = logging.getLogger("docsis.web.weather")
 
 bp = Blueprint("weather_module", __name__)
 
-# Lazy-initialized module-local storage
-_storage = None
-
-
 def _get_weather_storage():
-    global _storage
-    if _storage is None:
-        core_storage = get_storage()
-        if core_storage:
-            _storage = WeatherStorage(core_storage.db_path)
-    return _storage
+    core_storage = get_storage()
+    if not core_storage:
+        return None
+    return current_runtime().derived_storage.get(
+        "weather", lambda: WeatherStorage(core_storage.db_path)
+    )
 
 
 @bp.route("/api/weather")

--- a/app/runtime.py
+++ b/app/runtime.py
@@ -1,0 +1,411 @@
+"""Typed, per-application runtime state for DOCSight."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, TypeVar
+
+import requests
+from flask import Flask, current_app
+
+
+DOCSIGHT_EXTENSION_KEY = "docsight"
+_GITHUB_RELEASE_URL = "https://api.github.com/repos/itsDNNS/docsight/releases/latest"
+_T = TypeVar("_T")
+
+
+def _write_private_file(path: str, value: bytes) -> None:
+    """Atomically replace a private state file with mode 0600."""
+    data_dir = os.path.dirname(path)
+    os.makedirs(data_dir, exist_ok=True)
+    temp_path = f"{path}.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+    fd = None
+    try:
+        fd = os.open(
+            temp_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "wb") as handle:
+            fd = None
+            handle.write(value)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        try:
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+            directory_fd = os.open(data_dir, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            pass
+    finally:
+        if fd is not None:
+            os.close(fd)
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
+
+
+def _version_newer(latest: str, current: str) -> bool:
+    """Compare date-based release versions with a numeric build suffix."""
+    def parts(value: str) -> tuple[str, int]:
+        dot = value.rfind(".")
+        if dot == -1:
+            return value, 0
+        try:
+            build = int(value[dot + 1:])
+        except ValueError:
+            build = 0
+        return value[:dot], build
+
+    return parts(latest) > parts(current)
+
+
+def _fetch_latest_release() -> str:
+    response = requests.get(
+        _GITHUB_RELEASE_URL,
+        headers={"Accept": "application/vnd.github.v3+json"},
+        timeout=5,
+    )
+    if response.status_code != 200:
+        return ""
+    return str(response.json().get("tag_name", ""))
+
+
+def _spawn_daemon(target: Callable[[], None]) -> None:
+    threading.Thread(target=target, daemon=True).start()
+
+
+class RuntimeState:
+    """Lock-protected dashboard state shared with collector threads."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._values: dict[str, object] = {
+            "analysis": None,
+            "last_update": None,
+            "poll_interval": 900,
+            "error": None,
+            "connection_info": None,
+            "device_info": None,
+            "speedtest_latest": None,
+        }
+
+    def snapshot(self) -> dict[str, object]:
+        with self._lock:
+            return dict(self._values)
+
+    def update(
+        self,
+        *,
+        analysis=None,
+        error=None,
+        poll_interval=None,
+        connection_info=None,
+        device_info=None,
+        speedtest_latest=None,
+        weather_latest=None,
+    ) -> None:
+        with self._lock:
+            if analysis is not None:
+                self._values["analysis"] = analysis
+                self._values["last_update"] = time.strftime("%Y-%m-%d %H:%M:%S")
+                self._values["error"] = None
+            if error is not None:
+                self._values["error"] = str(error)
+            if poll_interval is not None:
+                self._values["poll_interval"] = poll_interval
+            if connection_info is not None:
+                self._values["connection_info"] = connection_info
+            if device_info is not None:
+                self._values["device_info"] = device_info
+            if speedtest_latest is not None:
+                self._values["speedtest_latest"] = speedtest_latest
+            if weather_latest is not None:
+                self._values["weather_latest"] = weather_latest
+
+    def clear_speedtest_latest(self) -> None:
+        with self._lock:
+            self._values["speedtest_latest"] = None
+
+    def reset_modem(self) -> None:
+        with self._lock:
+            self._values.update({
+                "analysis": None,
+                "last_update": None,
+                "error": None,
+                "connection_info": None,
+                "device_info": None,
+            })
+
+
+class LoginRateLimiter:
+    """Bounded, lock-protected login failure buckets for one application."""
+
+    def __init__(
+        self,
+        *,
+        max_attempts: int = 5,
+        window: float = 900,
+        lockout_base: float = 30,
+        max_tracked_ips: int = 2048,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._max_attempts = max_attempts
+        self._window = window
+        self._lockout_base = lockout_base
+        self._max_tracked_ips = max_tracked_ips
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._attempts: dict[str, list[float]] = {}
+
+    def _prune_locked(self, now: float) -> None:
+        for ip, attempts in list(self._attempts.items()):
+            current = [stamp for stamp in attempts if now - stamp < self._window]
+            if current:
+                self._attempts[ip] = current
+            else:
+                self._attempts.pop(ip, None)
+        if len(self._attempts) > self._max_tracked_ips:
+            oldest = sorted(
+                self._attempts,
+                key=lambda ip: self._attempts[ip][-1] if self._attempts[ip] else 0,
+            )
+            for ip in oldest[:len(self._attempts) - self._max_tracked_ips]:
+                self._attempts.pop(ip, None)
+
+    def prune(self, now: float | None = None) -> None:
+        with self._lock:
+            self._prune_locked(self._clock() if now is None else now)
+
+    def retry_after(self, ip: str) -> float:
+        now = self._clock()
+        with self._lock:
+            self._prune_locked(now)
+            attempts = self._attempts.get(ip, [])
+            if len(attempts) < self._max_attempts:
+                return 0
+            excess = len(attempts) - self._max_attempts
+            lockout = self._lockout_base * (2 ** min(excess, 8))
+            return max(0, lockout - (now - attempts[-1]))
+
+    def record_failure(self, ip: str) -> None:
+        now = self._clock()
+        with self._lock:
+            self._prune_locked(now)
+            self._attempts.setdefault(ip, []).append(now)
+            self._prune_locked(now)
+
+    def reset(self, ip: str) -> None:
+        with self._lock:
+            self._attempts.pop(ip, None)
+
+    def snapshot(self) -> dict[str, list[float]]:
+        with self._lock:
+            return {ip: list(attempts) for ip, attempts in self._attempts.items()}
+
+
+class UpdateChecker:
+    """One application's non-blocking release-check cache."""
+
+    def __init__(
+        self,
+        *,
+        app_version: str,
+        is_enabled: Callable[[], bool],
+        fetch: Callable[[], str] = _fetch_latest_release,
+        clock: Callable[[], float] = time.time,
+        spawn: Callable[[Callable[[], None]], None] = _spawn_daemon,
+        ttl: float = 3600,
+    ) -> None:
+        self._app_version = app_version
+        self._is_enabled = is_enabled
+        self._fetch = fetch
+        self._clock = clock
+        self._spawn = spawn
+        self._ttl = ttl
+        self._lock = threading.Lock()
+        self._latest: str | None = None
+        self._checked_at = 0.0
+        self._checking = False
+
+    def latest(self) -> str | None:
+        if not self._is_enabled() or self._app_version == "dev":
+            return None
+        now = self._clock()
+        should_start = False
+        with self._lock:
+            if now - self._checked_at < self._ttl:
+                return self._latest
+            if not self._checking:
+                self._checking = True
+                should_start = True
+            latest = self._latest
+        if should_start:
+            self._spawn(self._refresh)
+        return latest
+
+    def _refresh(self) -> None:
+        try:
+            tag = self._fetch()
+            current = self._app_version.lstrip("v")
+            latest = tag.lstrip("v")
+            result = tag if latest and latest != current and _version_newer(latest, current) else None
+            with self._lock:
+                self._latest = result
+        except Exception:
+            pass
+        finally:
+            with self._lock:
+                self._checked_at = self._clock()
+                self._checking = False
+
+    def snapshot(self) -> dict[str, object]:
+        with self._lock:
+            return {
+                "latest": self._latest,
+                "checked_at": self._checked_at,
+                "checking": self._checking,
+            }
+
+
+class AuthStateStore:
+    """Persistent signing and authentication state scoped to one data directory."""
+
+    def __init__(self, data_dir: str) -> None:
+        self.data_dir = data_dir
+        self.key_path = os.path.join(data_dir, ".session_key")
+        self.auth_state_path = os.path.join(data_dir, ".auth_state")
+
+    def load_or_create_session_key(self) -> bytes:
+        if os.path.exists(self.key_path):
+            with open(self.key_path, "rb") as handle:
+                return handle.read()
+        key = os.urandom(32)
+        _write_private_file(self.key_path, key)
+        return key
+
+    def rotate_session_key(self) -> bytes:
+        key = os.urandom(32)
+        _write_private_file(self.key_path, key)
+        return key
+
+    def read_fingerprint(self) -> str | None:
+        try:
+            with open(self.auth_state_path, "r", encoding="ascii") as handle:
+                value = handle.read().strip()
+        except (FileNotFoundError, OSError, UnicodeError):
+            return None
+        if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+            return None
+        return value
+
+    def write_fingerprint(self, value: str) -> None:
+        _write_private_file(self.auth_state_path, value.encode("ascii"))
+
+
+class DerivedStorageCache:
+    """Lock-protected cache for objects derived from one application's runtime."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._values: dict[str, Any] = {}
+
+    def get(self, key: str, factory: Callable[[], _T]) -> _T:
+        with self._lock:
+            if key not in self._values:
+                self._values[key] = factory()
+            return self._values[key]
+
+    def value(self, key: str, default: _T) -> _T:
+        with self._lock:
+            return self._values.get(key, default)
+
+    def set_value(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._values[key] = value
+
+
+@dataclass(repr=False)
+class DocsightRuntime:
+    """All mutable runtime collaborators belonging to one Flask application."""
+
+    config_manager: Any = field(repr=False)
+    auth_state: AuthStateStore = field(repr=False)
+    update_checker: UpdateChecker = field(repr=False)
+    storage: Any | None = field(default=None, repr=False)
+    on_config_changed: Callable[[], None] | None = field(default=None, repr=False)
+    state: RuntimeState = field(default_factory=RuntimeState, repr=False)
+    login_rate_limiter: LoginRateLimiter = field(default_factory=LoginRateLimiter, repr=False)
+    derived_storage: DerivedStorageCache = field(default_factory=DerivedStorageCache, repr=False)
+    module_loader: Any | None = field(default=None, repr=False)
+    modem_collector: Any | None = field(default=None, repr=False)
+    collectors: list[Any] = field(default_factory=list, repr=False)
+    last_manual_poll: float = field(default=0.0, repr=False)
+    _last_manual_poll_lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        repr=False,
+    )
+
+    def __repr__(self) -> str:
+        return "DocsightRuntime(<redacted>)"
+
+    def update_state(self, **fields: Any) -> None:
+        self.state.update(**fields)
+
+    def clear_speedtest_latest(self) -> None:
+        self.state.clear_speedtest_latest()
+
+    def reset_modem_state(self) -> None:
+        self.state.reset_modem()
+
+    def get_state(self) -> dict[str, object]:
+        return self.state.snapshot()
+
+    def get_module_loader(self):
+        return self.module_loader
+
+    def get_last_manual_poll(self) -> float:
+        with self._last_manual_poll_lock:
+            return self.last_manual_poll
+
+    def set_last_manual_poll(self, value: float) -> None:
+        with self._last_manual_poll_lock:
+            self.last_manual_poll = value
+
+    @property
+    def _state(self) -> Mapping[str, object]:
+        """Read-only snapshot retained for collector duck-type compatibility."""
+        return MappingProxyType(self.get_state())
+
+
+def attach_runtime(app: Flask, runtime: DocsightRuntime) -> None:
+    if DOCSIGHT_EXTENSION_KEY in app.extensions:
+        raise RuntimeError("DOCSight runtime is already attached")
+    app.extensions[DOCSIGHT_EXTENSION_KEY] = runtime
+
+
+def get_runtime(app: Flask) -> DocsightRuntime:
+    try:
+        runtime = app.extensions[DOCSIGHT_EXTENSION_KEY]
+    except KeyError as exc:
+        raise RuntimeError("DOCSight runtime is not attached") from exc
+    if not isinstance(runtime, DocsightRuntime):
+        raise TypeError("DOCSight extension has an invalid runtime")
+    return runtime
+
+
+def current_runtime() -> DocsightRuntime:
+    return get_runtime(current_app._get_current_object())

--- a/app/web.py
+++ b/app/web.py
@@ -7,17 +7,14 @@ import math
 import os
 import re
 import secrets
-import stat
-import threading
 import time
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from datetime import datetime
+from collections.abc import Callable, Mapping
 from urllib.parse import urlencode
 
-import requests as _requests
-
 from cryptography.hazmat.primitives import hashes, hmac
-from flask import Flask, render_template, request, jsonify, redirect, session, send_from_directory, url_for
-from jinja2 import FileSystemLoader, ChoiceLoader
+from flask import current_app, render_template, request, jsonify, redirect, session, send_from_directory, url_for
 from markupsafe import Markup
 from werkzeug.security import check_password_hash
 from zoneinfo import available_timezones
@@ -37,6 +34,7 @@ from .glossary import (
 from .i18n import get_translations, LANGUAGES, LANG_FLAGS
 from .maintainer_notices import coerce_dismissed_notice_ids, get_active_notices
 from .module_loader import module_static_url
+from .runtime import current_runtime, _version_newer as _runtime_version_newer
 from .tz import guess_iana_timezone as _guess_iana_timezone, get_tz_name as _get_public_tz_name, to_local as _to_local
 from .version import get_app_version
 
@@ -145,8 +143,6 @@ def _build_theme_collections(theme_modules):
 
     return collections
 
-# ── Login rate limiting (in-memory) ──
-_login_attempts = {}  # IP -> [timestamp, ...]
 _LOGIN_MAX_ATTEMPTS = 5
 _LOGIN_WINDOW = 900  # 15 min
 _LOGIN_LOCKOUT_BASE = 30  # seconds, doubles each excess attempt
@@ -174,45 +170,17 @@ def _get_client_ip():
 
 def _prune_login_attempts(now=None):
     """Drop expired and oldest login-attempt buckets to keep memory bounded."""
-    now = now or time.time()
-    expired = [ip for ip, attempts in _login_attempts.items() if not [t for t in attempts if now - t < _LOGIN_WINDOW]]
-    for ip in expired:
-        _login_attempts.pop(ip, None)
-
-    for ip, attempts in list(_login_attempts.items()):
-        _login_attempts[ip] = [t for t in attempts if now - t < _LOGIN_WINDOW]
-
-    if len(_login_attempts) <= _LOGIN_MAX_TRACKED_IPS:
-        return
-
-    oldest_first = sorted(
-        _login_attempts,
-        key=lambda ip: _login_attempts[ip][-1] if _login_attempts[ip] else 0,
-    )
-    for ip in oldest_first[: len(_login_attempts) - _LOGIN_MAX_TRACKED_IPS]:
-        _login_attempts.pop(ip, None)
+    current_runtime().login_rate_limiter.prune(now)
 
 
 def _check_login_rate_limit(ip):
     """Return seconds until retry allowed, or 0 if not limited."""
-    now = time.time()
-    _prune_login_attempts(now)
-    attempts = _login_attempts.get(ip, [])
-    if len(attempts) >= _LOGIN_MAX_ATTEMPTS:
-        excess = len(attempts) - _LOGIN_MAX_ATTEMPTS
-        lockout = _LOGIN_LOCKOUT_BASE * (2 ** min(excess, 8))
-        remaining = lockout - (now - attempts[-1])
-        if remaining > 0:
-            return remaining
-    return 0
+    return current_runtime().login_rate_limiter.retry_after(ip)
 
 
 def _record_failed_login(ip):
     """Record a failed login attempt."""
-    now = time.time()
-    _prune_login_attempts(now)
-    _login_attempts.setdefault(ip, []).append(now)
-    _prune_login_attempts(now)
+    current_runtime().login_rate_limiter.record_failure(ip)
 
 
 def _get_login_csrf_token():
@@ -234,46 +202,11 @@ def _valid_login_csrf_token(candidate):
 
 APP_VERSION = get_app_version()
 
-# GitHub update check (background, never blocks page loads)
-_update_cache = {"latest": None, "checked_at": 0, "checking": False}
 _UPDATE_CACHE_TTL = 3600  # 1 hour
 
 def _check_for_update():
     """Return cached update info. Triggers background check if stale."""
-    update_checks_enabled = getattr(_config_manager, "is_update_check_enabled", None)
-    if not callable(update_checks_enabled) or not update_checks_enabled():
-        return None
-    now = time.time()
-    if now - _update_cache["checked_at"] < _UPDATE_CACHE_TTL:
-        return _update_cache["latest"]
-    if APP_VERSION == "dev":
-        return None
-    if not _update_cache["checking"]:
-        _update_cache["checking"] = True
-        threading.Thread(target=_fetch_update, daemon=True).start()
-    return _update_cache["latest"]
-
-def _fetch_update():
-    """Background thread: fetch latest release from GitHub."""
-    try:
-        r = _requests.get(
-            "https://api.github.com/repos/itsDNNS/docsight/releases/latest",
-            headers={"Accept": "application/vnd.github.v3+json"},
-            timeout=5,
-        )
-        if r.status_code == 200:
-            tag = r.json().get("tag_name", "")
-            cur = APP_VERSION.lstrip("v")
-            lat = tag.lstrip("v")
-            if lat and lat != cur and _version_newer(lat, cur):
-                _update_cache["latest"] = tag
-            else:
-                _update_cache["latest"] = None
-    except Exception:
-        pass  # keep previous cache value
-    finally:
-        _update_cache["checked_at"] = time.time()
-        _update_cache["checking"] = False
+    return current_runtime().update_checker.latest()
 
 def _version_newer(latest, current):
     """Compare date-based version strings (e.g. '2026-02-16.1' > '2026-02-13.8').
@@ -281,29 +214,7 @@ def _version_newer(latest, current):
     Splits on '.' to compare the date part lexicographically and the
     trailing build number numerically so that '.10' > '.9'.
     """
-    def _parts(v):
-        # "2026-02-16.1" -> ("2026-02-16", 1)
-        dot = v.rfind(".")
-        if dot == -1:
-            return (v, 0)
-        date_part = v[:dot]
-        try:
-            build = int(v[dot + 1:])
-        except ValueError:
-            build = 0
-        return (date_part, build)
-
-    return _parts(latest) > _parts(current)
-
-
-app = Flask(__name__, template_folder="templates")
-app.secret_key = os.urandom(32)  # overwritten by _init_session_key
-app.config.update(
-    SESSION_COOKIE_HTTPONLY=True,
-    SESSION_COOKIE_SAMESITE="Lax",
-    PERMANENT_SESSION_LIFETIME=timedelta(days=_SESSION_LIFETIME_DEFAULT_DAYS),
-    SESSION_REFRESH_EACH_REQUEST=True,
-)
+    return _runtime_version_newer(latest, current)
 
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
@@ -345,7 +256,6 @@ def _clean_tag(match: re.Match) -> str:
     return '<a href="#">'
 
 
-@app.template_filter("safe_html")
 def safe_html_filter(value):
     """Allow only <b>, <a>, <strong>, <em>, <br> tags — strip everything else.
 
@@ -358,7 +268,6 @@ def safe_html_filter(value):
     return Markup(cleaned)
 
 
-@app.template_filter("fmt_k")
 def format_k(value):
     """Format large numbers with k/M suffix: 1200000 -> 1.2M, 132007 -> 132k, 5929 -> 5.9k."""
     try:
@@ -381,7 +290,6 @@ def format_k(value):
     return str(value)
 
 
-@app.template_filter("fmt_speed_value")
 def format_speed_value(value):
     """Format speed value: >= 1000 Mbps -> GBit value."""
     try:
@@ -396,7 +304,6 @@ def format_speed_value(value):
         return str(int(round(value)))
 
 
-@app.template_filter("fmt_speed_unit")
 def format_speed_unit(value):
     """Return speed unit: >= 1000 Mbps -> 'GBit/s', else 'MBit/s'."""
     try:
@@ -406,7 +313,6 @@ def format_speed_unit(value):
     return "GBit/s" if value >= 1000 else "MBit/s"
 
 
-@app.template_filter("fmt_uptime")
 def format_uptime(seconds):
     """Format uptime seconds to human-readable string: '3d 12h 5m'."""
     try:
@@ -427,6 +333,7 @@ def format_uptime(seconds):
 
 def _get_lang():
     """Get language from query param or config."""
+    _config_manager = get_config_manager()
     lang = request.args.get("lang")
     if lang and lang in LANGUAGES:
         return lang
@@ -437,6 +344,7 @@ def _get_lang():
 
 def _get_setup_lang():
     """Resolve and persist the language for the unconfigured setup route."""
+    _config_manager = get_config_manager()
     lang = request.args.get("lang")
     if lang in LANGUAGES:
         if _config_manager:
@@ -466,7 +374,7 @@ def _get_setup_lang():
 
 def _get_tz_name():
     """Get configured IANA timezone name."""
-    return _get_public_tz_name(_config_manager)
+    return _get_public_tz_name(get_config_manager())
 
 
 def _localize_timestamps(data, keys=("timestamp", "created_at", "updated_at", "last_used_at")):
@@ -505,58 +413,34 @@ def _jinja_localiso(value):
     return _jinja_localtime(value)
 
 
-app.jinja_env.filters["localtime"] = _jinja_localtime
-app.jinja_env.filters["localiso"] = _jinja_localiso
-
-
-# Shared state (updated from main loop)
-_state_lock = threading.Lock()
-_state = {
-    "analysis": None,
-    "last_update": None,
-    "poll_interval": 900,
-    "error": None,
-    "connection_info": None,
-    "device_info": None,
-    "speedtest_latest": None,
-}
-
-_storage = None
-_config_manager = None
-_on_config_changed = None
-_modem_collector = None
-_collectors = []
-_last_manual_poll = 0.0
-_module_loader = None
-
-
 def get_storage():
-    """Get the storage instance (set at runtime via init_storage)."""
-    return _storage
+    """Get this application's snapshot storage, if configured."""
+    return current_runtime().storage
 
 
 def get_config_manager():
-    """Get the config manager (set at runtime via init_config)."""
-    return _config_manager
+    """Get this application's configuration manager."""
+    return current_runtime().config_manager
 
 
 def get_modem_collector():
-    """Get the modem collector (set at runtime via init_collector)."""
-    return _modem_collector
+    """Get this application's modem collector, if running."""
+    return current_runtime().modem_collector
 
 
 def get_collectors():
-    """Get all collectors (set at runtime via init_collectors)."""
-    return _collectors
+    """Get this application's collectors."""
+    return current_runtime().collectors
 
 
 def get_module_loader():
     """Get the module loader instance."""
-    return _module_loader
+    return current_runtime().module_loader
 
 
 def _get_dismissed_notice_ids():
     """Return locally persisted maintainer notice dismissals."""
+    _config_manager = get_config_manager()
     if not _config_manager:
         return []
     return coerce_dismissed_notice_ids(_config_manager.get("dismissed_notice_ids", []))
@@ -564,117 +448,31 @@ def _get_dismissed_notice_ids():
 
 def get_on_config_changed():
     """Get the config changed callback."""
-    return _on_config_changed
+    return current_runtime().on_config_changed
 
 
 def get_last_manual_poll():
     """Get the timestamp of the last manual poll."""
-    return _last_manual_poll
+    return current_runtime().get_last_manual_poll()
 
 
 def set_last_manual_poll(value):
     """Set the timestamp of the last manual poll."""
-    global _last_manual_poll
-    _last_manual_poll = value
-
-
-def init_storage(storage):
-    """Set the snapshot storage instance."""
-    global _storage
-    _storage = storage
-
-
-def init_collector(modem_collector):
-    """Set the modem collector instance for manual polling."""
-    global _modem_collector
-    _modem_collector = modem_collector
-
-
-def init_collectors(collectors):
-    """Set the list of all collectors for status reporting."""
-    global _collectors
-    _collectors = collectors
-
-
-def init_modules(module_loader):
-    """Set the module loader instance."""
-    global _module_loader
-    _module_loader = module_loader
-
-
-def setup_module_templates(module_loader):
-    """Add module template directories to Jinja2's search path."""
-    loaders = [app.jinja_loader]  # keep default loader first
-    for mod in module_loader.get_enabled_modules():
-        tpl_dir = os.path.join(mod.path, "templates")
-        if os.path.isdir(tpl_dir):
-            loaders.append(FileSystemLoader(tpl_dir))
-    if len(loaders) > 1:
-        app.jinja_loader = ChoiceLoader(loaders)
-
-
-def _write_private_file(path, value):
-    """Atomically replace a private state file with mode 0600."""
-    data_dir = os.path.dirname(path)
-    os.makedirs(data_dir, exist_ok=True)
-    temp_path = f"{path}.tmp-{os.getpid()}-{secrets.token_hex(8)}"
-    fd = None
-    try:
-        fd = os.open(
-            temp_path,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-            stat.S_IRUSR | stat.S_IWUSR,
-        )
-        with os.fdopen(fd, "wb") as f:
-            fd = None
-            f.write(value)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(temp_path, path)
-        try:
-            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
-            directory_fd = os.open(data_dir, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
-        except OSError:
-            pass
-    finally:
-        if fd is not None:
-            os.close(fd)
-        try:
-            os.unlink(temp_path)
-        except FileNotFoundError:
-            pass
-
-
-def _init_session_key(data_dir):
-    """Load or generate a persistent session secret key."""
-    key_path = os.path.join(data_dir, ".session_key")
-    if os.path.exists(key_path):
-        with open(key_path, "rb") as f:
-            key = f.read()
-    else:
-        key = os.urandom(32)
-        _write_private_file(key_path, key)
-    app.secret_key = key
+    current_runtime().set_last_manual_poll(value)
 
 
 def _rotate_session_key():
     """Persist and activate a new signing key, invalidating all old cookies."""
-    if not _config_manager:
-        raise RuntimeError("Config not initialized")
-    key = os.urandom(32)
-    _write_private_file(os.path.join(_config_manager.data_dir, ".session_key"), key)
+    key = current_runtime().auth_state.rotate_session_key()
     # In-memory activation assumes today's single-process waitress deployment;
     # a future multi-worker server must coordinate shared signing-key rotation.
-    app.secret_key = key
+    current_app.secret_key = key
 
 
-def _session_lifetime_days():
+def _session_lifetime_days(environ: Mapping[str, str] | None = None):
     """Return the safe, bounded operator-configured session lifetime."""
-    configured = os.environ.get("SESSION_LIFETIME_DAYS", "").strip()
+    env = os.environ if environ is None else environ
+    configured = env.get("SESSION_LIFETIME_DAYS", "").strip()
     if not configured:
         return _SESSION_LIFETIME_DEFAULT_DAYS
     try:
@@ -686,17 +484,6 @@ def _session_lifetime_days():
         )
         return _SESSION_LIFETIME_DEFAULT_DAYS
     return max(_SESSION_LIFETIME_MIN_DAYS, min(_SESSION_LIFETIME_MAX_DAYS, days))
-
-
-def init_config(config_manager, on_config_changed=None):
-    """Set the config manager and optional change callback."""
-    global _config_manager, _on_config_changed
-    _config_manager = config_manager
-    _on_config_changed = on_config_changed
-    _init_session_key(config_manager.data_dir)
-    _init_auth_state()
-    app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=_session_lifetime_days())
-
 
 def _keyed_sha256_hexdigest(key: bytes, message: bytes) -> str:
     """Return the HMAC-SHA256 of message as lowercase hexadecimal."""
@@ -726,33 +513,23 @@ def _admin_password_matches(effective_password, candidate):
 
 def _auth_state_fingerprint(password_representation=None):
     """Return a keyed fingerprint of the effective admin-password state."""
+    _config_manager = get_config_manager()
     if password_representation is None:
         password_representation = (
             _config_manager.get("admin_password", "") if _config_manager else ""
         )
-    key = app.secret_key.encode() if isinstance(app.secret_key, str) else app.secret_key
+    key = current_app.secret_key.encode() if isinstance(current_app.secret_key, str) else current_app.secret_key
     value = _AUTH_STATE_CONTEXT + str(password_representation or "").encode("utf-8")
     return _keyed_sha256_hexdigest(key, value)
 
 
-def _auth_state_path():
-    return os.path.join(_config_manager.data_dir, _AUTH_STATE_FILENAME)
-
-
 def _read_auth_state():
-    try:
-        with open(_auth_state_path(), "r", encoding="ascii") as state_file:
-            value = state_file.read().strip()
-    except (FileNotFoundError, OSError, UnicodeError):
-        return None
-    if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
-        return None
-    return value
+    return current_runtime().auth_state.read_fingerprint()
 
 
 def _write_auth_state():
     fingerprint = _auth_state_fingerprint()
-    _write_private_file(_auth_state_path(), fingerprint.encode("ascii"))
+    current_runtime().auth_state.write_fingerprint(fingerprint)
 
 
 def _init_auth_state():
@@ -766,8 +543,17 @@ def _init_auth_state():
         _write_auth_state()
 
 
+def bootstrap_auth_state(app, runtime):
+    """Initialize durable authentication state for a newly created app."""
+    if app.extensions.get("docsight") is not runtime:
+        raise RuntimeError("DOCSight runtime is not attached to this application")
+    with app.app_context():
+        _init_auth_state()
+
+
 def _sync_auth_state():
     """Observe runtime auth changes and durably invalidate existing cookies."""
+    _config_manager = get_config_manager()
     if not _config_manager:
         return
     stored = _read_auth_state()
@@ -780,13 +566,14 @@ def _sync_auth_state():
 
 def _admin_session_marker(password_representation=None):
     """Create a keyed, non-reversible marker for the effective password state."""
+    _config_manager = get_config_manager()
     if password_representation is None:
         if not _config_manager:
             return ""
         password_representation = _config_manager.get("admin_password", "")
     if not password_representation:
         return ""
-    key = app.secret_key.encode() if isinstance(app.secret_key, str) else app.secret_key
+    key = current_app.secret_key.encode() if isinstance(current_app.secret_key, str) else current_app.secret_key
     value = _AUTH_MARKER_CONTEXT + str(password_representation).encode("utf-8")
     return _keyed_sha256_hexdigest(key, value)
 
@@ -818,6 +605,8 @@ def _auth_required():
     Also checks for valid Bearer token in Authorization header.
     Returns True if authentication is required but not provided.
     """
+    _config_manager = get_config_manager()
+    _storage = get_storage()
     if not _config_manager:
         return False
     _sync_auth_state()
@@ -852,6 +641,7 @@ def _require_session_auth(f):
     """Decorator: only allow session-based login, no API tokens."""
     @functools.wraps(f)
     def decorated(*args, **kwargs):
+        _config_manager = get_config_manager()
         _sync_auth_state()
         if not _config_manager or not _config_manager.get("admin_password", ""):
             return f(*args, **kwargs)
@@ -866,8 +656,8 @@ def _require_session_auth(f):
     return decorated
 
 
-@app.route("/login", methods=["GET", "POST"])
 def login():
+    _config_manager = get_config_manager()
     _sync_auth_state()
     if not _config_manager or not _config_manager.get("admin_password", ""):
         return redirect(url_for("index"))
@@ -903,7 +693,7 @@ def login():
                 _write_auth_state()
                 audit_log.info("Auto-upgraded plaintext password to hash for ip=%s", ip)
         if success:
-            _login_attempts.pop(ip, None)
+            current_runtime().login_rate_limiter.reset(ip)
             session.permanent = True
             session["authenticated"] = True
             session[_AUTH_MARKER_SESSION_KEY] = _admin_session_marker(stored)
@@ -916,13 +706,11 @@ def login():
     return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token)
 
 
-@app.route("/logout", methods=["POST"])
 def logout():
     session.clear()
     return redirect(url_for("login"))
 
 
-@app.context_processor
 def inject_browser_url_bootstrap():
     """Expose only the canonical mount path needed by browser URL sinks."""
     return {
@@ -932,9 +720,10 @@ def inject_browser_url_bootstrap():
     }
 
 
-@app.context_processor
 def inject_auth():
     """Make auth_enabled and module info available in all templates."""
+    _config_manager = get_config_manager()
+    _module_loader = get_module_loader()
     auth_enabled = bool(_config_manager and _config_manager.get("admin_password", ""))
     modules = _module_loader.get_enabled_modules() if _module_loader else []
 
@@ -993,35 +782,25 @@ def inject_auth():
 
 def update_state(analysis=None, error=None, poll_interval=None, connection_info=None, device_info=None, speedtest_latest=None, weather_latest=None):
     """Update the shared web state from the main loop (thread-safe)."""
-    with _state_lock:
-        if analysis is not None:
-            _state["analysis"] = analysis
-            _state["last_update"] = time.strftime("%Y-%m-%d %H:%M:%S")
-            _state["error"] = None
-        if error is not None:
-            _state["error"] = str(error)
-        if poll_interval is not None:
-            _state["poll_interval"] = poll_interval
-        if connection_info is not None:
-            _state["connection_info"] = connection_info
-        if device_info is not None:
-            _state["device_info"] = device_info
-        if speedtest_latest is not None:
-            _state["speedtest_latest"] = speedtest_latest
-        if weather_latest is not None:
-            _state["weather_latest"] = weather_latest
+    current_runtime().update_state(
+        analysis=analysis,
+        error=error,
+        poll_interval=poll_interval,
+        connection_info=connection_info,
+        device_info=device_info,
+        speedtest_latest=speedtest_latest,
+        weather_latest=weather_latest,
+    )
 
 
 def clear_speedtest_latest():
     """Clear the cached speedtest_latest from state (e.g. after server reset)."""
-    with _state_lock:
-        _state["speedtest_latest"] = None
+    current_runtime().clear_speedtest_latest()
 
 
 def get_state() -> dict[str, object]:
     """Return a snapshot of the shared web state (thread-safe)."""
-    with _state_lock:
-        return dict(_state)
+    return current_runtime().get_state()
 
 
 def reset_modem_state():
@@ -1031,12 +810,7 @@ def reset_modem_state():
     the dashboard only drops the modem-derived sections while a new poll
     is starting.
     """
-    with _state_lock:
-        _state["analysis"] = None
-        _state["last_update"] = None
-        _state["error"] = None
-        _state["connection_info"] = None
-        _state["device_info"] = None
+    current_runtime().reset_modem_state()
 
 
 def _to_float(value):
@@ -1537,14 +1311,12 @@ def _build_capacity_context(analysis, booked_download=0, booked_upload=0):
     }
 
 
-@app.route("/sw.js")
 def service_worker():
-    return send_from_directory(app.static_folder, "sw.js", mimetype="application/javascript")
+    return send_from_directory(current_app.static_folder, "sw.js", mimetype="application/javascript")
 
 
-@app.route("/static/manifest.json")
 def web_app_manifest():
-    with open(os.path.join(app.static_folder, "manifest.json"), encoding="utf-8") as handle:
+    with open(os.path.join(current_app.static_folder, "manifest.json"), encoding="utf-8") as handle:
         manifest = json.load(handle)
     manifest["id"] = url_for("index")
     response = jsonify(manifest)
@@ -1570,7 +1342,6 @@ def _build_glossary_context(lang, t, selected_term_id=None):
     }
 
 
-@app.route("/glossary")
 @require_auth
 def glossary_page():
     """Compatibility endpoint for existing glossary deep links."""
@@ -1586,9 +1357,10 @@ def glossary_page():
     )
 
 
-@app.route("/")
 @require_auth
 def index():
+    _config_manager = get_config_manager()
+    _storage = get_storage()
     demo_mode = _config_manager.is_demo_mode() if _config_manager else False
     if _config_manager and not demo_mode and not _config_manager.is_configured():
         return redirect(url_for("setup"))
@@ -1699,15 +1471,14 @@ def index():
     )
 
 
-@app.route("/health")
 def health():
     """Simple health check endpoint."""
-    if _state["analysis"]:
-        return {"status": "ok", "docsis_health": _state["analysis"]["summary"]["health"], "version": APP_VERSION}
+    state = get_state()
+    if state["analysis"]:
+        return {"status": "ok", "docsis_health": state["analysis"]["summary"]["health"], "version": APP_VERSION}
     return {"status": "ok", "docsis_health": "waiting", "version": APP_VERSION}
 
 
-@app.route("/desktop-runtime")
 def desktop_runtime():
     """Return authenticated process identity only for desktop loopback clients."""
     payload, status = desktop_runtime_payload(
@@ -1718,8 +1489,8 @@ def desktop_runtime():
     return jsonify(payload), status
 
 
-@app.route("/setup")
 def setup():
+    _config_manager = get_config_manager()
     if _config_manager and (_config_manager.is_configured() or _config_manager.is_demo_mode()):
         return redirect(url_for("index"))
     config = _config_manager.get_all(mask_secrets=True) if _config_manager else {}
@@ -1734,9 +1505,10 @@ def setup():
     return render_template("setup.html", config=config, poll_min=POLL_MIN, poll_max=POLL_MAX, t=t, lang=lang, languages=LANGUAGES, lang_flags=LANG_FLAGS, server_tz=tz_name, server_tz_offset=tz_offset, modem_types=modem_types, driver_hints=driver_hints, timezones=_get_iana_timezones(), iana_tz=iana_tz, theme=theme)
 
 
-@app.route("/settings")
 @require_auth
 def settings():
+    _config_manager = get_config_manager()
+    _module_loader = get_module_loader()
     config = _config_manager.get_all(mask_secrets=True) if _config_manager else {}
     theme = _config_manager.get_theme() if _config_manager else "dark"
     lang = _get_lang()
@@ -1820,7 +1592,6 @@ def settings():
     )
 
 
-@app.after_request
 def add_security_headers(response):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
@@ -1838,6 +1609,48 @@ def add_security_headers(response):
     return response
 
 
-# ── Blueprint Registration ──
-from .blueprints import register_blueprints  # noqa: E402
-register_blueprints(app)
+@dataclass(frozen=True)
+class RouteSpec:
+    rule: str
+    endpoint: str
+    view: Callable
+    methods: tuple[str, ...]
+
+
+CORE_ROUTES = (
+    RouteSpec("/login", "login", login, ("GET", "POST")),
+    RouteSpec("/logout", "logout", logout, ("POST",)),
+    RouteSpec("/", "index", index, ("GET",)),
+    RouteSpec("/glossary", "glossary_page", glossary_page, ("GET",)),
+    RouteSpec("/health", "health", health, ("GET",)),
+    RouteSpec("/desktop-runtime", "desktop_runtime", desktop_runtime, ("GET",)),
+    RouteSpec("/setup", "setup", setup, ("GET",)),
+    RouteSpec("/settings", "settings", settings, ("GET",)),
+    RouteSpec("/sw.js", "service_worker", service_worker, ("GET",)),
+    RouteSpec("/static/manifest.json", "web_app_manifest", web_app_manifest, ("GET",)),
+)
+CORE_TEMPLATE_FILTERS = {
+    "safe_html": safe_html_filter,
+    "fmt_k": format_k,
+    "fmt_speed_value": format_speed_value,
+    "fmt_speed_unit": format_speed_unit,
+    "fmt_uptime": format_uptime,
+    "localtime": _jinja_localtime,
+    "localiso": _jinja_localiso,
+}
+
+
+def register_core_routes(app) -> None:
+    """Register DOCSight's stable core HTTP surface on one application."""
+    for spec in CORE_ROUTES:
+        app.add_url_rule(
+            spec.rule,
+            endpoint=spec.endpoint,
+            view_func=spec.view,
+            methods=list(spec.methods),
+        )
+    for name, function in CORE_TEMPLATE_FILTERS.items():
+        app.add_template_filter(function, name)
+    app.context_processor(inject_browser_url_bootstrap)
+    app.context_processor(inject_auth)
+    app.after_request(add_security_headers)

--- a/tests/architecture/__init__.py
+++ b/tests/architecture/__init__.py
@@ -1,0 +1,1 @@
+"""Architecture invariants."""

--- a/tests/architecture/test_app_globals_guard.py
+++ b/tests/architecture/test_app_globals_guard.py
@@ -1,0 +1,90 @@
+"""Keep Flask applications and their mutable state instance-owned."""
+
+import ast
+from pathlib import Path
+
+import app.web as web
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARDED_FILES = (
+    ROOT / "app" / "web.py",
+    ROOT / "app" / "app_factory.py",
+    ROOT / "app" / "runtime.py",
+    *(ROOT / "app" / "blueprints").glob("*.py"),
+    *(ROOT / "app" / "modules").glob("*/routes.py"),
+    *(ROOT / "app" / "collectors").glob("*.py"),
+)
+ALLOWED_LOWERCASE_BINDINGS = {
+    "analysis_bp", "audit_log", "bp", "blueprint", "events_bp", "config_bp", "data_bp",
+    "log", "logger", "metrics_bp", "modules_bp", "notices_bp",
+    "polling_bp", "segment_bp", "smart_capture_bp", "ModuleLoaderFactory",
+}
+PROCESS_REGISTRY_ALLOWLIST = {
+    "app/config.py": "module configuration keys form a process-wide schema catalog",
+    "app/analyzer.py": "the analyzer threshold profile is a process-wide calculation catalog",
+    "app/i18n/__init__.py": "translations are a process-wide immutable-at-request-time catalog",
+    "app/theme_registry.py": "theme metadata is a process-wide catalog",
+    "app/drivers/registry.py": "driver classes form a process-wide plugin catalog",
+}
+FORBIDDEN_WEB_EXPORTS = {
+    "app", "init_config", "init_storage", "init_collector", "init_collectors",
+    "init_modules", "setup_module_templates",
+}
+
+
+def _tree(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _assigned_names(node):
+    targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+    return [target.id for target in targets if isinstance(target, ast.Name)]
+
+
+def test_guard_scope_excludes_documented_process_registries():
+    guarded = {str(path.relative_to(ROOT)) for path in GUARDED_FILES}
+    assert guarded.isdisjoint(PROCESS_REGISTRY_ALLOWLIST)
+
+
+def test_guarded_modules_have_no_global_or_nonlocal_statements():
+    violations = []
+    for path in GUARDED_FILES:
+        if not path.exists():
+            continue
+        for node in ast.walk(_tree(path)):
+            if isinstance(node, (ast.Global, ast.Nonlocal)):
+                violations.append(f"{path.relative_to(ROOT)}:{node.lineno}")
+    assert violations == []
+
+
+def test_factory_is_the_only_flask_constructor():
+    calls = []
+    for path in (ROOT / "app").rglob("*.py"):
+        for node in ast.walk(_tree(path)):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Flask":
+                calls.append(path.relative_to(ROOT).as_posix())
+    assert calls == ["app/app_factory.py"]
+
+
+def test_guarded_modules_have_no_lowercase_state_bindings():
+    violations = []
+    for path in GUARDED_FILES:
+        if not path.exists():
+            continue
+        for node in _tree(path).body:
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            for name in _assigned_names(node):
+                if (
+                    name.startswith("__")
+                    or name.isupper()
+                    or name in ALLOWED_LOWERCASE_BINDINGS
+                ):
+                    continue
+                violations.append(f"{path.relative_to(ROOT)}:{node.lineno}:{name}")
+    assert violations == []
+
+
+def test_web_has_no_legacy_application_or_initializer_exports():
+    assert FORBIDDEN_WEB_EXPORTS.isdisjoint(vars(web))

--- a/tests/architecture/test_repeated_creation.py
+++ b/tests/architecture/test_repeated_creation.py
@@ -1,0 +1,33 @@
+import gc
+
+from app.app_factory import create_app, default_module_loader_factory
+from app.config import ConfigManager
+
+
+def test_repeated_full_creation_has_identical_unique_routes(tmp_path):
+    snapshots = []
+    blueprint_sets = []
+    for index in range(3):
+        manager = ConfigManager(str(tmp_path / f"data-{index}"))
+        app = create_app(
+            config_manager=manager,
+            module_loader_factory=default_module_loader_factory(manager, search_paths=[]),
+            environ={},
+            testing=True,
+        )
+        snapshot = sorted(
+            (rule.endpoint, rule.rule, tuple(sorted(rule.methods)))
+            for rule in app.url_map.iter_rules()
+        )
+        snapshots.append(snapshot)
+        pairs = [(rule.endpoint, rule.rule) for rule in app.url_map.iter_rules()]
+        assert len(pairs) == len(set(pairs))
+        assert sorted(
+            rule.rule for rule in app.url_map.iter_rules()
+            if rule.endpoint == "polling_bp.api_test_modem"
+        ) == ["/api/test-fritz", "/api/test-modem"]
+        blueprint_sets.append(set(app.blueprints))
+        del app
+        gc.collect()
+    assert snapshots[0] == snapshots[1] == snapshots[2]
+    assert blueprint_sets[0] == blueprint_sets[1] == blueprint_sets[2]

--- a/tests/architecture/test_two_app_isolation.py
+++ b/tests/architecture/test_two_app_isolation.py
@@ -1,0 +1,136 @@
+from concurrent.futures import ThreadPoolExecutor
+import re
+
+import pytest
+
+from app.app_factory import create_app
+from app.config import ConfigManager
+from app.runtime import get_runtime
+from app.storage import SnapshotStorage
+
+
+class EmptyLoader:
+    def get_enabled_modules(self):
+        return []
+
+    def get_theme_modules(self):
+        return []
+
+
+def _login(client, password):
+    response = client.get("/login")
+    match = re.search(rb'name="csrf_token" value="([^"]+)"', response.data)
+    assert match
+    return client.post(
+        "/login",
+        data={"password": password, "csrf_token": match.group(1).decode()},
+        follow_redirects=False,
+    )
+
+
+@pytest.mark.parametrize("order", [("a", "b"), ("b", "a")])
+def test_two_apps_isolate_runtime_auth_storage_and_requests(tmp_path, order):
+    applications = {}
+    managers = {}
+    for name in order:
+        manager = ConfigManager(str(tmp_path / name))
+        manager.save({
+            "admin_password": f"secret-{name}",
+            "metrics_require_token": name == "a",
+            "update_check_enabled": name == "b",
+        })
+        storage = SnapshotStorage(str(tmp_path / f"{name}.db"), max_days=7)
+        managers[name] = manager
+        applications[name] = create_app(
+            config_manager=manager,
+            storage=storage,
+            module_loader_factory=lambda app: EmptyLoader(),
+            environ={},
+            testing=True,
+        )
+
+    app_a, app_b = applications["a"], applications["b"]
+    runtime_a, runtime_b = get_runtime(app_a), get_runtime(app_b)
+    assert runtime_a is not runtime_b
+    assert runtime_a.state is not runtime_b.state
+    assert runtime_a.login_rate_limiter is not runtime_b.login_rate_limiter
+    assert runtime_a.update_checker is not runtime_b.update_checker
+    assert runtime_a.auth_state is not runtime_b.auth_state
+    assert runtime_a.derived_storage is not runtime_b.derived_storage
+    assert runtime_a.module_loader is not runtime_b.module_loader
+    assert runtime_a.config_manager.data_dir != runtime_b.config_manager.data_dir
+    assert runtime_a.storage.db_path != runtime_b.storage.db_path
+    assert app_a.secret_key != app_b.secret_key
+    assert app_a.jinja_loader is not app_b.jinja_loader
+
+    client_a = app_a.test_client()
+    client_b = app_b.test_client()
+    assert _login(client_a, "secret-a").status_code == 302
+    assert _login(client_b, "secret-b").status_code == 302
+
+    cookie_a = client_a.get_cookie("session")
+    cookie_b = client_b.get_cookie("session")
+    replay_b = app_b.test_client()
+    replay_b.set_cookie("session", cookie_a.value)
+    assert replay_b.get("/api/connection").status_code == 401
+    replay_a = app_a.test_client()
+    replay_a.set_cookie("session", cookie_b.value)
+    assert replay_a.get("/api/connection").status_code == 401
+
+    _, token_a = runtime_a.storage.create_api_token("app-a")
+    _, token_b = runtime_b.storage.create_api_token("app-b")
+    bearer_a = {"Authorization": f"Bearer {token_a}"}
+    bearer_b = {"Authorization": f"Bearer {token_b}"}
+    assert app_a.test_client().get("/api/connection", headers=bearer_a).status_code == 200
+    assert app_b.test_client().get("/api/connection", headers=bearer_a).status_code == 401
+    assert app_b.test_client().get("/api/connection", headers=bearer_b).status_code == 200
+    assert app_a.test_client().get("/api/connection", headers=bearer_b).status_code == 401
+    assert app_a.test_client().get("/metrics").status_code == 401
+    assert app_a.test_client().get("/metrics", headers=bearer_a).status_code == 200
+    assert app_b.test_client().get("/metrics").status_code == 200
+
+    runtime_a.update_state(analysis={"summary": {"health": "poor"}})
+    assert client_a.get("/health").json["docsis_health"] == "poor"
+    assert client_b.get("/health").json["docsis_health"] == "waiting"
+    for application in (app_a, app_b):
+        headers = application.test_client().get("/health").headers
+        assert "Content-Security-Policy" in headers
+
+    from app.modules.bnetz.routes import _get_bnetz_storage
+    from app.modules.bqm.routes import _get_bqm_storage
+    from app.modules.speedtest.routes import _get_speedtest_storage
+
+    for application, runtime in ((app_a, runtime_a), (app_b, runtime_b)):
+        with application.app_context():
+            derived = (
+                _get_bnetz_storage(),
+                _get_bqm_storage(),
+                _get_speedtest_storage(),
+            )
+        assert all(item.db_path == runtime.storage.db_path for item in derived)
+
+    key_b = app_b.secret_key
+    auth_state_b = (tmp_path / "b" / ".auth_state").read_bytes()
+    key_a = app_a.secret_key
+    managers["a"].save({"admin_password": "replacement-a"})
+    assert client_a.get("/api/connection").status_code == 401
+    assert app_a.secret_key != key_a
+    assert app_b.secret_key == key_b
+    assert (tmp_path / "b" / ".auth_state").read_bytes() == auth_state_b
+    assert client_b.get("/api/connection").status_code == 200
+
+    for _ in range(6):
+        runtime_a.login_rate_limiter.record_failure("127.0.0.1")
+    assert runtime_a.login_rate_limiter.retry_after("127.0.0.1") > 0
+    assert runtime_b.login_rate_limiter.retry_after("127.0.0.1") == 0
+
+    def drive(name):
+        runtime = get_runtime(applications[name])
+        for value in range(25):
+            runtime.update_state(device_info={"app": name, "value": value})
+            assert applications[name].test_client().get("/health").status_code == 200
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(drive, ("a", "b")))
+    assert runtime_a.get_state()["device_info"] == {"app": "a", "value": 24}
+    assert runtime_b.get_state()["device_info"] == {"app": "b", "value": 24}

--- a/tests/collectors/test_discovery_orchestrator.py
+++ b/tests/collectors/test_discovery_orchestrator.py
@@ -304,7 +304,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = advance_tick
 
-        polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        polling_loop(config_mgr, storage, stop, mock_web)
 
         assert collector.collect_calls == 1
         assert collector.success_calls == 1
@@ -409,7 +411,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = advance_tick
 
-        main.polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        main.polling_loop(config_mgr, storage, stop, mock_web)
 
         assert old_collector.success_calls == 1
         assert replacement_collector.success_calls == 1
@@ -446,7 +450,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = stop_after_one_tick
 
-        polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        polling_loop(config_mgr, storage, stop, mock_web)
 
         mock_driver.login.assert_called()
         mock_driver.get_docsis_data.assert_called()
@@ -480,7 +486,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = stop_after_one_tick
 
-        polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        polling_loop(config_mgr, storage, stop, mock_web)
 
         # Core storage should not have speedtest/bqm methods called
         # (those are now handled by module-internal storage)
@@ -514,7 +522,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = stop_after_one_tick
 
-        polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        polling_loop(config_mgr, storage, stop, mock_web)
 
         mock_web.update_state.assert_any_call(error=mock_driver.login.side_effect)
 
@@ -532,7 +542,9 @@ class TestPollingLoopOrchestrator:
         stop = threading.Event()
         stop.set()  # Pre-set: should exit immediately
 
-        polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        polling_loop(config_mgr, storage, stop, mock_web)
         # If we get here without hanging, the test passes
 
     @patch("app.drivers.driver_registry.load_driver")
@@ -575,7 +587,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = change_modem_after_first_tick
 
-        polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        polling_loop(config_mgr, storage, stop, mock_web)
 
         # load_driver should have been called at least twice:
         # once for initial setup, once for hot-swap
@@ -585,7 +599,7 @@ class TestPollingLoopOrchestrator:
         assert second_call[0][0] == "tc4400"
         # Web state should have been reset for the swap
         mock_web.reset_modem_state.assert_called()
-        mock_web.init_collector.assert_called()
+        assert mock_web.modem_collector.name == "modem"
 
     @patch("app.drivers.driver_registry.load_driver")
     @patch("app.main.web")
@@ -626,7 +640,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = change_url_after_first_tick
 
-        polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        polling_loop(config_mgr, storage, stop, mock_web)
 
         # load_driver called twice: initial + hot-swap for URL change
         assert mock_load.call_count >= 2
@@ -662,7 +678,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = stop_after_ticks
 
-        polling_loop(config_mgr, storage, stop)
+        mock_web.derived_storage.value.return_value = 0
+
+        polling_loop(config_mgr, storage, stop, mock_web)
 
         # load_driver should only be called once (initial setup)
         assert mock_load.call_count == 1

--- a/tests/collectors/test_modem_collector.py
+++ b/tests/collectors/test_modem_collector.py
@@ -261,7 +261,7 @@ class TestModemCollectorSpikeSuppression:
         mock_storage.get_latest_spike_timestamp.return_value = None
         mock_storage.get_device_state.return_value = {}
         mock_web = MagicMock()
-        mock_web._state = {}
+        mock_web.get_state.return_value = {}
 
         fake_analysis = {
             "summary": {"health": "good", "health_issues": [], "ds_total": 0, "us_total": 0},
@@ -391,7 +391,7 @@ class TestDeviceEventSmartCaptureIsolation:
         storage.get_device_state.return_value = initial_state if initial_state is not None else {}
 
         web = MagicMock()
-        web._state = {}
+        web.get_state.return_value = {}
 
         smart_capture = MagicMock()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,46 @@
-"""Shared test fixtures and setup for DOCSight tests."""
+"""Shared factory fixtures for DOCSight tests."""
 
 import importlib
 import json
 import os
+from pathlib import Path
 
+import pytest
+
+from app.app_factory import create_app, default_module_loader_factory
+from app.config import ConfigManager
 from app.builtin_modules import BUILTIN_MODULE_DIRS
 from app.module_loader import module_static_endpoint, setup_module_static
-from app.web import app
+from app.runtime import DerivedStorageCache, LoginRateLimiter, RuntimeState, get_runtime
 
 
-def _register_module_blueprints():
-    """Register built-in module blueprints with the Flask app for testing.
+FACTORY_CONTEXT_MODULES = {
+    "tests.test_auth", "tests.test_bqm", "tests.test_channel_timeline",
+    "tests.test_comparison_module", "tests.test_correlation", "tests.test_demo_mode",
+    "tests.test_device_info_display", "tests.test_events", "tests.test_evidence_api",
+    "tests.test_first_run_demo", "tests.test_first_run_ux", "tests.test_metrics_endpoint",
+    "tests.test_module_install_api", "tests.test_pwa_web_push",
+    "tests.test_module_integration",
+    "tests.test_report_customer_defaults", "tests.test_security_audit_fixes",
+    "tests.test_security_hardening", "tests.test_smart_capture_api", "tests.test_speedtest",
+    "tests.test_trends_api", "tests.test_update_checks", "tests.test_weather",
+    "tests.test_web_theme", "tests.modules.connection_monitor.test_routes",
+    "tests.modules.connection_monitor.test_traceroute_routes",
+    "tests.modules.test_fritzbox_cable_routes",
+}
 
-    Module blueprints are normally registered by the module loader at runtime.
-    In tests, we register built-in routes early so they're available before the
-    first request and route-level coverage sees the same shipped module surface.
-    """
 
-    module_base = os.path.join(os.path.dirname(os.path.dirname(__file__)), "app", "modules")
-    existing = {b.name for b in app.blueprints.values()}
+def _uses_factory_context(module):
+    relative = Path(module.__file__).resolve().relative_to(Path(__file__).resolve().parent)
+    canonical = "tests." + ".".join(relative.with_suffix("").parts)
+    return canonical in FACTORY_CONTEXT_MODULES
 
+
+def register_builtin_test_routes(app):
+    """Register shipped module route and static contributions on one test app."""
+    module_base = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "app", "modules"))
+    blueprints = set(app.blueprints)
+    endpoints = {rule.endpoint for rule in app.url_map.iter_rules()}
     for module_dir in BUILTIN_MODULE_DIRS:
         manifest_path = os.path.join(module_base, module_dir, "manifest.json")
         try:
@@ -27,45 +48,124 @@ def _register_module_blueprints():
                 manifest = json.load(handle)
         except OSError:
             continue
-        if "routes" not in manifest.get("contributes", {}):
-            continue
-
-        try:
-            routes_module = importlib.import_module(f"app.modules.{module_dir}.routes")
-        except ImportError:
-            continue
-        blueprint = getattr(routes_module, "bp", None) or getattr(routes_module, "blueprint", None)
-        if blueprint is not None and blueprint.name not in existing:
-            app.register_blueprint(blueprint)
-            existing.add(blueprint.name)
-
-
-def _register_module_static_routes():
-    """Give the shared test app the built-in static routes used in production."""
-
-    module_base = os.path.join(os.path.dirname(os.path.dirname(__file__)), "app", "modules")
-    existing = {rule.endpoint for rule in app.url_map.iter_rules()}
-    for module_dir in BUILTIN_MODULE_DIRS:
-        manifest_path = os.path.join(module_base, module_dir, "manifest.json")
-        try:
-            with open(manifest_path, "r", encoding="utf-8") as handle:
-                manifest = json.load(handle)
-        except OSError:
-            continue
-        static_subdir = manifest.get("contributes", {}).get("static")
-        if not static_subdir:
-            continue
-        module_id = manifest["id"]
-        endpoint = module_static_endpoint(module_id)
-        if endpoint not in existing:
-            setup_module_static(
-                app,
-                module_id,
-                os.path.join(module_base, module_dir),
-                static_subdir,
-            )
-            existing.add(endpoint)
+        contributes = manifest.get("contributes", {})
+        if "routes" in contributes:
+            try:
+                routes = importlib.import_module(f"app.modules.{module_dir}.routes")
+            except ImportError:
+                routes = None
+            blueprint = getattr(routes, "bp", None) or getattr(routes, "blueprint", None)
+            if blueprint is not None and blueprint.name not in blueprints:
+                app.register_blueprint(blueprint)
+                blueprints.add(blueprint.name)
+        static_subdir = contributes.get("static")
+        endpoint = module_static_endpoint(manifest["id"])
+        if static_subdir and endpoint not in endpoints:
+            setup_module_static(app, manifest["id"], os.path.join(module_base, module_dir), static_subdir)
+            endpoints.add(endpoint)
+    return app
 
 
-_register_module_blueprints()
-_register_module_static_routes()
+@pytest.fixture(autouse=True, scope="module")
+def _factory_context_for_direct_route_tests(request, tmp_path_factory):
+    """Give direct route-unit modules an isolated factory app and context."""
+    if not _uses_factory_context(request.module):
+        yield
+        return
+    manager = ConfigManager(str(tmp_path_factory.mktemp("factory-context")))
+    application = register_builtin_test_routes(create_app(
+        config_manager=manager,
+        environ={},
+        testing=True,
+    ))
+    request.module.app = application
+    with application.app_context():
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_direct_route_runtime(request):
+    if not _uses_factory_context(request.module):
+        yield
+        return
+    runtime = get_runtime(request.module.app)
+    runtime.storage = None
+    runtime.on_config_changed = None
+    runtime.module_loader = None
+    runtime.modem_collector = None
+    runtime.collectors = []
+    runtime.state = RuntimeState()
+    runtime.login_rate_limiter = LoginRateLimiter()
+    runtime.derived_storage = DerivedStorageCache()
+    yield
+
+
+@pytest.fixture
+def make_config(tmp_path):
+    """Return a factory for isolated configuration managers."""
+    counter = 0
+
+    def factory(values=None, *, data_dir=None):
+        nonlocal counter
+        counter += 1
+        path = data_dir or str(tmp_path / f"config-{counter}")
+        manager = ConfigManager(path)
+        if values:
+            manager.save(values)
+        return manager
+
+    return factory
+
+
+@pytest.fixture
+def builtin_module_loader_factory():
+    """Return a loader-factory builder for all shipped modules."""
+    builtin_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "app", "modules"))
+
+    def factory(config_manager):
+        return default_module_loader_factory(
+            config_manager,
+            builtin_base_path=builtin_path,
+            search_paths=[],
+        )
+
+    return factory
+
+
+@pytest.fixture
+def make_app(make_config):
+    """Return a factory that creates an independent Flask application."""
+    def factory(
+        *,
+        config_manager=None,
+        storage=None,
+        on_config_changed=None,
+        module_loader_factory=None,
+        environ=None,
+        testing=True,
+    ):
+        manager = config_manager or make_config()
+        return create_app(
+            config_manager=manager,
+            storage=storage,
+            on_config_changed=on_config_changed,
+            module_loader_factory=module_loader_factory,
+            environ={} if environ is None else environ,
+            testing=testing,
+        )
+
+    return factory
+
+
+@pytest.fixture
+def app(make_app):
+    return make_app()
+
+
+@pytest.fixture
+def make_client(make_app):
+    """Return a factory producing a client for a new application."""
+    def factory(**kwargs):
+        return make_app(**kwargs).test_client()
+
+    return factory

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -87,35 +87,8 @@ def _configure_server_environment(target: _ServerTarget) -> None:
         os.environ["REVERSE_PROXY_PREFIX"] = str(target.trusted_prefix_hops)
 
 
-def _configure_base_path(target: _ServerTarget, application) -> None:
-    if target.base_path is None and target.trusted_prefix_hops is None:
-        return
-    from app.base_path import configure_base_path
-
-    configure_base_path(application)
-
-
-def _initialize_modules(web, db_path: str) -> None:
-    """Load built-ins and their storage tables exactly as production-like E2E needs."""
-    from app.module_loader import ModuleLoader
-
-    builtin_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..", "app", "modules")
-    )
-    module_loader = ModuleLoader(
-        web.app, search_paths=[], disabled_ids=set(), builtin_base_path=builtin_path
-    )
-    module_loader.load_all()
-    web.init_modules(module_loader)
-    web.setup_module_templates(module_loader)
-
-    existing = {blueprint.name for blueprint in web.app.blueprints.values()}
-    for module in module_loader.get_enabled_modules():
-        if hasattr(module, "blueprint") and module.blueprint:
-            if module.blueprint.name not in existing:
-                web.app.register_blueprint(module.blueprint)
-                existing.add(module.blueprint.name)
-
+def _initialize_module_storage(db_path: str) -> None:
+    """Initialize module storage tables needed by seeded E2E data."""
     try:
         from app.modules.speedtest.storage import SpeedtestStorage
 
@@ -157,15 +130,14 @@ def _serve_server(target: _ServerTarget) -> None:
 
     _configure_server_environment(target)
 
-    from app import analyzer, web
+    from app import analyzer
+    from app.app_factory import create_app, default_module_loader_factory
     from app.config import ConfigManager
+    from app.runtime import get_runtime
 
     config = ConfigManager(target.data_dir)
     if not target.configured:
-        web.init_config(config)
-        web.init_storage(None)
-        web.init_collector(None)
-        web.init_collectors([])
+        storage = None
     else:
         from app.collectors.demo import DemoCollector
         from app.event_detector import EventDetector
@@ -173,6 +145,7 @@ def _serve_server(target: _ServerTarget) -> None:
 
         config_data = {
             "demo_mode": target.demo_mode,
+            "disabled_modules": "",
             "modem_type": target.modem_type
             or ("demo" if target.demo_mode else "generic"),
         }
@@ -183,30 +156,35 @@ def _serve_server(target: _ServerTarget) -> None:
         db_path = os.path.join(target.data_dir, "docsis_history.db")
         storage = SnapshotStorage(db_path, max_days=7)
         storage.set_timezone("UTC")
-        web.init_storage(storage)
-        web.init_config(config)
-        web.init_collector(None)
-        web.init_collectors([])
-        _initialize_modules(web, db_path)
+        _initialize_module_storage(db_path)
+
+    application = create_app(
+        config_manager=config,
+        storage=storage,
+        module_loader_factory=default_module_loader_factory(config, search_paths=[]),
+        environ=os.environ,
+        testing=True,
+    )
+    runtime = get_runtime(application)
+
+    if target.configured:
 
         collector = DemoCollector(
             analyzer_fn=analyzer.analyze,
             event_detector=EventDetector(),
             storage=storage,
             mqtt_pub=None,
-            web=web,
+            web=runtime,
             poll_interval=300,
         )
         collector.collect()
         if target.post_seed_callback is not None:
             target.post_seed_callback(db_path)
 
-    _configure_base_path(target, web.app)
-
     from waitress import serve
 
     serve(
-        _mounted_app(web.app, target.mount_path),
+        _mounted_app(application, target.mount_path),
         host="127.0.0.1",
         port=target.port,
         **_WAITRESS_KWARGS,

--- a/tests/modules/connection_monitor/test_routes.py
+++ b/tests/modules/connection_monitor/test_routes.py
@@ -12,14 +12,14 @@ import pytest
 from app.modules.connection_monitor.routes import bp
 from app.modules.connection_monitor.probe import ProbeEngine
 from app.modules.connection_monitor.storage import ConnectionMonitorStorage
+from app.app_factory import create_app
+from app.config import ConfigManager
+from app.runtime import get_runtime
 
 
 @pytest.fixture
 def app(tmp_path):
-    from flask import Flask
-    app = Flask(__name__)
-    app.config["TESTING"] = True
-    app.config["SECRET_KEY"] = "test"
+    app = create_app(config_manager=ConfigManager(str(tmp_path / "config")), environ={}, testing=True)
     app.register_blueprint(bp)
 
     db_path = str(tmp_path / "test_cm.db")
@@ -28,17 +28,10 @@ def app(tmp_path):
     mock_probe = MagicMock()
     mock_probe.capability_info.return_value = {"method": "tcp", "reason": "no ICMP permission"}
 
-    # Set the module-level lazy storage directly
-    import app.modules.connection_monitor.routes as routes_mod
-    routes_mod._storage = storage
-
-    with patch("app.web._config_manager", None), \
+    with patch("app.modules.connection_monitor.routes._get_cm_storage", return_value=storage), \
          patch("app.modules.connection_monitor.routes._get_probe_engine", return_value=mock_probe), \
          patch("app.modules.connection_monitor.routes._get_tz", return_value="UTC"):
         yield app, storage
-
-    # Clean up
-    routes_mod._storage = None
 
 
 @pytest.fixture
@@ -729,7 +722,8 @@ class TestAuthProtection:
             "admin_password": "hashed_pw",
         }.get(key, default)
         mock_cfg.data_dir = os.path.dirname(storage.db_path)
-        with patch("app.web._config_manager", mock_cfg):
+        get_runtime(flask_app).config_manager = mock_cfg
+        with flask_app.app_context():
             from app.web import _init_auth_state
             _init_auth_state()
             yield flask_app.test_client(), storage

--- a/tests/modules/connection_monitor/test_traceroute_routes.py
+++ b/tests/modules/connection_monitor/test_traceroute_routes.py
@@ -9,6 +9,9 @@ import pytest
 from app.modules.connection_monitor.routes import bp
 from app.modules.connection_monitor.storage import ConnectionMonitorStorage
 from app.modules.connection_monitor.traceroute_probe import TracerouteHop, TracerouteResult
+from app.app_factory import create_app
+from app.config import ConfigManager
+from app.runtime import get_runtime
 
 
 def _make_traceroute_result(hops=None, reached=True, fingerprint="abc123"):
@@ -23,10 +26,7 @@ def _make_traceroute_result(hops=None, reached=True, fingerprint="abc123"):
 
 @pytest.fixture
 def app(tmp_path):
-    from flask import Flask
-    app = Flask(__name__)
-    app.config["TESTING"] = True
-    app.config["SECRET_KEY"] = "test"
+    app = create_app(config_manager=ConfigManager(str(tmp_path / "config")), environ={}, testing=True)
     app.register_blueprint(bp)
 
     db_path = str(tmp_path / "test_cm.db")
@@ -38,17 +38,11 @@ def app(tmp_path):
     mock_tr_probe = MagicMock()
     mock_tr_probe.run.return_value = _make_traceroute_result()
 
-    import app.modules.connection_monitor.routes as routes_mod
-    routes_mod._storage = storage
-    routes_mod._traceroute_probe = mock_tr_probe
-
-    with patch("app.web._config_manager", None), \
+    with patch("app.modules.connection_monitor.routes._get_cm_storage", return_value=storage), \
+         patch("app.modules.connection_monitor.routes._get_traceroute_probe", return_value=mock_tr_probe), \
          patch("app.modules.connection_monitor.routes._get_probe_engine", return_value=mock_probe), \
          patch("app.modules.connection_monitor.routes._get_tz", return_value="UTC"):
         yield app, storage, mock_tr_probe
-
-    routes_mod._storage = None
-    routes_mod._traceroute_probe = None
 
 
 @pytest.fixture
@@ -100,7 +94,8 @@ class TestManualTraceroute:
             "admin_password": "hashed_pw",
         }.get(key, default)
         mock_cfg.data_dir = os.path.dirname(storage.db_path)
-        with patch("app.web._config_manager", mock_cfg):
+        get_runtime(flask_app).config_manager = mock_cfg
+        with flask_app.app_context():
             from app.web import _init_auth_state
             _init_auth_state()
             c = flask_app.test_client()

--- a/tests/modules/test_fritzbox_cable_routes.py
+++ b/tests/modules/test_fritzbox_cable_routes.py
@@ -5,14 +5,14 @@ import pytest
 
 
 @pytest.fixture
-def app():
-    from flask import Flask
+def app(tmp_path):
+    from app.app_factory import create_app
+    from app.config import ConfigManager
     from app.blueprints import segment_bp as seg_mod
-    seg_mod._storage_instance = None  # reset singleton
-    app = Flask(__name__)
-    app.config["SECRET_KEY"] = "test"
-    app.register_blueprint(seg_mod.segment_bp)
-    return app
+    return create_app(
+        config_manager=ConfigManager(str(tmp_path / "segment-config")),
+        environ={}, testing=True,
+    )
 
 
 @pytest.fixture

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,56 @@
+import pytest
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+from app.app_factory import create_app
+from app.base_path import BasePathMiddleware, RequestScopedCookieSessionInterface
+from app.config import ConfigManager
+from app.runtime import get_runtime
+
+
+CORE_ENDPOINTS = {
+    "desktop_runtime": ("/desktop-runtime", {"GET", "HEAD", "OPTIONS"}),
+    "glossary_page": ("/glossary", {"GET", "HEAD", "OPTIONS"}),
+    "health": ("/health", {"GET", "HEAD", "OPTIONS"}),
+    "index": ("/", {"GET", "HEAD", "OPTIONS"}),
+    "login": ("/login", {"GET", "POST", "HEAD", "OPTIONS"}),
+    "logout": ("/logout", {"POST", "OPTIONS"}),
+    "service_worker": ("/sw.js", {"GET", "HEAD", "OPTIONS"}),
+    "settings": ("/settings", {"GET", "HEAD", "OPTIONS"}),
+    "setup": ("/setup", {"GET", "HEAD", "OPTIONS"}),
+    "web_app_manifest": ("/static/manifest.json", {"GET", "HEAD", "OPTIONS"}),
+}
+
+
+def test_create_app_requires_config_manager():
+    with pytest.raises(TypeError, match="config_manager"):
+        create_app(config_manager=None)
+
+
+def test_factory_preserves_core_endpoints_filters_and_manifest(tmp_path):
+    app = create_app(
+        config_manager=ConfigManager(str(tmp_path / "data")),
+        environ={},
+        testing=True,
+    )
+    rules = {rule.endpoint: (rule.rule, rule.methods) for rule in app.url_map.iter_rules()}
+    for endpoint, expected in CORE_ENDPOINTS.items():
+        assert rules[endpoint] == expected
+    assert {
+        "safe_html", "fmt_k", "fmt_speed_value", "fmt_speed_unit", "fmt_uptime",
+        "localtime", "localiso",
+    }.issubset(app.jinja_env.filters)
+    response = app.test_client().get("/static/manifest.json")
+    assert response.status_code == 200
+    assert response.mimetype == "application/manifest+json"
+    assert get_runtime(app).config_manager.data_dir == str(tmp_path / "data")
+
+
+def test_factory_installs_base_path_then_outer_proxy(tmp_path):
+    app = create_app(
+        config_manager=ConfigManager(str(tmp_path / "data")),
+        environ={"BASE_PATH": "/docsight", "REVERSE_PROXY": "1"},
+    )
+    assert isinstance(app.wsgi_app, ProxyFix)
+    assert isinstance(app.wsgi_app.app, BasePathMiddleware)
+    assert isinstance(app.session_interface, RequestScopedCookieSessionInterface)
+    assert app.config["SESSION_COOKIE_SECURE"] is True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,14 +13,11 @@ from app.web import (
     _AUTH_STATE_CONTEXT,
     _LOGIN_MAX_TRACKED_IPS,
     _keyed_sha256_hexdigest,
-    _login_attempts,
-    app,
-    init_config,
-    init_storage,
     update_state,
 )
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
+from app.runtime import current_runtime
 
 
 def _login_csrf(client):
@@ -77,8 +74,8 @@ def storage(tmp_path):
 
 @pytest.fixture
 def auth_client(auth_config):
-    init_config(auth_config)
-    init_storage(None)
+    current_runtime().config_manager = auth_config
+    current_runtime().storage = None
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
@@ -86,8 +83,8 @@ def auth_client(auth_config):
 
 @pytest.fixture
 def auth_client_with_storage(auth_config, storage):
-    init_config(auth_config)
-    init_storage(storage)
+    current_runtime().config_manager = auth_config
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
@@ -95,8 +92,8 @@ def auth_client_with_storage(auth_config, storage):
 
 @pytest.fixture
 def noauth_client(noauth_config):
-    init_config(noauth_config)
-    init_storage(None)
+    current_runtime().config_manager = noauth_config
+    current_runtime().storage = None
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
@@ -205,7 +202,7 @@ class TestAuthEnabled:
         _login(auth_client)
         original_key = app.secret_key
 
-        init_config(ConfigManager(auth_config.data_dir))
+        current_runtime().config_manager = ConfigManager(auth_config.data_dir)
 
         assert app.secret_key == original_key
         assert auth_client.get("/").status_code == 200
@@ -218,8 +215,8 @@ class TestAuthEnabled:
             encoding="utf-8",
         )
         manager = ConfigManager(str(data_dir))
-        init_config(manager)
-        init_storage(None)
+        current_runtime().config_manager = manager
+        current_runtime().storage = None
         app.config["TESTING"] = True
         client = app.test_client()
 
@@ -229,7 +226,7 @@ class TestAuthEnabled:
         assert manager.get("admin_password").startswith(("scrypt:", "pbkdf2:"))
         assert client.get("/").status_code == 200
 
-        init_config(ConfigManager(str(data_dir)))
+        current_runtime().config_manager = ConfigManager(str(data_dir))
         assert client.get("/").status_code == 200
 
     def test_cookie_fails_after_config_backed_password_changes(self, auth_client, auth_config):
@@ -245,8 +242,8 @@ class TestAuthEnabled:
         monkeypatch.setenv("ADMIN_PASSWORD", "environment-password")
         manager = ConfigManager(str(tmp_path / "env-auth"))
         manager.save({"modem_type": "generic"})
-        init_config(manager)
-        init_storage(None)
+        current_runtime().config_manager = manager
+        current_runtime().storage = None
         app.config["TESTING"] = True
         with app.test_client() as client:
             _login(client, "environment-password")
@@ -259,15 +256,13 @@ class TestAuthEnabled:
         assert "/login" in resp.headers["Location"]
 
     def test_cookie_does_not_revive_after_environment_password_removal_and_reenable(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, make_app
     ):
         monkeypatch.setenv("ADMIN_PASSWORD", "environment-password")
         manager = ConfigManager(str(tmp_path / "env-auth-reenabled"))
         manager.save({"modem_type": "generic"})
-        init_config(manager)
-        init_storage(None)
-        app.config["TESTING"] = True
-        with app.test_client() as client:
+        application = make_app(config_manager=manager)
+        with application.test_client() as client:
             _login(client, "environment-password")
             assert client.get("/").status_code == 200
 
@@ -285,20 +280,18 @@ class TestAuthEnabled:
         if os.name != "nt":
             assert os.stat(auth_state_path).st_mode & 0o777 == 0o600
 
-    def test_password_change_invalidates_current_and_other_sessions(self, auth_config):
-        init_config(auth_config)
-        init_storage(None)
-        app.config["TESTING"] = True
-        current = app.test_client()
-        other = app.test_client()
+    def test_password_change_invalidates_current_and_other_sessions(self, auth_config, make_app):
+        application = make_app(config_manager=auth_config)
+        current = application.test_client()
+        other = application.test_client()
         _login(current)
         _login(other)
-        old_key = app.secret_key
+        old_key = application.secret_key
 
         response = current.post("/api/config", json={"admin_password": "replacement-password"})
 
         assert response.status_code == 200
-        assert app.secret_key != old_key
+        assert application.secret_key != old_key
         session_key_path = os.path.join(auth_config.data_dir, ".session_key")
         assert os.path.isfile(session_key_path)
         if os.name != "nt":
@@ -307,8 +300,8 @@ class TestAuthEnabled:
         assert other.get("/").status_code == 302
 
     def test_password_removal_invalidates_sessions_before_password_is_reenabled(self, auth_config):
-        init_config(auth_config)
-        init_storage(None)
+        current_runtime().config_manager = auth_config
+        current_runtime().storage = None
         app.config["TESTING"] = True
         current = app.test_client()
         other = app.test_client()
@@ -335,8 +328,8 @@ class TestAuthEnabled:
         ids=["saved-mask", "omitted-password", "same-password"],
     )
     def test_unchanged_password_saves_do_not_invalidate_sessions(self, auth_config, saved_data):
-        init_config(auth_config)
-        init_storage(None)
+        current_runtime().config_manager = auth_config
+        current_runtime().storage = None
         app.config["TESTING"] = True
         current = app.test_client()
         other = app.test_client()
@@ -385,12 +378,10 @@ class TestAuthEnabled:
         assert resp.status_code == 400
 
     def test_login_attempt_tracking_is_bounded(self):
-        _login_attempts.clear()
+        limiter = current_runtime().login_rate_limiter
         for idx in range(_LOGIN_MAX_TRACKED_IPS + 25):
-            _login_attempts[f"198.51.100.{idx}"] = [idx + 1.0]
-        from app.web import _prune_login_attempts
-        _prune_login_attempts(now=10_000.0)
-        assert len(_login_attempts) <= _LOGIN_MAX_TRACKED_IPS
+            limiter.record_failure(f"198.51.100.{idx}")
+        assert len(limiter.snapshot()) <= _LOGIN_MAX_TRACKED_IPS
 
 
 class TestApiTokenAuth:

--- a/tests/test_auth_state_store.py
+++ b/tests/test_auth_state_store.py
@@ -1,0 +1,23 @@
+import os
+import stat
+
+from app.runtime import AuthStateStore
+
+
+def test_auth_state_store_persists_private_key_and_fingerprint(tmp_path):
+    store = AuthStateStore(str(tmp_path / "data"))
+    first = store.load_or_create_session_key()
+    assert len(first) == 32
+    if os.name != "nt":
+        assert stat.S_IMODE(os.stat(store.key_path).st_mode) == 0o600
+    assert store.load_or_create_session_key() == first
+
+    fingerprint = "a" * 64
+    store.write_fingerprint(fingerprint)
+    assert store.read_fingerprint() == fingerprint
+    if os.name != "nt":
+        assert stat.S_IMODE(os.stat(store.auth_state_path).st_mode) == 0o600
+
+    rotated = store.rotate_session_key()
+    assert rotated != first
+    assert store.load_or_create_session_key() == rotated

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -12,8 +12,8 @@ from app.modules.bqm.thinkbroadband import fetch_graph
 from app.modules.bqm.storage import BqmStorage
 from app.module_loader import ModuleInfo
 from app.storage import SnapshotStorage
-from app.web import app, init_config, init_modules, init_storage
 from app.config import ConfigManager
+from app.runtime import current_runtime
 
 
 # ── Fetcher Tests ──
@@ -341,7 +341,6 @@ class TestBQMCollector:
 def _reset_bqm_module_storage():
     """Reset the BQM module's lazy-initialized storage between tests."""
     import app.modules.bqm.routes as bqm_routes
-    bqm_routes._storage = None
 
 
 def _enabled_bqm_loader():
@@ -397,17 +396,17 @@ def bqm_client(tmp_path, bqm_api_storage):
     data_dir = str(tmp_path / "data")
     mgr = ConfigManager(data_dir)
     mgr.save({"modem_password": "test", "modem_type": "fritzbox", "bqm_url": "https://example.com/graph.png"})
-    init_config(mgr)
-    init_storage(s)
+    current_runtime().config_manager = mgr
+    current_runtime().storage = s
     previous_module_loader = web.get_module_loader()
-    init_modules(_enabled_bqm_loader())
+    current_runtime().module_loader = _enabled_bqm_loader()
     _reset_bqm_module_storage()
     app.config["TESTING"] = True
     try:
         with app.test_client() as client:
             yield client, today
     finally:
-        init_modules(previous_module_loader)
+        current_runtime().module_loader = previous_module_loader
         _reset_bqm_module_storage()
 
 
@@ -440,8 +439,8 @@ class TestBQMAPI:
         data_dir = str(tmp_path / "data3")
         mgr = ConfigManager(data_dir)
         mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         _reset_bqm_module_storage()
         app.config["TESTING"] = True
         with app.test_client() as client:
@@ -617,8 +616,8 @@ class TestBQMLive:
         data_dir = str(tmp_path / "data_live")
         mgr = ConfigManager(data_dir)
         mgr.save({"modem_password": "test", "modem_type": "fritzbox", "bqm_url": "https://example.com/graph.png"})
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         _reset_bqm_module_storage()
         app.config["TESTING"] = True
         with app.test_client() as client:
@@ -641,10 +640,10 @@ class TestBqmUiRender:
         client, _ = bqm_client
         enabled_loader = web.get_module_loader()
         try:
-            init_modules(None)
+            current_runtime().module_loader = None
             resp = client.get("/")
         finally:
-            init_modules(enabled_loader)
+            current_runtime().module_loader = enabled_loader
 
         assert resp.status_code == 200
         assert '/modules/docsight.bqm/static/js/bqm-chart.js' not in resp.get_data(

--- a/tests/test_channel_timeline.py
+++ b/tests/test_channel_timeline.py
@@ -7,8 +7,8 @@ import pytest
 from datetime import datetime, timedelta, timezone
 
 from app.storage import SnapshotStorage
-from app.web import app, init_config, init_storage
 from app.config import ConfigManager
+from app.runtime import current_runtime
 
 
 # ── Fixtures ──
@@ -82,8 +82,8 @@ def client(tmp_path):
     data_dir = str(tmp_path / "data")
     mgr = ConfigManager(data_dir)
     mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-    init_config(mgr)
-    init_storage(s)
+    current_runtime().config_manager = mgr
+    current_runtime().storage = s
     app.config["TESTING"] = True
     with app.test_client() as c:
         yield c, s
@@ -496,8 +496,8 @@ class TestChannelHistoryEndpoint:
         data_dir = str(tmp_path / "data2")
         mgr = ConfigManager(data_dir)
         mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         app.config["TESTING"] = True
         with app.test_client() as c:
             resp = c.get("/api/channel-history?channel_id=1&direction=ds")

--- a/tests/test_comparison_module.py
+++ b/tests/test_comparison_module.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 from unittest.mock import patch, MagicMock
 from flask import Flask
-from app.web import app
+from app.runtime import current_runtime
 
 
 @pytest.fixture
@@ -414,7 +414,7 @@ class TestModuleDiscovery:
                     sys.modules[key] = self._orig_sys_modules[key]
                 else:
                     del sys.modules[key]
-        web.init_modules(None)
+        current_runtime().module_loader = None
 
     def test_comparison_module_discovered(self):
         from app.module_loader import discover_modules

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -8,8 +8,9 @@ from datetime import datetime, timedelta, timezone
 from app.storage import SnapshotStorage
 from app.modules.speedtest.storage import SpeedtestStorage
 from app.tz import to_local, utc_now, utc_cutoff
-from app.web import app, update_state, init_config, init_storage, _get_tz_name
+from app.web import update_state, _get_tz_name
 from app.config import ConfigManager
+from app.runtime import current_runtime
 
 
 def _api_response_date(utc_ts: str) -> str:
@@ -61,8 +62,8 @@ def config_mgr(tmp_path):
 
 @pytest.fixture
 def client_with_storage(config_mgr, storage, speedtest_storage):
-    init_config(config_mgr)
-    init_storage(storage)
+    current_runtime().config_manager = config_mgr
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client

--- a/tests/test_demo_mode.py
+++ b/tests/test_demo_mode.py
@@ -24,8 +24,8 @@ from app.modules.speedtest.storage import SpeedtestStorage
 from app.modules.bqm.storage import BqmStorage
 from app.modules.bnetz.storage import BnetzStorage
 from app.modules.journal.storage import JournalStorage
-from app.web import app, init_config, init_storage
 from app.config import ConfigManager
+from app.runtime import current_runtime
 
 
 @pytest.fixture
@@ -83,8 +83,8 @@ def sample_analysis():
 
 @pytest.fixture
 def client(config_mgr, storage):
-    init_config(config_mgr)
-    init_storage(storage)
+    current_runtime().config_manager = config_mgr
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
@@ -224,7 +224,7 @@ class TestDemoMarking:
 
     def test_demo_collector_live_poll_rows_are_demo_and_purgeable(self, storage, sample_analysis):
         web = MagicMock()
-        web._state = {}
+        current_runtime().reset_modem_state()
         detector = MagicMock()
         detector.check.return_value = [{
             "timestamp": "2026-07-02T00:00:00Z",

--- a/tests/test_device_info_display.py
+++ b/tests/test_device_info_display.py
@@ -3,9 +3,10 @@
 import json
 import pytest
 
-from app.web import app, update_state, init_config, init_storage, format_uptime, _state
+from app.web import update_state, format_uptime
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
+from app.runtime import current_runtime
 
 
 _SAMPLE_ANALYSIS = {
@@ -37,8 +38,8 @@ def storage(tmp_path):
 
 @pytest.fixture
 def client(config_mgr, storage):
-    init_config(config_mgr)
-    init_storage(storage)
+    current_runtime().config_manager = config_mgr
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     # Seed analysis so the dashboard renders the hero card
     update_state(analysis=_SAMPLE_ANALYSIS)
@@ -116,7 +117,7 @@ class TestDeviceInfoAPI:
 
     def test_device_endpoint_no_data(self, client):
         """Device endpoint returns empty dict when no device info."""
-        _state["device_info"] = None
+        current_runtime().reset_modem_state()
         resp = client.get("/api/device")
         data = json.loads(resp.data)
         assert data == {}
@@ -153,7 +154,7 @@ class TestDeviceInfoDashboard:
 
     def test_no_badges_when_no_device_info(self, client):
         """No device badges when device_info is empty."""
-        _state["device_info"] = None
+        current_runtime().reset_modem_state()
         html = self._render_index(client)
         assert 'data-lucide="router"' not in html
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from app.storage import SnapshotStorage
 from app.analyzer import analyze, apply_cumulative_error_baseline
 from app.event_detector import EventDetector
-from app.web import app, init_config, init_storage
 from app.config import ConfigManager
+from app.runtime import current_runtime
 
 
 # ── Fixtures ──
@@ -30,8 +30,8 @@ def storage(tmp_path):
 def events_client(tmp_path, storage):
     config_mgr = ConfigManager(str(tmp_path / "config"))
     config_mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-    init_config(config_mgr)
-    init_storage(storage)
+    current_runtime().config_manager = config_mgr
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
@@ -323,8 +323,8 @@ class TestEventExportApi:
     def test_events_export_csv_respects_auth_boundary(self, tmp_path, storage):
         config_mgr = ConfigManager(str(tmp_path / "auth-config"))
         config_mgr.save({"modem_password": "test", "modem_type": "fritzbox", "admin_password": "admin-secret"})
-        init_config(config_mgr)
-        init_storage(storage)
+        current_runtime().config_manager = config_mgr
+        current_runtime().storage = storage
         app.config["TESTING"] = True
         with app.test_client() as client:
             resp = client.get("/api/events/export.csv")
@@ -1033,8 +1033,8 @@ def client(tmp_path, api_storage):
     data_dir = str(tmp_path / "data")
     mgr = ConfigManager(data_dir)
     mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-    init_config(mgr)
-    init_storage(api_storage)
+    current_runtime().config_manager = mgr
+    current_runtime().storage = api_storage
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client

--- a/tests/test_evidence_api.py
+++ b/tests/test_evidence_api.py
@@ -2,7 +2,7 @@ import builtins
 from unittest.mock import Mock, patch
 
 import app.web as web
-from app.web import app
+from app.runtime import current_runtime
 
 
 class FakeCoreStorage:
@@ -48,8 +48,8 @@ class TestEvidenceChecklistApi:
         config = Mock()
         config.get.side_effect = lambda key, default=None: {"admin_password": "secret"}.get(key, default)
         config.data_dir = str(tmp_path)
-        monkeypatch.setattr(web, "_config_manager", config)
-        monkeypatch.setattr(web, "_storage", None)
+        current_runtime().config_manager = config
+        current_runtime().storage = None
         web._init_auth_state()
         app.config["TESTING"] = True
 

--- a/tests/test_first_run_demo.py
+++ b/tests/test_first_run_demo.py
@@ -10,7 +10,7 @@ import pytest
 from app.collectors import DemoCollector, discover_collectors
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
-from app.web import app, init_config, init_storage
+from app.runtime import current_runtime
 
 
 @pytest.fixture
@@ -20,8 +20,9 @@ def fresh_demo_client(tmp_path, monkeypatch):
     manager = ConfigManager(str(data_dir))
     storage = SnapshotStorage(str(tmp_path / "history.db"), max_days=0)
     callbacks = []
-    init_config(manager, lambda: callbacks.append("changed"))
-    init_storage(storage)
+    current_runtime().config_manager = manager
+    current_runtime().on_config_changed = lambda: callbacks.append("changed")
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client, manager, storage, callbacks, data_dir
@@ -82,8 +83,9 @@ def test_demo_start_rolls_back_when_runtime_activation_fails(tmp_path, monkeypat
         if len(callbacks) == 1:
             raise RuntimeError("activation failed")
 
-    init_config(manager, on_config_changed)
-    init_storage(SnapshotStorage(str(tmp_path / "history.db"), max_days=0))
+    current_runtime().config_manager = manager
+    current_runtime().on_config_changed = on_config_changed
+    current_runtime().storage = SnapshotStorage(str(tmp_path / "history.db"), max_days=0)
     app.config["TESTING"] = True
 
     with app.test_client() as client:
@@ -107,8 +109,9 @@ def test_demo_start_rejects_configured_live_instance(tmp_path, monkeypatch):
     manager = ConfigManager(str(tmp_path / "data"))
     manager.save({"modem_type": "generic", "modem_url": "http://192.168.100.1"})
     callbacks = []
-    init_config(manager, lambda: callbacks.append("changed"))
-    init_storage(SnapshotStorage(str(tmp_path / "history.db"), max_days=0))
+    current_runtime().config_manager = manager
+    current_runtime().on_config_changed = lambda: callbacks.append("changed")
+    current_runtime().storage = SnapshotStorage(str(tmp_path / "history.db"), max_days=0)
     app.config["TESTING"] = True
 
     with app.test_client() as client:
@@ -127,8 +130,8 @@ def test_demo_start_requires_browser_session_when_auth_is_enabled(tmp_path, monk
     monkeypatch.delenv("DEMO_MODE", raising=False)
     manager = ConfigManager(str(tmp_path / "data"))
     manager.save({"admin_password": "secret"})
-    init_config(manager)
-    init_storage(SnapshotStorage(str(tmp_path / "history.db"), max_days=0))
+    current_runtime().config_manager = manager
+    current_runtime().storage = SnapshotStorage(str(tmp_path / "history.db"), max_days=0)
     app.config["TESTING"] = True
 
     with app.test_client() as client:
@@ -154,8 +157,9 @@ def test_demo_exit_uses_existing_purge_path_and_returns_next_path(
     manager.save({"demo_mode": True})
     storage = SnapshotStorage(str(tmp_path / "history.db"), max_days=0)
     callbacks = []
-    init_config(manager, lambda: callbacks.append("changed"))
-    init_storage(storage)
+    current_runtime().config_manager = manager
+    current_runtime().on_config_changed = lambda: callbacks.append("changed")
+    current_runtime().storage = storage
     app.config["TESTING"] = True
 
     with app.test_client() as client:
@@ -176,8 +180,8 @@ def test_demo_exit_purges_only_demo_connection_monitor_targets(tmp_path, monkeyp
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     manager = ConfigManager(str(tmp_path / "data"))
     manager.save({"demo_mode": True})
-    init_config(manager)
-    init_storage(SnapshotStorage(str(tmp_path / "history.db"), max_days=0))
+    current_runtime().config_manager = manager
+    current_runtime().storage = SnapshotStorage(str(tmp_path / "history.db"), max_days=0)
     app.config["TESTING"] = True
 
     connection_storage = ConnectionMonitorStorage(
@@ -210,8 +214,9 @@ def test_environment_forced_demo_cannot_be_disabled(tmp_path, monkeypatch):
     storage = SnapshotStorage(str(tmp_path / "history.db"), max_days=0)
     storage.purge_demo_data = MagicMock(return_value=0)
     callbacks = []
-    init_config(manager, lambda: callbacks.append("changed"))
-    init_storage(storage)
+    current_runtime().config_manager = manager
+    current_runtime().on_config_changed = lambda: callbacks.append("changed")
+    current_runtime().storage = storage
     app.config["TESTING"] = True
 
     assert manager.is_demo_mode_forced() is True

--- a/tests/test_first_run_ux.py
+++ b/tests/test_first_run_ux.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from app.config import ConfigManager
 from app.i18n import LANGUAGES
-from app.web import app, init_config, init_storage
+from app.runtime import current_runtime
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -79,8 +79,8 @@ def test_demo_banner_actions_render_on_dashboard_and_settings(tmp_path, monkeypa
     monkeypatch.delenv("DEMO_MODE", raising=False)
     manager = ConfigManager(str(tmp_path / "data"))
     manager.save({"demo_mode": True})
-    init_config(manager)
-    init_storage(None)
+    current_runtime().config_manager = manager
+    current_runtime().storage = None
     app.config["TESTING"] = True
 
     with app.test_client() as client:
@@ -97,8 +97,8 @@ def test_demo_banner_actions_render_on_dashboard_and_settings(tmp_path, monkeypa
 def test_environment_forced_demo_banner_is_locked(tmp_path, monkeypatch):
     monkeypatch.setenv("DEMO_MODE", "1")
     manager = ConfigManager(str(tmp_path / "data"))
-    init_config(manager)
-    init_storage(None)
+    current_runtime().config_manager = manager
+    current_runtime().storage = None
     app.config["TESTING"] = True
 
     with app.test_client() as client:
@@ -117,8 +117,8 @@ def test_environment_forced_demo_banner_is_locked(tmp_path, monkeypatch):
 
 def test_desktop_preview_setup_copy_is_env_gated(tmp_path, monkeypatch):
     manager = ConfigManager(str(tmp_path / "data"))
-    init_config(manager)
-    init_storage(None)
+    current_runtime().config_manager = manager
+    current_runtime().storage = None
     app.config["TESTING"] = True
 
     monkeypatch.delenv("DOCSIGHT_DESKTOP_MODE", raising=False)

--- a/tests/test_login_rate_limiter.py
+++ b/tests/test_login_rate_limiter.py
@@ -1,0 +1,29 @@
+from app.runtime import LoginRateLimiter
+
+
+def test_login_rate_limiter_window_backoff_reset_and_bound():
+    now = [1000.0]
+    limiter = LoginRateLimiter(
+        max_attempts=2,
+        window=100,
+        lockout_base=10,
+        max_tracked_ips=3,
+        clock=lambda: now[0],
+    )
+    limiter.record_failure("a")
+    limiter.record_failure("a")
+    assert limiter.retry_after("a") == 10
+    limiter.record_failure("a")
+    assert limiter.retry_after("a") == 20
+
+    limiter.reset("a")
+    assert limiter.retry_after("a") == 0
+    for ip in ("a", "b", "c", "d"):
+        now[0] += 1
+        limiter.record_failure(ip)
+    assert len(limiter.snapshot()) == 3
+    assert "a" not in limiter.snapshot()
+
+    now[0] += 101
+    limiter.prune()
+    assert limiter.snapshot() == {}

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,28 +1,17 @@
 """Integration tests for the GET /metrics HTTP endpoint."""
 
 import pytest
-import app.web as _web
-from app.web import app, update_state, init_config, init_storage
+from app.web import update_state
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
+from app.runtime import current_runtime
 
 
 @pytest.fixture(autouse=True)
 def reset_web_state():
-    """Reset shared web state before and after each test to prevent state pollution."""
-    _web._state["analysis"] = None
-    _web._state["last_update"] = None
-    _web._state["error"] = None
-    _web._state["connection_info"] = None
-    _web._state["device_info"] = None
-    _web._state["speedtest_latest"] = None
+    current_runtime().reset_modem_state()
+    current_runtime().clear_speedtest_latest()
     yield
-    _web._state["analysis"] = None
-    _web._state["last_update"] = None
-    _web._state["error"] = None
-    _web._state["connection_info"] = None
-    _web._state["device_info"] = None
-    _web._state["speedtest_latest"] = None
 
 
 @pytest.fixture
@@ -52,8 +41,8 @@ def protected_metrics_config(tmp_path):
 @pytest.fixture
 def metrics_client(noauth_config):
     """Flask test client with no authentication configured."""
-    init_config(noauth_config)
-    init_storage(None)
+    current_runtime().config_manager = noauth_config
+    current_runtime().storage = None
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
@@ -62,8 +51,8 @@ def metrics_client(noauth_config):
 @pytest.fixture
 def auth_client(auth_config):
     """Flask test client with authentication configured."""
-    init_config(auth_config)
-    init_storage(None)
+    current_runtime().config_manager = auth_config
+    current_runtime().storage = None
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
@@ -73,8 +62,8 @@ def auth_client(auth_config):
 def protected_metrics_client(protected_metrics_config, tmp_path):
     """Flask test client with token-protected metrics enabled."""
     storage = SnapshotStorage(str(tmp_path / "metrics-tokens.db"), max_days=7)
-    init_config(protected_metrics_config)
-    init_storage(storage)
+    current_runtime().config_manager = protected_metrics_config
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as client:
         client._docsight_storage = storage

--- a/tests/test_modulation_api.py
+++ b/tests/test_modulation_api.py
@@ -5,26 +5,15 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from app.web import app, init_config, init_storage
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
+from app.app_factory import create_app, default_module_loader_factory
 
 
 def _ts_days_ago(days):
     """Return a UTC ISO timestamp for N days ago at 10:00."""
     dt = datetime.now(timezone.utc) - timedelta(days=days)
     return dt.replace(hour=10, minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _ensure_blueprint():
-    """Register the modulation blueprint if not already registered."""
-    existing = {b.name for b in app.blueprints.values()}
-    if "modulation_bp" not in existing:
-        from app.modules.modulation.routes import bp
-        app.register_blueprint(bp)
-
-
-_ensure_blueprint()
 
 
 @pytest.fixture
@@ -37,12 +26,13 @@ def config_mgr(tmp_path):
 
 @pytest.fixture
 def client_no_storage(config_mgr):
-    init_config(config_mgr)
-    init_storage(None)
-    app.config["TESTING"] = True
+    app = create_app(
+        config_manager=config_mgr,
+        module_loader_factory=default_module_loader_factory(config_mgr, search_paths=[]),
+        environ={}, testing=True,
+    )
     with app.test_client() as client:
         yield client
-    init_storage(None)
 
 
 @pytest.fixture
@@ -50,12 +40,14 @@ def client_with_storage(tmp_path, config_mgr):
     db_path = str(tmp_path / "modulation_test.db")
     storage = SnapshotStorage(db_path, max_days=7)
     storage.set_timezone("UTC")
-    init_config(config_mgr)
-    init_storage(storage)
-    app.config["TESTING"] = True
+    app = create_app(
+        config_manager=config_mgr,
+        storage=storage,
+        module_loader_factory=default_module_loader_factory(config_mgr, search_paths=[]),
+        environ={}, testing=True,
+    )
     with app.test_client() as client:
         yield client, storage
-    init_storage(None)
 
 
 def _store_snapshot(storage, timestamp, us_channels=None, ds_channels=None):
@@ -197,7 +189,8 @@ class TestDistributionEndpoint:
         client, storage = client_with_storage
         from app.web import reset_modem_state, update_state
 
-        update_state(connection_info={"max_downstream_kbps": 50000, "max_upstream_kbps": 25000})
+        with client.application.app_context():
+            update_state(connection_info={"max_downstream_kbps": 50000, "max_upstream_kbps": 25000})
         day = _ts_days_ago(1)[:10]
         _store_snapshot(
             storage,
@@ -219,7 +212,8 @@ class TestDistributionEndpoint:
             assert us["tariff_met_pct"] == 0.0
             assert us["status"] == "below_some_samples"
         finally:
-            reset_modem_state()
+            with client.application.app_context():
+                reset_modem_state()
 
 
     def test_aggregate_low_qam_pct_weighted_across_protocol_sample_counts(self, client_with_storage):

--- a/tests/test_module_install_api.py
+++ b/tests/test_module_install_api.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, MagicMock
 from app.blueprints.modules_bp import _remove_downloaded_module
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
-from app.web import app, init_config, init_storage
+from app.runtime import current_runtime
 
 
 @pytest.fixture
@@ -20,8 +20,8 @@ def storage(tmp_path):
 def client(tmp_path, storage):
     config_mgr = ConfigManager(str(tmp_path / "config"))
     config_mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-    init_config(config_mgr)
-    init_storage(storage)
+    current_runtime().config_manager = config_mgr
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as c:
         yield c

--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -5,9 +5,10 @@ import shutil
 import sys
 
 import pytest
-from flask import Flask
+from flask import Flask, current_app
 
 from app.module_loader import ModuleLoader
+from app.runtime import current_runtime, get_runtime
 
 
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
@@ -25,9 +26,9 @@ class TestModuleIntegration:
         self._orig_bool_keys = set(cfg.BOOL_KEYS)
         self._orig_int_keys = set(cfg.INT_KEYS)
         self._orig_translations = {k: dict(v) for k, v in _TRANSLATIONS.items()}
-
         # Clean up any leftover dynamic module imports
         self._orig_sys_modules = set(sys.modules.keys())
+        self._runtime = current_runtime()
 
     def teardown_method(self):
         """Restore global state to avoid polluting other tests."""
@@ -51,7 +52,7 @@ class TestModuleIntegration:
 
         # Clean up global module loader to avoid polluting other tests
         from app import web
-        web.init_modules(None)
+        self._runtime.module_loader = None
 
     def test_full_load_cycle(self):
         """Discover -> validate -> load config + i18n + routes -> serve requests."""
@@ -199,6 +200,7 @@ class TestModuleManagementAPI:
         self._orig_int_keys = set(cfg.INT_KEYS)
         self._orig_translations = {k: dict(v) for k, v in _TRANSLATIONS.items()}
         self._orig_sys_modules = set(sys.modules.keys())
+        self._runtime = current_runtime()
 
     def teardown_method(self):
         from app import config as cfg
@@ -218,8 +220,8 @@ class TestModuleManagementAPI:
                 del sys.modules[key]
 
         from app import web
-        web._module_loader = getattr(self, '_orig_module_loader', None)
-        web._config_manager = getattr(self, '_orig_config_manager', None)
+        self._runtime.module_loader = getattr(self, '_orig_module_loader', None)
+        self._runtime.config_manager = getattr(self, '_orig_config_manager', None)
 
     def test_list_enable_disable_cycle(self, tmp_path):
         """Full cycle: list -> disable -> verify persisted -> enable -> verify."""
@@ -228,19 +230,15 @@ class TestModuleManagementAPI:
         config_mgr = ConfigManager(str(tmp_path))
         config_mgr.save({"disabled_modules": ""})
 
-        app = Flask(__name__)
-        app.config["TESTING"] = True
+        app = current_app._get_current_object()
         loader = ModuleLoader(app, search_paths=[FIXTURE_DIR])
         loader.load_all()
 
         from app import web
-        self._orig_module_loader = web._module_loader
-        self._orig_config_manager = web._config_manager
-        web.init_modules(loader)
-        web.init_config(config_mgr)
-
-        from app.blueprints.modules_bp import modules_bp
-        app.register_blueprint(modules_bp)
+        self._orig_module_loader = self._runtime.module_loader
+        self._orig_config_manager = self._runtime.config_manager
+        self._runtime.module_loader = loader
+        self._runtime.config_manager = config_mgr
 
         with app.test_client() as c:
             # List

--- a/tests/test_modules_api.py
+++ b/tests/test_modules_api.py
@@ -3,31 +3,45 @@
 import os
 
 import pytest
-from flask import Flask
 
 from app.module_loader import ModuleLoader
+from app.app_factory import create_app
+from app.config import ConfigManager
 
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
 
+def _create_module_app(config_manager, search_paths, *, disabled_ids=None):
+    loader_box = []
+
+    def build(application):
+        loader = ModuleLoader(
+            application,
+            search_paths=search_paths,
+            disabled_ids=disabled_ids,
+        )
+        loader.load_all()
+        loader_box.append(loader)
+        return loader
+
+    application = create_app(
+        config_manager=config_manager,
+        module_loader_factory=build,
+        environ={},
+        testing=True,
+    )
+    return application, loader_box[0]
+
+
 @pytest.fixture
-def app_with_modules():
+def app_with_modules(tmp_path):
     """Create a Flask app with modules loaded."""
-    app = Flask(__name__)
-    app.config["TESTING"] = True
-    loader = ModuleLoader(app, search_paths=[FIXTURE_DIR])
-    loader.load_all()
-
-    from app import web
-    web.init_modules(loader)
-
-    from app.blueprints.modules_bp import modules_bp
-    app.register_blueprint(modules_bp)
-
+    app, loader = _create_module_app(
+        ConfigManager(str(tmp_path / "modules-app")),
+        [FIXTURE_DIR],
+    )
     yield app, loader
 
-    # Clean up global state
-    web.init_modules(None)
 
 
 class TestGetModules:
@@ -54,30 +68,19 @@ class TestGetModules:
             for field in ("name", "version", "type", "author", "enabled", "builtin", "error", "description"):
                 assert field in mod
 
-    def test_disabled_module_shown(self):
+    def test_disabled_module_shown(self, tmp_path):
         """Disabled modules appear in the list with enabled=False."""
-        app = Flask(__name__)
-        app.config["TESTING"] = True
-        loader = ModuleLoader(
-            app, search_paths=[FIXTURE_DIR],
+        config = ConfigManager(str(tmp_path / "config"))
+        app, _ = _create_module_app(
+            config,
+            [FIXTURE_DIR],
             disabled_ids={"test.integration"},
         )
-        loader.load_all()
-
-        from app import web
-        web.init_modules(loader)
-
-        from app.blueprints.modules_bp import modules_bp
-        app.register_blueprint(modules_bp)
-
-        try:
-            with app.test_client() as c:
-                resp = c.get("/api/modules")
-                data = resp.get_json()
-                mod = next(m for m in data if m["id"] == "test.integration")
-                assert mod["enabled"] is False
-        finally:
-            web.init_modules(None)
+        with app.test_client() as c:
+            resp = c.get("/api/modules")
+            data = resp.get_json()
+            mod = next(m for m in data if m["id"] == "test.integration")
+            assert mod["enabled"] is False
 
 
 class TestEnableDisable:
@@ -85,33 +88,14 @@ class TestEnableDisable:
 
     @pytest.fixture(autouse=True)
     def setup_app(self, tmp_path):
-        from app.config import ConfigManager
-
-        self.app = Flask(__name__)
-        self.app.config["TESTING"] = True
-
         self.config_mgr = ConfigManager(str(tmp_path))
         self.config_mgr.save({"disabled_modules": ""})
-
-        self.loader = ModuleLoader(
-            self.app, search_paths=[FIXTURE_DIR],
+        self.app, self.loader = _create_module_app(
+            self.config_mgr,
+            [FIXTURE_DIR],
         )
-        self.loader.load_all()
-
-        from app import web
-        self._orig_module_loader = web._module_loader
-        self._orig_config_manager = web._config_manager
-        web.init_modules(self.loader)
-        web.init_config(self.config_mgr)
-
-        from app.blueprints.modules_bp import modules_bp
-        self.app.register_blueprint(modules_bp)
 
         yield
-
-        # Restore global state
-        web._module_loader = self._orig_module_loader
-        web._config_manager = self._orig_config_manager
 
     def test_disable_module(self):
         with self.app.test_client() as c:
@@ -186,28 +170,17 @@ class TestBatchModuleSettings:
             if contributes:
                 (mod_dir / "thresholds.json").write_text(json.dumps(threshold_data))
 
-        self.app = Flask(__name__)
-        self.app.config["TESTING"] = True
         self.config_mgr = ConfigManager(str(tmp_path / "config"))
         self.config_mgr.save({"disabled_modules": "test.thresholds_forum"})
-        self.loader = ModuleLoader(self.app, search_paths=[str(tmp_path)])
         from app import analyzer
         self._orig_thresholds = analyzer._thresholds.copy()
-        self.loader.load_all()
-
-        from app import web
-        self._orig_module_loader = web._module_loader
-        self._orig_config_manager = web._config_manager
-        web.init_modules(self.loader)
-        web.init_config(self.config_mgr)
-
-        from app.blueprints.modules_bp import modules_bp
-        self.app.register_blueprint(modules_bp)
+        self.app, self.loader = _create_module_app(
+            self.config_mgr,
+            [str(tmp_path)],
+        )
 
         yield
 
-        web._module_loader = self._orig_module_loader
-        web._config_manager = self._orig_config_manager
         analyzer._thresholds = self._orig_thresholds
 
     def test_batch_applies_multiple_modules_and_threshold_exclusivity(self):
@@ -269,25 +242,11 @@ class TestThemeMutualExclusion:
                 "light": {"--bg": "#fff", "--text": "#111"},
             }))
 
-        app = Flask(__name__)
-        app.config["TESTING"] = True
-        loader = ModuleLoader(app, search_paths=[str(tmp_path)])
-        loader.load_all()
-
-        from app import web
-        web.init_modules(loader)
-
-        from app.config import ConfigManager
         config = ConfigManager(str(tmp_path / "config"))
         config.save({"disabled_modules": ""})
-        web.init_config(config)
-
-        from app.blueprints.modules_bp import modules_bp
-        app.register_blueprint(modules_bp)
+        app, loader = _create_module_app(config, [str(tmp_path)])
 
         yield app, loader, config
-        web.init_modules(None)
-        web._config_manager = None
 
     def test_enable_theme_disables_other(self, app_with_themes):
         app, loader, config = app_with_themes
@@ -333,19 +292,10 @@ class TestThemesAPI:
             "light": {"--bg": "#fff", "--text": "#111"},
         }))
 
-        app = Flask(__name__)
-        app.config["TESTING"] = True
-        loader = ModuleLoader(app, search_paths=[str(tmp_path)])
-        loader.load_all()
-
-        from app import web
-        web.init_modules(loader)
-
-        from app.blueprints.modules_bp import modules_bp
-        app.register_blueprint(modules_bp)
+        config = ConfigManager(str(tmp_path / "config"))
+        app, loader = _create_module_app(config, [str(tmp_path)])
 
         yield app, loader
-        web.init_modules(None)
 
     def test_get_themes_returns_theme_data(self, app_with_theme):
         app, loader = app_with_theme

--- a/tests/test_pwa_web_push.py
+++ b/tests/test_pwa_web_push.py
@@ -10,7 +10,7 @@ from app.config import ConfigManager, PASSWORD_MASK
 from app.notifier import NotificationDispatcher, WebPushChannel
 from app.storage import SnapshotStorage
 from app import web
-from app.web import app
+from app.runtime import current_runtime
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -69,8 +69,8 @@ def test_pwa_push_status_endpoint_exposes_public_key_without_private_key(tmp_pat
     storage = make_storage(tmp_path)
     storage.upsert_pwa_push_subscription(VALID_SUBSCRIPTION, user_agent="Firefox")
     cfg = make_config(tmp_path)
-    web.init_storage(storage)
-    web.init_config(cfg)
+    current_runtime().storage = storage
+    current_runtime().config_manager = cfg
 
     resp = app.test_client().get("/api/notifications/pwa/status")
 
@@ -89,8 +89,8 @@ def test_pwa_push_status_endpoint_exposes_public_key_without_private_key(tmp_pat
 def test_pwa_push_subscribe_and_unsubscribe_api_validates_subscription(tmp_path):
     storage = make_storage(tmp_path)
     cfg = make_config(tmp_path)
-    web.init_storage(storage)
-    web.init_config(cfg)
+    current_runtime().storage = storage
+    current_runtime().config_manager = cfg
     client = app.test_client()
 
     bad = client.post("/api/notifications/pwa/subscribe", json={"endpoint": "missing keys"})

--- a/tests/test_report_customer_defaults.py
+++ b/tests/test_report_customer_defaults.py
@@ -14,6 +14,7 @@ from app import config as config_module
 from app import module_loader as module_loader_module
 from app import web
 from app.config import ConfigManager
+from app.runtime import current_runtime
 from app.module_loader import (
     ManifestError,
     ModuleLoader,
@@ -51,10 +52,10 @@ def config_mgr(tmp_path):
 
 @pytest.fixture
 def client(config_mgr):
-    web.init_config(config_mgr)
-    web.init_storage(None)
-    web.app.config["TESTING"] = True
-    with web.app.test_client() as test_client:
+    current_runtime().config_manager = config_mgr
+    current_runtime().storage = None
+    app.config["TESTING"] = True
+    with app.test_client() as test_client:
         yield test_client
 
 
@@ -118,19 +119,19 @@ def reports_settings_module(monkeypatch):
         get_theme_modules=lambda: [],
     )
 
-    old_module_loader = web._module_loader
-    old_jinja_loader = web.app.jinja_loader
-    web.init_modules(loader)
-    web.app.jinja_loader = ChoiceLoader(
+    old_module_loader = current_runtime().module_loader
+    old_jinja_loader = app.jinja_loader
+    current_runtime().module_loader = loader
+    app.jinja_loader = ChoiceLoader(
         [old_jinja_loader, FileSystemLoader(str(REPORTS_DIR / "templates"))]
     )
-    web.app.jinja_env.cache.clear()
+    app.jinja_env.cache.clear()
     try:
         yield info
     finally:
-        web.init_modules(old_module_loader)
-        web.app.jinja_loader = old_jinja_loader
-        web.app.jinja_env.cache.clear()
+        current_runtime().module_loader = old_module_loader
+        app.jinja_loader = old_jinja_loader
+        app.jinja_env.cache.clear()
 
 
 def test_private_keys_encrypt_display_and_clear(tmp_path, monkeypatch):
@@ -282,7 +283,7 @@ def test_reports_settings_panel_renders_saved_values(
         "report_customer_address": "Musterstraße 1\n12345 Musterstadt",
     }
     config_mgr.save(values.copy())
-    web.init_config(config_mgr)
+    current_runtime().config_manager = config_mgr
 
     response = client.get("/settings?lang=en")
 
@@ -328,7 +329,7 @@ def test_demo_settings_and_index_hide_saved_private_values(
         "report_customer_address": "Private Street",
         "demo_mode": True,
     })
-    web.init_config(config_mgr)
+    current_runtime().config_manager = config_mgr
     web.update_state(analysis=sample_analysis)
 
     settings_html = client.get("/settings?lang=en").get_data(as_text=True)
@@ -352,7 +353,7 @@ def test_index_prefills_saved_customer_defaults_with_autoescaping(
         "report_customer_address": '</textarea><img id="address-xss" src=x onerror=alert(1)>\nSecond line',
     }
     config_mgr.save(values.copy())
-    web.init_config(config_mgr)
+    current_runtime().config_manager = config_mgr
     web.update_state(analysis=sample_analysis)
 
     response = client.get("/?lang=en")
@@ -375,7 +376,7 @@ def test_index_prefills_saved_customer_defaults_with_autoescaping(
 
 
 def test_index_report_fields_have_empty_server_defaults(client, config_mgr, sample_analysis):
-    web.init_config(config_mgr)
+    current_runtime().config_manager = config_mgr
     web.update_state(analysis=sample_analysis)
 
     soup = BeautifulSoup(client.get("/?lang=en").get_data(as_text=True), "html.parser")
@@ -438,7 +439,7 @@ def test_direct_report_routes_do_not_fall_back_to_saved_customer_values():
     report_storage = Mock()
     report_storage.get_range_data.return_value = []
 
-    with web.app.test_request_context("/api/report"):
+    with app.test_request_context("/api/report"):
         with patch.object(report_routes, "get_storage", return_value=report_storage), patch.object(
             report_routes, "get_config_manager", return_value=config_manager
         ), patch.object(
@@ -449,7 +450,7 @@ def test_direct_report_routes_do_not_fall_back_to_saved_customer_values():
     assert generate_report.call_args.kwargs["customer_number"] == ""
     assert generate_report.call_args.kwargs["customer_address"] == ""
 
-    with web.app.test_request_context("/api/complaint"):
+    with app.test_request_context("/api/complaint"):
         with patch.object(report_routes, "get_storage", return_value=report_storage), patch.object(
             report_routes, "get_config_manager", return_value=config_manager
         ), patch.object(report_routes, "get_state", return_value={"analysis": analysis}), patch.object(
@@ -467,7 +468,7 @@ def test_direct_report_routes_do_not_fall_back_to_saved_customer_values():
         "end_date": None,
     }
     incident_storage.get_entries.return_value = []
-    with web.app.test_request_context("/api/incidents/7/report"):
+    with app.test_request_context("/api/incidents/7/report"):
         with patch.object(journal_routes, "_get_journal_storage", return_value=incident_storage), patch.object(
             journal_routes, "get_config_manager", return_value=config_manager
         ), patch.object(journal_routes, "get_state", return_value={"connection_info": {}}), patch(

--- a/tests/test_runtime_contract.py
+++ b/tests/test_runtime_contract.py
@@ -65,7 +65,7 @@ def test_run_web_defaults_to_public_bind(monkeypatch):
     )
     lifecycle = ServerLifecycleController()
 
-    app_main.run_web(8765, lifecycle)
+    app_main.run_web(object(), 8765, lifecycle)
     lifecycle.close()
 
     assert calls == [{"host": "0.0.0.0", "port": 8765, "threads": 4}]
@@ -93,7 +93,7 @@ def test_run_web_honors_web_host_env(monkeypatch):
         types.SimpleNamespace(create_server=fake_create_server),
     )
 
-    app_main.run_web(8770)
+    app_main.run_web(object(), 8770)
 
     assert calls == [
         {"host": "127.0.0.1", "port": 8770, "threads": 4},

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -1,0 +1,42 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from app.runtime import RuntimeState
+
+
+def test_runtime_state_preserves_update_and_reset_semantics():
+    state = RuntimeState()
+    state.update(
+        analysis={"summary": {"health": "good"}},
+        poll_interval=30,
+        connection_info={"kind": "cable"},
+        speedtest_latest={"id": 7},
+    )
+    state.update(analysis=None, error="offline")
+
+    snapshot = state.snapshot()
+    assert snapshot["analysis"]["summary"]["health"] == "good"
+    assert snapshot["error"] == "offline"
+    assert snapshot["poll_interval"] == 30
+
+    state.reset_modem()
+    snapshot = state.snapshot()
+    assert snapshot["analysis"] is None
+    assert snapshot["connection_info"] is None
+    assert snapshot["speedtest_latest"] == {"id": 7}
+
+    state.clear_speedtest_latest()
+    assert state.snapshot()["speedtest_latest"] is None
+
+
+def test_runtime_state_is_thread_safe():
+    state = RuntimeState()
+
+    def update(value):
+        for _ in range(100):
+            state.update(device_info={"value": value})
+            assert "device_info" in state.snapshot()
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        list(executor.map(update, range(4)))
+
+    assert state.snapshot()["device_info"]["value"] in range(4)

--- a/tests/test_security_audit_fixes.py
+++ b/tests/test_security_audit_fixes.py
@@ -81,32 +81,22 @@ class TestRestoreRateLimit:
 
     @pytest.fixture
     def client(self):
-        from flask import Flask
+        from app.app_factory import create_app
         from app.config import ConfigManager
         from app.modules.backup.routes import bp as backup_bp
-
-        test_app = Flask(__name__)
-        test_app.config["TESTING"] = True
-        test_app.secret_key = "test-secret"
 
         with tempfile.TemporaryDirectory() as td:
             cfg = ConfigManager(td)
             cfg.save({"demo_mode": False})
+            test_app = create_app(config_manager=cfg, environ={}, testing=True)
+            test_app.register_blueprint(backup_bp)
 
             # Patch the getters that backup routes use
             with patch("app.modules.backup.routes.get_config_manager", return_value=cfg), \
                  patch("app.modules.backup.routes._auth_required", return_value=False), \
                  patch("app.modules.backup.routes._get_client_ip", return_value="127.0.0.1"):
-                test_app.register_blueprint(backup_bp)
                 with test_app.test_client() as c:
                     yield c
-
-    @pytest.fixture(autouse=True)
-    def _clear_rate_limits(self):
-        from app.modules.backup import routes as br
-        br._restore_attempts.clear()
-        yield
-        br._restore_attempts.clear()
 
     def test_restore_validate_rate_limited(self, client):
         """After 5 attempts, further unauthenticated restore/validate should be blocked."""
@@ -145,13 +135,15 @@ class TestRestoreRateLimit:
     def test_restore_without_config_manager_rejected(self):
         """If the config manager is not initialized, /api/restore must bail out
         before touching the filesystem — no fallback to a hardcoded data dir."""
-        from flask import Flask
+        from app.app_factory import create_app
+        from app.config import ConfigManager
+        from app.runtime import get_runtime
         from app.modules.backup import routes as br
         from app.modules.backup.routes import bp as backup_bp
 
-        test_app = Flask(__name__)
-        test_app.config["TESTING"] = True
-        test_app.secret_key = "test-secret"
+        test_app = create_app(
+            config_manager=ConfigManager(tempfile.mkdtemp()), environ={}, testing=True
+        )
 
         with patch("app.modules.backup.routes.get_config_manager", return_value=None), \
              patch("app.modules.backup.routes._auth_required", return_value=False), \
@@ -170,31 +162,23 @@ class TestRestoreRateLimit:
             mock_restore.assert_not_called()
             # Must not count as a rate-limit attempt either — the request never
             # reached the rate-limited code path.
-            assert br._restore_attempts.get("127.0.0.1", []) == []
+            assert get_runtime(test_app).derived_storage.value("backup_restore_attempts", {}) == {}
 
     def test_authenticated_restore_not_rate_limited(self):
         """Configured+authenticated instances skip the rate limit path entirely."""
-        from flask import Flask
+        from app.app_factory import create_app
         from app.config import ConfigManager
         from app.modules.backup import routes as br
-
-        br._restore_attempts.clear()
-
-        test_app = Flask(__name__)
-        test_app.config["TESTING"] = True
-        test_app.secret_key = "test-secret"
 
         with tempfile.TemporaryDirectory() as td:
             cfg = ConfigManager(td)
             cfg.save({"admin_password": "testpass", "modem_type": "demo"})
+            test_app = create_app(config_manager=cfg, environ={}, testing=True)
 
             with patch("app.modules.backup.routes.get_config_manager", return_value=cfg), \
                  patch("app.modules.backup.routes._auth_required", return_value=False), \
                  patch("app.modules.backup.routes._get_client_ip", return_value="127.0.0.1"):
                 from app.modules.backup.routes import bp as backup_bp
-                fresh_bp = type(backup_bp)(backup_bp.name + "_auth_test", backup_bp.import_name)
-                for deferred in backup_bp.deferred_functions:
-                    fresh_bp.record(deferred)
                 test_app.register_blueprint(backup_bp)
                 with test_app.test_client() as c:
                     for i in range(10):

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -11,6 +11,7 @@ from flask import Flask
 from app.theme_registry import _is_trusted_url, download_theme
 from app.collectors import _ModuleConfigProxy
 from app.config import ConfigManager, SECRET_KEYS, HASH_KEYS
+from app.runtime import current_runtime
 
 
 # ── Reverse proxy / X-Forwarded-For ──
@@ -28,8 +29,7 @@ class TestClientIPWithoutProxy:
 
     def test_rate_limit_uses_remote_addr(self, client):
         """Rate limiting should use real remote_addr, not spoofed XFF."""
-        from app.web import _login_attempts
-        _login_attempts.clear()
+        current_runtime().login_rate_limiter.prune(float("inf"))
 
         # Simulate 6 failed logins with different spoofed IPs
         for i in range(6):
@@ -41,7 +41,7 @@ class TestClientIPWithoutProxy:
 
         # Without proxy trust, all requests come from same remote_addr,
         # so rate limiter should kick in.
-        attempts_keys = list(_login_attempts.keys())
+        attempts_keys = list(current_runtime().login_rate_limiter.snapshot())
         assert len(attempts_keys) == 1, (
             f"Expected 1 IP in rate limiter, got {len(attempts_keys)}: {attempts_keys}"
         )
@@ -359,10 +359,10 @@ def client():
     with tempfile.TemporaryDirectory() as td:
         cfg = ConfigManager(td)
         cfg.save({"admin_password": "testpass", "demo_mode": False, "modem_type": "demo"})
-        web.init_config(cfg)
-        web.init_storage(None)
-        web.init_collector(None)
-        web.init_collectors([])
-        web.app.config["TESTING"] = True
-        with web.app.test_client() as c:
+        current_runtime().config_manager = cfg
+        current_runtime().storage = None
+        current_runtime().modem_collector = None
+        current_runtime().collectors = []
+        app.config["TESTING"] = True
+        with app.test_client() as c:
             yield c

--- a/tests/test_smart_capture_api.py
+++ b/tests/test_smart_capture_api.py
@@ -6,7 +6,7 @@ import pytest
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.smart_capture.types import ExecutionStatus
-from app.web import app, init_config, init_storage
+from app.runtime import current_runtime
 
 
 @pytest.fixture
@@ -18,8 +18,8 @@ def storage(tmp_path):
 def client(tmp_path, storage):
     config_mgr = ConfigManager(str(tmp_path / "config"))
     config_mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-    init_config(config_mgr)
-    init_storage(storage)
+    current_runtime().config_manager = config_mgr
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as c:
         yield c

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -4,8 +4,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from app.modules.speedtest.client import SpeedtestClient
-from app.web import app, init_config, init_storage
 from app.config import ConfigManager, PASSWORD_MASK
+from app.runtime import current_runtime
 
 
 # ── Sample API responses ──
@@ -265,7 +265,6 @@ class TestSpeedtestConfig:
 def _reset_speedtest_module_storage():
     """Reset the speedtest module's lazy-initialized storage between tests."""
     import app.modules.speedtest.routes as speedtest_routes
-    speedtest_routes._storage = None
 
 
 @pytest.fixture
@@ -278,8 +277,8 @@ def speedtest_client(tmp_path):
         "speedtest_tracker_url": "http://speedtest.local:8999",
         "speedtest_tracker_token": "test-token",
     })
-    init_config(mgr)
-    init_storage(None)
+    current_runtime().config_manager = mgr
+    current_runtime().storage = None
     _reset_speedtest_module_storage()
     app.config["TESTING"] = True
     with app.test_client() as client:
@@ -479,8 +478,8 @@ class TestSpeedtestAPI:
         data_dir = str(tmp_path / "data2")
         mgr = ConfigManager(data_dir)
         mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         _reset_speedtest_module_storage()
         app.config["TESTING"] = True
         with app.test_client() as client:
@@ -494,7 +493,7 @@ class TestSpeedtestRun:
 
     def _reset_rate_limit(self):
         import app.modules.speedtest.routes as sr
-        sr._last_trigger_ts = 0
+        current_runtime().derived_storage.set_value("speedtest_last_trigger", 0.0)
 
     @patch("app.modules.speedtest.routes.requests.post")
     def test_run_success(self, mock_post, speedtest_client):
@@ -564,8 +563,8 @@ class TestSpeedtestRun:
         data_dir = str(tmp_path / "data3")
         mgr = ConfigManager(data_dir)
         mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         _reset_speedtest_module_storage()
         app.config["TESTING"] = True
         with app.test_client() as client:
@@ -583,8 +582,8 @@ class TestSpeedtestRun:
             "speedtest_tracker_url": "http://speedtest.local:8999",
             "speedtest_tracker_token": "[REDACTED]",
         })
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         _reset_speedtest_module_storage()
         app.config["TESTING"] = True
         with app.test_client() as client:

--- a/tests/test_trends_api.py
+++ b/tests/test_trends_api.py
@@ -11,7 +11,8 @@ from app.config import ConfigManager
 from app.modules.connection_monitor.storage import ConnectionMonitorStorage
 from app.modules.speedtest.storage import SpeedtestStorage
 from app.storage import SnapshotStorage
-from app.web import app, get_config_manager, init_config, init_storage
+from app.runtime import current_runtime
+from app.web import get_config_manager
 
 
 def _utc_ts(delta: timedelta) -> str:
@@ -64,8 +65,8 @@ def client(tmp_path):
     data_dir = str(tmp_path / "data")
     manager = ConfigManager(data_dir)
     manager.save({"modem_password": "test", "modem_type": "fritzbox"})
-    init_config(manager)
-    init_storage(storage)
+    current_runtime().config_manager = manager
+    current_runtime().storage = storage
     app.config["TESTING"] = True
     with app.test_client() as flask_client:
         yield flask_client, storage

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,0 +1,42 @@
+from app.runtime import UpdateChecker
+
+
+def test_update_checker_is_disabled_without_spawning():
+    spawned = []
+    checker = UpdateChecker(
+        app_version="2026-01-01.1",
+        is_enabled=lambda: False,
+        spawn=spawned.append,
+    )
+    assert checker.latest() is None
+    assert spawned == []
+
+
+def test_update_checker_has_one_inflight_fetch_and_honors_ttl():
+    now = [100.0]
+    spawned = []
+    checker = UpdateChecker(
+        app_version="2026-01-01.1",
+        is_enabled=lambda: True,
+        fetch=lambda: "v2026-01-02.1",
+        clock=lambda: now[0],
+        spawn=spawned.append,
+        ttl=60,
+    )
+    assert checker.latest() is None
+    assert checker.latest() is None
+    assert len(spawned) == 1
+    spawned.pop()()
+    assert checker.latest() == "v2026-01-02.1"
+    now[0] += 61
+    assert checker.latest() == "v2026-01-02.1"
+    assert len(spawned) == 1
+
+
+def test_update_checker_skips_dev_versions():
+    spawned = []
+    checker = UpdateChecker(
+        app_version="dev", is_enabled=lambda: True, spawn=spawned.append
+    )
+    assert checker.latest() is None
+    assert spawned == []

--- a/tests/test_update_checks.py
+++ b/tests/test_update_checks.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from app.config import ConfigManager
 from app import web
-from app.web import app, init_config, init_storage
+from app.runtime import UpdateChecker, current_runtime
 
 
 class _ThreadProbe:
@@ -20,40 +20,39 @@ class _ThreadProbe:
         self.started = True
 
 
-def _reset_update_cache():
-    web._update_cache.update({"latest": None, "checked_at": 0, "checking": False})
-
-
 def test_update_check_disabled_by_default_does_not_start_fetch_thread(tmp_path, monkeypatch):
     cfg = ConfigManager(str(tmp_path / "config"))
-    init_config(cfg)
-    _reset_update_cache()
-    monkeypatch.setattr(web, "APP_VERSION", "v2026-07-01.1")
-    monkeypatch.setattr(web.threading, "Thread", _ThreadProbe)
+    current_runtime().config_manager = cfg
     _ThreadProbe.calls.clear()
+    current_runtime().update_checker = UpdateChecker(
+        app_version="v2026-07-01.1",
+        is_enabled=cfg.is_update_check_enabled,
+        spawn=lambda target: _ThreadProbe(target, daemon=True).start(),
+    )
 
     assert web._check_for_update() is None
 
     assert _ThreadProbe.calls == []
-    assert web._update_cache["checking"] is False
+    assert current_runtime().update_checker.snapshot()["checking"] is False
 
 
 def test_update_check_enabled_starts_background_fetch_thread(tmp_path, monkeypatch):
     cfg = ConfigManager(str(tmp_path / "config"))
     cfg.save({"update_check_enabled": True})
-    init_config(cfg)
-    _reset_update_cache()
-    monkeypatch.setattr(web, "APP_VERSION", "v2026-07-01.1")
-    monkeypatch.setattr(web.threading, "Thread", _ThreadProbe)
+    current_runtime().config_manager = cfg
     _ThreadProbe.calls.clear()
+    current_runtime().update_checker = UpdateChecker(
+        app_version="v2026-07-01.1",
+        is_enabled=cfg.is_update_check_enabled,
+        spawn=lambda target: _ThreadProbe(target, daemon=True).start(),
+    )
 
     assert web._check_for_update() is None
 
     assert len(_ThreadProbe.calls) == 1
-    assert _ThreadProbe.calls[0].target is web._fetch_update
     assert _ThreadProbe.calls[0].daemon is True
     assert _ThreadProbe.calls[0].started is True
-    assert web._update_cache["checking"] is True
+    assert current_runtime().update_checker.snapshot()["checking"] is True
 
 
 def test_update_check_setting_persists_and_env_can_disable(tmp_path, monkeypatch):
@@ -68,8 +67,8 @@ def test_update_check_setting_persists_and_env_can_disable(tmp_path, monkeypatch
 def test_settings_renders_release_update_check_toggle(tmp_path):
     cfg = ConfigManager(str(tmp_path / "config"))
     cfg.save({"modem_password": "test", "modem_type": "fritzbox"})
-    init_config(cfg)
-    init_storage(None)
+    current_runtime().config_manager = cfg
+    current_runtime().storage = None
     app.config["TESTING"] = True
 
     with app.test_client() as client:
@@ -87,8 +86,9 @@ def test_api_config_saves_release_update_check_toggle(tmp_path):
     cfg = ConfigManager(str(tmp_path / "config"))
     cfg.save({"modem_password": "test", "modem_type": "fritzbox"})
     on_change = MagicMock()
-    init_config(cfg, on_config_changed=on_change)
-    init_storage(None)
+    current_runtime().config_manager = cfg
+    current_runtime().on_config_changed = on_change
+    current_runtime().storage = None
     app.config["TESTING"] = True
 
     with app.test_client() as client:

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -13,13 +13,8 @@ from app.modules.weather.client import OpenMeteoClient
 from app.modules.weather.collector import WeatherCollector
 from app.modules.weather.storage import WeatherStorage
 from app.config import ConfigManager
-from app.web import app, init_config, init_storage, update_state
-
-# Register the weather module blueprint once at import time
-# (must happen before any test_client() calls trigger _got_first_request)
-if "weather_module" not in app.blueprints:
-    from app.modules.weather.routes import bp as _weather_bp
-    app.register_blueprint(_weather_bp)
+from app.web import update_state
+from app.runtime import current_runtime
 
 
 # ── OpenMeteoClient Tests ──
@@ -315,23 +310,21 @@ class TestWeatherAPI:
     def weather_client(self, tmp_path):
         # Reset module-local storage
         from app.modules.weather import routes as weather_routes
-        weather_routes._storage = None
 
         data_dir = str(tmp_path / "data_w")
         mgr = ConfigManager(data_dir)
         mgr.save({"modem_password": "test", "modem_type": "fritzbox", "weather_enabled": True,
                    "weather_latitude": "52.52", "weather_longitude": "13.41"})
-        init_config(mgr)
+        current_runtime().config_manager = mgr
         from app.storage import SnapshotStorage
         storage = SnapshotStorage(str(tmp_path / "weather.db"))
-        init_storage(storage)
+        current_runtime().storage = storage
 
         app.config["TESTING"] = True
         with app.test_client() as client:
             yield client, WeatherStorage(str(tmp_path / "weather.db"))
 
         # Cleanup module-local storage
-        weather_routes._storage = None
 
     def test_api_weather_empty(self, weather_client):
         client, _ = weather_client
@@ -353,8 +346,7 @@ class TestWeatherAPI:
 
     def test_api_weather_current_no_data(self, weather_client):
         client, _ = weather_client
-        from app.web import _state
-        _state["weather_latest"] = None
+        current_runtime().state.reset_modem()
         resp = client.get("/api/weather/current")
         assert resp.status_code == 404
 
@@ -386,17 +378,15 @@ class TestWeatherAPI:
 
     def test_api_weather_not_configured(self, tmp_path):
         from app.modules.weather import routes as weather_routes
-        weather_routes._storage = None
         mgr = ConfigManager(str(tmp_path / "data_nc"))
         mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         app.config["TESTING"] = True
         with app.test_client() as client:
             resp = client.get("/api/weather")
             assert resp.status_code == 200
             assert resp.get_json() == []
-        weather_routes._storage = None
 
     def test_api_weather_count_param(self, weather_client):
         client, storage = weather_client

--- a/tests/test_web_theme.py
+++ b/tests/test_web_theme.py
@@ -2,6 +2,7 @@
 
 import pytest
 from app.module_loader import ModuleInfo
+from app.runtime import current_runtime
 
 
 class TestThemeContext:
@@ -33,19 +34,19 @@ class TestThemeContext:
                     return "test.theme"
                 return default
 
-        old_loader = web._module_loader
-        old_config = web._config_manager
+        old_loader = current_runtime().module_loader
+        old_config = current_runtime().config_manager
         try:
-            web._module_loader = FakeLoader()
-            web._config_manager = FakeConfig()
+            current_runtime().module_loader = FakeLoader()
+            current_runtime().config_manager = FakeConfig()
 
-            with web.app.test_request_context("/"):
+            with app.test_request_context("/"):
                 ctx = web.inject_auth()
                 assert "active_theme_data" in ctx
                 assert ctx["active_theme_data"]["dark"]["--bg"] == "#111"
         finally:
-            web._module_loader = old_loader
-            web._config_manager = old_config
+            current_runtime().module_loader = old_loader
+            current_runtime().config_manager = old_config
 
     def test_no_theme_returns_none(self):
         """Context processor returns None when no theme modules exist."""
@@ -61,19 +62,19 @@ class TestThemeContext:
             def get(self, key, default=""):
                 return default
 
-        old_loader = web._module_loader
-        old_config = web._config_manager
+        old_loader = current_runtime().module_loader
+        old_config = current_runtime().config_manager
         try:
-            web._module_loader = FakeLoader()
-            web._config_manager = FakeConfig()
+            current_runtime().module_loader = FakeLoader()
+            current_runtime().config_manager = FakeConfig()
 
-            with web.app.test_request_context("/"):
+            with app.test_request_context("/"):
                 ctx = web.inject_auth()
                 assert "active_theme_data" in ctx
                 assert ctx["active_theme_data"] is None
         finally:
-            web._module_loader = old_loader
-            web._config_manager = old_config
+            current_runtime().module_loader = old_loader
+            current_runtime().config_manager = old_config
 
     def test_fallback_prefers_classic_over_alphabetical(self):
         """When no active_theme is configured, Classic is chosen over alphabetically first."""
@@ -102,19 +103,19 @@ class TestThemeContext:
             def get(self, key, default=""):
                 return default  # no active_theme set
 
-        old_loader = web._module_loader
-        old_config = web._config_manager
+        old_loader = current_runtime().module_loader
+        old_config = current_runtime().config_manager
         try:
-            web._module_loader = FakeLoader()
-            web._config_manager = FakeConfig()
+            current_runtime().module_loader = FakeLoader()
+            current_runtime().config_manager = FakeConfig()
 
-            with web.app.test_request_context("/"):
+            with app.test_request_context("/"):
                 ctx = web.inject_auth()
                 assert ctx["active_theme_id"] == "docsight.theme_classic"
                 assert ctx["active_theme_data"]["dark"]["--bg"] == "#111"
         finally:
-            web._module_loader = old_loader
-            web._config_manager = old_config
+            current_runtime().module_loader = old_loader
+            current_runtime().config_manager = old_config
 
     def test_theme_collections_are_grouped_for_gallery(self):
         """Theme gallery collections group signature, community, and playful themes."""
@@ -151,13 +152,13 @@ class TestThemeContext:
                     return "docsight.theme_classic"
                 return default
 
-        old_loader = web._module_loader
-        old_config = web._config_manager
+        old_loader = current_runtime().module_loader
+        old_config = current_runtime().config_manager
         try:
-            web._module_loader = FakeLoader()
-            web._config_manager = FakeConfig()
+            current_runtime().module_loader = FakeLoader()
+            current_runtime().config_manager = FakeConfig()
 
-            with web.app.test_request_context("/settings"):
+            with app.test_request_context("/settings"):
                 ctx = web.inject_auth()
                 assert [c["key"] for c in ctx["theme_collections"]] == [
                     "signature",
@@ -168,5 +169,5 @@ class TestThemeContext:
                     "docsight.theme_tokyo_night",
                 ]
         finally:
-            web._module_loader = old_loader
-            web._config_manager = old_config
+            current_runtime().module_loader = old_loader
+            current_runtime().config_manager = old_config

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,26 +1,54 @@
 import io
 import pytest
 
-from app.web import app, init_config, init_storage
+from app.app_factory import create_app
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.modules.bnetz.storage import BnetzStorage
+from app.runtime import DerivedStorageCache, LoginRateLimiter, RuntimeState, get_runtime
+from tests.conftest import register_builtin_test_routes
 
 
 @pytest.fixture
 def config_mgr(tmp_path):
-    data_dir = str(tmp_path / "data")
+    data_dir = str(tmp_path / "web-default-data")
     mgr = ConfigManager(data_dir)
     mgr.save({"modem_password": "test", "modem_type": "fritzbox", "isp_name": "Vodafone"})
     return mgr
 
 
+@pytest.fixture(scope="module")
+def app(tmp_path_factory):
+    manager = ConfigManager(str(tmp_path_factory.mktemp("web-factory-app")))
+    application = create_app(
+        config_manager=manager,
+        storage=None,
+        environ={},
+        testing=True,
+    )
+    return register_builtin_test_routes(application)
+
+
+@pytest.fixture(autouse=True)
+def _app_context(app, request, config_mgr):
+    request.module.app = app
+    runtime = get_runtime(app)
+    runtime.config_manager = config_mgr
+    runtime.storage = None
+    runtime.on_config_changed = None
+    runtime.module_loader = None
+    runtime.modem_collector = None
+    runtime.collectors = []
+    runtime.state = RuntimeState()
+    runtime.login_rate_limiter = LoginRateLimiter()
+    runtime.derived_storage = DerivedStorageCache()
+    with app.app_context():
+        yield
+
+
 @pytest.fixture
-def client(config_mgr):
-    init_config(config_mgr)
-    init_storage(None)
-    app.config["TESTING"] = True
-    with app.test_client() as client:
+def client(app):
+    with app.app_context(), app.test_client() as client:
         yield client
 
 
@@ -88,16 +116,10 @@ def no_docsis_analysis():
 
 
 @pytest.fixture
-def storage_client(tmp_path, config_mgr):
+def storage_client(tmp_path, app):
     db_path = str(tmp_path / "test_web.db")
     storage = SnapshotStorage(db_path, max_days=7)
     bnetz_st = BnetzStorage(db_path)
-    init_config(config_mgr)
-    init_storage(storage)
-    import app.modules.bnetz.routes as bnetz_routes
-    bnetz_routes._storage = None
-    app.config["TESTING"] = True
-    with app.test_client() as client:
+    get_runtime(app).storage = storage
+    with app.app_context(), app.test_client() as client:
         yield client, storage, bnetz_st
-    init_storage(None)
-    bnetz_routes._storage = None

--- a/tests/web/test_connection_and_gaming_api.py
+++ b/tests/web/test_connection_and_gaming_api.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from app.web import app, init_config, update_state
+from app.web import update_state
 
 class TestConnectionEndpoint:
     def test_no_connection_info(self, client):
@@ -24,25 +24,15 @@ class TestConnectionEndpoint:
         assert data["max_downstream_kbps"] == 250000
         assert data["max_upstream_kbps"] == 40000
 
-    def test_isp_name_from_config(self, config_mgr):
+    def test_isp_name_from_config(self, config_mgr, make_app):
         config_mgr.save({"isp_name": "Vodafone"})
-        init_config(config_mgr)
-        app.config["TESTING"] = True
+        app = make_app(config_manager=config_mgr)
         with app.test_client() as c:
             data = c.get("/api/connection").get_json()
         assert data["isp_name"] == "Vodafone"
 
 
 class TestGamingScoreEndpoint:
-    @pytest.fixture(autouse=True)
-    def reset_state(self):
-        from app.web import _state
-        _state["analysis"] = None
-        _state["speedtest_latest"] = None
-        yield
-        _state["analysis"] = None
-        _state["speedtest_latest"] = None
-
     def test_no_data_returns_nulls(self, client):
         resp = client.get("/api/gaming-score")
         assert resp.status_code == 200
@@ -95,12 +85,10 @@ class TestGamingScoreEndpoint:
         # Without speedtest data the score may still be partial, but genres key must exist
         assert all(v in ("ok", "warn", "bad") for v in data["genres"].values())
 
-    def test_enabled_flag_reflects_config(self, config_mgr, sample_analysis):
+    def test_enabled_flag_reflects_config(self, config_mgr, sample_analysis, make_app):
         config_mgr.save({"gaming_quality_enabled": True})
-        init_config(config_mgr)
-        update_state(analysis=sample_analysis)
-        app.config["TESTING"] = True
-        with app.test_client() as c:
+        app = make_app(config_manager=config_mgr)
+        with app.app_context(), app.test_client() as c:
+            update_state(analysis=sample_analysis)
             data = c.get("/api/gaming-score").get_json()
         assert data["enabled"] is True
-

--- a/tests/web/test_device_channel_threshold_api.py
+++ b/tests/web/test_device_channel_threshold_api.py
@@ -2,10 +2,11 @@
 
 import pytest
 
-from app.web import app, update_state, init_storage, init_config
+from app.web import update_state
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.modules.speedtest.storage import SpeedtestStorage
+from app.runtime import current_runtime
 
 class TestChannelsAPI:
     def test_channels_includes_summary(self, client, sample_analysis, tmp_path):
@@ -13,7 +14,7 @@ class TestChannelsAPI:
         db_path = str(tmp_path / "channels_test.db")
         storage = SnapshotStorage(db_path, max_days=7)
         storage.save_snapshot(sample_analysis)
-        init_storage(storage)
+        current_runtime().storage = storage
         resp = client.get("/api/channels")
         assert resp.status_code == 200
         data = resp.get_json()
@@ -27,9 +28,8 @@ class TestChannelsAPI:
         assert "us_capacity_mbps" in data["summary"]
 
     def test_channels_no_storage(self, client):
-        from app.web import _state
-        _state["analysis"] = None
-        init_storage(None)
+        current_runtime().reset_modem_state()
+        current_runtime().storage = None
         resp = client.get("/api/channels")
         assert resp.status_code == 200
         data = resp.get_json()
@@ -52,8 +52,7 @@ class TestDeviceAPI:
         assert data["uptime_seconds"] == 86400
 
     def test_device_not_available(self, client):
-        from app.web import _state
-        _state["device_info"] = None
+        current_runtime().reset_modem_state()
         resp = client.get("/api/device")
         assert resp.status_code == 200
         data = resp.get_json()
@@ -62,8 +61,7 @@ class TestDeviceAPI:
 
 class TestSpeedtestDetailAPI:
     def _reset_speedtest_module(self):
-        import app.modules.speedtest.routes as st_routes
-        st_routes._storage = None
+        pass
 
     @pytest.fixture
     def storage_with_speedtest(self, tmp_path):
@@ -87,7 +85,7 @@ class TestSpeedtestDetailAPI:
 
     def test_speedtest_by_id(self, client, storage_with_speedtest):
         self._reset_speedtest_module()
-        init_storage(storage_with_speedtest)
+        current_runtime().storage = storage_with_speedtest
         resp = client.get("/api/speedtest/42")
         assert resp.status_code == 200
         data = resp.get_json()
@@ -96,7 +94,7 @@ class TestSpeedtestDetailAPI:
 
     def test_speedtest_not_found(self, client, storage_with_speedtest):
         self._reset_speedtest_module()
-        init_storage(storage_with_speedtest)
+        current_runtime().storage = storage_with_speedtest
         resp = client.get("/api/speedtest/9999")
         assert resp.status_code == 404
 
@@ -105,7 +103,7 @@ class TestSpeedtestDetailAPI:
         self._reset_speedtest_module()
         mgr = ConfigManager(str(tmp_path / "data_sq"))
         mgr.save({"modem_password": "test", "modem_type": "fritzbox", "booked_download": 1000, "booked_upload": 50})
-        init_config(mgr)
+        current_runtime().config_manager = mgr
         db_path = str(tmp_path / "sq.db")
         storage = SnapshotStorage(db_path, max_days=7)
         ss = SpeedtestStorage(db_path)
@@ -116,7 +114,7 @@ class TestSpeedtestDetailAPI:
             "ping_ms": 10.0, "jitter_ms": 1.0, "packet_loss_pct": 0.0,
             "server_id": 1, "server_name": "Frankfurt",
         }])
-        init_storage(storage)
+        current_runtime().storage = storage
         app.config["TESTING"] = True
         with app.test_client() as c:
             resp = c.get("/api/speedtest/1")
@@ -132,7 +130,7 @@ class TestSpeedtestDetailAPI:
         self._reset_speedtest_module()
         mgr = ConfigManager(str(tmp_path / "data_sq2"))
         mgr.save({"modem_password": "test", "modem_type": "fritzbox", "booked_download": 1000, "booked_upload": 100})
-        init_config(mgr)
+        current_runtime().config_manager = mgr
         db_path = str(tmp_path / "sq2.db")
         storage = SnapshotStorage(db_path, max_days=7)
         ss = SpeedtestStorage(db_path)
@@ -143,7 +141,7 @@ class TestSpeedtestDetailAPI:
             "ping_ms": 10.0, "jitter_ms": 1.0, "packet_loss_pct": 0.0,
             "server_id": 1, "server_name": "Frankfurt",
         }])
-        init_storage(storage)
+        current_runtime().storage = storage
         app.config["TESTING"] = True
         with app.test_client() as c:
             resp = c.get("/api/speedtest/10")
@@ -158,9 +156,8 @@ class TestSpeedtestDetailAPI:
     def test_speedtest_quality_no_booked_speeds(self, client, storage_with_speedtest):
         """Without booked speeds and no connection_info, quality fields should be null."""
         self._reset_speedtest_module()
-        from app.web import _state
-        _state["connection_info"] = None
-        init_storage(storage_with_speedtest)
+        current_runtime().reset_modem_state()
+        current_runtime().storage = storage_with_speedtest
         resp = client.get("/api/speedtest/42")
         data = resp.get_json()
         assert data["speed_health"] is None

--- a/tests/web/test_health_export.py
+++ b/tests/web/test_health_export.py
@@ -2,13 +2,13 @@
 
 import json
 from app.web import update_state, reset_modem_state, get_state
+from app.runtime import current_runtime
 
 class TestHealthEndpoint:
     def test_health_waiting(self, client):
         update_state(analysis=None)
         # Reset state
-        from app.web import _state
-        _state["analysis"] = None
+        current_runtime().reset_modem_state()
         resp = client.get("/health")
         assert resp.status_code == 200
         assert resp.get_json()["docsis_health"] == "waiting"
@@ -42,8 +42,7 @@ class TestHealthEndpoint:
 
 class TestExportEndpoint:
     def test_export_no_data(self, client):
-        from app.web import _state
-        _state["analysis"] = None
+        current_runtime().reset_modem_state()
         resp = client.get("/api/export")
         assert resp.status_code == 404
 

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from app.web import app, update_state, init_config, init_storage, _build_metric_ranges, _snr_channel_family
+from app.web import update_state, _build_metric_ranges, _snr_channel_family
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.modules.bnetz.storage import BnetzStorage
+from app.runtime import current_runtime
 
 
 def _metric_card(html, label):
@@ -147,7 +148,7 @@ class TestIndexRoute:
 
     def test_redirect_to_setup_when_unconfigured(self, tmp_path):
         mgr = ConfigManager(str(tmp_path / "data2"))
-        init_config(mgr)
+        current_runtime().config_manager = mgr
         app.config["TESTING"] = True
         with app.test_client() as c:
             resp = c.get("/")
@@ -1136,9 +1137,9 @@ class TestIndexRoute:
         """Dashboard hides BNetzA card when entry has NULL fields (#148)."""
         mgr = ConfigManager(str(tmp_path / "data_bnetz"))
         mgr.save({"modem_password": "test", "modem_type": "fritzbox"})
-        init_config(mgr)
+        current_runtime().config_manager = mgr
         storage = SnapshotStorage(str(tmp_path / "data_bnetz" / "docsight.db"))
-        init_storage(storage)
+        current_runtime().storage = storage
         app.config["TESTING"] = True
         # Save a BNetzA measurement with all numeric fields as None
         bs = BnetzStorage(storage.db_path)
@@ -1187,8 +1188,8 @@ class TestIndexRoute:
             "booked_download": 250,
             "booked_upload": 50,
         })
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         app.config["TESTING"] = True
 
         analysis = {
@@ -1237,8 +1238,8 @@ class TestIndexRoute:
             "booked_download": 250,
             "booked_upload": 50,
         })
-        init_config(mgr)
-        init_storage(None)
+        current_runtime().config_manager = mgr
+        current_runtime().storage = None
         app.config["TESTING"] = True
 
         analysis = {
@@ -1284,7 +1285,7 @@ class TestIndexRoute:
 class TestIndexSegmentUtilizationVisibility:
     def test_index_hides_segment_tab_when_disabled(self, client, config_mgr, sample_analysis):
         config_mgr.save({"segment_utilization_enabled": False})
-        init_config(config_mgr)
+        current_runtime().config_manager = config_mgr
         update_state(analysis=sample_analysis)
         resp = client.get("/?lang=en")
         assert resp.status_code == 200

--- a/tests/web/test_path_prefix_urls.py
+++ b/tests/web/test_path_prefix_urls.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 import json
 import re
 from urllib.parse import urljoin, urlsplit
@@ -14,44 +13,12 @@ import app.web as web
 from app.config import ConfigManager
 from app.module_loader import ModuleInfo
 from app.web import (
-    _login_attempts,
-    app,
-    init_config,
-    init_modules,
-    init_storage,
     update_state,
 )
+from app.runtime import current_runtime
 
 
 PREFIX_ENV = {"SCRIPT_NAME": "/docsight"}
-
-
-@pytest.fixture(autouse=True)
-def _restore_app_globals():
-    """Keep this module's singleton app mutations isolated from other tests."""
-    previous_config_manager = web.get_config_manager()
-    previous_config_callback = web.get_on_config_changed()
-    previous_storage = web.get_storage()
-    previous_state = web.get_state()
-    previous_module_loader = web._module_loader
-    previous_login_attempts = deepcopy(_login_attempts)
-    previous_app_config = {
-        key: app.config[key]
-        for key in ("PERMANENT_SESSION_LIFETIME", "SECRET_KEY", "TESTING")
-    }
-
-    yield
-
-    web._config_manager = previous_config_manager
-    web._on_config_changed = previous_config_callback
-    init_modules(previous_module_loader)
-    init_storage(previous_storage)
-    with web._state_lock:
-        web._state.clear()
-        web._state.update(previous_state)
-    _login_attempts.clear()
-    _login_attempts.update(previous_login_attempts)
-    app.config.update(previous_app_config)
 
 
 @pytest.fixture
@@ -82,9 +49,9 @@ def sample_analysis():
 @pytest.fixture
 def client(tmp_path):
     """Create a configured client without relying on tests/web/conftest.py."""
-    init_config(_configured_manager(tmp_path))
-    init_modules(_enabled_bqm_loader())
-    init_storage(None)
+    current_runtime().config_manager = _configured_manager(tmp_path)
+    current_runtime().module_loader = _enabled_bqm_loader()
+    current_runtime().storage = None
     app.config["TESTING"] = True
     with app.test_client() as test_client:
         yield test_client
@@ -207,8 +174,8 @@ def test_dashboard_and_settings_render_prefix_aware_navigation_and_assets(
 def test_login_and_setup_render_prefix_aware_assets_forms_and_navigation(tmp_path):
     credential = "prefix-" + "credential"
     auth_manager = _configured_manager(tmp_path, password=credential)
-    init_config(auth_manager)
-    init_storage(None)
+    current_runtime().config_manager = auth_manager
+    current_runtime().storage = None
     app.config["TESTING"] = True
     with app.test_client() as client:
         login = client.get("/login", environ_overrides=PREFIX_ENV)
@@ -223,7 +190,7 @@ def test_login_and_setup_render_prefix_aware_assets_forms_and_navigation(tmp_pat
     assert 'href="/docsight/static/css/fonts.css?v=' in login_html
 
     setup_manager = ConfigManager(str(tmp_path / "setup-data"))
-    init_config(setup_manager)
+    current_runtime().config_manager = setup_manager
     with app.test_client() as client:
         setup = client.get("/setup", environ_overrides=PREFIX_ENV)
 
@@ -239,11 +206,11 @@ def test_login_and_setup_render_prefix_aware_assets_forms_and_navigation(tmp_pat
 
 
 def test_auth_setup_glossary_and_backup_redirects_preserve_script_name(tmp_path):
-    _login_attempts.clear()
+    current_runtime().login_rate_limiter.prune(float("inf"))
     credential = "prefix-" + "credential"
     auth_manager = _configured_manager(tmp_path, password=credential)
-    init_config(auth_manager)
-    init_storage(None)
+    current_runtime().config_manager = auth_manager
+    current_runtime().storage = None
     app.config["TESTING"] = True
     with app.test_client() as client:
         auth_redirect = client.get("/settings", environ_overrides=PREFIX_ENV)
@@ -270,7 +237,7 @@ def test_auth_setup_glossary_and_backup_redirects_preserve_script_name(tmp_path)
     assert logout_redirect.headers["Location"] == "/docsight/login"
 
     configured_manager = _configured_manager(tmp_path / "configured")
-    init_config(configured_manager)
+    current_runtime().config_manager = configured_manager
     with app.test_client() as client:
         setup_redirect = client.get("/setup", environ_overrides=PREFIX_ENV)
         glossary_redirect = client.get(
@@ -283,7 +250,7 @@ def test_auth_setup_glossary_and_backup_redirects_preserve_script_name(tmp_path)
     )
 
     unconfigured_manager = ConfigManager(str(tmp_path / "unconfigured"))
-    init_config(unconfigured_manager)
+    current_runtime().config_manager = unconfigured_manager
     with app.test_client() as client:
         index_redirect = client.get("/", environ_overrides=PREFIX_ENV)
     assert index_redirect.headers["Location"] == "/docsight/setup"
@@ -355,12 +322,12 @@ def test_browser_url_bootstrap_is_minimal_canonical_and_early(
     ).get_data(as_text=True)
 
     credential = "bootstrap-credential"
-    init_config(_configured_manager(tmp_path / "auth", password=credential))
+    current_runtime().config_manager = _configured_manager(tmp_path / "auth", password=credential)
     login_html = client.get(
         "/login", environ_overrides=PREFIX_ENV
     ).get_data(as_text=True)
 
-    init_config(ConfigManager(str(tmp_path / "setup")))
+    current_runtime().config_manager = ConfigManager(str(tmp_path / "setup"))
     setup_html = client.get(
         "/setup", environ_overrides=PREFIX_ENV
     ).get_data(as_text=True)

--- a/tests/web/test_poll_utils.py
+++ b/tests/web/test_poll_utils.py
@@ -2,15 +2,14 @@
 
 import json
 
-from app.web import format_k, init_config, app
+from app.web import format_k
+from app.runtime import get_runtime
 from app.config import ConfigManager
 
 class TestPollEndpoint:
-    def test_poll_not_configured(self, tmp_path):
-        from app.web import _state
+    def test_poll_not_configured(self, tmp_path, make_app):
         mgr = ConfigManager(str(tmp_path / "data_poll"))
-        init_config(mgr)
-        app.config["TESTING"] = True
+        app = make_app(config_manager=mgr)
         with app.test_client() as c:
             resp = c.post("/api/poll")
             # Unconfigured -> redirects to setup on GET, but POST /api/poll
@@ -18,18 +17,15 @@ class TestPollEndpoint:
             assert resp.status_code in (302, 500)
 
     def test_poll_rate_limit(self, client, sample_analysis):
-        import app.web as web_module
         from unittest.mock import MagicMock
         mock_collector = MagicMock()
-        web_module._modem_collector = mock_collector
-        web_module._last_manual_poll = __import__('time').time()
+        runtime = get_runtime(client.application)
+        runtime.modem_collector = mock_collector
+        runtime.set_last_manual_poll(__import__('time').time())
         resp = client.post("/api/poll")
         assert resp.status_code == 429
         data = json.loads(resp.data)
         assert data["success"] is False
-        # Reset for other tests
-        web_module._last_manual_poll = 0.0
-        web_module._modem_collector = None
 
 
 class TestFormatK:
@@ -45,4 +41,3 @@ class TestFormatK:
 
         for label, value, expected in cases:
             assert format_k(value) == expected, label
-

--- a/tests/web/test_report_period.py
+++ b/tests/web/test_report_period.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from app.web import app
 
 
 def _call_route(route, path, *, storage=None, state=None, generated="artifact"):

--- a/tests/web/test_reports.py
+++ b/tests/web/test_reports.py
@@ -3,7 +3,6 @@
 from unittest.mock import Mock, patch
 from app.analyzer import analyze
 from app.threshold_profiles import BUILTIN_THRESHOLD_PROFILES
-from app.web import app
 
 
 def _analyze_downstream_channel(*, docsis, power, quality, modulation, channel_type):

--- a/tests/web/test_route_auth_coverage.py
+++ b/tests/web/test_route_auth_coverage.py
@@ -7,7 +7,7 @@ from flask import url_for
 
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
-from app.web import app, init_config, init_storage
+from app.runtime import current_runtime
 
 
 # Public routes are intentionally small and documented here so newly added
@@ -58,8 +58,8 @@ def auth_client(tmp_path):
         "modem_password": "test",
         "modem_type": "fritzbox",
     })
-    init_config(config)
-    init_storage(SnapshotStorage(str(tmp_path / "auth-routes.db"), max_days=7))
+    current_runtime().config_manager = config
+    current_runtime().storage = SnapshotStorage(str(tmp_path / "auth-routes.db"), max_days=7)
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client

--- a/tests/web/test_security.py
+++ b/tests/web/test_security.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 import pytest
 
-from app.web import app, update_state, init_config
+from app.web import update_state
 from app.config import ConfigManager
 
 class TestSecurityHeaders:
@@ -31,39 +31,31 @@ class TestTimestampValidation:
 
 
 class TestSessionKeyPersistence:
-    def test_session_key_file_created(self, tmp_path):
+    def test_session_key_file_created(self, tmp_path, make_app):
         data_dir = str(tmp_path / "data_sk")
         mgr = ConfigManager(data_dir)
-        init_config(mgr)
+        make_app(config_manager=mgr)
         import os
         assert os.path.exists(os.path.join(data_dir, ".session_key"))
 
-    def test_session_key_persisted(self, tmp_path):
+    def test_session_key_persisted(self, tmp_path, make_app):
         data_dir = str(tmp_path / "data_sk2")
         mgr = ConfigManager(data_dir)
-        init_config(mgr)
-        key1 = app.secret_key
-        # Re-init should load same key
-        init_config(mgr)
-        assert app.secret_key == key1
+        key1 = make_app(config_manager=mgr).secret_key
+        assert make_app(config_manager=mgr).secret_key == key1
 
 
 class TestSessionLifetime:
-    def test_default_is_thirty_days(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("SESSION_LIFETIME_DAYS", raising=False)
-        init_config(ConfigManager(str(tmp_path / "default_lifetime")))
+    def test_default_is_thirty_days(self, tmp_path, make_app):
+        app = make_app(config_manager=ConfigManager(str(tmp_path / "default_lifetime")), environ={})
         assert app.config["PERMANENT_SESSION_LIFETIME"] == timedelta(days=30)
 
-    def test_operator_override(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("SESSION_LIFETIME_DAYS", "45")
-        init_config(ConfigManager(str(tmp_path / "custom_lifetime")))
+    def test_operator_override(self, tmp_path, make_app):
+        app = make_app(config_manager=ConfigManager(str(tmp_path / "custom_lifetime")), environ={"SESSION_LIFETIME_DAYS": "45"})
         assert app.config["PERMANENT_SESSION_LIFETIME"] == timedelta(days=45)
 
-    def test_init_config_preserves_reverse_proxy_secure_cookie(self, tmp_path, monkeypatch):
-        monkeypatch.setitem(app.config, "SESSION_COOKIE_SECURE", True)
-
-        init_config(ConfigManager(str(tmp_path / "secure_cookie")))
-
+    def test_factory_enables_reverse_proxy_secure_cookie(self, tmp_path, make_app):
+        app = make_app(config_manager=ConfigManager(str(tmp_path / "secure_cookie")), environ={"REVERSE_PROXY": "1"})
         assert app.config["SESSION_COOKIE_SECURE"] is True
 
     @pytest.mark.parametrize(
@@ -77,8 +69,10 @@ class TestSessionLifetime:
         ],
     )
     def test_invalid_and_unsafe_values_are_defaulted_or_clamped(
-        self, tmp_path, monkeypatch, configured, expected_days
+        self, tmp_path, make_app, configured, expected_days
     ):
-        monkeypatch.setenv("SESSION_LIFETIME_DAYS", configured)
-        init_config(ConfigManager(str(tmp_path / f"lifetime_{expected_days}_{configured}")))
+        app = make_app(
+            config_manager=ConfigManager(str(tmp_path / f"lifetime_{expected_days}_{configured}")),
+            environ={"SESSION_LIFETIME_DAYS": configured},
+        )
         assert app.config["PERMANENT_SESSION_LIFETIME"] == timedelta(days=expected_days)

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 from bs4 import BeautifulSoup
 
-from app.web import init_config, app, _login_attempts
 from app.config import ConfigManager
 from app.module_loader import register_module_config
+from app.runtime import current_runtime
 from app import config as config_module
 
 
@@ -20,7 +20,7 @@ def _rendered_panel(html: str, panel_id: str):
 
 
 def _login(client, password):
-    _login_attempts.clear()
+    current_runtime().login_rate_limiter.prune(float("inf"))
     response = client.get("/login")
     csrf_token = re.search(rb'name="csrf_token" value="([^"]+)"', response.data)
     assert csrf_token
@@ -51,7 +51,7 @@ class TestSettingsRoute:
                 {key: ""}, module_id="community.runtime", builtin=False
             )
             config_mgr.save({key: "runtime-secret-value"})
-            init_config(config_mgr)
+            current_runtime().config_manager = config_mgr
 
             response = client.get("/settings?lang=en")
             html = response.data.decode("utf-8")
@@ -135,7 +135,7 @@ class TestSettingsRoute:
 
     def test_settings_modules_shows_segment_disabled_status(self, client, config_mgr):
         config_mgr.save({"segment_utilization_enabled": False})
-        init_config(config_mgr)
+        current_runtime().config_manager = config_mgr
         resp = client.get("/settings?lang=en")
         assert resp.status_code == 200
         assert b"Segment Utilization" in resp.data
@@ -155,7 +155,7 @@ class TestSettingsRoute:
 
     def test_settings_icon_only_controls_have_accessible_names(self, client, config_mgr):
         config_mgr.save({"admin_password": "admin-secret-value"})
-        init_config(config_mgr)
+        current_runtime().config_manager = config_mgr
         _login(client, "admin-secret-value")
 
         resp = client.get("/settings?lang=en")
@@ -239,7 +239,7 @@ class TestSettingsRoute:
 
     def test_settings_admin_password_field_uses_saved_secret_placeholder(self, client, config_mgr):
         config_mgr.save({"admin_password": "admin-secret-value"})
-        init_config(config_mgr)
+        current_runtime().config_manager = config_mgr
         _login(client, "admin-secret-value")
 
         resp = client.get("/settings?lang=en")
@@ -263,7 +263,7 @@ class TestSetupRoute:
 
     def test_setup_renders_when_unconfigured(self, tmp_path):
         mgr = ConfigManager(str(tmp_path / "data3"))
-        init_config(mgr)
+        current_runtime().config_manager = mgr
         app.config["TESTING"] = True
         with app.test_client() as c:
             resp = c.get("/setup")

--- a/tests/web/test_setup_language.py
+++ b/tests/web/test_setup_language.py
@@ -7,7 +7,7 @@ import pytest
 
 from app.config import ConfigManager
 from app.i18n import LANGUAGES
-from app.web import app, init_config, init_storage
+from app.runtime import current_runtime
 
 
 def _html_lang(response):
@@ -24,8 +24,8 @@ def _stored_config(manager):
 @pytest.fixture
 def fresh_manager(tmp_path):
     manager = ConfigManager(str(tmp_path / "data"))
-    init_config(manager)
-    init_storage(None)
+    current_runtime().config_manager = manager
+    current_runtime().storage = None
     app.config["TESTING"] = True
     return manager
 
@@ -73,7 +73,7 @@ def test_first_inference_survives_new_manager_client_and_changed_header(
         )
 
     reloaded = ConfigManager(fresh_manager.data_dir)
-    init_config(reloaded)
+    current_runtime().config_manager = reloaded
     with app.test_client() as second_client:
         second_response = second_client.get(
             "/setup", headers={"Accept-Language": "fr-FR"}

--- a/tests/web/test_snapshots.py
+++ b/tests/web/test_snapshots.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from app.web import init_storage
 from app.storage import SnapshotStorage
+from app.runtime import current_runtime
 
 class TestSnapshotsAPI:
     @pytest.fixture
@@ -13,7 +13,7 @@ class TestSnapshotsAPI:
         return storage
 
     def test_snapshots_list(self, client, storage_with_data):
-        init_storage(storage_with_data)
+        current_runtime().storage = storage_with_data
         resp = client.get("/api/snapshots")
         assert resp.status_code == 200
         data = resp.get_json()
@@ -21,13 +21,13 @@ class TestSnapshotsAPI:
         assert len(data) >= 1
 
     def test_snapshots_list_no_storage(self, client):
-        init_storage(None)
+        current_runtime().storage = None
         resp = client.get("/api/snapshots")
         assert resp.status_code == 200
         assert resp.get_json() == []
 
     def test_snapshot_by_timestamp(self, client, storage_with_data):
-        init_storage(storage_with_data)
+        current_runtime().storage = storage_with_data
         timestamps = storage_with_data.get_snapshot_list()
         resp = client.get(f"/api/snapshots/{timestamps[0]}")
         assert resp.status_code == 200
@@ -36,7 +36,7 @@ class TestSnapshotsAPI:
         assert "ds_channels" in data
 
     def test_snapshot_not_found(self, client, storage_with_data):
-        init_storage(storage_with_data)
+        current_runtime().storage = storage_with_data
         resp = client.get("/api/snapshots/1999-01-01T00:00:00Z")
         assert resp.status_code == 404
 
@@ -60,7 +60,7 @@ class TestSnapshotsAPI:
         })
         storage = SnapshotStorage(str(tmp_path / "partial.db"), max_days=7)
         storage.save_snapshot(sample_analysis)
-        init_storage(storage)
+        current_runtime().storage = storage
 
         timestamp = storage.get_snapshot_list()[0]
         response = client.get(f"/api/snapshots/{timestamp}")


### PR DESCRIPTION
## Summary
- construct DOCSight through an explicit application factory instead of at import time
- move mutable web runtime state into a typed per-application extension
- pass explicit application/runtime instances through production startup, collectors, modules, and test servers
- add architecture guards plus repeated-construction and two-application isolation coverage
- document the factory and runtime ownership contract

## Validation
- `234 passed` focused factory, runtime, lifecycle, auth, and module tests
- `3620 passed, 2 skipped` complete non-E2E suite
- `531 passed` complete E2E suite
- `git diff --check`

## Scope
Process-wide schema and plugin catalogs remain process-wide by design. Application configuration, storage, authentication, caches, collectors, and derived storage are isolated per Flask instance.

Addresses itsDNNS/docsight-optimization-offensive#1.