### PR TITLE
Accelerate full browser E2E with isolated server profiles

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -67,10 +67,14 @@ jobs:
       E2E_SELECTION: ${{ matrix.shard }}
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
-        shard: ${{ fromJSON(inputs.single_process && '["all"]' || '["1","2","3"]') }}
+        shard: ${{ fromJSON(inputs.single_process && '["all"]' || '["1","2","3","4"]') }}
 
     steps:
+      - name: Record shard job start
+        run: echo "E2E_JOB_STARTED_EPOCH=$EPOCHREALTIME" >> "$GITHUB_ENV"
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -4,6 +4,17 @@ on:
   schedule:
     - cron: "23 3 * * 1"
   workflow_dispatch:
+    inputs:
+      reverse:
+        description: Run each shard's files in reverse order
+        required: false
+        default: false
+        type: boolean
+      single_process:
+        description: Run the canonical unsharded CPU/RAM baseline
+        required: false
+        default: false
+        type: boolean
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
@@ -30,14 +41,19 @@ jobs:
               - 'app/modules/**'
               - 'app/web.py'
               - 'tests/e2e/**'
+              - 'tests/test_e2e_harness.py'
+              - 'tests/test_e2e_shards.py'
+              - 'scripts/e2e_shards.py'
               - 'requirements.txt'
               - 'requirements-test.txt'
               - '.github/workflows/full-e2e.yml'
 
-  full-e2e:
+  e2e-shards:
     needs: changes
     if: >-
+      always() &&
       !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.result == 'success') &&
       (
         github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch' ||
@@ -45,6 +61,14 @@ jobs:
         needs.changes.outputs.browser == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.single_process && 35 || 18 }}
+    env:
+      E2E_REVERSE: ${{ inputs.reverse || 'false' }}
+      E2E_SELECTION: ${{ matrix.shard }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(inputs.single_process && '["all"]' || '["1","2","3"]') }}
 
     steps:
       - name: Checkout
@@ -66,16 +90,109 @@ jobs:
           pip install pytest-playwright==0.7.2 playwright==1.58.0
           python -m playwright install --with-deps chromium
 
-      - name: Run full browser E2E suite
-        run: TZ=UTC python -m pytest -q tests/e2e --tb=short
+      - name: Validate and collect shard
+        run: |
+          selection_args=(--shard "$E2E_SELECTION")
+          if [ "$E2E_SELECTION" = "all" ]; then
+            selection_args=(--all)
+          fi
+          reverse_args=()
+          if [ "$E2E_REVERSE" = "true" ]; then
+            reverse_args+=(--reverse)
+          fi
+          python scripts/e2e_shards.py collect \
+            "${selection_args[@]}" \
+            --output-dir "test-results/shard-${{ matrix.shard }}" \
+            "${reverse_args[@]}"
 
-      - name: Upload E2E artifacts
+      - name: Run browser shard
+        env:
+          TZ: UTC
+          E2E_ARTIFACT_DIR: test-results/shard-${{ matrix.shard }}
+        run: |
+          selection_args=(--shard "$E2E_SELECTION")
+          if [ "$E2E_SELECTION" = "all" ]; then
+            selection_args=(--all)
+          fi
+          reverse_args=()
+          if [ "$E2E_REVERSE" = "true" ]; then
+            reverse_args+=(--reverse)
+          fi
+          python scripts/e2e_shards.py run \
+            "${selection_args[@]}" \
+            "${reverse_args[@]}" \
+            --junit "test-results/shard-${{ matrix.shard }}/junit.xml" \
+            --receipt "test-results/shard-${{ matrix.shard }}/run-receipt.json" \
+            -- \
+            -q \
+            --tb=short \
+            --output="test-results/shard-${{ matrix.shard }}/playwright" \
+            --tracing=retain-on-failure
+
+      - name: Upload shard results, logs, and traces
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: full-e2e-artifacts
-          if-no-files-found: ignore
+          name: full-e2e-shard-${{ matrix.shard }}
+          if-no-files-found: error
           path: |
-            test-results/
-            playwright-report/
+            test-results/shard-${{ matrix.shard }}/
             tests/e2e/screenshots/
+            playwright-report/
+
+  full-e2e:
+    name: full-e2e
+    needs: [changes, e2e-shards]
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      E2E_REQUIRED: >-
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          contains(github.event.pull_request.labels.*.name, 'full-e2e') ||
+          needs.changes.outputs.browser == 'true'
+        }}
+      SHARD_JOB_RESULT: ${{ needs.e2e-shards.result }}
+      CHANGE_DETECTION_RESULT: ${{ needs.changes.result }}
+
+    steps:
+      - name: Fail closed when PR change detection did not succeed
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ "$CHANGE_DETECTION_RESULT" != "success" ]; then
+            echo "Browser change detection result was $CHANGE_DETECTION_RESULT"
+            exit 1
+          fi
+
+      - name: Checkout
+        if: env.E2E_REQUIRED == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        if: env.E2E_REQUIRED == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Download every shard artifact
+        if: env.E2E_REQUIRED == 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: full-e2e-shard-*
+          path: shard-artifacts
+
+      - name: Verify complete successful 531-case union
+        if: env.E2E_REQUIRED == 'true'
+        run: |
+          if [ "$SHARD_JOB_RESULT" != "success" ]; then
+            echo "E2E shard matrix result was $SHARD_JOB_RESULT"
+            exit 1
+          fi
+          python scripts/e2e_shards.py summarize \
+            --results-root shard-artifacts \
+            --expected-total 531
+
+      - name: Browser gate not required for this change
+        if: env.E2E_REQUIRED != 'true'
+        run: echo "Browser-relevant paths and the full-e2e label were not present."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,11 +77,11 @@ python scripts/e2e_shards.py validate
 python -m pytest --collect-only -q tests/e2e
 ```
 
-Run one shard, all three shards, one shard in reverse file order, or the canonical unsharded selection:
+Run one shard, all four shards, one shard in reverse file order, or the canonical unsharded selection:
 
 ```bash
 TZ=UTC python scripts/e2e_shards.py run --shard 1 -- -q --tb=short
-for shard in 1 2 3; do TZ=UTC python scripts/e2e_shards.py run --shard "$shard" -- -q --tb=short || exit; done
+for shard in 1 2 3 4; do TZ=UTC python scripts/e2e_shards.py run --shard "$shard" -- -q --tb=short || exit; done
 TZ=UTC python scripts/e2e_shards.py run --shard 1 --reverse -- -q --tb=short
 TZ=UTC python scripts/e2e_shards.py run --all -- -q --tb=short
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,37 @@ npm test
 
 The Python suite covers analyzers, collectors, drivers, event detection, API endpoints, config, MQTT, i18n, and PDF generation. The zero-dependency JavaScript lane uses Node 22's built-in test runner for browser bootstrap and pure frontend contracts. Run both suites before submitting a PR.
 
+### Browser E2E suite
+
+Install the browser test dependencies before running this suite:
+
+```bash
+python -m pip install pytest-playwright==0.7.2 playwright==1.58.0
+python -m playwright install chromium
+```
+
+The shard manifest assigns every `tests/e2e/test_*.py` file exactly once. Validate the manifest and collection denominator without launching a browser:
+
+```bash
+python scripts/e2e_shards.py validate
+python -m pytest --collect-only -q tests/e2e
+```
+
+Run one shard, all three shards, one shard in reverse file order, or the canonical unsharded selection:
+
+```bash
+TZ=UTC python scripts/e2e_shards.py run --shard 1 -- -q --tb=short
+for shard in 1 2 3; do TZ=UTC python scripts/e2e_shards.py run --shard "$shard" -- -q --tb=short || exit; done
+TZ=UTC python scripts/e2e_shards.py run --shard 1 --reverse -- -q --tb=short
+TZ=UTC python scripts/e2e_shards.py run --all -- -q --tb=short
+```
+
+The original canonical single-process command also remains available for rollback comparison:
+
+```bash
+TZ=UTC python -m pytest -q tests/e2e --tb=short
+```
+
 ## Running Locally
 
 ```bash

--- a/scripts/e2e_shards.py
+++ b/scripts/e2e_shards.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Validate, select, run, and aggregate deterministic file-level E2E shards."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - Windows can validate manifests only
+    resource = None
+
+ROOT = Path(__file__).resolve().parents[1]
+E2E_DIR = ROOT / "tests" / "e2e"
+DEFAULT_MANIFEST = E2E_DIR / "shards.json"
+EXPECTED_TOTAL = 531
+
+
+class ManifestError(ValueError):
+    """The shard manifest does not exactly cover the E2E file set."""
+
+
+class ResultError(RuntimeError):
+    """Shard artifacts do not prove a complete successful test union."""
+
+
+@dataclass(frozen=True)
+class ResultSummary:
+    total: int
+    per_shard: tuple[int, ...]
+    wall_seconds: tuple[float, ...]
+    cpu_seconds: float
+    peak_rss_kb: int
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"cannot read shard manifest {path}: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ManifestError("shard manifest root must be an object")
+    return manifest
+
+
+def validate_manifest(manifest: dict, e2e_dir: Path = E2E_DIR) -> tuple[str, ...]:
+    if manifest.get("version") != 1:
+        raise ManifestError("unsupported shard manifest version")
+    shards = manifest.get("shards")
+    if not isinstance(shards, list) or not shards:
+        raise ManifestError("shard manifest must contain shards")
+    shard_ids = [shard.get("id") for shard in shards]
+    if shard_ids != list(range(1, len(shards) + 1)):
+        raise ManifestError("shard ids must be consecutive and ordered from 1")
+
+    listed = [name for shard in shards for name in shard.get("files", [])]
+    counts = Counter(listed)
+    duplicates = sorted(name for name, count in counts.items() if count > 1)
+    if duplicates:
+        raise ManifestError(f"duplicate files in shard manifest: {duplicates}")
+
+    actual = {path.name for path in e2e_dir.glob("test_*.py")}
+    listed_set = set(listed)
+    stale = sorted(listed_set - actual)
+    if stale:
+        raise ManifestError(f"stale files in shard manifest: {stale}")
+    missing = sorted(actual - listed_set)
+    if missing:
+        raise ManifestError(f"missing files from shard manifest: {missing}")
+    if any(Path(name).name != name or not name.startswith("test_") for name in listed):
+        raise ManifestError("manifest entries must be plain test_*.py file names")
+
+    expected_total = manifest.get("expected_total")
+    collected_counts = [shard.get("collected_cases") for shard in shards]
+    if expected_total is not None:
+        if not all(isinstance(count, int) and count > 0 for count in collected_counts):
+            raise ManifestError("every shard needs a positive collected_cases count")
+        if sum(collected_counts) != expected_total:
+            raise ManifestError("shard collected_cases do not equal expected_total")
+    return tuple(listed)
+
+
+def _selected_shard(manifest: dict, shard_id: int) -> dict:
+    validate_manifest(manifest)
+    try:
+        return next(shard for shard in manifest["shards"] if shard["id"] == shard_id)
+    except StopIteration as exc:
+        raise ManifestError(f"unknown shard {shard_id}") from exc
+
+
+def shard_files(manifest: dict, shard_id: int, reverse: bool = False) -> list[str]:
+    files = list(_selected_shard(manifest, shard_id)["files"])
+    return list(reversed(files)) if reverse else files
+
+
+def _selection(manifest: dict, args) -> dict:
+    if args.all:
+        selected = {
+            "id": "all",
+            "files": list(validate_manifest(manifest)),
+            "collected_cases": manifest["expected_total"],
+        }
+    else:
+        selected = _selected_shard(manifest, args.shard)
+    run_files = list(selected["files"])
+    if args.reverse:
+        run_files.reverse()
+    return {**selected, "run_files": run_files}
+
+
+def _junit_totals(path: Path) -> tuple[int, int, int, int]:
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as exc:
+        raise ResultError(f"cannot read JUnit result {path}: {exc}") from exc
+    roots = [root] if "tests" in root.attrib else list(root.findall("testsuite"))
+    return tuple(
+        sum(int(element.attrib.get(name, "0")) for element in roots)
+        for name in ("tests", "failures", "errors", "skipped")
+    )
+
+
+def _child_usage() -> tuple[float, float, int]:
+    if resource is None:
+        return 0.0, 0.0, 0
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return usage.ru_utime, usage.ru_stime, usage.ru_maxrss
+
+
+def _marked_process_inventory(marker: str) -> tuple[list[dict], list[dict]]:
+    """Return Linux processes/listeners inheriting this run's unique marker."""
+    proc_root = Path("/proc")
+    if not proc_root.is_dir():
+        return [], []
+    marker_bytes = f"DOCSIGHT_E2E_RUN_ID={marker}".encode()
+    listener_inodes = {}
+    for table in (proc_root / "net/tcp", proc_root / "net/tcp6"):
+        try:
+            lines = table.read_text(encoding="ascii").splitlines()[1:]
+        except OSError:
+            continue
+        for line in lines:
+            fields = line.split()
+            if len(fields) > 9 and fields[3] == "0A":
+                listener_inodes[fields[9]] = int(fields[1].rsplit(":", 1)[1], 16)
+
+    processes = []
+    listeners = []
+    for environ_path in proc_root.glob("[0-9]*/environ"):
+        try:
+            environment = environ_path.read_bytes().split(b"\0")
+            if marker_bytes not in environment:
+                continue
+            pid = int(environ_path.parent.name)
+            name = (environ_path.parent / "comm").read_text(encoding="utf-8").strip()
+        except (OSError, ValueError):
+            continue
+        processes.append({"pid": pid, "name": name})
+        try:
+            file_descriptors = (environ_path.parent / "fd").iterdir()
+        except OSError:
+            continue
+        for descriptor in file_descriptors:
+            try:
+                target = descriptor.readlink().as_posix()
+            except OSError:
+                continue
+            if target.startswith("socket:[") and target.endswith("]"):
+                inode = target[8:-1]
+                if inode in listener_inodes:
+                    listeners.append(
+                        {"pid": pid, "name": name, "port": listener_inodes[inode]}
+                    )
+    return sorted(processes, key=lambda item: item["pid"]), sorted(
+        listeners, key=lambda item: (item["pid"], item["port"])
+    )
+
+
+def _read_receipt(path: Path) -> dict:
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ResultError(f"invalid run receipt {path}: {exc}") from exc
+    if not isinstance(receipt, dict):
+        raise ResultError(f"run receipt {path} must be an object")
+    return receipt
+
+
+def summarize_results(
+    results_root: Path,
+    manifest: dict,
+    *,
+    expected_total: int,
+    e2e_dir: Path = E2E_DIR,
+) -> ResultSummary:
+    canonical_files = list(validate_manifest(manifest, e2e_dir))
+    metadata_paths = sorted(results_root.rglob("shard-metadata.json"))
+    by_shard = {}
+    for metadata_path in metadata_paths:
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ResultError(f"invalid shard metadata {metadata_path}: {exc}") from exc
+        shard_id = metadata.get("shard")
+        if shard_id in by_shard:
+            raise ResultError(f"duplicate shard result for shard {shard_id}")
+        by_shard[shard_id] = (metadata_path.parent, metadata)
+
+    if "all" in by_shard:
+        expected_shards = [
+            {
+                "id": "all",
+                "files": canonical_files,
+                "collected_cases": expected_total,
+            }
+        ]
+    else:
+        expected_shards = manifest["shards"]
+    required_ids = [shard["id"] for shard in expected_shards]
+    missing_ids = sorted(set(required_ids) - set(by_shard), key=str)
+    if missing_ids:
+        raise ResultError(f"missing shard result artifacts: {missing_ids}")
+    unexpected_ids = sorted(set(by_shard) - set(required_ids), key=str)
+    if unexpected_ids:
+        raise ResultError(f"unexpected shard result artifacts: {unexpected_ids}")
+
+    all_nodes = []
+    per_shard = []
+    wall_seconds = []
+    total_cpu_seconds = 0.0
+    peak_rss_kb = 0
+    for shard in expected_shards:
+        shard_id = shard["id"]
+        directory, metadata = by_shard[shard_id]
+        if metadata.get("files") != shard["files"]:
+            raise ResultError(f"shard {shard_id} file receipt does not match manifest")
+        try:
+            nodes = [
+                line.strip()
+                for line in (directory / "collected.txt")
+                .read_text(encoding="utf-8")
+                .splitlines()
+                if line.strip()
+            ]
+        except OSError as exc:
+            raise ResultError(f"missing collection result for shard {shard_id}") from exc
+        allowed_prefixes = tuple(f"tests/e2e/{name}::" for name in shard["files"])
+        if any(not node.startswith(allowed_prefixes) for node in nodes):
+            raise ResultError(f"shard {shard_id} collected nodes outside its manifest")
+        if len(nodes) != shard["collected_cases"]:
+            raise ResultError(
+                f"shard {shard_id} collected {len(nodes)} nodes; "
+                f"expected {shard['collected_cases']}"
+            )
+
+        junit = _junit_totals(directory / "junit.xml")
+        tests, failures, errors, skipped = junit
+        if tests != len(nodes) or failures or errors or skipped:
+            raise ResultError(
+                f"shard {shard_id} has failed, errored, or skipped tests "
+                f"(tests={tests}, failures={failures}, errors={errors}, skipped={skipped})"
+            )
+        receipt = _read_receipt(directory / "run-receipt.json")
+        expected_junit = dict(
+            zip(("tests", "failures", "errors", "skipped"), junit, strict=True)
+        )
+        if receipt.get("selection") != shard_id or receipt.get("junit") != expected_junit:
+            raise ResultError(f"shard {shard_id} run receipt does not match JUnit")
+        if receipt.get("returncode") != 0:
+            raise ResultError(f"shard {shard_id} run receipt reports failure")
+        if receipt.get("retry_count") != 0:
+            raise ResultError(f"shard {shard_id} used retries")
+        if any(
+            receipt.get(field)
+            for field in (
+                "baseline_processes",
+                "baseline_listeners",
+                "leaked_processes",
+                "leaked_listeners",
+            )
+        ):
+            raise ResultError(f"shard {shard_id} reports process or listener leaks")
+        for field in ("started_utc", "ended_utc", "platform"):
+            if not isinstance(receipt.get(field), str) or not receipt[field]:
+                raise ResultError(f"shard {shard_id} run receipt lacks {field}")
+        wall = receipt.get("wall_seconds")
+        cpu = receipt.get("cpu_seconds")
+        rss = receipt.get("peak_rss_kb")
+        if not isinstance(wall, (int, float)) or wall < 0:
+            raise ResultError(f"shard {shard_id} has invalid wall time")
+        if not isinstance(cpu, (int, float)) or cpu < 0:
+            raise ResultError(f"shard {shard_id} has invalid CPU time")
+        if not isinstance(rss, int) or rss < 0:
+            raise ResultError(f"shard {shard_id} has invalid peak RSS")
+        if shard_id != "all" and wall >= 720:
+            raise ResultError(f"shard {shard_id} exceeded the 12-minute wall limit")
+
+        per_shard.append(len(nodes))
+        all_nodes.extend(nodes)
+        wall_seconds.append(float(wall))
+        total_cpu_seconds += float(cpu)
+        peak_rss_kb = max(peak_rss_kb, rss)
+
+    duplicates = sorted(node for node, count in Counter(all_nodes).items() if count > 1)
+    if duplicates:
+        raise ResultError(f"duplicate collected node ids: {duplicates[:5]}")
+    if len(all_nodes) != expected_total:
+        raise ResultError(
+            f"collected union is {len(all_nodes)}; expected exactly {expected_total}"
+        )
+    baseline_cpu_seconds = manifest.get("baseline_cpu_seconds")
+    if required_ids != ["all"]:
+        if not isinstance(baseline_cpu_seconds, (int, float)) or baseline_cpu_seconds <= 0:
+            raise ResultError("manifest lacks a measured positive baseline_cpu_seconds")
+        if total_cpu_seconds > baseline_cpu_seconds * 1.25:
+            raise ResultError(
+                f"aggregate CPU {total_cpu_seconds:.2f}s exceeds the 25% budget over "
+                f"baseline {baseline_cpu_seconds:.2f}s"
+            )
+    return ResultSummary(
+        len(all_nodes),
+        tuple(per_shard),
+        tuple(wall_seconds),
+        total_cpu_seconds,
+        peak_rss_kb,
+    )
+
+
+def _write_metadata(output_dir: Path, shard: dict) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "shard-metadata.json").write_text(
+        json.dumps(
+            {"shard": shard["id"], "files": shard["files"]},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _collect(args, manifest: dict) -> int:
+    shard = _selection(manifest, args)
+    files = shard["run_files"]
+    output_dir = Path(args.output_dir)
+    _write_metadata(output_dir, shard)
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "--collect-only",
+        "-q",
+        *(str(E2E_DIR / name) for name in files),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    (output_dir / "collection.log").write_text(completed.stdout, encoding="utf-8")
+    nodes = [
+        line.strip()
+        for line in completed.stdout.splitlines()
+        if line.startswith("tests/e2e/") and "::" in line
+    ]
+    if completed.returncode == 0:
+        (output_dir / "collected.txt").write_text(
+            "".join(f"{node}\n" for node in nodes), encoding="utf-8"
+        )
+        if len(nodes) != shard["collected_cases"]:
+            print(
+                f"selection {shard['id']} collected {len(nodes)} cases; "
+                f"expected {shard['collected_cases']}",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        sys.stdout.write(completed.stdout)
+    return completed.returncode
+
+
+def _run(args, manifest: dict) -> int:
+    selection = _selection(manifest, args)
+    pytest_args = list(args.pytest_args)
+    if pytest_args[:1] == ["--"]:
+        pytest_args.pop(0)
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        *(str(E2E_DIR / name) for name in selection["run_files"]),
+        *pytest_args,
+    ]
+    junit_path = ROOT / args.junit if args.junit and not args.junit.is_absolute() else args.junit
+    receipt_path = (
+        ROOT / args.receipt if args.receipt and not args.receipt.is_absolute() else args.receipt
+    )
+    if junit_path is not None:
+        junit_path.parent.mkdir(parents=True, exist_ok=True)
+        command.append(f"--junitxml={junit_path}")
+    if args.receipt is None:
+        return subprocess.call(command, cwd=ROOT)
+    if junit_path is None:
+        raise ManifestError("--receipt requires --junit")
+
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    marker = f"{os.getpid()}-{selection['id']}-{time.time_ns()}"
+    environment = os.environ.copy()
+    environment["DOCSIGHT_E2E_RUN_ID"] = marker
+    baseline_processes, baseline_listeners = _marked_process_inventory(marker)
+    before_user, before_system, _ = _child_usage()
+    started_utc = dt.datetime.now(dt.UTC).isoformat()
+    started = time.monotonic()
+    completed = subprocess.run(command, cwd=ROOT, env=environment, check=False)
+    wall_seconds = time.monotonic() - started
+    ended_utc = dt.datetime.now(dt.UTC).isoformat()
+    after_user, after_system, peak_rss_kb = _child_usage()
+    leaked_processes = []
+    leaked_listeners = []
+    for _ in range(50):
+        leaked_processes, leaked_listeners = _marked_process_inventory(marker)
+        if not leaked_processes and not leaked_listeners:
+            break
+        time.sleep(0.1)
+    try:
+        junit = dict(
+            zip(
+                ("tests", "failures", "errors", "skipped"),
+                _junit_totals(junit_path),
+                strict=True,
+            )
+        )
+    except ResultError:
+        junit = None
+    receipt = {
+        "selection": selection["id"],
+        "started_utc": started_utc,
+        "ended_utc": ended_utc,
+        "wall_seconds": round(wall_seconds, 3),
+        "cpu_seconds": round(
+            (after_user - before_user) + (after_system - before_system), 3
+        ),
+        "peak_rss_kb": peak_rss_kb,
+        "platform": platform.platform(),
+        "retry_count": 0,
+        "returncode": completed.returncode,
+        "junit": junit,
+        "baseline_processes": baseline_processes,
+        "baseline_listeners": baseline_listeners,
+        "leaked_processes": leaked_processes,
+        "leaked_listeners": leaked_listeners,
+    }
+    receipt_path.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    if leaked_processes or leaked_listeners:
+        print("E2E process/listener leak detected; see run receipt", file=sys.stderr)
+        return 1
+    if selection["id"] != "all" and wall_seconds >= 720:
+        print("E2E shard exceeded the 12-minute wall limit", file=sys.stderr)
+        return 1
+    return completed.returncode
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate")
+
+    def add_selection(parser):
+        selection = parser.add_mutually_exclusive_group(required=True)
+        selection.add_argument("--shard", type=int)
+        selection.add_argument("--all", action="store_true")
+        parser.add_argument("--reverse", action="store_true")
+
+    list_parser = subparsers.add_parser("list")
+    add_selection(list_parser)
+
+    collect_parser = subparsers.add_parser("collect")
+    add_selection(collect_parser)
+    collect_parser.add_argument("--output-dir", required=True)
+
+    run_parser = subparsers.add_parser("run")
+    add_selection(run_parser)
+    run_parser.add_argument("--junit", type=Path)
+    run_parser.add_argument("--receipt", type=Path)
+    run_parser.add_argument("pytest_args", nargs=argparse.REMAINDER)
+
+    summary_parser = subparsers.add_parser("summarize")
+    summary_parser.add_argument("--results-root", type=Path, required=True)
+    summary_parser.add_argument("--expected-total", type=int, default=EXPECTED_TOTAL)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = load_manifest(args.manifest)
+        validate_manifest(manifest)
+        if args.command == "validate":
+            print(
+                f"{len(manifest['shards'])} shards cover "
+                f"{len(validate_manifest(manifest))} files and "
+                f"{manifest['expected_total']} cases"
+            )
+        elif args.command == "list":
+            print("\n".join(_selection(manifest, args)["run_files"]))
+        elif args.command == "collect":
+            return _collect(args, manifest)
+        elif args.command == "run":
+            return _run(args, manifest)
+        else:
+            summary = summarize_results(
+                args.results_root,
+                manifest,
+                expected_total=args.expected_total,
+            )
+            print(
+                f"complete E2E union: {summary.total} cases "
+                f"across shards {summary.per_shard}; wall={summary.wall_seconds}; "
+                f"cpu={summary.cpu_seconds:.2f}s; peak-rss={summary.peak_rss_kb} KiB"
+            )
+    except (ManifestError, ResultError) as exc:
+        print(f"E2E shard validation failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_shards.py
+++ b/scripts/e2e_shards.py
@@ -40,6 +40,7 @@ class ResultSummary:
     total: int
     per_shard: tuple[int, ...]
     wall_seconds: tuple[float, ...]
+    job_wall_seconds: tuple[float, ...]
     cpu_seconds: float
     peak_rss_kb: int
 
@@ -238,6 +239,7 @@ def summarize_results(
     all_nodes = []
     per_shard = []
     wall_seconds = []
+    job_wall_seconds = []
     total_cpu_seconds = 0.0
     peak_rss_kb = 0
     for shard in expected_shards:
@@ -295,20 +297,26 @@ def summarize_results(
             if not isinstance(receipt.get(field), str) or not receipt[field]:
                 raise ResultError(f"shard {shard_id} run receipt lacks {field}")
         wall = receipt.get("wall_seconds")
+        job_wall = receipt.get("job_wall_seconds")
         cpu = receipt.get("cpu_seconds")
         rss = receipt.get("peak_rss_kb")
         if not isinstance(wall, (int, float)) or wall < 0:
             raise ResultError(f"shard {shard_id} has invalid wall time")
+        if not isinstance(job_wall, (int, float)) or job_wall < wall:
+            raise ResultError(f"shard {shard_id} has invalid job wall time")
         if not isinstance(cpu, (int, float)) or cpu < 0:
             raise ResultError(f"shard {shard_id} has invalid CPU time")
         if not isinstance(rss, int) or rss < 0:
             raise ResultError(f"shard {shard_id} has invalid peak RSS")
         if shard_id != "all" and wall >= 720:
             raise ResultError(f"shard {shard_id} exceeded the 12-minute wall limit")
+        if shard_id != "all" and job_wall >= 720:
+            raise ResultError(f"shard {shard_id} exceeded the 12-minute job wall limit")
 
         per_shard.append(len(nodes))
         all_nodes.extend(nodes)
         wall_seconds.append(float(wall))
+        job_wall_seconds.append(float(job_wall))
         total_cpu_seconds += float(cpu)
         peak_rss_kb = max(peak_rss_kb, rss)
 
@@ -332,6 +340,7 @@ def summarize_results(
         len(all_nodes),
         tuple(per_shard),
         tuple(wall_seconds),
+        tuple(job_wall_seconds),
         total_cpu_seconds,
         peak_rss_kb,
     )
@@ -427,6 +436,14 @@ def _run(args, manifest: dict) -> int:
     started = time.monotonic()
     completed = subprocess.run(command, cwd=ROOT, env=environment, check=False)
     wall_seconds = time.monotonic() - started
+    job_started_epoch = os.environ.get("E2E_JOB_STARTED_EPOCH")
+    if job_started_epoch is None:
+        job_wall_seconds = wall_seconds
+    else:
+        try:
+            job_wall_seconds = time.time() - float(job_started_epoch)
+        except ValueError:
+            job_wall_seconds = wall_seconds
     ended_utc = dt.datetime.now(dt.UTC).isoformat()
     after_user, after_system, peak_rss_kb = _child_usage()
     leaked_processes = []
@@ -451,6 +468,7 @@ def _run(args, manifest: dict) -> int:
         "started_utc": started_utc,
         "ended_utc": ended_utc,
         "wall_seconds": round(wall_seconds, 3),
+        "job_wall_seconds": round(max(job_wall_seconds, wall_seconds), 3),
         "cpu_seconds": round(
             (after_user - before_user) + (after_system - before_system), 3
         ),
@@ -472,6 +490,9 @@ def _run(args, manifest: dict) -> int:
         return 1
     if selection["id"] != "all" and wall_seconds >= 720:
         print("E2E shard exceeded the 12-minute wall limit", file=sys.stderr)
+        return 1
+    if selection["id"] != "all" and job_wall_seconds >= 720:
+        print("E2E shard exceeded the 12-minute job wall limit", file=sys.stderr)
         return 1
     return completed.returncode
 
@@ -533,6 +554,7 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 f"complete E2E union: {summary.total} cases "
                 f"across shards {summary.per_shard}; wall={summary.wall_seconds}; "
+                f"job-wall={summary.job_wall_seconds}; "
                 f"cpu={summary.cpu_seconds:.2f}s; peak-rss={summary.peak_rss_kb} KiB"
             )
     except (ManifestError, ResultError) as exc:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,23 +1,51 @@
-"""E2E test fixtures — live server via multiprocessing + waitress."""
+"""Declarative E2E fixture and server-profile wiring."""
 
-import multiprocessing
+from __future__ import annotations
+
 import os
-import socket
-import time
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
 from dataclasses import dataclass
 
 import pytest
-import requests
 
-_MP_CTX = multiprocessing.get_context("spawn")
-_WAITRESS_KWARGS = {"threads": 2, "_quiet": True, "asyncore_use_poll": True}
+from tests.e2e.prefix_proxy import serve_prefix_proxy
+from tests.e2e.support.application import (
+    seed_fritzbox_segment_data,
+    serve_server,
+)
+from tests.e2e.support.lifecycle import (
+    ProcessSpec,
+    artifact_log_path,
+    reserve_local_port,
+    running_processes,
+)
+from tests.e2e.support.profiles import ServerProfile, ServerTarget
+
+DEMO_PROFILE = ServerProfile("demo", configured=True, demo_mode=True)
+AUTH_PROFILE = ServerProfile("auth", configured=True, demo_mode=True)
+CONFIGURED_PROFILE = ServerProfile(
+    "configured", configured=True, demo_mode=False
+)
+SETUP_PROFILE = ServerProfile("setup", configured=False, demo_mode=False)
+FIRST_RUN_PROFILE = ServerProfile(
+    "first-run-production-startup",
+    configured=False,
+    demo_mode=False,
+    production_startup=True,
+)
+FRITZBOX_PROFILE = ServerProfile(
+    "fritzbox",
+    configured=True,
+    demo_mode=True,
+    modem_type="fritzbox",
+    post_seed_callback=seed_fritzbox_segment_data,
+)
+AUTH_TEST_CREDENTIAL = "e2e-test-password"
 
 
 @pytest.fixture(scope="session")
 def browser_type_launch_args(browser_type_launch_args):
     """WSL2-friendly Chromium launch arguments to prevent flakiness."""
+
     return {
         **browser_type_launch_args,
         "args": [
@@ -30,243 +58,130 @@ def browser_type_launch_args(browser_type_launch_args):
     }
 
 
-def _find_free_port():
-    """Return an available TCP port on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def _not_found(environ, start_response):
-    """Reject every request that escapes a mounted DOCSight application."""
-    from werkzeug.wrappers import Response
-
-    return Response("Not Found\n", status=404)(environ, start_response)
-
-
-def _mounted_app(application, mount_path):
-    if not mount_path:
-        return application
-    from werkzeug.middleware.dispatcher import DispatcherMiddleware
-
-    return DispatcherMiddleware(
-        _not_found,
-        {mount_path: application},
+def _new_target(
+    label,
+    data_dir,
+    profile,
+    *,
+    admin_password=None,
+    readiness_headers=(),
+):
+    reservation = reserve_local_port()
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+    identity = f"{label}-{worker}-{reservation.port}"
+    target = ServerTarget(
+        identity=identity,
+        data_dir=str(data_dir),
+        port=reservation.port,
+        profile=profile,
+        admin_password=admin_password,
     )
-
-
-@dataclass(frozen=True)
-class _ServerTarget:
-    """Pickle-safe configuration for one isolated E2E server process."""
-
-    data_dir: str
-    port: int
-    configured: bool = True
-    admin_password: str | None = None
-    demo_mode: bool = True
-    modem_type: str | None = None
-    mount_path: str = ""
-    base_path: str | None = None
-    trusted_prefix_hops: int | None = None
-    production_startup: bool = False
-    post_seed_callback: Callable[[str], None] | None = None
-
-
-def _configure_server_environment(target: _ServerTarget) -> None:
-    os.environ["DATA_DIR"] = target.data_dir
-    if target.demo_mode:
-        os.environ["DEMO_MODE"] = "1"
-    else:
-        os.environ.pop("DEMO_MODE", None)
-    os.environ["LOG_LEVEL"] = "WARNING"
-    os.environ.pop("BASE_PATH", None)
-    os.environ.pop("REVERSE_PROXY_PREFIX", None)
-    if target.base_path is not None:
-        os.environ["BASE_PATH"] = target.base_path
-    if target.trusted_prefix_hops is not None:
-        os.environ["REVERSE_PROXY_PREFIX"] = str(target.trusted_prefix_hops)
-
-
-def _initialize_module_storage(db_path: str) -> None:
-    """Initialize module storage tables needed by seeded E2E data."""
-    try:
-        from app.modules.speedtest.storage import SpeedtestStorage
-
-        SpeedtestStorage(db_path)
-    except ImportError:
-        pass
-    try:
-        from app.modules.bqm.storage import BqmStorage
-
-        BqmStorage(db_path)
-    except ImportError:
-        pass
-    try:
-        from app.modules.bnetz.storage import BnetzStorage
-
-        BnetzStorage(db_path)
-    except ImportError:
-        pass
-    try:
-        from app.modules.journal.storage import JournalStorage
-
-        JournalStorage(db_path)
-    except ImportError:
-        pass
-
-
-def _serve_server(target: _ServerTarget) -> None:
-    """Boot any E2E DOCSight server variant inside a child process."""
-    if target.production_startup:
-        os.environ["DATA_DIR"] = target.data_dir
-        os.environ["WEB_HOST"] = "127.0.0.1"
-        os.environ["WEB_PORT"] = str(target.port)
-        os.environ.pop("DEMO_MODE", None)
-        os.environ["LOG_LEVEL"] = "WARNING"
-        from app.main import main
-
-        main()
-        return
-
-    _configure_server_environment(target)
-
-    from app import analyzer
-    from app.app_factory import create_app, default_module_loader_factory
-    from app.config import ConfigManager
-    from app.runtime import get_runtime
-
-    config = ConfigManager(target.data_dir)
-    if not target.configured:
-        storage = None
-    else:
-        from app.collectors.demo import DemoCollector
-        from app.event_detector import EventDetector
-        from app.storage import SnapshotStorage
-
-        config_data = {
-            "demo_mode": target.demo_mode,
-            "disabled_modules": "",
-            "modem_type": target.modem_type
-            or ("demo" if target.demo_mode else "generic"),
-        }
-        if target.admin_password:
-            config_data["admin_password"] = target.admin_password
-        config.save(config_data)
-
-        db_path = os.path.join(target.data_dir, "docsis_history.db")
-        storage = SnapshotStorage(db_path, max_days=7)
-        storage.set_timezone("UTC")
-        _initialize_module_storage(db_path)
-
-    application = create_app(
-        config_manager=config,
-        storage=storage,
-        module_loader_factory=default_module_loader_factory(config, search_paths=[]),
-        environ=os.environ,
-        testing=True,
+    spec = ProcessSpec(
+        identity=identity,
+        reservation=reservation,
+        process_target=serve_server,
+        args=(target,),
+        readiness_path=profile.mount_path,
+        readiness_headers=readiness_headers,
+        log_path=artifact_log_path(identity),
+        secrets=(admin_password,) if admin_password else (),
+        data_path=target.data_dir,
     )
-    runtime = get_runtime(application)
+    return target, spec
 
-    if target.configured:
 
-        collector = DemoCollector(
-            analyzer_fn=analyzer.analyze,
-            event_detector=EventDetector(),
-            storage=storage,
-            mqtt_pub=None,
-            web=runtime,
-            poll_interval=300,
-        )
-        collector.collect()
-        if target.post_seed_callback is not None:
-            target.post_seed_callback(db_path)
-
-    from waitress import serve
-
-    serve(
-        _mounted_app(application, target.mount_path),
-        host="127.0.0.1",
-        port=target.port,
-        **_WAITRESS_KWARGS,
+def _new_proxy(label, upstream_port, mount_path, forwarded_prefix_chain):
+    reservation = reserve_local_port()
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+    identity = f"{label}-{worker}-{reservation.port}"
+    spec = ProcessSpec(
+        identity=identity,
+        reservation=reservation,
+        process_target=serve_prefix_proxy,
+        args=(
+            reservation.port,
+            upstream_port,
+            mount_path,
+            forwarded_prefix_chain,
+        ),
+        readiness_path=mount_path,
+        log_path=artifact_log_path(identity),
     )
-
-
-def _wait_for_server(port, timeout=150, mount_path=""):
-    """Poll /health until the server responds or timeout."""
-    url = f"http://127.0.0.1:{port}{mount_path}/health"
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            r = requests.get(url, timeout=2)
-            if r.status_code == 200:
-                return
-        except requests.ConnectionError:
-            pass
-        time.sleep(0.3)
-    raise RuntimeError(f"Live server on port {port} did not start within {timeout}s")
-
-
-@contextmanager
-def _running_processes(
-    process_specs: list[tuple[Callable[..., None], tuple]],
-    readiness_targets: list[tuple[int, str]],
-) -> Iterator[None]:
-    """Start, await, and always terminate an isolated group of child processes."""
-    processes = []
-    try:
-        for process_target, args in process_specs:
-            process = _MP_CTX.Process(target=process_target, args=args, daemon=True)
-            process.start()
-            processes.append(process)
-        for port, mount_path in readiness_targets:
-            _wait_for_server(port, mount_path=mount_path)
-        yield
-    finally:
-        for process in processes:
-            if process.is_alive():
-                process.terminate()
-        for process in processes:
-            process.join(timeout=5)
+    return reservation.port, spec
 
 
 @pytest.fixture(scope="session")
-def _demo_data_dir(tmp_path_factory):
-    """Session-scoped temp directory for the demo server."""
-    return str(tmp_path_factory.mktemp("docsight_e2e"))
-
-
-@pytest.fixture(scope="session")
-def _auth_data_dir(tmp_path_factory):
-    """Session-scoped temp directory for the auth server."""
-    return str(tmp_path_factory.mktemp("docsight_e2e_auth"))
-
-
-@pytest.fixture(scope="session")
-def live_server(_demo_data_dir):
-    """Start a DOCSight demo server (no auth) and return its base URL."""
-    port = _find_free_port()
-    target = _ServerTarget(_demo_data_dir, port)
-    with _running_processes([(_serve_server, (target,))], [(port, "")]):
-        yield f"http://127.0.0.1:{port}"
-
-
-@pytest.fixture(scope="session")
-def auth_server(_auth_data_dir):
-    """Start a DOCSight server with admin password and return its base URL."""
-    port = _find_free_port()
-    credential = "e2e-test-password"
-    target = _ServerTarget(
-        _auth_data_dir,
-        port,
-        admin_password=credential,
+def live_server(tmp_path_factory):
+    target, spec = _new_target(
+        "demo", tmp_path_factory.mktemp("docsight_e2e_demo"), DEMO_PROFILE
     )
-    with _running_processes([(_serve_server, (target,))], [(port, "")]):
-        yield f"http://127.0.0.1:{port}"
+    with running_processes([spec]):
+        yield target.base_url
+
+
+@pytest.fixture(scope="session")
+def auth_server(tmp_path_factory):
+    target, spec = _new_target(
+        "auth",
+        tmp_path_factory.mktemp("docsight_e2e_auth"),
+        AUTH_PROFILE,
+        admin_password=AUTH_TEST_CREDENTIAL,
+    )
+    with running_processes([spec]):
+        yield target.base_url
+
+
+@pytest.fixture(scope="session")
+def configured_server(tmp_path_factory):
+    target, spec = _new_target(
+        "configured",
+        tmp_path_factory.mktemp("docsight_e2e_configured"),
+        CONFIGURED_PROFILE,
+    )
+    with running_processes([spec]):
+        yield target.base_url
+
+
+@pytest.fixture()
+def first_run_server(tmp_path):
+    target, spec = _new_target(
+        "first-run", tmp_path / "first-run", FIRST_RUN_PROFILE
+    )
+    with running_processes([spec]):
+        yield target.base_url
+
+
+@pytest.fixture(scope="session")
+def setup_server(tmp_path_factory):
+    target, spec = _new_target(
+        "setup", tmp_path_factory.mktemp("docsight_e2e_setup"), SETUP_PROFILE
+    )
+    with running_processes([spec]):
+        yield target.base_url
+
+
+@pytest.fixture()
+def isolated_setup_server(tmp_path):
+    target, spec = _new_target(
+        "isolated-setup", tmp_path / "isolated-setup", SETUP_PROFILE
+    )
+    with running_processes([spec]):
+        yield {"url": target.base_url, "data_dir": target.data_dir}
+
+
+@pytest.fixture(scope="session")
+def fritzbox_server(tmp_path_factory):
+    target, spec = _new_target(
+        "fritzbox",
+        tmp_path_factory.mktemp("docsight_e2e_fritzbox"),
+        FRITZBOX_PROFILE,
+    )
+    with running_processes([spec]):
+        yield target.base_url
 
 
 @pytest.fixture()
 def demo_page(page, live_server):
-    """Navigate to the demo server dashboard."""
     page.goto(live_server)
     page.wait_for_load_state("networkidle")
     return page
@@ -274,30 +189,13 @@ def demo_page(page, live_server):
 
 @pytest.fixture()
 def settings_page(page, live_server):
-    """Navigate to the settings page."""
     page.goto(f"{live_server}/settings")
     page.wait_for_load_state("networkidle")
     return page
 
 
-@pytest.fixture(scope="session")
-def _configured_data_dir(tmp_path_factory):
-    """Session-scoped data directory for non-demo persisted-settings tests."""
-    return str(tmp_path_factory.mktemp("docsight_e2e_configured"))
-
-
-@pytest.fixture(scope="session")
-def configured_server(_configured_data_dir):
-    """Start a configured non-demo instance with seeded dashboard data."""
-    port = _find_free_port()
-    target = _ServerTarget(_configured_data_dir, port, demo_mode=False)
-    with _running_processes([(_serve_server, (target,))], [(port, "")]):
-        yield f"http://127.0.0.1:{port}"
-
-
 @pytest.fixture()
 def configured_page(page, configured_server):
-    """Navigate to a configured non-demo dashboard."""
     page.goto(configured_server)
     page.wait_for_load_state("networkidle")
     return page
@@ -305,70 +203,19 @@ def configured_page(page, configured_server):
 
 @pytest.fixture()
 def auth_page(page, auth_server):
-    """Provide a page pointed at the auth-protected server."""
     return page
-
-
-# ── Unconfigured server (setup wizard) ──
-
-
-@pytest.fixture()
-def first_run_server(tmp_path):
-    """Start a fresh production-path instance for one-click activation tests."""
-    port = _find_free_port()
-    target = _ServerTarget(
-        str(tmp_path / "first-run"),
-        port,
-        configured=False,
-        demo_mode=False,
-        production_startup=True,
-    )
-    with _running_processes([(_serve_server, (target,))], [(port, "")]):
-        yield f"http://127.0.0.1:{port}"
-
-
-@pytest.fixture(scope="session")
-def _setup_data_dir(tmp_path_factory):
-    """Session-scoped temp directory for the unconfigured server."""
-    return str(tmp_path_factory.mktemp("docsight_e2e_setup"))
-
-
-@pytest.fixture(scope="session")
-def setup_server(_setup_data_dir):
-    """Start an unconfigured DOCSight server and return its base URL."""
-    port = _find_free_port()
-    target = _ServerTarget(
-        _setup_data_dir,
-        port,
-        configured=False,
-        demo_mode=False,
-    )
-    with _running_processes([(_serve_server, (target,))], [(port, "")]):
-        yield f"http://127.0.0.1:{port}"
-
-
-@pytest.fixture()
-def isolated_setup_server(tmp_path):
-    """Start an unconfigured server with fresh data for one language test."""
-    data_dir = str(tmp_path / "isolated-setup")
-    port = _find_free_port()
-    target = _ServerTarget(
-        data_dir,
-        port,
-        configured=False,
-        demo_mode=False,
-    )
-    with _running_processes([(_serve_server, (target,))], [(port, "")]):
-        yield {
-            "url": f"http://127.0.0.1:{port}",
-            "data_dir": data_dir,
-        }
 
 
 @pytest.fixture()
 def setup_page(page, setup_server):
-    """Navigate to the unconfigured server — lands on /setup."""
     page.goto(setup_server)
+    page.wait_for_load_state("networkidle")
+    return page
+
+
+@pytest.fixture()
+def fritzbox_page(page, fritzbox_server):
+    page.goto(fritzbox_server)
     page.wait_for_load_state("networkidle")
     return page
 
@@ -380,70 +227,80 @@ def setup_page(page, setup_server):
 )
 def path_prefix_servers(request, tmp_path_factory):
     """Serve auth and setup apps through real root/prefix WSGI mounts."""
+
     mount_path = request.param
     label = "root" if not mount_path else "docsight"
-    auth_port = _find_free_port()
-    setup_port = _find_free_port()
     credential = "browser-contract-password"
-    auth_dir = str(tmp_path_factory.mktemp(f"docsight_mount_auth_{label}"))
-    setup_dir = str(tmp_path_factory.mktemp(f"docsight_mount_setup_{label}"))
-    auth_target = _ServerTarget(
-        auth_dir,
-        auth_port,
-        admin_password=credential,
+    auth_profile = ServerProfile(
+        f"path-prefix-auth-{label}",
+        configured=True,
+        demo_mode=True,
         mount_path=mount_path,
     )
-    setup_target = _ServerTarget(
-        setup_dir,
-        setup_port,
+    setup_profile = ServerProfile(
+        f"path-prefix-setup-{label}",
         configured=False,
         demo_mode=False,
         mount_path=mount_path,
     )
-    with _running_processes(
-        [
-            (_serve_server, (auth_target,)),
-            (_serve_server, (setup_target,)),
-        ],
-        [(auth_port, mount_path), (setup_port, mount_path)],
-    ):
+    auth_target, auth_spec = _new_target(
+        f"mount-auth-{label}",
+        tmp_path_factory.mktemp(f"docsight_mount_auth_{label}"),
+        auth_profile,
+        admin_password=credential,
+    )
+    setup_target, setup_spec = _new_target(
+        f"mount-setup-{label}",
+        tmp_path_factory.mktemp(f"docsight_mount_setup_{label}"),
+        setup_profile,
+    )
+    with running_processes([auth_spec, setup_spec]):
         yield {
             "mount_path": mount_path,
-            "app_url": f"http://127.0.0.1:{auth_port}{mount_path}",
-            "setup_url": f"http://127.0.0.1:{setup_port}{mount_path}",
+            "app_url": auth_target.base_url,
+            "setup_url": setup_target.base_url,
             "password": credential,
         }
 
 
+@dataclass(frozen=True)
+class NetworkPrefixCase:
+    label: str
+    mount_path: str
+    base_path: str | None
+    trusted_prefix_hops: int | None
+    forwarded_prefix_chain: str | None
+
+
 _NETWORK_PREFIX_CASES = [
     pytest.param(
-        {
-            "label": "explicit_docsight",
-            "mount_path": "/docsight",
-            "base_path": "/docsight",
-            "trusted_prefix_hops": None,
-            "forwarded_prefix_chain": None,
-        },
+        NetworkPrefixCase(
+            "explicit-docsight",
+            "/docsight",
+            "/docsight",
+            None,
+            None,
+        ),
         id="explicit-docsight-mount",
     ),
     pytest.param(
-        {
-            "label": "trusted_docsight",
-            "mount_path": "/docsight",
-            "base_path": None,
-            "trusted_prefix_hops": 2,
-            "forwarded_prefix_chain": "/docsight, /docsight",
-        },
+        NetworkPrefixCase(
+            "trusted-docsight",
+            "/docsight",
+            None,
+            2,
+            "/docsight, /docsight",
+        ),
         id="trusted-docsight-mount",
     ),
     pytest.param(
-        {
-            "label": "explicit_wrapper_shape",
-            "mount_path": "/api/hassio_ingress/synthetic-test-entry",
-            "base_path": "/api/hassio_ingress/synthetic-test-entry",
-            "trusted_prefix_hops": None,
-            "forwarded_prefix_chain": None,
-        },
+        NetworkPrefixCase(
+            "explicit-wrapper-shape",
+            "/api/hassio_ingress/synthetic-test-entry",
+            "/api/hassio_ingress/synthetic-test-entry",
+            None,
+            None,
+        ),
         id="explicit-wrapper-shaped-mount",
     ),
 ]
@@ -456,129 +313,69 @@ class _RedactedProxyServers(dict):
 
 @pytest.fixture(scope="session", params=_NETWORK_PREFIX_CASES)
 def real_proxy_servers(request, tmp_path_factory):
-    """Run DOCSight behind a separate prefix-stripping HTTP proxy process."""
-    from tests.e2e.prefix_proxy import serve_prefix_proxy
+    """Run DOCSight behind separate prefix-stripping HTTP proxy processes."""
 
     case = request.param
-    auth_upstream_port = _find_free_port()
-    setup_upstream_port = _find_free_port()
-    auth_proxy_port = _find_free_port()
-    setup_proxy_port = _find_free_port()
     credential = "network-proxy-test-password"
-    label = case["label"]
-    auth_dir = str(tmp_path_factory.mktemp(f"network_proxy_auth_{label}"))
-    setup_dir = str(tmp_path_factory.mktemp(f"network_proxy_setup_{label}"))
-
-    auth_target = _ServerTarget(
-        auth_dir,
-        auth_upstream_port,
-        admin_password=credential,
-        base_path=case["base_path"],
-        trusted_prefix_hops=case["trusted_prefix_hops"],
+    auth_profile = ServerProfile(
+        f"network-proxy-auth-{case.label}",
+        configured=True,
+        demo_mode=True,
+        base_path=case.base_path,
+        trusted_prefix_hops=case.trusted_prefix_hops,
     )
-    setup_target = _ServerTarget(
-        setup_dir,
-        setup_upstream_port,
+    setup_profile = ServerProfile(
+        f"network-proxy-setup-{case.label}",
         configured=False,
         demo_mode=False,
-        base_path=case["base_path"],
-        trusted_prefix_hops=case["trusted_prefix_hops"],
+        base_path=case.base_path,
+        trusted_prefix_hops=case.trusted_prefix_hops,
     )
-    with _running_processes(
-        [
-            (_serve_server, (auth_target,)),
-            (_serve_server, (setup_target,)),
-            (
-                serve_prefix_proxy,
-                (
-                    auth_proxy_port,
-                    auth_upstream_port,
-                    case["mount_path"],
-                    case["forwarded_prefix_chain"],
-                ),
-            ),
-            (
-                serve_prefix_proxy,
-                (
-                    setup_proxy_port,
-                    setup_upstream_port,
-                    case["mount_path"],
-                    case["forwarded_prefix_chain"],
-                ),
-            ),
-        ],
-        [
-            (auth_proxy_port, case["mount_path"]),
-            (setup_proxy_port, case["mount_path"]),
-        ],
+    auth_target, auth_spec = _new_target(
+        f"proxy-upstream-auth-{case.label}",
+        tmp_path_factory.mktemp(f"network_proxy_auth_{case.label}"),
+        auth_profile,
+        admin_password=credential,
+        readiness_headers=(
+            (("X-Forwarded-Prefix", case.forwarded_prefix_chain),)
+            if case.forwarded_prefix_chain
+            else ()
+        ),
+    )
+    setup_target, setup_spec = _new_target(
+        f"proxy-upstream-setup-{case.label}",
+        tmp_path_factory.mktemp(f"network_proxy_setup_{case.label}"),
+        setup_profile,
+        readiness_headers=(
+            (("X-Forwarded-Prefix", case.forwarded_prefix_chain),)
+            if case.forwarded_prefix_chain
+            else ()
+        ),
+    )
+    auth_proxy_port, auth_proxy_spec = _new_proxy(
+        f"proxy-auth-{case.label}",
+        auth_target.port,
+        case.mount_path,
+        case.forwarded_prefix_chain,
+    )
+    setup_proxy_port, setup_proxy_spec = _new_proxy(
+        f"proxy-setup-{case.label}",
+        setup_target.port,
+        case.mount_path,
+        case.forwarded_prefix_chain,
+    )
+    with running_processes(
+        [auth_spec, setup_spec, auth_proxy_spec, setup_proxy_spec]
     ):
         yield _RedactedProxyServers(
             {
-                "mount_path": case["mount_path"],
+                "mount_path": case.mount_path,
                 "app_url": (
-                    f"http://127.0.0.1:{auth_proxy_port}{case['mount_path']}"
+                    f"http://127.0.0.1:{auth_proxy_port}{case.mount_path}"
                 ),
                 "setup_url": (
-                    f"http://127.0.0.1:{setup_proxy_port}{case['mount_path']}"
+                    f"http://127.0.0.1:{setup_proxy_port}{case.mount_path}"
                 ),
                 "password": credential,
             }
         )
-
-
-# ── FritzBox server (segment utilization) ──
-
-
-def _seed_fritzbox_segment_data(db_path: str) -> None:
-    """Seed 48 hours of deterministic one-minute segment utilization samples."""
-    import random
-    from datetime import datetime, timedelta, timezone
-
-    from app.storage.segment_utilization import SegmentUtilizationStorage
-
-    segment_storage = SegmentUtilizationStorage(db_path)
-    now = datetime.now(timezone.utc)
-    random.seed(42)
-    for index in range(2880):
-        timestamp = (now - timedelta(minutes=2880 - index)).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
-        downstream_total = 15.0 + random.uniform(-5, 25)
-        upstream_total = 8.0 + random.uniform(-3, 15)
-        downstream_own = downstream_total * random.uniform(0.01, 0.15)
-        upstream_own = upstream_total * random.uniform(0.01, 0.10)
-        segment_storage.save_at(
-            timestamp,
-            round(downstream_total, 1),
-            round(upstream_total, 1),
-            round(downstream_own, 2),
-            round(upstream_own, 2),
-        )
-
-
-@pytest.fixture(scope="session")
-def _fritzbox_data_dir(tmp_path_factory):
-    """Session-scoped temp directory for the FritzBox server."""
-    return str(tmp_path_factory.mktemp("docsight_e2e_fritzbox"))
-
-
-@pytest.fixture(scope="session")
-def fritzbox_server(_fritzbox_data_dir):
-    """Start a DOCSight server with modem_type=fritzbox and segment data."""
-    port = _find_free_port()
-    target = _ServerTarget(
-        _fritzbox_data_dir,
-        port,
-        modem_type="fritzbox",
-        post_seed_callback=_seed_fritzbox_segment_data,
-    )
-    with _running_processes([(_serve_server, (target,))], [(port, "")]):
-        yield f"http://127.0.0.1:{port}"
-
-
-@pytest.fixture()
-def fritzbox_page(page, fritzbox_server):
-    """Navigate to the FritzBox server dashboard."""
-    page.goto(fritzbox_server)
-    page.wait_for_load_state("networkidle")
-    return page

--- a/tests/e2e/prefix_proxy.py
+++ b/tests/e2e/prefix_proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import http.client
+import socket
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlsplit
 
@@ -86,6 +87,8 @@ def serve_prefix_proxy(
     upstream_port: int,
     mount_path: str,
     forwarded_prefix_chain: str | None,
+    *,
+    listener_socket: socket.socket | None = None,
 ) -> None:
     """Serve one quiet same-origin prefix boundary until terminated."""
 
@@ -225,6 +228,13 @@ def serve_prefix_proxy(
             return
 
     server = QuietThreadingHTTPServer(
-        ("127.0.0.1", listen_port), PrefixProxyHandler
+        ("127.0.0.1", listen_port),
+        PrefixProxyHandler,
+        bind_and_activate=listener_socket is None,
     )
+    if listener_socket is not None:
+        server.socket.close()
+        server.socket = listener_socket
+        server.server_address = listener_socket.getsockname()
+        server.server_activate()
     server.serve_forever()

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -5,46 +5,52 @@
   "shards": [
     {
       "id": 1,
-      "collected_cases": 126,
+      "collected_cases": 80,
       "files": [
-        "test_channels.py",
-        "test_comparison.py",
+        "test_connection_monitor.py",
+        "test_event_log_redesign.py",
+        "test_i18n.py",
+        "test_path_prefix_browser.py",
+        "test_real_proxy_path_prefix.py",
+        "test_segment_utilization.py"
+      ]
+    },
+    {
+      "id": 2,
+      "collected_cases": 125,
+      "files": [
+        "test_auth.py",
+        "test_charts.py",
+        "test_dashboard.py",
         "test_evidence_report_scope.py",
         "test_glossary_visual.py",
-        "test_real_proxy_path_prefix.py",
-        "test_responsive.py",
-        "test_segment_utilization.py",
         "test_setup.py",
         "test_theme.py"
       ]
     },
     {
-      "id": 2,
-      "collected_cases": 214,
+      "id": 3,
+      "collected_cases": 158,
       "files": [
-        "test_charts.py",
-        "test_events.py",
-        "test_glossary.py",
+        "test_comparison.py",
+        "test_correlation_ui.py",
         "test_glossary_page.py",
-        "test_i18n.py",
-        "test_mobile_quality_gate.py",
-        "test_modals.py",
-        "test_modulation.py",
+        "test_modulation_visual.py",
+        "test_pwa_gate.py",
+        "test_responsive.py",
         "test_security.py"
       ]
     },
     {
-      "id": 3,
-      "collected_cases": 191,
+      "id": 4,
+      "collected_cases": 168,
       "files": [
-        "test_auth.py",
-        "test_connection_monitor.py",
-        "test_correlation_ui.py",
-        "test_dashboard.py",
-        "test_event_log_redesign.py",
-        "test_modulation_visual.py",
-        "test_path_prefix_browser.py",
-        "test_pwa_gate.py",
+        "test_channels.py",
+        "test_events.py",
+        "test_glossary.py",
+        "test_mobile_quality_gate.py",
+        "test_modals.py",
+        "test_modulation.py",
         "test_settings.py"
       ]
     }

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -5,47 +5,47 @@
   "shards": [
     {
       "id": 1,
-      "collected_cases": 177,
+      "collected_cases": 126,
       "files": [
+        "test_channels.py",
         "test_comparison.py",
-        "test_glossary.py",
+        "test_evidence_report_scope.py",
+        "test_glossary_visual.py",
+        "test_real_proxy_path_prefix.py",
+        "test_responsive.py",
         "test_segment_utilization.py",
-        "test_settings.py",
-        "test_setup.py"
+        "test_setup.py",
+        "test_theme.py"
       ]
     },
     {
       "id": 2,
-      "collected_cases": 177,
+      "collected_cases": 214,
       "files": [
         "test_charts.py",
-        "test_correlation_ui.py",
+        "test_events.py",
+        "test_glossary.py",
         "test_glossary_page.py",
         "test_i18n.py",
-        "test_responsive.py",
+        "test_mobile_quality_gate.py",
+        "test_modals.py",
+        "test_modulation.py",
         "test_security.py"
       ]
     },
     {
       "id": 3,
-      "collected_cases": 177,
+      "collected_cases": 191,
       "files": [
         "test_auth.py",
-        "test_channels.py",
         "test_connection_monitor.py",
+        "test_correlation_ui.py",
         "test_dashboard.py",
         "test_event_log_redesign.py",
-        "test_events.py",
-        "test_evidence_report_scope.py",
-        "test_glossary_visual.py",
-        "test_mobile_quality_gate.py",
-        "test_modals.py",
-        "test_modulation.py",
         "test_modulation_visual.py",
         "test_path_prefix_browser.py",
         "test_pwa_gate.py",
-        "test_real_proxy_path_prefix.py",
-        "test_theme.py"
+        "test_settings.py"
       ]
     }
   ]

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "expected_total": 531,
+  "baseline_cpu_seconds": 865.343,
+  "shards": [
+    {
+      "id": 1,
+      "collected_cases": 177,
+      "files": [
+        "test_comparison.py",
+        "test_glossary.py",
+        "test_segment_utilization.py",
+        "test_settings.py",
+        "test_setup.py"
+      ]
+    },
+    {
+      "id": 2,
+      "collected_cases": 177,
+      "files": [
+        "test_charts.py",
+        "test_correlation_ui.py",
+        "test_glossary_page.py",
+        "test_i18n.py",
+        "test_responsive.py",
+        "test_security.py"
+      ]
+    },
+    {
+      "id": 3,
+      "collected_cases": 177,
+      "files": [
+        "test_auth.py",
+        "test_channels.py",
+        "test_connection_monitor.py",
+        "test_dashboard.py",
+        "test_event_log_redesign.py",
+        "test_events.py",
+        "test_evidence_report_scope.py",
+        "test_glossary_visual.py",
+        "test_mobile_quality_gate.py",
+        "test_modals.py",
+        "test_modulation.py",
+        "test_modulation_visual.py",
+        "test_path_prefix_browser.py",
+        "test_pwa_gate.py",
+        "test_real_proxy_path_prefix.py",
+        "test_theme.py"
+      ]
+    }
+  ]
+}

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "expected_total": 531,
-  "baseline_cpu_seconds": 865.343,
+  "baseline_cpu_seconds": 1534.372,
   "shards": [
     {
       "id": 1,

--- a/tests/e2e/support/__init__.py
+++ b/tests/e2e/support/__init__.py
@@ -1,0 +1,1 @@
+"""Test-only process and application support for browser qualification."""

--- a/tests/e2e/support/application.py
+++ b/tests/e2e/support/application.py
@@ -1,0 +1,172 @@
+"""Application construction and deterministic data seeding for E2E servers."""
+
+from __future__ import annotations
+
+import os
+import random
+import socket
+from datetime import datetime, timedelta, timezone
+
+from tests.e2e.support.profiles import ServerTarget
+
+_WAITRESS_KWARGS = {"threads": 2, "asyncore_use_poll": True}
+
+
+def _not_found(environ, start_response):
+    """Reject every request that escapes a mounted DOCSight application."""
+
+    from werkzeug.wrappers import Response
+
+    return Response("Not Found\n", status=404)(environ, start_response)
+
+
+def _mounted_app(application, mount_path):
+    if not mount_path:
+        return application
+    from werkzeug.middleware.dispatcher import DispatcherMiddleware
+
+    return DispatcherMiddleware(_not_found, {mount_path: application})
+
+
+def _initialize_module_storage(db_path: str) -> None:
+    """Initialize module tables used by deterministic E2E seed data."""
+
+    try:
+        from app.modules.speedtest.storage import SpeedtestStorage
+
+        SpeedtestStorage(db_path)
+    except ImportError:
+        pass
+    try:
+        from app.modules.bqm.storage import BqmStorage
+
+        BqmStorage(db_path)
+    except ImportError:
+        pass
+    try:
+        from app.modules.bnetz.storage import BnetzStorage
+
+        BnetzStorage(db_path)
+    except ImportError:
+        pass
+    try:
+        from app.modules.journal.storage import JournalStorage
+
+        JournalStorage(db_path)
+    except ImportError:
+        pass
+
+
+def seed_fritzbox_segment_data(db_path: str) -> None:
+    """Seed 48 hours of deterministic one-minute utilization samples."""
+
+    from app.storage.segment_utilization import SegmentUtilizationStorage
+
+    segment_storage = SegmentUtilizationStorage(db_path)
+    now = datetime.now(timezone.utc)
+    generator = random.Random(42)
+    for index in range(2880):
+        timestamp = (now - timedelta(minutes=2880 - index)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        downstream_total = 15.0 + generator.uniform(-5, 25)
+        upstream_total = 8.0 + generator.uniform(-3, 15)
+        downstream_own = downstream_total * generator.uniform(0.01, 0.15)
+        upstream_own = upstream_total * generator.uniform(0.01, 0.10)
+        segment_storage.save_at(
+            timestamp,
+            round(downstream_total, 1),
+            round(upstream_total, 1),
+            round(downstream_own, 2),
+            round(upstream_own, 2),
+        )
+
+
+def serve_server(
+    target: ServerTarget, *, listener_socket: socket.socket | None = None
+) -> None:
+    """Boot one E2E DOCSight variant inside a spawned child process."""
+
+    target.apply_environment()
+    if target.profile.production_startup:
+        if listener_socket is None:
+            raise ValueError("production startup requires its reserved test socket")
+        import waitress
+
+        create_server = waitress.create_server
+
+        def create_server_on_reserved_socket(application, **kwargs):
+            kwargs.pop("host", None)
+            kwargs.pop("port", None)
+            return create_server(
+                application, sockets=[listener_socket], **kwargs
+            )
+
+        waitress.create_server = create_server_on_reserved_socket
+        from app.main import main
+
+        main()
+        return
+
+    from app import analyzer
+    from app.app_factory import create_app, default_module_loader_factory
+    from app.config import ConfigManager
+    from app.runtime import get_runtime
+
+    config = ConfigManager(target.data_dir)
+    if not target.profile.configured:
+        storage = None
+    else:
+        from app.collectors.demo import DemoCollector
+        from app.event_detector import EventDetector
+        from app.storage import SnapshotStorage
+
+        config_data = {
+            "demo_mode": target.profile.demo_mode,
+            "disabled_modules": "",
+            "modem_type": target.profile.modem_type
+            or ("demo" if target.profile.demo_mode else "generic"),
+        }
+        if target.admin_password:
+            config_data["admin_password"] = target.admin_password
+        config.save(config_data)
+
+        db_path = os.path.join(target.data_dir, "docsis_history.db")
+        storage = SnapshotStorage(db_path, max_days=7)
+        storage.set_timezone("UTC")
+        _initialize_module_storage(db_path)
+
+    application = create_app(
+        config_manager=config,
+        storage=storage,
+        module_loader_factory=default_module_loader_factory(
+            config, search_paths=[]
+        ),
+        environ=os.environ,
+        testing=True,
+    )
+    runtime = get_runtime(application)
+    if target.profile.configured:
+        collector = DemoCollector(
+            analyzer_fn=analyzer.analyze,
+            event_detector=EventDetector(),
+            storage=storage,
+            mqtt_pub=None,
+            web=runtime,
+            poll_interval=300,
+        )
+        collector.collect()
+        if target.profile.post_seed_callback is not None:
+            target.profile.post_seed_callback(db_path)
+
+    from waitress.server import create_server
+
+    kwargs = dict(_WAITRESS_KWARGS)
+    if listener_socket is None:
+        kwargs.update(host="127.0.0.1", port=target.port)
+    else:
+        kwargs["sockets"] = [listener_socket]
+    server = create_server(
+        _mounted_app(application, target.profile.mount_path), **kwargs
+    )
+    server.run()

--- a/tests/e2e/support/lifecycle.py
+++ b/tests/e2e/support/lifecycle.py
@@ -1,0 +1,279 @@
+"""Worker-safe port, readiness, diagnostics, and process cleanup ownership."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import re
+import socket
+import time
+import traceback
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import requests
+
+_MP_CTX = multiprocessing.get_context("spawn")
+_IDENTITY_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+class ReadinessError(RuntimeError):
+    """A child exited or failed to become healthy."""
+
+
+class HarnessCleanupError(RuntimeError):
+    """One or more child processes or listening ports leaked."""
+
+
+@dataclass
+class PortReservation:
+    """A localhost port held by an OS-bound socket until child handoff."""
+
+    _socket: socket.socket
+    _closed: bool = False
+
+    @property
+    def address(self) -> tuple[str, int]:
+        host, port = self._socket.getsockname()[:2]
+        return str(host), int(port)
+
+    @property
+    def port(self) -> int:
+        return self.address[1]
+
+    @property
+    def socket(self) -> socket.socket:
+        if self._closed:
+            raise RuntimeError("port reservation is already closed")
+        return self._socket
+
+    def close(self) -> None:
+        if not self._closed:
+            self._socket.close()
+            self._closed = True
+
+
+def reserve_local_port() -> PortReservation:
+    """Ask the OS for and retain one isolated IPv4 localhost port."""
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    return PortReservation(listener)
+
+
+@dataclass(frozen=True)
+class ServerEndpoint:
+    identity: str
+    port: int
+    mount_path: str
+    log_path: Path | None
+    readiness_headers: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def health_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}{self.mount_path}/health"
+
+
+@dataclass(frozen=True)
+class ProcessSpec:
+    """Everything needed to start and diagnose one isolated child."""
+
+    identity: str
+    reservation: PortReservation = field(repr=False, compare=False)
+    process_target: Callable[..., None] = field(repr=False, compare=False)
+    args: tuple[Any, ...] = field(default=(), repr=False, compare=False)
+    readiness_path: str = ""
+    readiness_headers: tuple[tuple[str, str], ...] = ()
+    log_path: Path | None = None
+    secrets: tuple[str, ...] = field(default=(), repr=False, compare=False)
+    data_path: str | None = None
+
+    @property
+    def endpoint(self) -> ServerEndpoint:
+        return ServerEndpoint(
+            self.identity,
+            self.reservation.port,
+            self.readiness_path,
+            self.log_path,
+            self.readiness_headers,
+        )
+
+
+class _RedactingWriter:
+    def __init__(self, stream, secrets: Sequence[str]):
+        self._stream = stream
+        self._secrets = tuple(secret for secret in secrets if secret)
+
+    def write(self, value):
+        for secret in self._secrets:
+            value = value.replace(secret, "<redacted>")
+        return self._stream.write(value)
+
+    def flush(self):
+        return self._stream.flush()
+
+
+def _run_logged(
+    log_path: str | None,
+    secrets: tuple[str, ...],
+    process_target: Callable[..., None],
+    args: tuple[Any, ...],
+    listener_socket: socket.socket | None,
+) -> None:
+    if log_path is None:
+        process_target(*args, listener_socket=listener_socket)
+        return
+    path = Path(log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8", buffering=1) as raw_log:
+        log = _RedactingWriter(raw_log, secrets)
+        with redirect_stdout(log), redirect_stderr(log):
+            try:
+                process_target(*args, listener_socket=listener_socket)
+            except BaseException:  # noqa: BLE001 - redact every child-boundary failure
+                traceback.print_exc()
+                raise SystemExit(1) from None
+
+
+def _log_tail(path: Path | None, limit: int = 4000) -> str:
+    if path is None:
+        return "<log capture disabled>"
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")[-limit:]
+    except OSError as exc:
+        return f"<log unavailable: {exc}>"
+
+
+def wait_for_server(
+    endpoint: ServerEndpoint,
+    process,
+    *,
+    timeout: float = 150,
+    request_get: Callable[..., Any] = requests.get,
+) -> None:
+    """Wait for health, failing immediately on child exit with diagnostics."""
+
+    deadline = time.monotonic() + timeout
+    last_status = None
+    while time.monotonic() < deadline:
+        if process.exitcode is not None:
+            raise ReadinessError(
+                f"{endpoint.identity} exited with exit code {process.exitcode} "
+                f"before {endpoint.health_url} became ready. Log tail:\n"
+                f"{_log_tail(endpoint.log_path)}"
+            )
+        try:
+            response = request_get(
+                endpoint.health_url,
+                timeout=2,
+                headers=dict(endpoint.readiness_headers),
+            )
+            last_status = response.status_code
+            if last_status == 200:
+                return
+        except requests.RequestException as exc:
+            last_status = type(exc).__name__
+        time.sleep(0.3)
+    raise ReadinessError(
+        f"{endpoint.identity} did not become ready at {endpoint.health_url} "
+        f"within {timeout}s (last result: {last_status}). Log tail:\n"
+        f"{_log_tail(endpoint.log_path)}"
+    )
+
+
+def _port_is_open(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.2)
+        return probe.connect_ex(("127.0.0.1", port)) == 0
+
+
+def cleanup_processes(
+    processes: Sequence[tuple[Any, ServerEndpoint]],
+    *,
+    join_timeout: float = 5,
+    port_is_open: Callable[[int], bool] = _port_is_open,
+) -> None:
+    """Terminate, join, kill if required, and prove every port is closed."""
+
+    for process, _endpoint in processes:
+        if process.is_alive():
+            process.terminate()
+    for process, _endpoint in processes:
+        process.join(join_timeout)
+    for process, _endpoint in processes:
+        if process.is_alive():
+            process.kill()
+            process.join(join_timeout)
+
+    failures = []
+    for process, endpoint in processes:
+        if process.is_alive():
+            failures.append(
+                f"{endpoint.identity} process remained alive after kill"
+            )
+            continue
+        deadline = time.monotonic() + join_timeout
+        while port_is_open(endpoint.port) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        if port_is_open(endpoint.port):
+            failures.append(
+                f"{endpoint.identity} port {endpoint.port} remained open"
+            )
+    if failures:
+        raise HarnessCleanupError("; ".join(failures))
+
+
+def _validate_specs(specs: Sequence[ProcessSpec]) -> None:
+    identities = [spec.identity for spec in specs]
+    ports = [spec.reservation.port for spec in specs]
+    if len(set(identities)) != len(identities):
+        raise ValueError("process identities must be unique")
+    if len(set(ports)) != len(ports):
+        raise ValueError("process ports must be unique")
+    data_paths = [spec.data_path for spec in specs if spec.data_path is not None]
+    if len(set(data_paths)) != len(data_paths):
+        raise ValueError("application data paths must be unique")
+
+
+@contextmanager
+def running_processes(specs: Sequence[ProcessSpec]) -> Iterator[None]:
+    """Run a healthy isolated process group and enforce clean teardown."""
+
+    _validate_specs(specs)
+    started = []
+    try:
+        for spec in specs:
+            endpoint = spec.endpoint
+            listener = spec.reservation.socket
+            process = _MP_CTX.Process(
+                name=spec.identity,
+                target=_run_logged,
+                args=(
+                    str(spec.log_path) if spec.log_path else None,
+                    spec.secrets,
+                    spec.process_target,
+                    spec.args,
+                    listener,
+                ),
+                daemon=True,
+            )
+            process.start()
+            spec.reservation.close()
+            started.append((process, endpoint))
+        for process, endpoint in started:
+            wait_for_server(endpoint, process)
+        yield
+    finally:
+        for spec in specs:
+            spec.reservation.close()
+        cleanup_processes(started)
+
+
+def artifact_log_path(identity: str) -> Path:
+    root = Path(os.environ.get("E2E_ARTIFACT_DIR", "test-results/e2e"))
+    safe_identity = _IDENTITY_PATTERN.sub("-", identity).strip("-")
+    return root / "server-logs" / f"{safe_identity}.log"

--- a/tests/e2e/support/profiles.py
+++ b/tests/e2e/support/profiles.py
@@ -1,0 +1,105 @@
+"""Immutable configuration for isolated E2E application processes."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+
+_INHERITED_ENVIRONMENT = {
+    "HOME",
+    "LANG",
+    "PATH",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "TZ",
+    "WINDIR",
+    "DOCSIGHT_E2E_RUN_ID",
+}
+
+
+@dataclass(frozen=True)
+class ServerProfile:
+    """Pickle-safe behavior shared by one explicit server variant."""
+
+    name: str
+    configured: bool
+    demo_mode: bool
+    modem_type: str | None = None
+    mount_path: str = ""
+    base_path: str | None = None
+    trusted_prefix_hops: int | None = None
+    production_startup: bool = False
+    post_seed_callback: Callable[[str], None] | None = field(
+        default=None, repr=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("server profile name must not be empty")
+        if self.mount_path and not self.mount_path.startswith("/"):
+            raise ValueError("mount_path must be empty or absolute")
+
+
+@dataclass(frozen=True)
+class ServerTarget:
+    """Unique identity, data path, port, and profile for one app process."""
+
+    identity: str
+    data_dir: str
+    port: int
+    profile: ServerProfile
+    admin_password: str | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not self.identity:
+            raise ValueError("server target identity must not be empty")
+        if not self.data_dir:
+            raise ValueError("server target data_dir must not be empty")
+        if not 0 < self.port < 65536:
+            raise ValueError("server target port is outside the TCP range")
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}{self.profile.mount_path}"
+
+    def environment(
+        self, inherited: Mapping[str, str] | None = None
+    ) -> dict[str, str]:
+        """Return a clean child environment for exactly this target."""
+
+        source = os.environ if inherited is None else inherited
+        environment = {
+            key: value
+            for key, value in source.items()
+            if key in _INHERITED_ENVIRONMENT or key.startswith("LC_")
+        }
+        environment.update(
+            {
+                "DATA_DIR": self.data_dir,
+                "LOG_LEVEL": "WARNING",
+            }
+        )
+        if self.profile.demo_mode:
+            environment["DEMO_MODE"] = "1"
+        if self.profile.base_path is not None:
+            environment["BASE_PATH"] = self.profile.base_path
+        if self.profile.trusted_prefix_hops is not None:
+            environment["REVERSE_PROXY_PREFIX"] = str(
+                self.profile.trusted_prefix_hops
+            )
+        if self.profile.production_startup:
+            environment.update(
+                {
+                    "WEB_HOST": "127.0.0.1",
+                    "WEB_PORT": str(self.port),
+                }
+            )
+        return environment
+
+    def apply_environment(self) -> None:
+        environment = self.environment()
+        os.environ.clear()
+        os.environ.update(environment)

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -32,6 +32,18 @@ def count_uplot_canvases(page, container_id):
     return page.locator(f"#{container_id} .uplot canvas").count()
 
 
+def wait_for_uplot_replacement(page, container_id, previous_canvas, timeout=5000):
+    """Wait until an asynchronous theme refresh installs a new canvas."""
+    page.wait_for_function(
+        f"""previous => {{
+            const current = document.querySelector('#{container_id} .uplot canvas');
+            return current && current !== previous && current.isConnected;
+        }}""",
+        arg=previous_canvas,
+        timeout=timeout,
+    )
+
+
 def has_no_console_errors(page):
     """Check that no JS errors were logged."""
     errors = []
@@ -69,21 +81,32 @@ class TestHeroChart:
     def test_hero_chart_rerenders_on_theme_toggle(self, demo_page):
         """Hero chart should re-render when theme is toggled."""
         wait_for_uplot(demo_page, "hero-trend-chart")
+        canvas = demo_page.locator("#hero-trend-chart .uplot canvas").first
+        previous_canvas = canvas.element_handle()
+        assert previous_canvas is not None
         # Use JS to toggle theme directly (checkbox may be hidden in sidebar)
         demo_page.evaluate("""
             var toggle = document.getElementById('theme-toggle-sidebar');
             if (toggle) { toggle.checked = !toggle.checked; toggle.dispatchEvent(new Event('change')); }
         """)
-        wait_for_uplot(demo_page, "hero-trend-chart")
+        wait_for_uplot_replacement(
+            demo_page, "hero-trend-chart", previous_canvas
+        )
+        previous_canvas.dispose()
         # Chart should still be present after theme toggle
         canvases = count_uplot_canvases(demo_page, "hero-trend-chart")
         assert canvases >= 1
         # Toggle back
+        previous_canvas = canvas.element_handle()
+        assert previous_canvas is not None
         demo_page.evaluate("""
             var toggle = document.getElementById('theme-toggle-sidebar');
             if (toggle) { toggle.checked = !toggle.checked; toggle.dispatchEvent(new Event('change')); }
         """)
-        wait_for_uplot(demo_page, "hero-trend-chart")
+        wait_for_uplot_replacement(
+            demo_page, "hero-trend-chart", previous_canvas
+        )
+        previous_canvas.dispose()
 
 
 # ── Trend Charts ──

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -5,9 +5,7 @@ Tests cover: hero chart, trend charts, channel charts, compare charts,
 zoom modal, theme switching, responsive sizing, and crosshair sync.
 """
 
-import pytest
 from playwright.sync_api import expect
-
 
 # ── Helpers ──
 
@@ -25,8 +23,8 @@ def navigate_to_channels(page):
 
 
 def wait_for_uplot(page, container_id, timeout=5000):
-    """Wait for a uPlot chart to render inside a container."""
-    page.wait_for_selector(f"#{container_id} .uplot", timeout=timeout)
+    """Wait for a complete uPlot canvas, not its transient empty wrapper."""
+    page.wait_for_selector(f"#{container_id} .uplot canvas", timeout=timeout)
 
 
 def count_uplot_canvases(page, container_id):
@@ -85,7 +83,7 @@ class TestHeroChart:
             var toggle = document.getElementById('theme-toggle-sidebar');
             if (toggle) { toggle.checked = !toggle.checked; toggle.dispatchEvent(new Event('change')); }
         """)
-        demo_page.wait_for_timeout(300)
+        wait_for_uplot(demo_page, "hero-trend-chart")
 
 
 # ── Trend Charts ──

--- a/tests/test_e2e_harness.py
+++ b/tests/test_e2e_harness.py
@@ -1,0 +1,342 @@
+"""Focused contracts for the test-only browser server harness."""
+
+from __future__ import annotations
+
+import socket
+import sys
+import urllib.request
+from types import ModuleType
+
+import pytest
+
+from tests.e2e.support.application import serve_server
+from tests.e2e.support.lifecycle import (
+    HarnessCleanupError,
+    ProcessSpec,
+    ReadinessError,
+    ServerEndpoint,
+    _run_logged,
+    cleanup_processes,
+    reserve_local_port,
+    running_processes,
+    wait_for_server,
+)
+from tests.e2e.support.profiles import ServerProfile, ServerTarget
+
+
+class _ExitedProcess:
+    exitcode = 17
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout):
+        return None
+
+
+class _RunningProcess:
+    exitcode = None
+
+
+class _KillFallbackProcess:
+    exitcode = None
+
+    def __init__(self):
+        self.calls = []
+        self.alive = True
+
+    def is_alive(self):
+        return self.alive
+
+    def terminate(self):
+        self.calls.append("terminate")
+
+    def join(self, timeout):
+        self.calls.append(("join", timeout))
+
+    def kill(self):
+        self.calls.append("kill")
+        self.alive = False
+        self.exitcode = -9
+
+
+def _serve_health_forever(*, listener_socket):
+    listener_socket.listen()
+    while True:
+        connection, _ = listener_socket.accept()
+        with connection:
+            connection.recv(4096)
+            connection.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+            )
+
+
+def _fail_during_startup(*, listener_socket):
+    listener_socket.close()
+    raise RuntimeError("startup credential must be redacted")
+
+
+def _assert_port_reusable(port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        probe.bind(("127.0.0.1", port))
+
+
+def test_os_assigned_port_reservations_are_unique_and_bound():
+    try:
+        reservations = [reserve_local_port() for _ in range(8)]
+    except PermissionError:
+        pytest.skip("this execution sandbox does not permit local sockets")
+    try:
+        assert len({reservation.port for reservation in reservations}) == 8
+        for reservation in reservations:
+            assert reservation.address == ("127.0.0.1", reservation.port)
+            with pytest.raises(OSError):
+                contender = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    contender.bind(reservation.address)
+                finally:
+                    contender.close()
+    finally:
+        for reservation in reservations:
+            reservation.close()
+
+
+def test_readiness_failure_reports_identity_exit_code_and_redacted_log(tmp_path):
+    log_path = tmp_path / "configured.log"
+    log_path.write_text("startup failed for <redacted>\n", encoding="utf-8")
+    endpoint = ServerEndpoint("configured-7", 43123, "", log_path)
+
+    with pytest.raises(ReadinessError) as exc_info:
+        wait_for_server(endpoint, _ExitedProcess(), timeout=0.01)
+
+    message = str(exc_info.value)
+    assert "configured-7" in message
+    assert "exit code 17" in message
+    assert "startup failed for <redacted>" in message
+
+
+def test_readiness_sends_profile_specific_forwarded_prefix_headers():
+    observed = {}
+
+    class _Response:
+        status_code = 200
+
+    def request_get(url, **kwargs):
+        observed.update(url=url, **kwargs)
+        return _Response()
+
+    endpoint = ServerEndpoint(
+        "trusted-prefix",
+        43129,
+        "",
+        None,
+        (("X-Forwarded-Prefix", "/docsight, /docsight"),),
+    )
+
+    wait_for_server(endpoint, _RunningProcess(), request_get=request_get)
+
+    assert observed == {
+        "url": "http://127.0.0.1:43129/health",
+        "timeout": 2,
+        "headers": {"X-Forwarded-Prefix": "/docsight, /docsight"},
+    }
+
+
+def test_cleanup_uses_kill_fallback_and_verifies_closed_port():
+    process = _KillFallbackProcess()
+    endpoint = ServerEndpoint("demo-3", 43124, "", None)
+
+    cleanup_processes(
+        [(process, endpoint)],
+        join_timeout=0.01,
+        port_is_open=lambda _port: False,
+    )
+
+    assert process.calls == [
+        "terminate",
+        ("join", 0.01),
+        "kill",
+        ("join", 0.01),
+    ]
+
+
+def test_cleanup_fails_when_a_port_leaks_even_after_process_exit():
+    process = _ExitedProcess()
+    endpoint = ServerEndpoint("setup-2", 43125, "", None)
+
+    with pytest.raises(HarnessCleanupError, match="setup-2.*43125.*open"):
+        cleanup_processes(
+            [(process, endpoint)],
+            join_timeout=0.01,
+            port_is_open=lambda _port: True,
+        )
+
+
+def test_spawn_handoff_runs_two_isolated_servers_and_releases_ports(tmp_path):
+    reservations = [reserve_local_port(), reserve_local_port()]
+    ports = [reservation.port for reservation in reservations]
+    specs = [
+        ProcessSpec(
+            f"spawn-{index}",
+            reservation,
+            _serve_health_forever,
+            log_path=tmp_path / f"spawn-{index}.log",
+        )
+        for index, reservation in enumerate(reservations, 1)
+    ]
+
+    with running_processes(specs):
+        for port in ports:
+            assert urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/health", timeout=2
+            ).status == 200
+            with (
+                pytest.raises(OSError),
+                socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender,
+            ):
+                contender.bind(("127.0.0.1", port))
+
+    for port in ports:
+        _assert_port_reusable(port)
+
+
+def test_partial_spawn_failure_cleans_started_peer_and_redacts_log(tmp_path, capfd):
+    healthy = reserve_local_port()
+    failing = reserve_local_port()
+    ports = [healthy.port, failing.port]
+    credential = "startup credential"
+    specs = [
+        ProcessSpec(
+            "healthy-peer",
+            healthy,
+            _serve_health_forever,
+            log_path=tmp_path / "healthy.log",
+        ),
+        ProcessSpec(
+            "failing-peer",
+            failing,
+            _fail_during_startup,
+            log_path=tmp_path / "failing.log",
+            secrets=(credential,),
+        ),
+    ]
+
+    with pytest.raises(ReadinessError) as exc_info, running_processes(specs):
+        pytest.fail("partial startup unexpectedly succeeded")
+
+    assert credential not in str(exc_info.value)
+    assert "<redacted>" in str(exc_info.value)
+    assert credential not in capfd.readouterr().err
+    for port in ports:
+        _assert_port_reusable(port)
+
+
+def test_profiles_and_targets_are_immutable_and_environment_isolated(
+    tmp_path, monkeypatch
+):
+    profile = ServerProfile(
+        name="configured",
+        configured=True,
+        demo_mode=False,
+        base_path="/docsight",
+    )
+    target = ServerTarget(
+        identity="configured-gw0",
+        data_dir=str(tmp_path / "configured-gw0"),
+        port=43126,
+        profile=profile,
+    )
+
+    with pytest.raises(AttributeError):
+        profile.name = "changed"
+    with pytest.raises(AttributeError):
+        target.port = 1
+
+    monkeypatch.setenv("DEMO_MODE", "stale")
+    monkeypatch.setenv("REVERSE_PROXY_PREFIX", "9")
+    monkeypatch.setenv("ADMIN_PASSWORD", "must-not-leak")
+    monkeypatch.setenv("MODEM_TYPE", "must-not-leak")
+    monkeypatch.setenv("NOTIFY_APPRISE_TOKEN", "must-not-leak")
+    monkeypatch.setenv("UNRELATED_SECRET", "must-not-leak")
+    environment = target.environment()
+    assert environment["DATA_DIR"] == str(tmp_path / "configured-gw0")
+    assert environment["BASE_PATH"] == "/docsight"
+    assert environment["LOG_LEVEL"] == "WARNING"
+    assert "DEMO_MODE" not in environment
+    assert "REVERSE_PROXY_PREFIX" not in environment
+    assert "ADMIN_PASSWORD" not in environment
+    assert "MODEM_TYPE" not in environment
+    assert "NOTIFY_APPRISE_TOKEN" not in environment
+    assert "UNRELATED_SECRET" not in environment
+
+
+def test_target_repr_never_contains_credentials(tmp_path):
+    credential = "test-credential-value"
+    target = ServerTarget(
+        identity="auth-gw0",
+        data_dir=str(tmp_path / "auth-gw0"),
+        port=43127,
+        profile=ServerProfile(name="auth", configured=True, demo_mode=True),
+        admin_password=credential,
+    )
+
+    assert credential not in repr(target)
+
+
+def test_child_log_capture_redacts_credentials(tmp_path):
+    log_path = tmp_path / "auth.log"
+
+    def emit_secret(*, listener_socket):
+        assert listener_socket is None
+        print("credential=do-not-log-this")
+
+    _run_logged(
+        str(log_path),
+        ("do-not-log-this",),
+        emit_secret,
+        (),
+        None,
+    )
+
+    assert log_path.read_text(encoding="utf-8") == "credential=<redacted>\n"
+
+
+def test_production_startup_keeps_reserved_socket_through_app_main(
+    tmp_path, monkeypatch
+):
+    import waitress
+
+    listener = object()
+    observed = {}
+
+    def original_create_server(application, **kwargs):
+        observed.update(kwargs)
+        return object()
+
+    fake_main_module = ModuleType("app.main")
+
+    def fake_main():
+        from waitress import create_server
+
+        create_server(object(), host="127.0.0.1", port=43128, threads=4)
+
+    fake_main_module.main = fake_main
+    monkeypatch.setitem(sys.modules, "app.main", fake_main_module)
+    monkeypatch.setattr(waitress, "create_server", original_create_server)
+    monkeypatch.setattr(ServerTarget, "apply_environment", lambda self: None)
+    target = ServerTarget(
+        identity="first-run-gw0",
+        data_dir=str(tmp_path / "first-run-gw0"),
+        port=43128,
+        profile=ServerProfile(
+            name="first-run-production-startup",
+            configured=False,
+            demo_mode=False,
+            production_startup=True,
+        ),
+    )
+
+    serve_server(target, listener_socket=listener)
+
+    assert observed == {"sockets": [listener], "threads": 4}

--- a/tests/test_e2e_shards.py
+++ b/tests/test_e2e_shards.py
@@ -90,9 +90,9 @@ def test_repository_manifest_covers_every_e2e_file_once_and_531_cases():
     assert manifest["expected_total"] == EXPECTED_TOTAL == 531
     assert manifest["baseline_cpu_seconds"] > 0
     assert [shard["collected_cases"] for shard in manifest["shards"]] == [
-        177,
-        177,
-        177,
+        126,
+        214,
+        191,
     ]
     assert len(validated) == 27
 

--- a/tests/test_e2e_shards.py
+++ b/tests/test_e2e_shards.py
@@ -61,6 +61,7 @@ def _write_result(
         "started_utc": "2026-08-15T10:00:00+00:00",
         "ended_utc": "2026-08-15T10:00:01+00:00",
         "wall_seconds": 1.0,
+        "job_wall_seconds": 1.0,
         "cpu_seconds": 1.0,
         "peak_rss_kb": 1024,
         "platform": "test-linux",
@@ -90,9 +91,10 @@ def test_repository_manifest_covers_every_e2e_file_once_and_531_cases():
     assert manifest["expected_total"] == EXPECTED_TOTAL == 531
     assert manifest["baseline_cpu_seconds"] > 0
     assert [shard["collected_cases"] for shard in manifest["shards"]] == [
-        126,
-        214,
-        191,
+        80,
+        125,
+        158,
+        168,
     ]
     assert len(validated) == 27
 
@@ -169,6 +171,7 @@ def test_summary_rejects_cross_shard_nodes_and_failed_junit(tmp_path):
     [
         ("missing-receipt", "invalid run receipt"),
         ("wall", "12-minute"),
+        ("job-wall", "12-minute job wall"),
         ("cpu", "25% budget"),
         ("retry", "used retries"),
         ("process", "process or listener leaks"),
@@ -198,6 +201,9 @@ def test_summary_rejects_incomplete_or_over_budget_run_receipts(
         receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
         if defect == "wall":
             receipt["wall_seconds"] = 720
+            receipt["job_wall_seconds"] = 720
+        elif defect == "job-wall":
+            receipt["job_wall_seconds"] = 720
         elif defect == "cpu":
             manifest["baseline_cpu_seconds"] = 1
         elif defect == "retry":
@@ -227,7 +233,11 @@ def test_single_process_baseline_receipt_may_exceed_shard_wall_limit(tmp_path):
         "all",
         files,
         nodes,
-        receipt_overrides={"wall_seconds": 1800, "cpu_seconds": 1200},
+        receipt_overrides={
+            "wall_seconds": 1800,
+            "job_wall_seconds": 1800,
+            "cpu_seconds": 1200,
+        },
     )
 
     summary = summarize_results(
@@ -235,6 +245,7 @@ def test_single_process_baseline_receipt_may_exceed_shard_wall_limit(tmp_path):
     )
     assert summary.per_shard == (3,)
     assert summary.wall_seconds == (1800.0,)
+    assert summary.job_wall_seconds == (1800.0,)
 
 
 def test_workflow_runs_safe_non_retrying_shards_and_an_always_gate():
@@ -242,7 +253,9 @@ def test_workflow_runs_safe_non_retrying_shards_and_an_always_gate():
 
     assert "fail-fast: false" in workflow
     assert "single_process:" in workflow
-    assert "'[\"1\",\"2\",\"3\"]'" in workflow
+    assert "'[\"1\",\"2\",\"3\",\"4\"]'" in workflow
+    assert "max-parallel: 4" in workflow
+    assert "E2E_JOB_STARTED_EPOCH" in workflow
     assert "python scripts/e2e_shards.py run" in workflow
     assert "python scripts/e2e_shards.py summarize" in workflow
     assert "--expected-total 531" in workflow

--- a/tests/test_e2e_shards.py
+++ b/tests/test_e2e_shards.py
@@ -1,0 +1,263 @@
+"""Contracts for deterministic browser shard selection and aggregation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.e2e_shards import (
+    EXPECTED_TOTAL,
+    ManifestError,
+    ResultError,
+    load_manifest,
+    summarize_results,
+    validate_manifest,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+E2E_DIR = ROOT / "tests" / "e2e"
+MANIFEST = E2E_DIR / "shards.json"
+WORKFLOW = ROOT / ".github" / "workflows" / "full-e2e.yml"
+
+
+def _manifest(*shards):
+    return {
+        "version": 1,
+        "expected_total": 3,
+        "baseline_cpu_seconds": 100,
+        "shards": [
+            {
+                "id": index,
+                "collected_cases": len(files),
+                "files": list(files),
+            }
+            for index, files in enumerate(shards, 1)
+        ],
+    }
+
+
+def _write_result(
+    root, shard_id, files, node_ids, *, failures=0, receipt_overrides=None
+):
+    directory = root / f"full-e2e-shard-{shard_id}"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "shard-metadata.json").write_text(
+        json.dumps({"shard": shard_id, "files": files}), encoding="utf-8"
+    )
+    (directory / "collected.txt").write_text(
+        "".join(f"{node_id}\n" for node_id in node_ids), encoding="utf-8"
+    )
+    (directory / "junit.xml").write_text(
+        (
+            f'<testsuites tests="{len(node_ids)}" failures="{failures}" '
+            'errors="0" skipped="0"><testsuite/></testsuites>'
+        ),
+        encoding="utf-8",
+    )
+    receipt = {
+        "selection": shard_id,
+        "started_utc": "2026-08-15T10:00:00+00:00",
+        "ended_utc": "2026-08-15T10:00:01+00:00",
+        "wall_seconds": 1.0,
+        "cpu_seconds": 1.0,
+        "peak_rss_kb": 1024,
+        "platform": "test-linux",
+        "retry_count": 0,
+        "returncode": 0,
+        "junit": {
+            "tests": len(node_ids),
+            "failures": failures,
+            "errors": 0,
+            "skipped": 0,
+        },
+        "baseline_processes": [],
+        "baseline_listeners": [],
+        "leaked_processes": [],
+        "leaked_listeners": [],
+    }
+    receipt.update(receipt_overrides or {})
+    (directory / "run-receipt.json").write_text(
+        json.dumps(receipt), encoding="utf-8"
+    )
+
+
+def test_repository_manifest_covers_every_e2e_file_once_and_531_cases():
+    manifest = load_manifest(MANIFEST)
+    validated = validate_manifest(manifest, E2E_DIR)
+
+    assert manifest["expected_total"] == EXPECTED_TOTAL == 531
+    assert manifest["baseline_cpu_seconds"] > 0
+    assert [shard["collected_cases"] for shard in manifest["shards"]] == [
+        177,
+        177,
+        177,
+    ]
+    assert len(validated) == 27
+
+
+@pytest.mark.parametrize("defect", ["missing", "duplicate", "stale"])
+def test_manifest_validation_rejects_incomplete_or_ambiguous_membership(
+    tmp_path, defect
+):
+    e2e_dir = tmp_path / "e2e"
+    e2e_dir.mkdir()
+    for name in ("test_a.py", "test_b.py", "test_c.py"):
+        (e2e_dir / name).write_text("def test_case(): pass\n", encoding="utf-8")
+    manifest = _manifest(["test_a.py"], ["test_b.py"], ["test_c.py"])
+    if defect == "missing":
+        manifest["shards"][2]["files"] = []
+    elif defect == "duplicate":
+        manifest["shards"][2]["files"] = ["test_a.py", "test_c.py"]
+    else:
+        manifest["shards"][2]["files"] = ["test_c.py", "test_removed.py"]
+
+    with pytest.raises(ManifestError, match=defect):
+        validate_manifest(manifest, e2e_dir)
+
+
+def test_summary_requires_every_shard_and_exact_node_id_union(tmp_path):
+    manifest = _manifest(["test_a.py"], ["test_b.py"], ["test_c.py"])
+    e2e_dir = tmp_path / "e2e"
+    e2e_dir.mkdir()
+    for name in ("test_a.py", "test_b.py", "test_c.py"):
+        (e2e_dir / name).write_text("", encoding="utf-8")
+    _write_result(tmp_path, 1, ["test_a.py"], ["tests/e2e/test_a.py::test_a"])
+    _write_result(tmp_path, 2, ["test_b.py"], ["tests/e2e/test_b.py::test_b"])
+
+    with pytest.raises(ResultError, match="missing shard result.*3"):
+        summarize_results(tmp_path, manifest, expected_total=3, e2e_dir=e2e_dir)
+
+    _write_result(tmp_path, 3, ["test_c.py"], ["tests/e2e/test_c.py::test_c"])
+    assert summarize_results(
+        tmp_path, manifest, expected_total=3, e2e_dir=e2e_dir
+    ).total == 3
+
+
+def test_summary_rejects_cross_shard_nodes_and_failed_junit(tmp_path):
+    manifest = _manifest(["test_a.py"], ["test_b.py"], ["test_c.py"])
+    e2e_dir = tmp_path / "e2e"
+    e2e_dir.mkdir()
+    for name in ("test_a.py", "test_b.py", "test_c.py"):
+        (e2e_dir / name).write_text("", encoding="utf-8")
+    duplicate = "tests/e2e/test_a.py::test_a"
+    _write_result(tmp_path, 1, ["test_a.py"], [duplicate])
+    _write_result(tmp_path, 2, ["test_b.py"], [duplicate])
+    _write_result(
+        tmp_path,
+        3,
+        ["test_c.py"],
+        ["tests/e2e/test_c.py::test_c"],
+    )
+    with pytest.raises(ResultError, match="outside its manifest"):
+        summarize_results(tmp_path, manifest, expected_total=3, e2e_dir=e2e_dir)
+
+    _write_result(
+        tmp_path,
+        2,
+        ["test_b.py"],
+        ["tests/e2e/test_b.py::test_b"],
+        failures=1,
+    )
+    with pytest.raises(ResultError, match="failed, errored, or skipped"):
+        summarize_results(tmp_path, manifest, expected_total=3, e2e_dir=e2e_dir)
+
+
+@pytest.mark.parametrize(
+    ("defect", "match"),
+    [
+        ("missing-receipt", "invalid run receipt"),
+        ("wall", "12-minute"),
+        ("cpu", "25% budget"),
+        ("retry", "used retries"),
+        ("process", "process or listener leaks"),
+        ("listener", "process or listener leaks"),
+        ("missing-metric", "invalid wall time"),
+    ],
+)
+def test_summary_rejects_incomplete_or_over_budget_run_receipts(
+    tmp_path, defect, match
+):
+    manifest = _manifest(["test_a.py"], ["test_b.py"], ["test_c.py"])
+    e2e_dir = tmp_path / "e2e"
+    e2e_dir.mkdir()
+    for index, name in enumerate(("test_a.py", "test_b.py", "test_c.py"), 1):
+        (e2e_dir / name).write_text("", encoding="utf-8")
+        _write_result(
+            tmp_path,
+            index,
+            [name],
+            [f"tests/e2e/{name}::test_{index}"],
+        )
+
+    receipt_path = tmp_path / "full-e2e-shard-1" / "run-receipt.json"
+    if defect == "missing-receipt":
+        receipt_path.unlink()
+    else:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if defect == "wall":
+            receipt["wall_seconds"] = 720
+        elif defect == "cpu":
+            manifest["baseline_cpu_seconds"] = 1
+        elif defect == "retry":
+            receipt["retry_count"] = 1
+        elif defect == "process":
+            receipt["leaked_processes"] = [{"pid": 42, "name": "python"}]
+        elif defect == "listener":
+            receipt["leaked_listeners"] = [{"pid": 42, "port": 43129}]
+        else:
+            receipt["wall_seconds"] = None
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(ResultError, match=match):
+        summarize_results(tmp_path, manifest, expected_total=3, e2e_dir=e2e_dir)
+
+
+def test_single_process_baseline_receipt_may_exceed_shard_wall_limit(tmp_path):
+    manifest = _manifest(["test_a.py"], ["test_b.py"], ["test_c.py"])
+    e2e_dir = tmp_path / "e2e"
+    e2e_dir.mkdir()
+    files = ["test_a.py", "test_b.py", "test_c.py"]
+    for name in files:
+        (e2e_dir / name).write_text("", encoding="utf-8")
+    nodes = [f"tests/e2e/{name}::test_case" for name in files]
+    _write_result(
+        tmp_path,
+        "all",
+        files,
+        nodes,
+        receipt_overrides={"wall_seconds": 1800, "cpu_seconds": 1200},
+    )
+
+    summary = summarize_results(
+        tmp_path, manifest, expected_total=3, e2e_dir=e2e_dir
+    )
+    assert summary.per_shard == (3,)
+    assert summary.wall_seconds == (1800.0,)
+
+
+def test_workflow_runs_safe_non_retrying_shards_and_an_always_gate():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "fail-fast: false" in workflow
+    assert "single_process:" in workflow
+    assert "'[\"1\",\"2\",\"3\"]'" in workflow
+    assert "python scripts/e2e_shards.py run" in workflow
+    assert "python scripts/e2e_shards.py summarize" in workflow
+    assert "--expected-total 531" in workflow
+    assert "--receipt" in workflow
+    assert "run-receipt.json" in workflow
+    assert "if: always()" in workflow
+    assert "Upload shard results, logs, and traces" in workflow
+    assert "tests/e2e/screenshots/" in workflow
+    assert "--tracing=retain-on-failure" in workflow
+    assert "reverse:" in workflow
+    assert "E2E_REVERSE" in workflow
+    assert "CHANGE_DETECTION_RESULT" in workflow
+    assert "Fail closed when PR change detection did not succeed" in workflow
+    assert "actions/upload-artifact@v" not in workflow
+    assert "actions/download-artifact@v" not in workflow
+    assert "rerun" not in workflow.lower()
+    assert "retry" not in workflow.lower()
+    assert "$(" not in workflow


### PR DESCRIPTION
## Summary

- centralize E2E server startup, readiness, isolation, shutdown, and redacted diagnostics behind explicit immutable profiles
- split the canonical browser suite into four deterministic whole-file shards with fail-closed collection and result aggregation
- record JUnit, CPU, RSS, retry, process/listener leak, test wall, and CI job wall evidence for every shard
- retain the canonical unsharded path for rollback and baseline comparisons

## Before / After / Evidence

| Metric | Before | After | Evidence |
|---|---:|---:|---|
| Canonical E2E node IDs | 531 | 531 | `pytest --collect-only`; exact manifest union |
| E2E test functions | 469 | 469 | AST count in 27 `test_*.py` files |
| Complete workflow wall, run 1 | 27:38 | 10:12 | Actions runs [31872628493](https://github.com/itsDNNS/docsight/actions/runs/31872628493) / [31884046948](https://github.com/itsDNNS/docsight/actions/runs/31884046948) |
| Complete workflow wall, run 2 | 28:07 | 10:21 | Actions runs [31872627566](https://github.com/itsDNNS/docsight/actions/runs/31872627566) / [31884720838](https://github.com/itsDNNS/docsight/actions/runs/31884720838) |
| Complete workflow wall, run 3 | 27:44 | 10:16 | Actions runs [31872626428](https://github.com/itsDNNS/docsight/actions/runs/31872626428) / [31885195937](https://github.com/itsDNNS/docsight/actions/runs/31885195937) |
| Shard distribution | n/a | 80 / 125 / 158 / 168 | versioned whole-file manifest; 531 total |
| Aggregate shard CPU | 1,534.372 s baseline mean | 1,539.022 / 1,668.717 / 1,704.922 s | all below the 1,917.965 s budget |
| Retries / process leaks / listener leaks | newly instrumented | 0 / 0 / 0 in all three runs | machine-readable run receipts |
| Production Python | 39,499 LOC / 168 files | 39,499 LOC / 168 files | unchanged |
| Functional E2E tests | 9,802 LOC / 27 files | 9,823 LOC / 27 files | +21 LOC; no test removed |
| Fixture/server harness | 814 LOC / 2 files | 1,178 LOC / 6 files | lifecycle and profiles extracted from `conftest.py` |
| All Python tests | 66,773 LOC / 236 files | 67,776 LOC / 242 files | +1,003 LOC for harness and failure contracts |
| Complete diff | n/a | +2,242 / -462, net +1,780 LOC | explicit infrastructure investment, not code reduction |

## Validation

- `3758 passed, 2 skipped` in the complete non-E2E suite
- `51 passed` across shard, lifecycle, proxy, and defensive workflow contracts after the final four-shard change
- `9/9` native JavaScript tests
- canonical local browser run: `531 passed`
- reverse-order shard run: `177 passed`
- three sequential hosted qualification runs: exact 531-case union, no failures, skips, retries, or leaks; every full workflow below 12 minutes
- Ruff, compileall, YAML parsing, actionlint 1.7.12, and `git diff --check`

## Compatibility and rollback

Production startup and behavior are unchanged. Auth, setup, first-run, FritzBox, URL-prefix, real-proxy, reports, PWA, responsive, module, and security paths remain in the canonical suite. The server lifecycle and CI sharding are separate commits, and the original unsharded command remains available for rollback comparison.
