### PR TITLE
Centralize SQLite infrastructure and migrations

### DIFF
--- a/app/collectors/demo.py
+++ b/app/collectors/demo.py
@@ -7,9 +7,8 @@ import logging
 import math
 import os
 import random
-import sqlite3
 
-from app.storage.sqlite import connect_sqlite
+from app.storage.sqlite import bulk_write
 import struct
 import time
 import zlib
@@ -302,12 +301,12 @@ class DemoCollector(Collector):
             ))
 
         # Bulk insert for speed
-        with connect_sqlite(self._storage.db_path) as conn:
-            conn.executemany(
-                "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo) "
-                "VALUES (?, ?, ?, ?, ?)",
-                rows,
-            )
+        bulk_write(
+            self._storage.db_path,
+            "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo) "
+            "VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
         log.info("Demo: seeded %d historical snapshots (%d days)", len(rows), days)
 
     def _generate_historical_analysis(self, index, diurnal, seasonal, bad_period, hour=12, day_of_year=1):
@@ -838,21 +837,21 @@ class DemoCollector(Collector):
 
         # Bulk insert with is_demo=1 directly (save_speedtest_results doesn't support is_demo)
         if results:
-            with connect_sqlite(self._storage.db_path) as conn:
-                conn.executemany(
-                    "INSERT OR IGNORE INTO speedtest_results "
-                    "(id, timestamp, download_mbps, upload_mbps, download_human, "
-                    "upload_human, ping_ms, jitter_ms, packet_loss_pct, "
-                    "server_id, server_name, is_demo) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
-                    [
-                        (r["id"], r["timestamp"], r["download_mbps"],
-                         r["upload_mbps"], r["download_human"], r["upload_human"],
-                         r["ping_ms"], r["jitter_ms"], r["packet_loss_pct"],
-                         r["server_id"], r["server_name"])
-                        for r in results
-                    ],
-                )
+            bulk_write(
+                self._storage.db_path,
+                "INSERT OR IGNORE INTO speedtest_results "
+                "(id, timestamp, download_mbps, upload_mbps, download_human, "
+                "upload_human, ping_ms, jitter_ms, packet_loss_pct, "
+                "server_id, server_name, is_demo) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
+                [
+                    (r["id"], r["timestamp"], r["download_mbps"],
+                     r["upload_mbps"], r["download_human"], r["upload_human"],
+                     r["ping_ms"], r["jitter_ms"], r["packet_loss_pct"],
+                     r["server_id"], r["server_name"])
+                    for r in results
+                ],
+            )
 
         # Set latest result in web state for dashboard card
         if results:
@@ -862,16 +861,18 @@ class DemoCollector(Collector):
 
     def _seed_bqm_graphs(self, now):
         """Seed BQM placeholder graphs for the last 30 days."""
+        rows = []
         for d in range(DEMO_BQM_DAYS):
             date = (now - timedelta(days=d)).strftime("%Y-%m-%d")
             ts = (now - timedelta(days=d)).strftime("%Y-%m-%dT%H:%M:%SZ")
             png = self._generate_bqm_png(seed=d)
-            with connect_sqlite(self._storage.db_path) as conn:
-                conn.execute(
-                    "INSERT OR IGNORE INTO bqm_graphs (date, timestamp, image_blob, is_demo) "
-                    "VALUES (?, ?, ?, 1)",
-                    (date, ts, png),
-                )
+            rows.append((date, ts, png))
+        bulk_write(
+            self._storage.db_path,
+            "INSERT OR IGNORE INTO bqm_graphs (date, timestamp, image_blob, is_demo) "
+            "VALUES (?, ?, ?, 1)",
+            rows,
+        )
         log.info("Demo: seeded 30 BQM graphs")
 
     def _seed_bnetz_measurements(self, now):
@@ -954,17 +955,17 @@ class DemoCollector(Collector):
                 1,                    # is_demo
             ))
 
-        with connect_sqlite(self._storage.db_path) as conn:
-            conn.executemany(
-                "INSERT INTO bnetz_measurements "
-                "(date, timestamp, provider, tariff, "
-                "download_max_tariff, download_normal_tariff, download_min_tariff, "
-                "upload_max_tariff, upload_normal_tariff, upload_min_tariff, "
-                "download_measured_avg, upload_measured_avg, measurement_count, "
-                "verdict_download, verdict_upload, measurements_json, pdf_blob, source, is_demo) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                rows,
-            )
+        bulk_write(
+            self._storage.db_path,
+            "INSERT INTO bnetz_measurements "
+            "(date, timestamp, provider, tariff, "
+            "download_max_tariff, download_normal_tariff, download_min_tariff, "
+            "upload_max_tariff, upload_normal_tariff, upload_min_tariff, "
+            "download_measured_avg, upload_measured_avg, measurement_count, "
+            "verdict_download, verdict_upload, measurements_json, pdf_blob, source, is_demo) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
         log.info("Demo: seeded %d BNetzA measurement campaigns", len(rows))
 
     def _seed_weather_data(self, now):
@@ -988,12 +989,12 @@ class DemoCollector(Collector):
                     "timestamp": ts.strftime("%Y-%m-%d %H:%M:%SZ"),
                     "temperature": temp,
                 })
-        with connect_sqlite(self._storage.db_path) as conn:
-            conn.executemany(
-                "INSERT OR IGNORE INTO weather_data "
-                "(timestamp, temperature, is_demo) VALUES (?, ?, 1)",
-                [(r["timestamp"], r["temperature"]) for r in records],
-            )
+        bulk_write(
+            self._storage.db_path,
+            "INSERT OR IGNORE INTO weather_data "
+            "(timestamp, temperature, is_demo) VALUES (?, ?, 1)",
+            [(r["timestamp"], r["temperature"]) for r in records],
+        )
         log.info("Demo: seeded %d weather records (%d days)", len(records), days)
 
     def _seed_connection_monitor_data(self, now):
@@ -1081,12 +1082,12 @@ class DemoCollector(Collector):
                         lat = round(base + rng.uniform(-2, 3), 2)
                         rows.append((tid, ts, lat, False, "tcp"))
 
-        with cm._connect() as conn:
-            conn.executemany(
-                "INSERT INTO connection_samples (target_id, timestamp, latency_ms, timeout, probe_method) "
-                "VALUES (?, ?, ?, ?, ?)",
-                rows,
-            )
+        bulk_write(
+            cm.db_path,
+            "INSERT INTO connection_samples (target_id, timestamp, latency_ms, timeout, probe_method) "
+            "VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
 
         log.info("Demo: seeded %d connection monitor samples (%d days, 3 targets)", len(rows), days)
 

--- a/app/doctor.py
+++ b/app/doctor.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from typing import Any, Mapping
 from urllib.parse import urlsplit
 
+from app.storage.sqlite import open_readonly
+
 from .config import (
     DEFAULTS,
     DEMO_HIDE_KEYS,
@@ -302,7 +304,7 @@ def _check_database(data_dir: Path) -> CheckResult:
             details={"path": _safe_path(db_path)},
         )
     try:
-        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2) as conn:
+        with open_readonly(db_path, timeout=2) as conn:
             integrity = conn.execute("PRAGMA quick_check").fetchone()
             integrity_value = integrity[0] if integrity else "unknown"
             journal = conn.execute("PRAGMA journal_mode").fetchone()

--- a/app/modules/backup/backup.py
+++ b/app/modules/backup/backup.py
@@ -10,7 +10,12 @@ import os
 import shutil
 import sqlite3
 
-from app.storage.sqlite import connect_sqlite
+from app.storage.sqlite import (
+    consistent_copy,
+    open_readonly,
+    verify_database,
+    write_transaction,
+)
 import tarfile
 import tempfile
 from datetime import datetime, timezone
@@ -46,13 +51,14 @@ def _get_table_counts(db_path):
     """Return {table_name: row_count} for all user tables."""
     counts = {}
     try:
-        conn = connect_sqlite(db_path)
-        tables = [r[0] for r in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
-        ).fetchall()]
-        for t in tables:
-            counts[t] = conn.execute(f"SELECT COUNT(*) FROM [{t}]").fetchone()[0]  # noqa: S608
-        conn.close()
+        with open_readonly(db_path) as conn:
+            tables = [r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            ).fetchall()]
+            for table in tables:
+                counts[table] = conn.execute(
+                    f"SELECT COUNT(*) FROM [{table}]"  # noqa: S608
+                ).fetchone()[0]
     except Exception as e:
         log.warning("Could not read table counts: %s", e)
     return counts
@@ -67,24 +73,22 @@ def _vacuum_db(data_dir, db_name, dest_path):
     if not os.path.exists(src):
         return False
 
-    conn = connect_sqlite(src)
-    conn.execute(f"VACUUM INTO '{dest_path}'")
-    conn.close()
+    consistent_copy(src, dest_path)
 
     # Remove demo data from copy (only relevant for main DB)
     if db_name == "docsis_history.db":
-        copy_conn = connect_sqlite(dest_path)
         demo_tables = [
             "snapshots", "events", "journal_entries", "incidents",
             "speedtest_results", "bqm_graphs", "bnetz_measurements",
         ]
-        for table in demo_tables:
-            try:
-                copy_conn.execute(f"DELETE FROM [{table}] WHERE is_demo = 1")  # noqa: S608
-            except sqlite3.OperationalError:
-                pass  # table may not exist or lack is_demo column
-        copy_conn.commit()
-        copy_conn.close()
+        with write_transaction(dest_path) as conn:
+            for table in demo_tables:
+                try:
+                    conn.execute(
+                        f"DELETE FROM [{table}] WHERE is_demo = 1"  # noqa: S608
+                    )
+                except sqlite3.OperationalError:
+                    pass  # table may not exist or lack is_demo column
     return True
 
 
@@ -233,28 +237,72 @@ def restore_backup(archive_bytes, data_dir):
 
     os.makedirs(data_dir, exist_ok=True)
     restored_files = []
+    database_names = {"docsis_history.db", "connection_monitor.db"}
+    staged = {}
 
-    with tarfile.open(fileobj=archive_bytes, mode="r:gz") as tar:
-        for member in tar.getmembers():
-            if member.name == BACKUP_META_FILE:
-                continue
-            if member.name not in DATA_FILES:
-                log.warning("Skipping unknown file in backup: %s", member.name)
-                continue
+    try:
+        with tarfile.open(fileobj=archive_bytes, mode="r:gz") as tar:
+            for member in tar.getmembers():
+                if member.name == BACKUP_META_FILE:
+                    continue
+                if member.name not in DATA_FILES:
+                    log.warning("Skipping unknown file in backup: %s", member.name)
+                    continue
+                source = tar.extractfile(member)
+                if source is None:
+                    continue
 
-            # Security: ensure no path traversal
-            dest = os.path.join(data_dir, member.name)
-            if not os.path.realpath(dest).startswith(os.path.realpath(data_dir)):
-                log.warning("Skipping path traversal attempt: %s", member.name)
-                continue
+                fd, staged_path = tempfile.mkstemp(
+                    prefix=f".docsight-restore-{member.name}.",
+                    suffix=".tmp",
+                    dir=data_dir,
+                )
+                try:
+                    with os.fdopen(fd, "wb") as destination:
+                        shutil.copyfileobj(source, destination)
+                except BaseException:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+                    try:
+                        os.remove(staged_path)
+                    except FileNotFoundError:
+                        pass
+                    raise
+                staged[member.name] = staged_path
 
-            source = tar.extractfile(member)
-            if source is None:
+        for name, staged_path in staged.items():
+            if name not in database_names:
                 continue
+            try:
+                integrity = verify_database(staged_path)
+            except sqlite3.DatabaseError as exc:
+                raise ValueError(f"Restored database failed verification: {name}") from exc
+            if integrity.lower() != "ok":
+                raise ValueError(
+                    f"Restored database failed integrity check: {name}: {integrity}"
+                )
 
-            with open(dest, "wb") as f:
-                shutil.copyfileobj(source, f)
-            restored_files.append(member.name)
+        for name, staged_path in staged.items():
+            destination = os.path.join(data_dir, name)
+            os.replace(staged_path, destination)
+            staged[name] = None
+            if name in database_names:
+                for suffix in ("-wal", "-shm"):
+                    try:
+                        os.remove(destination + suffix)
+                    except FileNotFoundError:
+                        pass
+            restored_files.append(name)
+    finally:
+        for staged_path in staged.values():
+            if staged_path is None:
+                continue
+            try:
+                os.remove(staged_path)
+            except FileNotFoundError:
+                pass
 
     log.info("Restored %d files to %s", len(restored_files), data_dir)
     return {

--- a/app/modules/bnetz/migrations.py
+++ b/app/modules/bnetz/migrations.py
@@ -1,0 +1,46 @@
+"""BNetz storage schema migrations."""
+
+from app.storage.migrations import Migration, add_column_if_missing, table_columns, table_exists
+
+
+def _apply_baseline(conn):
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS bnetz_measurements (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, date TEXT NOT NULL,
+            timestamp TEXT NOT NULL, provider TEXT, tariff TEXT,
+            download_max_tariff REAL, download_normal_tariff REAL,
+            download_min_tariff REAL, upload_max_tariff REAL,
+            upload_normal_tariff REAL, upload_min_tariff REAL,
+            download_measured_avg REAL, upload_measured_avg REAL,
+            measurement_count INTEGER, verdict_download TEXT, verdict_upload TEXT,
+            measurements_json TEXT, pdf_blob BLOB, source TEXT DEFAULT 'upload',
+            is_demo INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+
+
+def _baseline_applied(_conn):
+    # Replay idempotent schema declarations once to repair missing indexes.
+    return False
+
+
+def _columns_applied(conn):
+    columns = table_columns(conn, "bnetz_measurements")
+    return not columns or {"source", "is_demo"} <= columns
+
+
+def _apply_columns(conn):
+    add_column_if_missing(
+        conn, "bnetz_measurements", "source", "source TEXT DEFAULT 'upload'"
+    )
+    add_column_if_missing(
+        conn, "bnetz_measurements", "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0"
+    )
+
+
+MIGRATIONS = (
+    Migration("bnetz-0001-baseline", _apply_baseline, _baseline_applied),
+    Migration("bnetz-0002-columns", _apply_columns, _columns_applied),
+)

--- a/app/modules/bnetz/storage.py
+++ b/app/modules/bnetz/storage.py
@@ -2,9 +2,10 @@
 
 import json
 import logging
-import sqlite3
 
-from app.storage.sqlite import connect_sqlite
+from app.storage.migrations import run_migrations
+from app.storage.sqlite import open_read, write_transaction
+from .migrations import MIGRATIONS
 
 from app.tz import utc_now
 
@@ -23,40 +24,7 @@ class BnetzStorage:
 
     def _ensure_table(self):
         """Create the bnetz_measurements table if it doesn't exist."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS bnetz_measurements ("
-                "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                "  date TEXT NOT NULL,"
-                "  timestamp TEXT NOT NULL,"
-                "  provider TEXT,"
-                "  tariff TEXT,"
-                "  download_max_tariff REAL,"
-                "  download_normal_tariff REAL,"
-                "  download_min_tariff REAL,"
-                "  upload_max_tariff REAL,"
-                "  upload_normal_tariff REAL,"
-                "  upload_min_tariff REAL,"
-                "  download_measured_avg REAL,"
-                "  upload_measured_avg REAL,"
-                "  measurement_count INTEGER,"
-                "  verdict_download TEXT,"
-                "  verdict_upload TEXT,"
-                "  measurements_json TEXT,"
-                "  pdf_blob BLOB,"
-                "  source TEXT DEFAULT 'upload',"
-                "  is_demo INTEGER NOT NULL DEFAULT 0"
-                ")"
-            )
-            # Migration: add source/is_demo columns if missing
-            try:
-                cols = [r[1] for r in conn.execute("PRAGMA table_info(bnetz_measurements)").fetchall()]
-                if "source" not in cols:
-                    conn.execute("ALTER TABLE bnetz_measurements ADD COLUMN source TEXT DEFAULT 'upload'")
-                if "is_demo" not in cols:
-                    conn.execute("ALTER TABLE bnetz_measurements ADD COLUMN is_demo INTEGER NOT NULL DEFAULT 0")
-            except Exception:
-                pass
+        run_migrations(self.db_path, MIGRATIONS)
 
     def save_bnetz_measurement(self, parsed_data, pdf_bytes=None, source="upload"):
         """Save a parsed BNetzA measurement with optional PDF. Returns the new id."""
@@ -65,7 +33,7 @@ class BnetzStorage:
             "download": parsed_data.get("measurements_download", []),
             "upload": parsed_data.get("measurements_upload", []),
         }
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             cur = conn.execute(
                 "INSERT INTO bnetz_measurements "
                 "(date, timestamp, provider, tariff, "
@@ -99,8 +67,7 @@ class BnetzStorage:
 
     def get_bnetz_measurements(self, limit=50):
         """Return list of BNetzA measurements (without PDF blob), newest first."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT id, date, timestamp, provider, tariff, "
                 "download_max_tariff, download_normal_tariff, download_min_tariff, "
@@ -126,7 +93,7 @@ class BnetzStorage:
 
     def get_bnetz_pdf(self, measurement_id):
         """Return the original PDF bytes for a BNetzA measurement, or None."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             row = conn.execute(
                 "SELECT pdf_blob FROM bnetz_measurements WHERE id = ?",
                 (measurement_id,),
@@ -135,7 +102,7 @@ class BnetzStorage:
 
     def delete_bnetz_measurement(self, measurement_id):
         """Delete a BNetzA measurement. Returns True if found."""
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             rowcount = conn.execute(
                 "DELETE FROM bnetz_measurements WHERE id = ?",
                 (measurement_id,),
@@ -144,8 +111,7 @@ class BnetzStorage:
 
     def get_bnetz_in_range(self, start_ts, end_ts):
         """Return BNetzA measurements within a time range, oldest first."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT id, date, timestamp, provider, tariff, "
                 "download_max_tariff, download_measured_avg, "
@@ -160,8 +126,7 @@ class BnetzStorage:
 
     def get_latest_bnetz(self):
         """Return the most recent BNetzA measurement (without blob), or None."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             row = conn.execute(
                 "SELECT id, date, timestamp, provider, tariff, "
                 "download_max_tariff, download_normal_tariff, download_min_tariff, "

--- a/app/modules/bqm/migrations.py
+++ b/app/modules/bqm/migrations.py
@@ -1,0 +1,50 @@
+"""BQM storage schema migrations."""
+
+from app.storage.migrations import Migration, add_column_if_missing, table_columns, table_exists
+
+
+_SCHEMA = (
+    """
+    CREATE TABLE IF NOT EXISTS bqm_graphs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, date TEXT NOT NULL UNIQUE,
+        timestamp TEXT NOT NULL, image_blob BLOB NOT NULL,
+        is_demo INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS bqm_data (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL,
+        date TEXT NOT NULL, sent_polls INTEGER NOT NULL,
+        lost_polls INTEGER NOT NULL DEFAULT 0, latency_min_ms REAL NOT NULL,
+        latency_avg_ms REAL NOT NULL, latency_max_ms REAL NOT NULL,
+        score INTEGER NOT NULL, UNIQUE(timestamp)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_bqm_data_date ON bqm_data(date)",
+    "CREATE TABLE IF NOT EXISTS bqm_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+)
+
+
+def _apply_baseline(conn):
+    for statement in _SCHEMA:
+        conn.execute(statement)
+
+
+def _baseline_applied(_conn):
+    # Replay idempotent schema declarations once to repair missing indexes.
+    return False
+
+
+def _demo_applied(conn):
+    columns = table_columns(conn, "bqm_graphs")
+    return not columns or "is_demo" in columns
+
+
+def _apply_demo(conn):
+    add_column_if_missing(conn, "bqm_graphs", "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0")
+
+
+MIGRATIONS = (
+    Migration("bqm-0001-baseline", _apply_baseline, _baseline_applied),
+    Migration("bqm-0002-demo-flag", _apply_demo, _demo_applied),
+)

--- a/app/modules/bqm/storage.py
+++ b/app/modules/bqm/storage.py
@@ -1,9 +1,10 @@
 """Standalone BQM storage for legacy PNG graphs and native CSV data."""
 
 import logging
-import sqlite3
 
-from app.storage.sqlite import connect_sqlite
+from app.storage.migrations import run_migrations
+from app.storage.sqlite import bulk_write, open_read, write_transaction
+from .migrations import MIGRATIONS
 
 from app.tz import local_today, utc_now
 
@@ -23,56 +24,15 @@ class BqmStorage:
 
     def _ensure_table(self):
         """Create the BQM tables if they don't exist."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS bqm_graphs ("
-                "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                "  date TEXT NOT NULL UNIQUE,"
-                "  timestamp TEXT NOT NULL,"
-                "  image_blob BLOB NOT NULL,"
-                "  is_demo INTEGER NOT NULL DEFAULT 0"
-                ")"
-            )
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS bqm_data ("
-                "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                "  timestamp TEXT NOT NULL,"
-                "  date TEXT NOT NULL,"
-                "  sent_polls INTEGER NOT NULL,"
-                "  lost_polls INTEGER NOT NULL DEFAULT 0,"
-                "  latency_min_ms REAL NOT NULL,"
-                "  latency_avg_ms REAL NOT NULL,"
-                "  latency_max_ms REAL NOT NULL,"
-                "  score INTEGER NOT NULL,"
-                "  UNIQUE(timestamp)"
-                ")"
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_bqm_data_date "
-                "ON bqm_data(date)"
-            )
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS bqm_meta ("
-                "  key TEXT PRIMARY KEY,"
-                "  value TEXT NOT NULL"
-                ")"
-            )
-            # Migration: add is_demo column if missing
-            try:
-                cols = [r[1] for r in conn.execute("PRAGMA table_info(bqm_graphs)").fetchall()]
-                if "is_demo" not in cols:
-                    conn.execute("ALTER TABLE bqm_graphs ADD COLUMN is_demo INTEGER NOT NULL DEFAULT 0")
-            except Exception:
-                pass
+        run_migrations(self.db_path, MIGRATIONS)
 
     def store_csv_data(self, rows):
         """Bulk insert CSV-derived BQM rows, ignoring duplicates by timestamp."""
         if not rows:
             return
         try:
-            with connect_sqlite(self.db_path) as conn:
-                conn.execute("PRAGMA busy_timeout = 5000")
-                conn.executemany(
+            bulk_write(
+                self.db_path,
                     "INSERT OR IGNORE INTO bqm_data "
                     "(timestamp, date, sent_polls, lost_polls, latency_min_ms, "
                     "latency_avg_ms, latency_max_ms, score) "
@@ -97,8 +57,7 @@ class BqmStorage:
             raise
 
     def _rows_for_query(self, query, params):
-        with connect_sqlite(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             rows = conn.execute(query, params).fetchall()
         return [dict(r) for r in rows]
 
@@ -122,7 +81,7 @@ class BqmStorage:
 
     def get_csv_dates(self):
         """Return list of dates with CSV data (newest first)."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT DISTINCT date FROM bqm_data ORDER BY date DESC"
             ).fetchall()
@@ -130,7 +89,7 @@ class BqmStorage:
 
     def has_csv_data(self, target_date):
         """Return True if CSV data exists for the given date."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             row = conn.execute(
                 "SELECT 1 FROM bqm_data WHERE date = ? LIMIT 1",
                 (target_date,),
@@ -142,7 +101,7 @@ class BqmStorage:
         target_date = graph_date or local_today(self.tz_name)
         ts = utc_now()
         try:
-            with connect_sqlite(self.db_path) as conn:
+            with write_transaction(self.db_path) as conn:
                 conn.execute(
                     "INSERT OR IGNORE INTO bqm_graphs (date, timestamp, image_blob) VALUES (?, ?, ?)",
                     (target_date, ts, image_data),
@@ -155,7 +114,7 @@ class BqmStorage:
         """Import a BQM graph for a specific date.
         Returns: 'imported', 'skipped', or 'replaced'."""
         ts = date + "T00:00:00"
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             existing = conn.execute(
                 "SELECT 1 FROM bqm_graphs WHERE date = ?", (date,)
             ).fetchone()
@@ -175,13 +134,13 @@ class BqmStorage:
 
     def delete_bqm_graph(self, date):
         """Delete a single BQM graph. Returns True if deleted."""
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             cur = conn.execute("DELETE FROM bqm_graphs WHERE date = ?", (date,))
         return cur.rowcount > 0
 
     def delete_bqm_graphs_range(self, start_date, end_date):
         """Delete BQM graphs in date range (inclusive). Returns count."""
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             cur = conn.execute(
                 "DELETE FROM bqm_graphs WHERE date >= ? AND date <= ?",
                 (start_date, end_date),
@@ -190,13 +149,13 @@ class BqmStorage:
 
     def delete_all_bqm_graphs(self):
         """Delete all BQM graphs. Returns count."""
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             cur = conn.execute("DELETE FROM bqm_graphs")
         return cur.rowcount
 
     def get_bqm_dates(self):
         """Return list of dates with BQM graphs (newest first)."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT date FROM bqm_graphs ORDER BY date DESC"
             ).fetchall()
@@ -204,7 +163,7 @@ class BqmStorage:
 
     def get_bqm_graph(self, date):
         """Return BQM graph PNG bytes for a date, or None."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             row = conn.execute(
                 "SELECT image_blob FROM bqm_graphs WHERE date = ?", (date,)
             ).fetchone()
@@ -212,7 +171,7 @@ class BqmStorage:
 
     def set_meta(self, key, value):
         """Persist a module metadata key."""
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             conn.execute(
                 "INSERT INTO bqm_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -221,7 +180,7 @@ class BqmStorage:
 
     def get_collection_metadata(self):
         """Return persisted BQM collection metadata."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             rows = conn.execute("SELECT key, value FROM bqm_meta").fetchall()
         return {key: value for key, value in rows}
 
@@ -234,8 +193,8 @@ class BqmStorage:
             "last_success_mode": mode,
             "last_success_rows": rows,
         }
-        with connect_sqlite(self.db_path) as conn:
-            conn.executemany(
+        bulk_write(
+            self.db_path,
                 "INSERT INTO bqm_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                 [(key, str(value)) for key, value in values.items()],

--- a/app/modules/connection_monitor/migrations.py
+++ b/app/modules/connection_monitor/migrations.py
@@ -1,0 +1,89 @@
+"""Connection Monitor storage schema migrations."""
+
+from app.storage.migrations import Migration, add_column_if_missing, table_columns, table_exists
+
+
+_SCHEMA = (
+    """
+    CREATE TABLE IF NOT EXISTS connection_targets (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT NOT NULL, host TEXT NOT NULL,
+        enabled BOOLEAN NOT NULL DEFAULT 1, poll_interval_ms INTEGER NOT NULL DEFAULT 5000,
+        probe_method TEXT NOT NULL DEFAULT 'auto', tcp_port INTEGER NOT NULL DEFAULT 443,
+        is_demo INTEGER NOT NULL DEFAULT 0, created_at REAL NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS connection_samples (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, target_id INTEGER NOT NULL,
+        timestamp REAL NOT NULL, latency_ms REAL, timeout BOOLEAN NOT NULL DEFAULT 0,
+        probe_method TEXT NOT NULL,
+        FOREIGN KEY (target_id) REFERENCES connection_targets(id) ON DELETE CASCADE
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_samples_target_ts ON connection_samples (target_id, timestamp)",
+    """
+    CREATE TABLE IF NOT EXISTS connection_samples_aggregated (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, target_id INTEGER NOT NULL,
+        bucket_start REAL NOT NULL, bucket_seconds INTEGER NOT NULL,
+        avg_latency_ms REAL, min_latency_ms REAL, max_latency_ms REAL,
+        p95_latency_ms REAL, packet_loss_pct REAL NOT NULL, sample_count INTEGER NOT NULL,
+        FOREIGN KEY (target_id) REFERENCES connection_targets(id) ON DELETE CASCADE,
+        UNIQUE(target_id, bucket_start, bucket_seconds)
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_agg_target_bucket
+    ON connection_samples_aggregated (target_id, bucket_seconds, bucket_start)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS connection_monitor_pinned_days (
+        date TEXT NOT NULL PRIMARY KEY, label TEXT, created_at REAL NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS traceroute_traces (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, target_id INTEGER NOT NULL,
+        timestamp REAL NOT NULL, trigger_reason TEXT NOT NULL, hop_count INTEGER NOT NULL,
+        route_fingerprint TEXT, reached_target INTEGER NOT NULL DEFAULT 0,
+        is_demo INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (target_id) REFERENCES connection_targets(id) ON DELETE CASCADE
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_traces_target_ts ON traceroute_traces(target_id, timestamp)",
+    """
+    CREATE TABLE IF NOT EXISTS traceroute_hops (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, trace_id INTEGER NOT NULL,
+        hop_index INTEGER NOT NULL, hop_ip TEXT, hop_host TEXT, latency_ms REAL,
+        probes_responded INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (trace_id) REFERENCES traceroute_traces(id) ON DELETE CASCADE
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_hops_trace ON traceroute_hops(trace_id)",
+)
+
+
+def _apply_baseline(conn):
+    for statement in _SCHEMA:
+        conn.execute(statement)
+
+
+def _baseline_applied(_conn):
+    # Replay idempotent schema declarations once to repair missing indexes.
+    return False
+
+
+def _demo_applied(conn):
+    columns = table_columns(conn, "connection_targets")
+    return not columns or "is_demo" in columns
+
+
+def _apply_demo(conn):
+    add_column_if_missing(
+        conn, "connection_targets", "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0"
+    )
+
+
+MIGRATIONS = (
+    Migration("connection-monitor-0001-baseline", _apply_baseline, _baseline_applied),
+    Migration("connection-monitor-0002-demo-flag", _apply_demo, _demo_applied),
+)

--- a/app/modules/connection_monitor/storage.py
+++ b/app/modules/connection_monitor/storage.py
@@ -3,9 +3,10 @@
 import logging
 import math
 import os
-import sqlite3
 
-from app.storage.sqlite import connect_sqlite
+from app.storage.migrations import run_migrations
+from app.storage.sqlite import bulk_write, open_read, write_transaction
+from .migrations import MIGRATIONS
 import time
 
 logger = logging.getLogger(__name__)
@@ -19,134 +20,44 @@ class ConnectionMonitorStorage:
         os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
         self._init_tables()
 
-    def _connect(self) -> sqlite3.Connection:
-        conn = connect_sqlite(self.db_path)
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA foreign_keys=ON")
-        conn.row_factory = sqlite3.Row
-        return conn
+    def _connect(self):
+        """Compatibility context for internal test setup writes."""
+        return write_transaction(self.db_path)
+
+    def _read(self):
+        return open_read(self.db_path)
+
+    def _write(self):
+        return write_transaction(self.db_path)
 
     def _init_tables(self):
-        with self._connect() as conn:
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS connection_targets (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    label TEXT NOT NULL,
-                    host TEXT NOT NULL,
-                    enabled BOOLEAN NOT NULL DEFAULT 1,
-                    poll_interval_ms INTEGER NOT NULL DEFAULT 5000,
-                    probe_method TEXT NOT NULL DEFAULT 'auto',
-                    tcp_port INTEGER NOT NULL DEFAULT 443,
-                    is_demo INTEGER NOT NULL DEFAULT 0,
-                    created_at REAL NOT NULL
-                )
-            """)
-            target_columns = {
-                row["name"]
-                for row in conn.execute("PRAGMA table_info(connection_targets)")
-            }
-            if "is_demo" not in target_columns:
-                conn.execute(
-                    "ALTER TABLE connection_targets "
-                    "ADD COLUMN is_demo INTEGER NOT NULL DEFAULT 0"
-                )
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS connection_samples (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    target_id INTEGER NOT NULL,
-                    timestamp REAL NOT NULL,
-                    latency_ms REAL,
-                    timeout BOOLEAN NOT NULL DEFAULT 0,
-                    probe_method TEXT NOT NULL,
-                    FOREIGN KEY (target_id) REFERENCES connection_targets(id)
-                        ON DELETE CASCADE
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_samples_target_ts
-                ON connection_samples (target_id, timestamp)
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS connection_samples_aggregated (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    target_id INTEGER NOT NULL,
-                    bucket_start REAL NOT NULL,
-                    bucket_seconds INTEGER NOT NULL,
-                    avg_latency_ms REAL,
-                    min_latency_ms REAL,
-                    max_latency_ms REAL,
-                    p95_latency_ms REAL,
-                    packet_loss_pct REAL NOT NULL,
-                    sample_count INTEGER NOT NULL,
-                    FOREIGN KEY (target_id) REFERENCES connection_targets(id)
-                        ON DELETE CASCADE,
-                    UNIQUE(target_id, bucket_start, bucket_seconds)
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_agg_target_bucket
-                ON connection_samples_aggregated (target_id, bucket_seconds, bucket_start)
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS connection_monitor_pinned_days (
-                    date TEXT NOT NULL PRIMARY KEY,
-                    label TEXT,
-                    created_at REAL NOT NULL
-                )
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS traceroute_traces (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    target_id INTEGER NOT NULL,
-                    timestamp REAL NOT NULL,
-                    trigger_reason TEXT NOT NULL,
-                    hop_count INTEGER NOT NULL,
-                    route_fingerprint TEXT,
-                    reached_target INTEGER NOT NULL DEFAULT 0,
-                    is_demo INTEGER NOT NULL DEFAULT 0,
-                    FOREIGN KEY (target_id) REFERENCES connection_targets(id) ON DELETE CASCADE
-                )
-            """)
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_traces_target_ts ON traceroute_traces(target_id, timestamp)")
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS traceroute_hops (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    trace_id INTEGER NOT NULL,
-                    hop_index INTEGER NOT NULL,
-                    hop_ip TEXT,
-                    hop_host TEXT,
-                    latency_ms REAL,
-                    probes_responded INTEGER NOT NULL DEFAULT 0,
-                    FOREIGN KEY (trace_id) REFERENCES traceroute_traces(id) ON DELETE CASCADE
-                )
-            """)
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_hops_trace ON traceroute_hops(trace_id)")
+        run_migrations(self.db_path, MIGRATIONS)
 
     # --- Pinned Days ---
 
     def pin_day(self, date: str, label: str | None = None):
-        with self._connect() as conn:
+        with self._write() as conn:
             conn.execute(
                 "INSERT OR IGNORE INTO connection_monitor_pinned_days (date, label, created_at) VALUES (?, ?, ?)",
                 (date, label, time.time()),
             )
 
     def unpin_day(self, date: str) -> bool:
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "DELETE FROM connection_monitor_pinned_days WHERE date = ?", (date,)
             )
             return cur.rowcount > 0
 
     def get_pinned_days(self) -> list[dict]:
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT * FROM connection_monitor_pinned_days ORDER BY date DESC"
             ).fetchall()
             return [dict(r) for r in rows]
 
     def is_day_pinned(self, date: str) -> bool:
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT 1 FROM connection_monitor_pinned_days WHERE date = ?", (date,)
             ).fetchone()
@@ -164,7 +75,7 @@ class ConnectionMonitorStorage:
         tcp_port: int = 443,
         is_demo: bool = False,
     ) -> int:
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 """INSERT INTO connection_targets
                    (label, host, enabled, poll_interval_ms, probe_method, tcp_port,
@@ -178,14 +89,14 @@ class ConnectionMonitorStorage:
             return cur.lastrowid
 
     def get_targets(self) -> list[dict]:
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT * FROM connection_targets ORDER BY id"
             ).fetchall()
             return [dict(r) for r in rows]
 
     def get_target(self, target_id: int) -> dict | None:
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT * FROM connection_targets WHERE id = ?", (target_id,)
             ).fetchone()
@@ -198,7 +109,7 @@ class ConnectionMonitorStorage:
             return False
         set_clause = ", ".join(f"{k} = ?" for k in updates)
         values = list(updates.values()) + [target_id]
-        with self._connect() as conn:
+        with self._write() as conn:
             conn.execute(
                 f"UPDATE connection_targets SET {set_clause} WHERE id = ?",
                 values,
@@ -206,14 +117,14 @@ class ConnectionMonitorStorage:
             return True
 
     def delete_target(self, target_id: int):
-        with self._connect() as conn:
+        with self._write() as conn:
             conn.execute(
                 "DELETE FROM connection_targets WHERE id = ?", (target_id,)
             )
 
     def purge_demo_targets(self) -> int:
         """Delete demo targets and their cascaded samples without touching user targets."""
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "DELETE FROM connection_targets WHERE is_demo = 1"
             )
@@ -224,13 +135,13 @@ class ConnectionMonitorStorage:
     def save_samples(self, samples: list[dict]):
         if not samples:
             return
-        with self._connect() as conn:
-            conn.executemany(
-                """INSERT INTO connection_samples
-                   (target_id, timestamp, latency_ms, timeout, probe_method)
-                   VALUES (:target_id, :timestamp, :latency_ms, :timeout, :probe_method)""",
-                samples,
-            )
+        bulk_write(
+            self.db_path,
+            """INSERT INTO connection_samples
+               (target_id, timestamp, latency_ms, timeout, probe_method)
+               VALUES (:target_id, :timestamp, :latency_ms, :timeout, :probe_method)""",
+            samples,
+        )
 
     def _build_sample_where(
         self,
@@ -262,7 +173,7 @@ class ConnectionMonitorStorage:
         if limit > 0:
             query += " LIMIT ?"
             params.append(limit)
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(query, params).fetchall()
             return [dict(r) for r in rows]
 
@@ -273,7 +184,7 @@ class ConnectionMonitorStorage:
         end: float | None = None,
     ) -> dict[str, object]:
         where, params = self._build_sample_where(target_id, start=start, end=end)
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 f"""
                 SELECT
@@ -314,7 +225,7 @@ class ConnectionMonitorStorage:
 
     def get_summary(self, target_id: int, window_seconds: int = 60) -> dict[str, object]:
         cutoff = time.time() - window_seconds
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 """SELECT
                     COUNT(*) as sample_count,
@@ -347,7 +258,7 @@ class ConnectionMonitorStorage:
             clauses.append("timestamp <= ?")
             params.append(end)
         where = " AND ".join(clauses)
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 f"SELECT timestamp, timeout FROM connection_samples WHERE {where} ORDER BY timestamp",
                 params,
@@ -401,7 +312,7 @@ class ConnectionMonitorStorage:
             clauses.append("bucket_start <= ?")
             params.append(end)
         where = " AND ".join(clauses)
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 f"SELECT * FROM connection_samples_aggregated WHERE {where} ORDER BY bucket_start",
                 params,
@@ -417,7 +328,7 @@ class ConnectionMonitorStorage:
         per bucket. Deletes aggregated raw samples. Returns number of
         buckets created.
         """
-        with self._connect() as conn:
+        with self._write() as conn:
             rows = conn.execute(
                 """SELECT timestamp, latency_ms, timeout
                    FROM connection_samples
@@ -496,7 +407,7 @@ class ConnectionMonitorStorage:
         p95 is approximated as MAX(p95) of constituent buckets.
         Returns number of target buckets created.
         """
-        with self._connect() as conn:
+        with self._write() as conn:
             rows = conn.execute(
                 """SELECT bucket_start, avg_latency_ms, min_latency_ms,
                           max_latency_ms, p95_latency_ms, packet_loss_pct,
@@ -601,7 +512,7 @@ class ConnectionMonitorStorage:
 
     def save_trace(self, target_id, timestamp, trigger_reason, hops,
                    route_fingerprint, reached_target, is_demo=False):
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 """INSERT INTO traceroute_traces
                    (target_id, timestamp, trigger_reason, hop_count,
@@ -612,18 +523,18 @@ class ConnectionMonitorStorage:
             )
             trace_id = cur.lastrowid
             if hops:
-                conn.executemany(
-                    """INSERT INTO traceroute_hops
-                       (trace_id, hop_index, hop_ip, hop_host, latency_ms, probes_responded)
-                       VALUES (?, ?, ?, ?, ?, ?)""",
-                    [(trace_id, h["hop_index"], h["hop_ip"], h.get("hop_host"),
-                      h.get("latency_ms"), h.get("probes_responded", 0)) for h in hops],
-                )
+                for hop in hops:
+                    conn.execute(
+                        """INSERT INTO traceroute_hops
+                           (trace_id, hop_index, hop_ip, hop_host, latency_ms, probes_responded)
+                           VALUES (?, ?, ?, ?, ?, ?)""",
+                        (trace_id, hop["hop_index"], hop["hop_ip"], hop.get("hop_host"),
+                         hop.get("latency_ms"), hop.get("probes_responded", 0)),
+                    )
             return trace_id
 
     def get_traces(self, target_id, start=None, end=None, limit=100):
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             sql = "SELECT * FROM traceroute_traces WHERE target_id = ?"
             params = [target_id]
             if start is not None:
@@ -638,16 +549,14 @@ class ConnectionMonitorStorage:
             return [dict(r) for r in rows]
 
     def get_trace(self, trace_id):
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT * FROM traceroute_traces WHERE id = ?", (trace_id,)
             ).fetchone()
             return dict(row) if row else None
 
     def get_trace_hops(self, trace_id):
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT * FROM traceroute_hops WHERE trace_id = ? ORDER BY hop_index",
                 (trace_id,),
@@ -659,7 +568,7 @@ class ConnectionMonitorStorage:
             return
         cutoff = time.time() - (retention_days * 86400)
         pinned = self.get_pinned_days()
-        with self._connect() as conn:
+        with self._write() as conn:
             if pinned:
                 placeholders = ",".join("?" * len(pinned))
                 conn.execute(
@@ -670,7 +579,7 @@ class ConnectionMonitorStorage:
                 conn.execute("DELETE FROM traceroute_traces WHERE timestamp < ?", (cutoff,))
 
     def purge_demo_traces(self):
-        with self._connect() as conn:
+        with self._write() as conn:
             conn.execute("DELETE FROM traceroute_traces WHERE is_demo = 1")
 
     # --- Retention ---
@@ -679,7 +588,7 @@ class ConnectionMonitorStorage:
         if retention_days <= 0:
             return 0
         cutoff = time.time() - (retention_days * 86400)
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 """DELETE FROM connection_samples WHERE timestamp < ?
                    AND date(timestamp, 'unixepoch', 'localtime')

--- a/app/modules/evidence/routes.py
+++ b/app/modules/evidence/routes.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sqlite3
 
-from app.storage.sqlite import connect_sqlite
+from app.storage.sqlite import open_read
 from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -79,8 +79,7 @@ def _normalise_window_ts(value: str, tz_name: str) -> str:
 
 def _get_journal_entries_for_window(db_path: str, start_ts: str, end_ts: str) -> list[dict[str, Any]]:
     start_date, end_date = _local_date_bounds_for_window(start_ts, end_ts, _get_tz_name())
-    with connect_sqlite(db_path) as conn:
-        conn.row_factory = sqlite3.Row
+    with open_read(db_path) as conn:
         rows = conn.execute(
             "SELECT id, date, title, description, icon, incident_id, created_at, updated_at "
             "FROM journal_entries WHERE date >= ? AND date <= ? ORDER BY date DESC, id DESC",
@@ -144,8 +143,7 @@ def _get_connection_latency_rows(start_ts: str, end_ts: str) -> list[dict[str, A
     end_epoch = _utc_ts_to_epoch(end_ts)
     rows: list[dict[str, Any]] = []
     try:
-        with connect_sqlite(db_path) as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(db_path) as conn:
             raw = conn.execute(
                 """
                 SELECT

--- a/app/modules/journal/migrations.py
+++ b/app/modules/journal/migrations.py
@@ -1,0 +1,63 @@
+"""Journal storage schema migrations."""
+
+from app.storage.migrations import (
+    Migration,
+    add_column_if_missing,
+    table_columns,
+    table_exists,
+)
+
+
+_SCHEMA = (
+    """
+    CREATE TABLE IF NOT EXISTS journal_entries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, date TEXT NOT NULL, title TEXT NOT NULL,
+        description TEXT, icon TEXT, incident_id INTEGER, created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL, is_demo INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS journal_attachments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, entry_id INTEGER NOT NULL,
+        filename TEXT NOT NULL, mime_type TEXT NOT NULL, data BLOB NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (entry_id) REFERENCES journal_entries(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS incidents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT,
+        status TEXT NOT NULL DEFAULT 'open', start_date TEXT, end_date TEXT, icon TEXT,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+        is_demo INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+)
+
+
+def _apply_baseline(conn):
+    for statement in _SCHEMA:
+        conn.execute(statement)
+
+
+def _baseline_applied(_conn):
+    # Replay idempotent schema declarations once to repair missing indexes.
+    return False
+
+
+def _demo_applied(conn):
+    return all(
+        not table_exists(conn, table) or "is_demo" in table_columns(conn, table)
+        for table in ("journal_entries", "incidents")
+    )
+
+
+def _apply_demo(conn):
+    for table in ("journal_entries", "incidents"):
+        add_column_if_missing(conn, table, "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0")
+
+
+MIGRATIONS = (
+    Migration("journal-0001-baseline", _apply_baseline, _baseline_applied),
+    Migration("journal-0002-demo-flags", _apply_demo, _demo_applied),
+)

--- a/app/modules/journal/storage.py
+++ b/app/modules/journal/storage.py
@@ -1,9 +1,9 @@
 """Standalone journal entries, attachments, and incidents storage."""
 
 import logging
-import sqlite3
-
-from app.storage.sqlite import connect_sqlite
+from app.storage.migrations import run_migrations
+from app.storage.sqlite import open_read, write_transaction
+from .migrations import MIGRATIONS
 
 from app.tz import utc_now
 
@@ -23,66 +23,24 @@ class JournalStorage:
 
     def _ensure_table(self):
         """Create the journal tables if they don't exist."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS journal_entries (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    date TEXT NOT NULL,
-                    title TEXT NOT NULL,
-                    description TEXT,
-                    icon TEXT,
-                    incident_id INTEGER,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    is_demo INTEGER NOT NULL DEFAULT 0
-                )
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS journal_attachments (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    entry_id INTEGER NOT NULL,
-                    filename TEXT NOT NULL,
-                    mime_type TEXT NOT NULL,
-                    data BLOB NOT NULL,
-                    created_at TEXT NOT NULL,
-                    FOREIGN KEY (entry_id) REFERENCES journal_entries(id) ON DELETE CASCADE
-                )
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS incidents (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    name TEXT NOT NULL,
-                    description TEXT,
-                    status TEXT NOT NULL DEFAULT 'open',
-                    start_date TEXT,
-                    end_date TEXT,
-                    icon TEXT,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    is_demo INTEGER NOT NULL DEFAULT 0
-                )
-            """)
-            # Migration: add is_demo column if missing
-            for tbl in ("journal_entries", "incidents"):
-                try:
-                    cols = [r[1] for r in conn.execute(f"PRAGMA table_info({tbl})").fetchall()]
-                    if "is_demo" not in cols:
-                        conn.execute(f"ALTER TABLE {tbl} ADD COLUMN is_demo INTEGER NOT NULL DEFAULT 0")
-                except Exception:
-                    pass
+        run_migrations(self.db_path, MIGRATIONS)
 
     def _connect(self):
-        """Return a connection with foreign keys enabled."""
-        conn = connect_sqlite(self.db_path)
-        conn.execute("PRAGMA foreign_keys = ON")
-        return conn
+        """Compatibility context for internal test setup writes."""
+        return write_transaction(self.db_path)
+
+    def _read(self):
+        return open_read(self.db_path)
+
+    def _write(self):
+        return write_transaction(self.db_path)
 
     # ── Journal Entries ──
 
     def save_entry(self, date, title, description, icon=None, incident_id=None, is_demo=False):
         """Create a new journal entry. Returns the new entry id."""
         now = utc_now()
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "INSERT INTO journal_entries (date, title, description, icon, incident_id, created_at, updated_at, is_demo) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
@@ -93,7 +51,7 @@ class JournalStorage:
     def update_entry(self, entry_id, date, title, description, icon=None, incident_id=None):
         """Update an existing journal entry. Returns True if found."""
         now = utc_now()
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "UPDATE journal_entries SET date=?, title=?, description=?, icon=?, incident_id=?, updated_at=? WHERE id=?",
                 (date, title, description, icon, incident_id, now, entry_id),
@@ -102,7 +60,7 @@ class JournalStorage:
 
     def delete_entry(self, entry_id):
         """Delete a journal entry (CASCADE deletes attachments). Returns True if found."""
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "DELETE FROM journal_entries WHERE id=?", (entry_id,)
             ).rowcount
@@ -137,15 +95,13 @@ class JournalStorage:
             query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY i.date DESC, i.created_at DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(query, params).fetchall()
         return [dict(r) for r in rows]
 
     def get_entry(self, entry_id):
         """Return single journal entry with attachment metadata (no blob data)."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT id, date, title, description, icon, incident_id, created_at, updated_at FROM journal_entries WHERE id=?",
                 (entry_id,),
@@ -163,7 +119,7 @@ class JournalStorage:
     def save_attachment(self, entry_id, filename, mime_type, data):
         """Save a file attachment for a journal entry. Returns attachment id."""
         now = utc_now()
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "INSERT INTO journal_attachments (entry_id, filename, mime_type, data, created_at) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -173,8 +129,7 @@ class JournalStorage:
 
     def get_attachment(self, attachment_id):
         """Return attachment dict with data bytes, or None."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT id, entry_id, filename, mime_type, data, created_at "
                 "FROM journal_attachments WHERE id=?",
@@ -188,7 +143,7 @@ class JournalStorage:
 
     def delete_attachment(self, attachment_id):
         """Delete a single attachment. Returns True if found."""
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "DELETE FROM journal_attachments WHERE id=?", (attachment_id,)
             ).rowcount
@@ -196,7 +151,7 @@ class JournalStorage:
 
     def get_attachment_count(self, entry_id):
         """Return number of attachments for a journal entry."""
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT COUNT(*) FROM journal_attachments WHERE entry_id=?",
                 (entry_id,),
@@ -205,7 +160,7 @@ class JournalStorage:
 
     def check_entry_exists(self, date, title):
         """Check if a journal entry with same date + title exists. Returns True/False."""
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT 1 FROM journal_entries WHERE date=? AND title=? LIMIT 1",
                 (date, title),
@@ -214,7 +169,7 @@ class JournalStorage:
 
     def delete_all_entries(self):
         """Delete all journal entries (CASCADE deletes attachments). Returns count."""
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute("DELETE FROM journal_entries").rowcount
         return rowcount
 
@@ -223,7 +178,7 @@ class JournalStorage:
         if not ids:
             return 0
         placeholders = ",".join("?" for _ in ids)
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "DELETE FROM journal_entries WHERE id IN (%s)" % placeholders, ids
             ).rowcount
@@ -263,8 +218,7 @@ class JournalStorage:
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY i.date DESC, i.created_at DESC"
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(query, params).fetchall()
         return [dict(r) for r in rows]
 
@@ -273,7 +227,7 @@ class JournalStorage:
     def save_incident(self, name, description=None, status="open", start_date=None, end_date=None, icon=None, is_demo=False):
         """Create a new incident container. Returns the new incident id."""
         now = utc_now()
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "INSERT INTO incidents (name, description, status, start_date, end_date, icon, created_at, updated_at, is_demo) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -284,7 +238,7 @@ class JournalStorage:
     def update_incident(self, incident_id, name, description=None, status="open", start_date=None, end_date=None, icon=None):
         """Update an existing incident container. Returns True if found."""
         now = utc_now()
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "UPDATE incidents SET name=?, description=?, status=?, start_date=?, end_date=?, icon=?, updated_at=? WHERE id=?",
                 (name, description, status, start_date, end_date, icon, now, incident_id),
@@ -293,7 +247,7 @@ class JournalStorage:
 
     def delete_incident(self, incident_id):
         """Delete an incident container. Entries become unassigned (SET NULL). Returns True if found."""
-        with self._connect() as conn:
+        with self._write() as conn:
             # Unassign entries first
             conn.execute(
                 "UPDATE journal_entries SET incident_id = NULL WHERE incident_id = ?",
@@ -317,15 +271,13 @@ class JournalStorage:
             query += " WHERE i.status = ?"
             params.append(status)
         query += " ORDER BY i.created_at DESC"
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(query, params).fetchall()
         return [dict(r) for r in rows]
 
     def get_incident(self, incident_id):
         """Return single incident container with entry_count."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT i.id, i.name, i.description, i.status, i.start_date, i.end_date, "
                 "i.icon, i.created_at, i.updated_at, "
@@ -340,7 +292,7 @@ class JournalStorage:
         if not entry_ids:
             return 0
         placeholders = ",".join("?" for _ in entry_ids)
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "UPDATE journal_entries SET incident_id = ? WHERE id IN (%s)" % placeholders,
                 [incident_id] + list(entry_ids),
@@ -352,7 +304,7 @@ class JournalStorage:
         if not entry_ids:
             return 0
         placeholders = ",".join("?" for _ in entry_ids)
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "UPDATE journal_entries SET incident_id = NULL WHERE id IN (%s)" % placeholders,
                 list(entry_ids),
@@ -361,7 +313,7 @@ class JournalStorage:
 
     def assign_entries_by_date_range(self, incident_id, start_date, end_date):
         """Assign all journal entries in a date range to an incident. Returns count."""
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "UPDATE journal_entries SET incident_id = ? WHERE date >= ? AND date <= ?",
                 (incident_id, start_date, end_date),

--- a/app/modules/speedtest/migrations.py
+++ b/app/modules/speedtest/migrations.py
@@ -1,0 +1,56 @@
+"""Speedtest storage schema migrations."""
+
+from app.storage.migrations import Migration, add_column_if_missing, table_columns, table_exists
+
+
+_ENRICHED_COLUMNS = (
+    ("isp", "TEXT"), ("server_host", "TEXT"), ("server_location", "TEXT"),
+    ("server_country", "TEXT"), ("server_ip", "TEXT"), ("ping_low", "REAL"),
+    ("ping_high", "REAL"), ("dl_latency_iqm", "REAL"),
+    ("dl_latency_jitter", "REAL"), ("ul_latency_iqm", "REAL"),
+    ("ul_latency_jitter", "REAL"), ("dl_bytes", "INTEGER"),
+    ("ul_bytes", "INTEGER"), ("dl_elapsed_ms", "INTEGER"),
+    ("ul_elapsed_ms", "INTEGER"), ("external_ip", "TEXT"),
+    ("is_vpn", "INTEGER"), ("result_url", "TEXT"),
+)
+
+
+def _apply_baseline(conn):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS speedtest_results ("
+        "id INTEGER PRIMARY KEY, timestamp TEXT NOT NULL, download_mbps REAL, upload_mbps REAL, "
+        "download_human TEXT, upload_human TEXT, ping_ms REAL, jitter_ms REAL, "
+        "packet_loss_pct REAL, server_id INTEGER, server_name TEXT, "
+        "is_demo INTEGER NOT NULL DEFAULT 0)"
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_speedtest_ts ON speedtest_results(timestamp)")
+    conn.execute("CREATE TABLE IF NOT EXISTS speedtest_meta (key TEXT PRIMARY KEY, value TEXT)")
+
+
+def _baseline_applied(_conn):
+    # Replay idempotent schema declarations once to repair missing indexes.
+    return False
+
+
+def _columns_applied(conn):
+    columns = table_columns(conn, "speedtest_results")
+    required = {"server_id", "server_name", "is_demo", *(name for name, _ in _ENRICHED_COLUMNS)}
+    return not columns or required <= columns
+
+
+def _apply_columns(conn):
+    add_column_if_missing(conn, "speedtest_results", "server_id", "server_id INTEGER")
+    add_column_if_missing(conn, "speedtest_results", "server_name", "server_name TEXT")
+    add_column_if_missing(
+        conn, "speedtest_results", "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0"
+    )
+    for name, column_type in _ENRICHED_COLUMNS:
+        add_column_if_missing(
+            conn, "speedtest_results", name, f"{name} {column_type}"
+        )
+
+
+MIGRATIONS = (
+    Migration("speedtest-0001-baseline", _apply_baseline, _baseline_applied),
+    Migration("speedtest-0002-columns", _apply_columns, _columns_applied),
+)

--- a/app/modules/speedtest/routes.py
+++ b/app/modules/speedtest/routes.py
@@ -10,7 +10,7 @@ from app.config import parse_config_bool
 from app.web import require_auth, get_config_manager, get_state, get_storage, clear_speedtest_latest
 from app.runtime import current_runtime
 from app.i18n import get_translations
-from app.storage.sqlite import connect_sqlite
+from app.storage.sqlite import open_read
 
 from .client import SpeedtestClient
 from .storage import SpeedtestStorage
@@ -71,7 +71,7 @@ def _enrich_speedtest(result):
 def _annotate_smart_capture(results, db_path):
     """Annotate speedtest results with smart_capture flag."""
     try:
-        with connect_sqlite(db_path) as conn:
+        with open_read(db_path) as conn:
             rows = conn.execute(
                 "SELECT linked_result_id FROM smart_capture_executions "
                 "WHERE status = 'completed' AND linked_result_id IS NOT NULL"

--- a/app/modules/speedtest/storage.py
+++ b/app/modules/speedtest/storage.py
@@ -1,9 +1,10 @@
 """Standalone speedtest result storage."""
 
 import logging
-import sqlite3
 
-from app.storage.sqlite import connect_sqlite
+from app.storage.migrations import run_migrations
+from app.storage.sqlite import bulk_write, open_read, write_transaction
+from .migrations import MIGRATIONS
 from datetime import datetime, timezone
 
 log = logging.getLogger("docsis.storage.speedtest")
@@ -20,122 +21,49 @@ class SpeedtestStorage:
         self._ensure_table()
 
     def _ensure_table(self):
-        """Create the speedtest_results and speedtest_meta tables if they don't exist."""
-        with connect_sqlite(self.db_path) as conn:
+        """Create and migrate the speedtest tables."""
+        run_migrations(self.db_path, MIGRATIONS)
+        self._migrate_timestamps()
+
+    def _migrate_timestamps(self):
+        """Normalize offset-bearing timestamps once, preserving existing behavior."""
+        with write_transaction(self.db_path) as conn:
+            migrated = conn.execute(
+                "SELECT value FROM speedtest_meta WHERE key = 'ts_migrated'"
+            ).fetchone()
+            if migrated:
+                return
+            rows = conn.execute(
+                "SELECT id, timestamp FROM speedtest_results "
+                "WHERE timestamp GLOB '*[+-][0-9][0-9]:[0-9][0-9]'"
+            ).fetchall()
+            updated = 0
+            for row_id, timestamp in rows:
+                try:
+                    parsed = datetime.fromisoformat(timestamp)
+                except (ValueError, TypeError):
+                    continue
+                if parsed.tzinfo is None:
+                    continue
+                normalized = parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                conn.execute(
+                    "UPDATE speedtest_results SET timestamp = ? WHERE id = ?",
+                    (normalized, row_id),
+                )
+                updated += 1
             conn.execute(
-                "CREATE TABLE IF NOT EXISTS speedtest_results ("
-                "  id INTEGER PRIMARY KEY,"
-                "  timestamp TEXT NOT NULL,"
-                "  download_mbps REAL,"
-                "  upload_mbps REAL,"
-                "  download_human TEXT,"
-                "  upload_human TEXT,"
-                "  ping_ms REAL,"
-                "  jitter_ms REAL,"
-                "  packet_loss_pct REAL,"
-                "  server_id INTEGER,"
-                "  server_name TEXT,"
-                "  is_demo INTEGER NOT NULL DEFAULT 0"
-                ")"
+                "INSERT OR REPLACE INTO speedtest_meta (key, value) VALUES ('ts_migrated', '1')"
             )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_speedtest_ts "
-                "ON speedtest_results(timestamp)"
-            )
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS speedtest_meta ("
-                "  key TEXT PRIMARY KEY,"
-                "  value TEXT"
-                ")"
-            )
-            # Migration: add server_id/server_name columns if missing
-            try:
-                conn.execute("ALTER TABLE speedtest_results ADD COLUMN server_id INTEGER")
-            except Exception:
-                pass
-            try:
-                conn.execute("ALTER TABLE speedtest_results ADD COLUMN server_name TEXT")
-            except Exception:
-                pass
-            # Migration: add is_demo column if missing
-            try:
-                cols = [r[1] for r in conn.execute("PRAGMA table_info(speedtest_results)").fetchall()]
-                if "is_demo" not in cols:
-                    conn.execute("ALTER TABLE speedtest_results ADD COLUMN is_demo INTEGER NOT NULL DEFAULT 0")
-            except Exception:
-                pass
-            # Migration: add enriched detail columns if missing
-            try:
-                cols = [r[1] for r in conn.execute("PRAGMA table_info(speedtest_results)").fetchall()]
-                enriched_cols = [
-                    ("isp", "TEXT"),
-                    ("server_host", "TEXT"),
-                    ("server_location", "TEXT"),
-                    ("server_country", "TEXT"),
-                    ("server_ip", "TEXT"),
-                    ("ping_low", "REAL"),
-                    ("ping_high", "REAL"),
-                    ("dl_latency_iqm", "REAL"),
-                    ("dl_latency_jitter", "REAL"),
-                    ("ul_latency_iqm", "REAL"),
-                    ("ul_latency_jitter", "REAL"),
-                    ("dl_bytes", "INTEGER"),
-                    ("ul_bytes", "INTEGER"),
-                    ("dl_elapsed_ms", "INTEGER"),
-                    ("ul_elapsed_ms", "INTEGER"),
-                    ("external_ip", "TEXT"),
-                    ("is_vpn", "INTEGER"),
-                    ("result_url", "TEXT"),
-                ]
-                for col_name, col_type in enriched_cols:
-                    if col_name not in cols:
-                        conn.execute(
-                            f"ALTER TABLE speedtest_results ADD COLUMN {col_name} {col_type}"
-                        )
-            except Exception:
-                pass
-            # One-time migration: normalize offset-bearing timestamps to UTC Z-suffix.
-            # Only runs once, tracked via speedtest_meta to avoid repeated scans.
-            try:
-                migrated = conn.execute(
-                    "SELECT value FROM speedtest_meta WHERE key = 'ts_migrated'"
-                ).fetchone()
-                if not migrated:
-                    # Match only timestamps with explicit +HH:MM or -HH:MM offset
-                    # (not plain ISO like 2026-03-21T12:34:56 or ...Z)
-                    rows = conn.execute(
-                        "SELECT id, timestamp FROM speedtest_results "
-                        "WHERE timestamp GLOB '*[+-][0-9][0-9]:[0-9][0-9]'"
-                    ).fetchall()
-                    if rows:
-                        updates = []
-                        for row_id, ts in rows:
-                            try:
-                                dt = datetime.fromisoformat(ts)
-                                if dt.tzinfo is not None:
-                                    dt = dt.astimezone(timezone.utc)
-                                    updates.append((dt.strftime("%Y-%m-%dT%H:%M:%SZ"), row_id))
-                            except (ValueError, TypeError):
-                                pass
-                        if updates:
-                            conn.executemany(
-                                "UPDATE speedtest_results SET timestamp = ? WHERE id = ?",
-                                updates,
-                            )
-                            log.info("Normalized %d existing timestamps to UTC", len(updates))
-                    conn.execute(
-                        "INSERT OR REPLACE INTO speedtest_meta (key, value) VALUES ('ts_migrated', '1')"
-                    )
-            except Exception:
-                pass
+            if updated:
+                log.info("Normalized %d existing timestamps to UTC", updated)
 
     def save_speedtest_results(self, results):
         """Bulk insert speedtest results, upserting enriched fields on conflict."""
         if not results:
             return
         try:
-            with connect_sqlite(self.db_path) as conn:
-                conn.executemany(
+            bulk_write(
+                self.db_path,
                     "INSERT INTO speedtest_results "
                     "(id, timestamp, download_mbps, upload_mbps, download_human, "
                     "upload_human, ping_ms, jitter_ms, packet_loss_pct, "
@@ -190,8 +118,7 @@ class SpeedtestStorage:
 
     def get_speedtest_results(self, limit=2000):
         """Return cached speedtest results, newest first."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT id, timestamp, download_mbps, upload_mbps, download_human, "
                 "upload_human, ping_ms, jitter_ms, packet_loss_pct, "
@@ -203,8 +130,7 @@ class SpeedtestStorage:
 
     def get_speedtest_by_id(self, result_id):
         """Return a single speedtest result by id, or None (includes enriched fields)."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             row = conn.execute(
                 "SELECT id, timestamp, download_mbps, upload_mbps, download_human, "
                 "upload_human, ping_ms, jitter_ms, packet_loss_pct, "
@@ -220,13 +146,13 @@ class SpeedtestStorage:
 
     def get_speedtest_count(self):
         """Return number of cached speedtest results."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             row = conn.execute("SELECT COUNT(*) FROM speedtest_results").fetchone()
         return row[0] if row else 0
 
     def get_latest_speedtest_id(self):
         """Return the highest speedtest result id, or 0 if none."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             row = conn.execute(
                 "SELECT MAX(id) FROM speedtest_results"
             ).fetchone()
@@ -238,7 +164,7 @@ class SpeedtestStorage:
 
     def get_meta(self, key):
         """Return a metadata value, or None."""
-        with connect_sqlite(self.db_path) as conn:
+        with open_read(self.db_path) as conn:
             row = conn.execute(
                 "SELECT value FROM speedtest_meta WHERE key = ?", (key,)
             ).fetchone()
@@ -246,7 +172,7 @@ class SpeedtestStorage:
 
     def set_meta(self, key, value):
         """Set a metadata value (upsert)."""
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             conn.execute(
                 "INSERT INTO speedtest_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -292,7 +218,7 @@ class SpeedtestStorage:
 
     def clear_cache(self):
         """Delete all cached speedtest results (non-demo)."""
-        with connect_sqlite(self.db_path) as conn:
+        with write_transaction(self.db_path) as conn:
             count = conn.execute(
                 "SELECT COUNT(*) FROM speedtest_results WHERE is_demo = 0"
             ).fetchone()[0]
@@ -302,8 +228,7 @@ class SpeedtestStorage:
 
     def get_speedtest_in_range(self, start_ts, end_ts):
         """Return speedtest results within a time range, oldest first."""
-        with connect_sqlite(self.db_path) as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT id, timestamp, download_mbps, upload_mbps, download_human, "
                 "upload_human, ping_ms, jitter_ms, packet_loss_pct "

--- a/app/modules/weather/migrations.py
+++ b/app/modules/weather/migrations.py
@@ -1,0 +1,32 @@
+"""Weather storage schema migrations."""
+
+from app.storage.migrations import Migration, add_column_if_missing, table_columns, table_exists
+
+
+def _apply_baseline(conn):
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS weather_data ("
+        "timestamp TEXT PRIMARY KEY, temperature REAL NOT NULL, is_demo INTEGER DEFAULT 0)"
+    )
+
+
+def _baseline_applied(_conn):
+    # Replay idempotent schema declarations once to repair missing indexes.
+    return False
+
+
+def _demo_applied(conn):
+    columns = table_columns(conn, "weather_data")
+    return not columns or "is_demo" in columns
+
+
+def _apply_demo(conn):
+    add_column_if_missing(
+        conn, "weather_data", "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0"
+    )
+
+
+MIGRATIONS = (
+    Migration("weather-0001-baseline", _apply_baseline, _baseline_applied),
+    Migration("weather-0002-demo-flag", _apply_demo, _demo_applied),
+)

--- a/app/modules/weather/storage.py
+++ b/app/modules/weather/storage.py
@@ -1,9 +1,14 @@
 """Standalone weather data storage."""
 
 import logging
-import sqlite3
-
-from app.storage.sqlite import DEFAULT_SQLITE_BUSY_TIMEOUT_MS, connect_sqlite
+from app.storage.migrations import run_migrations
+from app.storage.sqlite import (
+    DEFAULT_SQLITE_BUSY_TIMEOUT_MS,
+    bulk_write,
+    open_read,
+    write_transaction,
+)
+from .migrations import MIGRATIONS
 import threading
 from collections import defaultdict
 from pathlib import Path
@@ -36,22 +41,13 @@ class WeatherStorage:
         self._ensure_table()
 
     def _connect(self):
-        """Return a connection with WAL mode and busy timeout."""
-        conn = connect_sqlite(self.db_path)
-        conn.execute("PRAGMA journal_mode=WAL")
-        return conn
+        """Compatibility context for internal test setup writes."""
+        return write_transaction(self.db_path)
 
     def _ensure_table(self):
         """Create the weather_data table if it doesn't exist."""
         with self._lock:
-            with self._connect() as conn:
-                conn.execute(
-                    "CREATE TABLE IF NOT EXISTS weather_data ("
-                    "  timestamp TEXT PRIMARY KEY,"
-                    "  temperature REAL NOT NULL,"
-                    "  is_demo INTEGER DEFAULT 0"
-                    ")"
-                )
+            run_migrations(self.db_path, MIGRATIONS)
 
     def save_weather_data(self, records, is_demo=False):
         """Bulk insert weather records, ignoring duplicates by timestamp.
@@ -64,20 +60,19 @@ class WeatherStorage:
             return
         try:
             with self._lock:
-                with self._connect() as conn:
-                    conn.executemany(
-                        "INSERT OR IGNORE INTO weather_data "
-                        "(timestamp, temperature, is_demo) VALUES (?, ?, ?)",
-                        [(r["timestamp"], r["temperature"], int(is_demo)) for r in records],
-                    )
+                bulk_write(
+                    self.db_path,
+                    "INSERT OR IGNORE INTO weather_data "
+                    "(timestamp, temperature, is_demo) VALUES (?, ?, ?)",
+                    [(r["timestamp"], r["temperature"], int(is_demo)) for r in records],
+                )
             log.debug("Saved %d weather records", len(records))
         except Exception as e:
             log.error("Failed to save weather data: %s", e)
 
     def get_weather_data(self, limit=2000):
         """Return weather data, newest first."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT timestamp, temperature FROM weather_data "
                 "ORDER BY timestamp DESC LIMIT ?",
@@ -89,8 +84,7 @@ class WeatherStorage:
         """Return weather data within a timestamp range, oldest first."""
         start_ts = _normalize_range_ts(start_ts, " ")
         end_ts = _normalize_range_ts(end_ts, " ")
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT timestamp, temperature FROM weather_data "
                 "WHERE timestamp >= ? AND timestamp <= ? "
@@ -101,6 +95,6 @@ class WeatherStorage:
 
     def get_weather_count(self):
         """Return number of weather records."""
-        with self._connect() as conn:
+        with open_read(self.db_path) as conn:
             row = conn.execute("SELECT COUNT(*) FROM weather_data").fetchone()
         return row[0] if row else 0

--- a/app/storage/analysis.py
+++ b/app/storage/analysis.py
@@ -1,7 +1,6 @@
 """Channel history and correlation timeline mixin."""
 
 import json
-import sqlite3
 
 from app.channel_selector import match_channel, match_channels
 
@@ -87,8 +86,7 @@ class AnalysisMethods:
                 })
 
         if "events" in sources:
-            with self._connect() as conn:
-                conn.row_factory = sqlite3.Row
+            with self._read() as conn:
                 rows = conn.execute(
                     "SELECT id, timestamp, severity, event_type, message, details "
                     "FROM events WHERE timestamp >= ? AND timestamp <= ? "
@@ -133,8 +131,7 @@ class AnalysisMethods:
         # Smart Capture executions
         if "capture" in sources:
             try:
-                with self._connect() as conn:
-                    conn.row_factory = sqlite3.Row
+                with self._read() as conn:
                     rows = conn.execute(
                         "SELECT * FROM smart_capture_executions "
                         "WHERE created_at >= ? AND created_at <= ? "
@@ -195,7 +192,7 @@ class AnalysisMethods:
         _COL_MAP = {"ds": "ds_channels_json", "us": "us_channels_json"}
         _COL_MAP[direction]  # validated in web.py to be 'ds' or 'us'
         cutoff = utc_cutoff(hours=hours) if hours is not None else utc_cutoff(days=days)
-        with self._connect() as conn:
+        with self._read() as conn:
             if direction == "ds":
                 rows = conn.execute(
                     "SELECT timestamp, ds_channels_json FROM snapshots WHERE timestamp >= ? ORDER BY timestamp",
@@ -232,7 +229,7 @@ class AnalysisMethods:
         )
         cutoff = utc_cutoff(hours=hours) if hours is not None else utc_cutoff(days=days)
         col = "ds_channels_json" if direction == "ds" else "us_channels_json"
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 f"SELECT timestamp, {col} FROM snapshots WHERE timestamp >= ? ORDER BY timestamp",
                 (cutoff,),

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -1,52 +1,17 @@
-"""Storage base class with schema init and constants."""
+"""Storage base class with managed SQLite access."""
 
-import logging
 import os
-import sqlite3
 
-from .sqlite import connect_sqlite
-from contextlib import contextmanager
+from .migrations import CORE_MIGRATIONS, SCHEMA_VERSION, run_migrations
+from .sqlite import open_read, write_transaction
 
 
 ALLOWED_MIME_TYPES = {
     "image/png", "image/jpeg", "image/gif", "image/webp",
     "application/pdf", "text/plain",
 }
-MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10 MB
+MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024
 MAX_ATTACHMENTS_PER_ENTRY = 10
-
-log = logging.getLogger("docsis.storage")
-SCHEMA_VERSION = 2
-
-
-def _table_columns(conn, table):
-    return [row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()]
-
-
-def _table_exists(conn, table):
-    row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
-        (table,),
-    ).fetchone()
-    return row is not None
-
-
-def _add_column_if_missing(conn, table, column, ddl):
-    if not _table_exists(conn, table):
-        return False
-    if column in _table_columns(conn, table):
-        return False
-    conn.execute(f"ALTER TABLE {table} ADD COLUMN {ddl}")
-    log.info("Migration: added %s column to %s", column, table)
-    return True
-
-
-def _set_schema_version(conn):
-    conn.execute(
-        "INSERT INTO _docsight_meta (key, value) VALUES ('schema_version', ?) "
-        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        (str(SCHEMA_VERSION),),
-    )
 
 
 class StorageBase:
@@ -60,204 +25,10 @@ class StorageBase:
         self._init_db()
 
     def _init_db(self):
-        with self._connect() as conn:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS _docsight_meta (
-                    key TEXT PRIMARY KEY,
-                    value TEXT NOT NULL
-                )
-            """)
+        run_migrations(self.db_path, CORE_MIGRATIONS)
 
-            # ── Migration: rename incidents → journal_entries ──
-            # Detect old schema: incidents table has a 'title' column
-            try:
-                cols = [r[1] for r in conn.execute("PRAGMA table_info(incidents)").fetchall()]
-                if "title" in cols:
-                    log.info("Migrating: incidents → journal_entries")
-                    conn.execute("ALTER TABLE incidents RENAME TO journal_entries")
-                    # Recreate attachments table with entry_id
-                    conn.execute("""
-                        CREATE TABLE IF NOT EXISTS journal_attachments (
-                            id INTEGER PRIMARY KEY AUTOINCREMENT,
-                            entry_id INTEGER NOT NULL,
-                            filename TEXT NOT NULL,
-                            mime_type TEXT NOT NULL,
-                            data BLOB NOT NULL,
-                            created_at TEXT NOT NULL,
-                            FOREIGN KEY (entry_id) REFERENCES journal_entries(id) ON DELETE CASCADE
-                        )
-                    """)
-                    # Copy data from old table
-                    try:
-                        conn.execute("""
-                            INSERT INTO journal_attachments (id, entry_id, filename, mime_type, data, created_at)
-                            SELECT id, incident_id, filename, mime_type, data, created_at
-                            FROM incident_attachments
-                        """)
-                        conn.execute("DROP TABLE incident_attachments")
-                    except Exception:
-                        pass  # incident_attachments may not exist
-                    # Add incident_id column for grouping
-                    try:
-                        conn.execute("ALTER TABLE journal_entries ADD COLUMN incident_id INTEGER")
-                    except Exception:
-                        pass  # column already exists
-                    # Add icon column if missing
-                    try:
-                        conn.execute("ALTER TABLE journal_entries ADD COLUMN icon TEXT")
-                    except Exception:
-                        pass
-                    log.info("Migration complete: journal_entries + journal_attachments")
-            except Exception:
-                pass  # incidents table doesn't exist yet, fresh install
+    def _read(self):
+        return open_read(self.db_path)
 
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS snapshots (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT NOT NULL,
-                    summary_json TEXT NOT NULL,
-                    ds_channels_json TEXT NOT NULL,
-                    us_channels_json TEXT NOT NULL,
-                    raw_json TEXT,
-                    analysis_meta_json TEXT
-                )
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS device_state (
-                    id INTEGER PRIMARY KEY CHECK (id = 1),
-                    uptime_seconds INTEGER,
-                    sw_version TEXT,
-                    wan_ipv4 TEXT,
-                    wan_ipv6 TEXT,
-                    updated_at TEXT NOT NULL
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_snapshots_ts
-                ON snapshots(timestamp)
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS events (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT NOT NULL,
-                    severity TEXT NOT NULL,
-                    event_type TEXT NOT NULL,
-                    message TEXT NOT NULL,
-                    details TEXT,
-                    acknowledged INTEGER NOT NULL DEFAULT 0
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_events_ts
-                ON events(timestamp)
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_events_ack
-                ON events(acknowledged)
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_events_type_ts
-                ON events(event_type, timestamp DESC)
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_snapshots_ts_id
-                ON snapshots(timestamp DESC, id DESC)
-            """)
-            # ── Migration: add is_demo column to demo-seeded tables ──
-            # Note: speedtest_results, bqm_graphs, bnetz_measurements tables are
-            # now created by their respective modules. We still try the migration
-            # here because the tables may already exist from a previous version.
-            _demo_tables = ["snapshots", "events", "journal_entries", "incidents", "speedtest_results", "bqm_graphs", "bnetz_measurements", "weather_data"]
-            for tbl in _demo_tables:
-                _add_column_if_missing(conn, tbl, "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0")
-
-            _add_column_if_missing(conn, "snapshots", "analysis_meta_json", "analysis_meta_json TEXT")
-            _add_column_if_missing(conn, "snapshots", "raw_json", "raw_json TEXT")
-
-            # ── Weather data table ──
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS weather_data (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT NOT NULL UNIQUE,
-                    temperature REAL NOT NULL,
-                    is_demo INTEGER NOT NULL DEFAULT 0
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_weather_ts
-                ON weather_data(timestamp)
-            """)
-
-            # ── API tokens table ──
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS api_tokens (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    name TEXT NOT NULL,
-                    token_hash TEXT NOT NULL,
-                    token_prefix TEXT NOT NULL,
-                    created_at TEXT NOT NULL,
-                    last_used_at TEXT,
-                    revoked INTEGER NOT NULL DEFAULT 0
-                )
-            """)
-
-            # ── Browser PWA Web Push subscriptions ──
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS pwa_push_subscriptions (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    endpoint TEXT NOT NULL UNIQUE,
-                    subscription_json TEXT NOT NULL,
-                    user_agent TEXT,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_pwa_push_subscriptions_updated
-                ON pwa_push_subscriptions(updated_at)
-            """)
-
-            # ── Smart Capture executions ──
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS smart_capture_executions (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    trigger_event_id INTEGER,
-                    trigger_timestamp TEXT,
-                    trigger_type TEXT NOT NULL,
-                    action_type TEXT NOT NULL,
-                    status TEXT NOT NULL DEFAULT 'pending',
-                    fired_at TEXT,
-                    completed_at TEXT,
-                    claimed_at TEXT,
-                    attempt_count INTEGER NOT NULL DEFAULT 0,
-                    last_error TEXT,
-                    suppression_reason TEXT,
-                    linked_result_id INTEGER,
-                    details TEXT,
-                    created_at TEXT NOT NULL
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_sc_exec_status
-                ON smart_capture_executions(status)
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_sc_exec_created
-                ON smart_capture_executions(created_at)
-            """)
-            _set_schema_version(conn)
-
-    @contextmanager
-    def _connect(self):
-        """Yield a connection with foreign keys enabled and close it afterwards."""
-        conn = connect_sqlite(self.db_path)
-        conn.execute("PRAGMA foreign_keys = ON")
-        try:
-            yield conn
-            conn.commit()
-        except Exception:
-            conn.rollback()
-            raise
-        finally:
-            conn.close()
+    def _write(self):
+        return write_transaction(self.db_path)

--- a/app/storage/cleanup.py
+++ b/app/storage/cleanup.py
@@ -49,7 +49,7 @@ class CleanupMethods:
         - Runs in a single transaction (automatic rollback on error)
         - Skips NULL, empty, and already-UTC (Z-suffix) values
         """
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT value FROM _docsight_meta WHERE key = 'tz_migrated'"
             ).fetchone()
@@ -64,7 +64,7 @@ class CleanupMethods:
             log.info("UTC migration: backup created at %s", backup_path)
 
         migrated_count = 0
-        with self._connect() as conn:
+        with self._write() as conn:
             for table, column in self._TIMESTAMP_COLUMNS:
                 # Check table and column exist
                 try:
@@ -155,7 +155,7 @@ class CleanupMethods:
         Order matters: delete attachments for demo journal entries first,
         unassign entries from demo incidents, then delete from each table.
         """
-        with self._connect() as conn:
+        with self._write() as conn:
             # 1. Delete attachments belonging to demo journal entries
             try:
                 conn.execute(
@@ -194,7 +194,7 @@ class CleanupMethods:
         if self.max_days <= 0:
             return
         cutoff = utc_cutoff(days=self.max_days)
-        with self._connect() as conn:
+        with self._write() as conn:
             deleted = self._delete_expired_unprotected_rows(
                 conn, "snapshots", "timestamp", cutoff
             )
@@ -204,7 +204,7 @@ class CleanupMethods:
         today = local_today(tz)
         cutoff_date = (datetime.strptime(today, "%Y-%m-%d") - timedelta(days=self.max_days)).strftime("%Y-%m-%d")
         try:
-            with self._connect() as conn:
+            with self._write() as conn:
                 bqm_deleted = conn.execute(
                     "DELETE FROM bqm_graphs WHERE date < ?", (cutoff_date,)
                 ).rowcount
@@ -213,7 +213,7 @@ class CleanupMethods:
         except sqlite3.OperationalError:
             pass  # Table may not exist if BQM module not loaded
         try:
-            with self._connect() as conn:
+            with self._write() as conn:
                 weather_deleted = conn.execute(
                     "DELETE FROM weather_data WHERE timestamp < ?", (cutoff,)
                 ).rowcount
@@ -225,7 +225,7 @@ class CleanupMethods:
         if events_deleted:
             log.info("Cleaned up %d old events (before %s)", events_deleted, cutoff)
         try:
-            with self._connect() as conn:
+            with self._write() as conn:
                 sc_deleted = conn.execute(
                     "DELETE FROM smart_capture_executions WHERE created_at < ?", (cutoff,)
                 ).rowcount

--- a/app/storage/device.py
+++ b/app/storage/device.py
@@ -1,13 +1,11 @@
 """Storage mixin for device state."""
 
-import sqlite3
 from typing import Dict, Any
 
 class DeviceStorageMethods:
     def get_device_state(self) -> Dict[str, Any]:
         """Fetch the current tracked device state."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             row = conn.execute("SELECT * FROM device_state WHERE id = 1").fetchone()
             if row:
                 return dict(row)
@@ -15,7 +13,7 @@ class DeviceStorageMethods:
 
     def update_device_state(self, uptime: int | None, sw_version: str | None, ipv4: str | None, ipv6: str | None, updated_at: str):
         """Update the tracked device state. Inserts if missing, otherwise overwrites."""
-        with self._connect() as conn:
+        with self._write() as conn:
             conn.execute("""
                 INSERT INTO device_state (id, uptime_seconds, sw_version, wan_ipv4, wan_ipv6, updated_at)
                 VALUES (1, ?, ?, ?, ?, ?)

--- a/app/storage/events.py
+++ b/app/storage/events.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import json
-import sqlite3
 
 from ..types import EventDict
 from ..tz import utc_cutoff
+from .sqlite import bulk_write
 
 
 class EventMethods:
 
     def save_event(self, timestamp: str, severity: str, event_type: str, message: str, details: dict | None = None) -> int:
         """Save a single event. Returns the new event id."""
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "INSERT INTO events (timestamp, severity, event_type, message, details) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -26,17 +26,17 @@ class EventMethods:
         """Bulk insert events. Returns count of inserted rows."""
         if not events_list:
             return 0
-        with self._connect() as conn:
-            conn.executemany(
-                "INSERT INTO events (timestamp, severity, event_type, message, details, is_demo) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                [
-                    (e["timestamp"], e["severity"], e["event_type"], e["message"],
-                     json.dumps(e.get("details")) if e.get("details") else None,
-                     int(is_demo))
-                    for e in events_list
-                ],
-            )
+        bulk_write(
+            self.db_path,
+            "INSERT INTO events (timestamp, severity, event_type, message, details, is_demo) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (e["timestamp"], e["severity"], e["event_type"], e["message"],
+                 json.dumps(e.get("details")) if e.get("details") else None,
+                 int(is_demo))
+                for e in events_list
+            ],
+        )
         return len(events_list)
 
     def save_events_with_ids(self, events_list: list[EventDict], is_demo: bool = False) -> list[int]:
@@ -51,7 +51,7 @@ class EventMethods:
         if not events_list:
             return []
         ids = []
-        with self._connect() as conn:
+        with self._write() as conn:
             for e in events_list:
                 cur = conn.execute(
                     "INSERT INTO events (timestamp, severity, event_type, message, details, is_demo) "
@@ -88,8 +88,7 @@ class EventMethods:
             query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(query, params).fetchall()
         results = []
         for r in rows:
@@ -122,13 +121,13 @@ class EventMethods:
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
 
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(query, params).fetchone()
         return row[0] if row else 0
 
     def acknowledge_event(self, event_id):
         """Acknowledge a single event. Returns True if found."""
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "UPDATE events SET acknowledged = 1 WHERE id = ?", (event_id,)
             ).rowcount
@@ -136,7 +135,7 @@ class EventMethods:
 
     def acknowledge_all_events(self):
         """Acknowledge all unacknowledged events. Returns rows affected."""
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "UPDATE events SET acknowledged = 1 WHERE acknowledged = 0"
             ).rowcount
@@ -145,8 +144,7 @@ class EventMethods:
     def get_recent_events(self, hours: int = 48) -> list[dict]:
         """Return events from the last N hours, newest first."""
         cutoff = utc_cutoff(hours=hours)
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT id, timestamp, severity, event_type, message, details, acknowledged "
                 "FROM events WHERE timestamp >= ? ORDER BY timestamp DESC",
@@ -168,7 +166,7 @@ class EventMethods:
         if days <= 0:
             return 0
         cutoff = utc_cutoff(days=days)
-        with self._connect() as conn:
+        with self._write() as conn:
             deleted = self._delete_expired_unprotected_rows(  # type: ignore[attr-defined]
                 conn, "events", "timestamp", cutoff
             )
@@ -176,7 +174,7 @@ class EventMethods:
 
     def get_latest_spike_timestamp(self):
         """Return timestamp of the most recent error_spike event, or None."""
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT timestamp FROM events WHERE event_type = 'error_spike' "
                 "ORDER BY timestamp DESC LIMIT 1"

--- a/app/storage/migrations.py
+++ b/app/storage/migrations.py
@@ -1,0 +1,267 @@
+"""Ordered, idempotent, shape-aware SQLite migrations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+import sqlite3
+
+from .schema import CORE_SCHEMA, SEGMENT_SCHEMA
+from .sqlite import open_read, write_transaction
+
+log = logging.getLogger("docsis.storage.migrations")
+SCHEMA_VERSION = 2
+
+
+@dataclass(frozen=True)
+class Migration:
+    migration_id: str
+    apply: Callable[[sqlite3.Connection], None]
+    is_applied: Callable[[sqlite3.Connection], bool]
+
+
+def table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone() is not None
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not table_exists(conn, table):
+        return set()
+    quoted = table.replace('"', '""')
+    return {row[1] for row in conn.execute(f'PRAGMA table_info("{quoted}")')}
+
+
+def add_column_if_missing(
+    conn: sqlite3.Connection, table: str, column: str, declaration: str
+) -> bool:
+    if not table_exists(conn, table) or column in table_columns(conn, table):
+        return False
+    quoted = table.replace('"', '""')
+    conn.execute(f'ALTER TABLE "{quoted}" ADD COLUMN {declaration}')
+    log.info("Migration: added %s column to %s", column, table)
+    return True
+
+
+def execute_schema(conn: sqlite3.Connection, statements: Sequence[str]) -> None:
+    for statement in statements:
+        conn.execute(statement)
+
+
+def _registry_exists(conn: sqlite3.Connection) -> bool:
+    return table_exists(conn, "_docsight_migrations")
+
+
+def _ensure_registry(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS _docsight_migrations (
+            id TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def run_migrations(db_path: str, migrations: Sequence[Migration]) -> list[str]:
+    """Apply or shape-stamp migrations in order, one transaction per step."""
+    if not migrations:
+        return []
+    with open_read(db_path) as conn:
+        if _registry_exists(conn):
+            recorded = {
+                row[0]
+                for row in conn.execute("SELECT id FROM _docsight_migrations")
+            }
+            if all(migration.migration_id in recorded for migration in migrations):
+                return []
+
+    newly_recorded = []
+    with write_transaction(db_path) as conn:
+        _ensure_registry(conn)
+    for migration in migrations:
+        with write_transaction(db_path) as conn:
+            if conn.execute(
+                "SELECT 1 FROM _docsight_migrations WHERE id=?",
+                (migration.migration_id,),
+            ).fetchone():
+                continue
+            if not migration.is_applied(conn):
+                migration.apply(conn)
+            conn.execute(
+                "INSERT INTO _docsight_migrations (id, applied_at) VALUES (?, ?)",
+                (
+                    migration.migration_id,
+                    datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+            newly_recorded.append(migration.migration_id)
+    return newly_recorded
+
+
+def _core_baseline_applied(_conn: sqlite3.Connection) -> bool:
+    # Replay the idempotent declarations once when adopting the registry.  A
+    # table-only shape probe would stamp historical databases that have all
+    # tables but are missing one of the required indexes.
+    return False
+
+
+def _apply_core_baseline(conn: sqlite3.Connection) -> None:
+    execute_schema(conn, CORE_SCHEMA)
+
+
+_LEGACY_INCIDENT_COLUMNS = {
+    "id", "date", "title", "description", "created_at", "updated_at",
+}
+
+
+def _incidents_migration_applied(conn: sqlite3.Connection) -> bool:
+    incidents_columns = table_columns(conn, "incidents")
+    journal_exists = table_exists(conn, "journal_entries")
+    if "title" in incidents_columns and journal_exists:
+        log.warning(
+            "Hybrid journal schema detected; preserving incidents and journal_entries unchanged"
+        )
+        return True
+    if "title" in incidents_columns and not _LEGACY_INCIDENT_COLUMNS <= incidents_columns:
+        log.warning("Unknown incidents schema; preserving table unchanged")
+        return True
+    return "title" not in incidents_columns
+
+
+def _apply_incidents_migration(conn: sqlite3.Connection) -> None:
+    incidents_columns = table_columns(conn, "incidents")
+    if _LEGACY_INCIDENT_COLUMNS <= incidents_columns:
+        if table_exists(conn, "journal_entries"):
+            log.warning(
+                "Hybrid journal schema detected; preserving incidents and journal_entries unchanged"
+            )
+            return
+        conn.execute("ALTER TABLE incidents RENAME TO journal_entries")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS journal_attachments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                entry_id INTEGER NOT NULL,
+                filename TEXT NOT NULL,
+                mime_type TEXT NOT NULL,
+                data BLOB NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (entry_id) REFERENCES journal_entries(id) ON DELETE CASCADE
+            )
+            """
+        )
+        if table_exists(conn, "incident_attachments"):
+            attachment_columns = table_columns(conn, "incident_attachments")
+            expected = {"id", "incident_id", "filename", "mime_type", "data", "created_at"}
+            if expected <= attachment_columns:
+                orphan_count = conn.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM incident_attachments AS attachment
+                    LEFT JOIN journal_entries AS entry ON entry.id = attachment.incident_id
+                    WHERE entry.id IS NULL
+                    """
+                ).fetchone()[0]
+                conn.execute(
+                    """
+                    INSERT INTO journal_attachments
+                        (id, entry_id, filename, mime_type, data, created_at)
+                    SELECT id, incident_id, filename, mime_type, data, created_at
+                    FROM incident_attachments
+                    WHERE incident_id IN (SELECT id FROM journal_entries)
+                    """
+                )
+                if orphan_count:
+                    log.warning(
+                        "Preserving incident_attachments with %d orphaned row(s)",
+                        orphan_count,
+                    )
+                else:
+                    conn.execute("DROP TABLE incident_attachments")
+            else:
+                log.warning("Unknown incident_attachments shape; preserving table unchanged")
+        add_column_if_missing(conn, "journal_entries", "incident_id", "incident_id INTEGER")
+        add_column_if_missing(conn, "journal_entries", "icon", "icon TEXT")
+
+
+_DEMO_TABLES = (
+    "snapshots", "events", "journal_entries", "incidents", "speedtest_results",
+    "bqm_graphs", "bnetz_measurements", "weather_data",
+)
+
+
+def _demo_flags_applied(conn: sqlite3.Connection) -> bool:
+    return all(
+        not table_exists(conn, table) or "is_demo" in table_columns(conn, table)
+        for table in _DEMO_TABLES
+    )
+
+
+def _apply_demo_flags(conn: sqlite3.Connection) -> None:
+    for table in _DEMO_TABLES:
+        add_column_if_missing(
+            conn, table, "is_demo", "is_demo INTEGER NOT NULL DEFAULT 0"
+        )
+
+
+def _snapshot_columns_applied(conn: sqlite3.Connection) -> bool:
+    columns = table_columns(conn, "snapshots")
+    return not columns or {"analysis_meta_json", "raw_json"} <= columns
+
+
+def _apply_snapshot_columns(conn: sqlite3.Connection) -> None:
+    add_column_if_missing(
+        conn, "snapshots", "analysis_meta_json", "analysis_meta_json TEXT"
+    )
+    add_column_if_missing(conn, "snapshots", "raw_json", "raw_json TEXT")
+
+
+def _meta_version_applied(conn: sqlite3.Connection) -> bool:
+    if not table_exists(conn, "_docsight_meta"):
+        return False
+    row = conn.execute(
+        "SELECT value FROM _docsight_meta WHERE key='schema_version'"
+    ).fetchone()
+    return row is not None and row[0] == str(SCHEMA_VERSION)
+
+
+def _apply_meta_version(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO _docsight_meta (key, value) VALUES ('schema_version', ?) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+        (str(SCHEMA_VERSION),),
+    )
+
+
+def _segment_applied(_conn: sqlite3.Connection) -> bool:
+    # CREATE IF NOT EXISTS also repairs missing indexes on legacy databases.
+    return False
+
+
+CORE_MIGRATIONS: tuple[Migration, ...] = (
+    Migration("core-0001-baseline", _apply_core_baseline, _core_baseline_applied),
+    Migration(
+        "core-0002-incidents-to-journal",
+        _apply_incidents_migration,
+        _incidents_migration_applied,
+    ),
+    Migration("core-0003-demo-flags", _apply_demo_flags, _demo_flags_applied),
+    Migration(
+        "core-0004-snapshot-columns",
+        _apply_snapshot_columns,
+        _snapshot_columns_applied,
+    ),
+    Migration("core-0005-meta-version", _apply_meta_version, _meta_version_applied),
+)
+
+SEGMENT_MIGRATIONS: tuple[Migration, ...] = (
+    Migration(
+        "segment-0001-baseline",
+        lambda conn: execute_schema(conn, SEGMENT_SCHEMA),
+        _segment_applied,
+    ),
+)

--- a/app/storage/pwa_push.py
+++ b/app/storage/pwa_push.py
@@ -39,7 +39,7 @@ class PwaPushMethods:
         endpoint = normalized["endpoint"]
         now = self._utc_now_iso()
         payload = json.dumps(normalized, sort_keys=True, separators=(",", ":"))
-        with self._connect() as conn:
+        with self._write() as conn:
             conn.execute(
                 """
                 INSERT INTO pwa_push_subscriptions
@@ -74,7 +74,7 @@ class PwaPushMethods:
         }
 
     def list_pwa_push_subscriptions(self) -> list[dict]:
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 """
                 SELECT id, endpoint, subscription_json, user_agent, created_at, updated_at
@@ -85,7 +85,7 @@ class PwaPushMethods:
         return [self._row_to_pwa_subscription(row) for row in rows]
 
     def count_pwa_push_subscriptions(self) -> int:
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute("SELECT COUNT(*) FROM pwa_push_subscriptions").fetchone()
         return int(row[0] if row else 0)
 
@@ -93,6 +93,6 @@ class PwaPushMethods:
         endpoint = str(endpoint or "").strip()
         if not endpoint:
             return False
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute("DELETE FROM pwa_push_subscriptions WHERE endpoint = ?", (endpoint,))
         return cur.rowcount > 0

--- a/app/storage/schema.py
+++ b/app/storage/schema.py
@@ -1,0 +1,139 @@
+"""Declarative SQLite schema statements; execution belongs to migrations."""
+
+CORE_SCHEMA: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS _docsight_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS snapshots (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp TEXT NOT NULL,
+        summary_json TEXT NOT NULL,
+        ds_channels_json TEXT NOT NULL,
+        us_channels_json TEXT NOT NULL,
+        raw_json TEXT,
+        analysis_meta_json TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS device_state (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        uptime_seconds INTEGER,
+        sw_version TEXT,
+        wan_ipv4 TEXT,
+        wan_ipv6 TEXT,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_snapshots_ts ON snapshots(timestamp)",
+    """
+    CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        message TEXT NOT NULL,
+        details TEXT,
+        acknowledged INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_events_ts ON events(timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_events_ack ON events(acknowledged)",
+    "CREATE INDEX IF NOT EXISTS idx_events_type_ts ON events(event_type, timestamp DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_snapshots_ts_id ON snapshots(timestamp DESC, id DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS weather_data (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp TEXT NOT NULL UNIQUE,
+        temperature REAL NOT NULL,
+        is_demo INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_weather_ts ON weather_data(timestamp)",
+    """
+    CREATE TABLE IF NOT EXISTS api_tokens (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        token_hash TEXT NOT NULL,
+        token_prefix TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        last_used_at TEXT,
+        revoked INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS pwa_push_subscriptions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        endpoint TEXT NOT NULL UNIQUE,
+        subscription_json TEXT NOT NULL,
+        user_agent TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_pwa_push_subscriptions_updated
+    ON pwa_push_subscriptions(updated_at)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS smart_capture_executions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        trigger_event_id INTEGER,
+        trigger_timestamp TEXT,
+        trigger_type TEXT NOT NULL,
+        action_type TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        fired_at TEXT,
+        completed_at TEXT,
+        claimed_at TEXT,
+        attempt_count INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        suppression_reason TEXT,
+        linked_result_id INTEGER,
+        details TEXT,
+        created_at TEXT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_sc_exec_status ON smart_capture_executions(status)",
+    "CREATE INDEX IF NOT EXISTS idx_sc_exec_created ON smart_capture_executions(created_at)",
+)
+
+
+SEGMENT_SCHEMA: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS segment_utilization (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp TEXT NOT NULL,
+        ds_total REAL,
+        us_total REAL,
+        ds_own REAL,
+        us_own REAL
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_segment_util_ts
+    ON segment_utilization(timestamp)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS segment_utilization_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        direction TEXT NOT NULL,
+        start_ts TEXT NOT NULL,
+        end_ts TEXT NOT NULL,
+        duration_minutes INTEGER NOT NULL,
+        peak_total REAL,
+        peak_own REAL,
+        peak_neighbor_load REAL,
+        confidence TEXT,
+        threshold INTEGER NOT NULL,
+        min_minutes INTEGER NOT NULL
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_segment_util_events_key
+    ON segment_utilization_events(direction, start_ts, threshold, min_minutes)
+    """,
+)

--- a/app/storage/segment_utilization.py
+++ b/app/storage/segment_utilization.py
@@ -1,8 +1,7 @@
 """Segment utilization storage (standalone, not a core mixin)."""
 
-import sqlite3
-
-from app.storage.sqlite import connect_sqlite
+from app.storage.migrations import SEGMENT_MIGRATIONS, run_migrations
+from app.storage.sqlite import open_read, write_transaction
 import threading
 from datetime import datetime, timedelta, timezone
 
@@ -50,49 +49,7 @@ class SegmentUtilizationStorage:
         self._ensure_table()
 
     def _ensure_table(self):
-        conn = connect_sqlite(self.db_path)
-        try:
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS segment_utilization (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT NOT NULL,
-                    ds_total REAL,
-                    us_total REAL,
-                    ds_own REAL,
-                    us_own REAL
-                )
-            """)
-            conn.execute("""
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_segment_util_ts
-                ON segment_utilization(timestamp)
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS segment_utilization_events (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    direction TEXT NOT NULL,
-                    start_ts TEXT NOT NULL,
-                    end_ts TEXT NOT NULL,
-                    duration_minutes INTEGER NOT NULL,
-                    peak_total REAL,
-                    peak_own REAL,
-                    peak_neighbor_load REAL,
-                    confidence TEXT,
-                    threshold INTEGER NOT NULL,
-                    min_minutes INTEGER NOT NULL
-                )
-            """)
-            conn.execute("""
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_segment_util_events_key
-                ON segment_utilization_events(direction, start_ts, threshold, min_minutes)
-            """)
-            conn.commit()
-        finally:
-            conn.close()
-
-    def _connect(self):
-        conn = connect_sqlite(self.db_path)
-        conn.row_factory = sqlite3.Row
-        return conn
+        run_migrations(self.db_path, SEGMENT_MIGRATIONS)
 
     def save(self, ds_total, us_total, ds_own, us_own):
         """Store a utilization sample with the current UTC timestamp."""
@@ -102,48 +59,37 @@ class SegmentUtilizationStorage:
     def save_at(self, ts, ds_total, us_total, ds_own, us_own):
         """Store a utilization sample at a specific timestamp (ISO format). Skips duplicates."""
         with self._lock:
-            conn = self._connect()
-            try:
+            with write_transaction(self.db_path) as conn:
                 conn.execute(
                     "INSERT OR IGNORE INTO segment_utilization (timestamp, ds_total, us_total, ds_own, us_own) VALUES (?, ?, ?, ?, ?)",
                     (ts, ds_total, us_total, ds_own, us_own),
                 )
-                conn.commit()
-            finally:
-                conn.close()
 
     def get_range(self, start_ts, end_ts):
         """Return records within a time range, sorted by timestamp ascending."""
         start_ts = _normalize_range_ts(start_ts, "T")
         end_ts = _normalize_range_ts(end_ts, "T")
-        conn = self._connect()
-        try:
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT timestamp, ds_total, us_total, ds_own, us_own FROM segment_utilization WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp",
                 (start_ts, end_ts),
             ).fetchall()
             return [dict(r) for r in rows]
-        finally:
-            conn.close()
 
     def get_latest(self, n=1):
         """Return the N most recent records, most recent first."""
-        conn = self._connect()
-        try:
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT timestamp, ds_total, us_total, ds_own, us_own FROM segment_utilization ORDER BY timestamp DESC LIMIT ?",
                 (n,),
             ).fetchall()
             return [dict(r) for r in rows]
-        finally:
-            conn.close()
 
     def get_stats(self, start_ts, end_ts):
         """Return min/max/avg statistics for the given time range."""
         start_ts = _normalize_range_ts(start_ts, "T")
         end_ts = _normalize_range_ts(end_ts, "T")
-        conn = self._connect()
-        try:
+        with open_read(self.db_path) as conn:
             row = conn.execute(
                 """SELECT
                     COUNT(*) as count,
@@ -158,8 +104,6 @@ class SegmentUtilizationStorage:
                 (start_ts, end_ts),
             ).fetchone()
             return dict(row)
-        finally:
-            conn.close()
 
     def downsample(self, fine_after_days=7, fine_bucket_min=5, coarse_after_days=30, coarse_bucket_min=15):
         """Aggregate old samples into time-bucketed averages.
@@ -221,8 +165,7 @@ class SegmentUtilizationStorage:
 
         inserted = 0
         with self._lock:
-            conn = self._connect()
-            try:
+            with write_transaction(self.db_path) as conn:
                 for ev in events:
                     cur = conn.execute(
                         "INSERT OR IGNORE INTO segment_utilization_events "
@@ -237,17 +180,13 @@ class SegmentUtilizationStorage:
                     )
                     if cur.rowcount:
                         inserted += 1
-                conn.commit()
-            finally:
-                conn.close()
         return inserted
 
     def _load_materialized_events(self, start_ts, end_ts, threshold, min_minutes):
         """Return materialized events that fall within the requested range."""
         start_ts = _normalize_range_ts(start_ts, "T")
         end_ts = _normalize_range_ts(end_ts, "T")
-        conn = self._connect()
-        try:
+        with open_read(self.db_path) as conn:
             rows = conn.execute(
                 "SELECT direction, start_ts, end_ts, duration_minutes, peak_total, peak_own, "
                 "peak_neighbor_load, confidence "
@@ -270,14 +209,11 @@ class SegmentUtilizationStorage:
                 }
                 for r in rows
             ]
-        finally:
-            conn.close()
 
     def _downsample_range(self, before_ts, bucket_minutes):
         """Aggregate all samples before before_ts into bucket_minutes-wide averages."""
         with self._lock:
-            conn = self._connect()
-            try:
+            with write_transaction(self.db_path) as conn:
                 # Bucket key: floor minute to nearest bucket boundary
                 # timestamp format: 2025-03-02T14:23:45Z
                 # substr(timestamp,1,14) = "2025-03-02T14:"
@@ -321,10 +257,7 @@ class SegmentUtilizationStorage:
                     )
                     removed += deleted - 1  # -1 because we re-inserted one averaged row
 
-                conn.commit()
                 return removed
-            finally:
-                conn.close()
 
     def get_events(self, start_ts, end_ts, threshold=EVENT_DEFAULT_THRESHOLD,
                    min_minutes=EVENT_DEFAULT_MIN_MINUTES):
@@ -416,12 +349,8 @@ class SegmentUtilizationStorage:
         """Delete records older than the given number of days. Returns count deleted."""
         cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with self._lock:
-            conn = self._connect()
-            try:
+            with write_transaction(self.db_path) as conn:
                 cursor = conn.execute(
                     "DELETE FROM segment_utilization WHERE timestamp < ?", (cutoff,)
                 )
-                conn.commit()
                 return cursor.rowcount
-            finally:
-                conn.close()

--- a/app/storage/smart_capture.py
+++ b/app/storage/smart_capture.py
@@ -18,7 +18,7 @@ class SmartCaptureMethods:
         assigned a DB id at evaluation time. trigger_timestamp is stored
         as a secondary correlation key.
         """
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "INSERT INTO smart_capture_executions "
                 "(trigger_event_id, trigger_timestamp, trigger_type, action_type, status, "
@@ -33,8 +33,7 @@ class SmartCaptureMethods:
 
     def get_execution(self, execution_id):
         """Return a single execution record by id, or None."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT * FROM smart_capture_executions WHERE id = ?",
                 (execution_id,),
@@ -80,7 +79,7 @@ class SmartCaptureMethods:
         if not updates:
             return
         params.append(execution_id)
-        with self._connect() as conn:
+        with self._write() as conn:
             conn.execute(
                 f"UPDATE smart_capture_executions SET {', '.join(updates)} WHERE id = ?",
                 params,
@@ -89,8 +88,7 @@ class SmartCaptureMethods:
     def get_fired_unmatched(self, action_type):
         """Return FIRED executions without a linked result, filtered by action_type.
         Ordered by fired_at ASC (oldest first) for FIFO matching."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT * FROM smart_capture_executions "
                 "WHERE status = 'fired' AND linked_result_id IS NULL "
@@ -110,7 +108,7 @@ class SmartCaptureMethods:
 
     def get_latest_smart_capture_fire(self, action_type):
         """Return the latest fired_at timestamp for accepted Smart Capture actions."""
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT fired_at FROM smart_capture_executions "
                 "WHERE action_type = ? AND fired_at IS NOT NULL "
@@ -121,7 +119,7 @@ class SmartCaptureMethods:
 
     def count_smart_capture_fires_since(self, action_type, since_timestamp):
         """Count accepted Smart Capture actions since a UTC timestamp."""
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT COUNT(*) FROM smart_capture_executions "
                 "WHERE action_type = ? AND fired_at IS NOT NULL AND fired_at >= ?",
@@ -132,7 +130,7 @@ class SmartCaptureMethods:
     def get_latest_speedtest_result_timestamp(self):
         """Return latest cached Speedtest Tracker result timestamp, if present."""
         try:
-            with self._connect() as conn:
+            with self._read() as conn:
                 row = conn.execute(
                     "SELECT timestamp FROM speedtest_results "
                     "WHERE COALESCE(is_demo, 0) = 0 "
@@ -155,7 +153,7 @@ class SmartCaptureMethods:
         if action_type:
             query += " AND action_type = ?"
             params.append(action_type)
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(query, params).rowcount
         return rowcount
 
@@ -173,7 +171,7 @@ class SmartCaptureMethods:
             updates.append("linked_result_id = ?")
             params.append(linked_result_id)
         params.extend([execution_id, expected_status])
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 f"UPDATE smart_capture_executions SET {', '.join(updates)} "
                 "WHERE id = ? AND status = ?",
@@ -190,8 +188,7 @@ class SmartCaptureMethods:
             params.append(status)
         query += " ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(query, params).fetchall()
         results = []
         for r in rows:
@@ -207,7 +204,7 @@ class SmartCaptureMethods:
     def expire_stale_pending(self, cutoff_timestamp):
         """Bulk-expire PENDING executions with created_at before cutoff.
         Handles orphaned executions when no adapter is registered."""
-        with self._connect() as conn:
+        with self._write() as conn:
             rowcount = conn.execute(
                 "UPDATE smart_capture_executions "
                 "SET status = 'expired', "
@@ -216,4 +213,3 @@ class SmartCaptureMethods:
                 (cutoff_timestamp,),
             ).rowcount
         return rowcount
-

--- a/app/storage/snapshot.py
+++ b/app/storage/snapshot.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sqlite3
 from datetime import timedelta
 from typing import Any, cast
 
@@ -139,7 +138,7 @@ class SnapshotMethods:
         analysis_meta = get_analysis_metadata(app_version=get_available_app_version())
         raw_json = _dump_raw_data(raw_data)
         try:
-            with self._connect() as conn:
+            with self._write() as conn:
                 cur = conn.execute(
                     "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json, is_demo, raw_json, analysis_meta_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
@@ -162,7 +161,7 @@ class SnapshotMethods:
 
     def get_snapshot_list(self) -> list[str]:
         """Return list of available snapshot timestamps (newest first)."""
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT timestamp FROM snapshots ORDER BY timestamp DESC"
             ).fetchall()
@@ -170,7 +169,7 @@ class SnapshotMethods:
 
     def get_latest_snapshot(self) -> AnalysisResult | None:
         """Load the latest stored snapshot, or None when no baseline exists."""
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT id, timestamp, summary_json, ds_channels_json, us_channels_json, analysis_meta_json, raw_json FROM snapshots ORDER BY timestamp DESC, rowid DESC LIMIT 1"
             ).fetchone()
@@ -188,7 +187,7 @@ class SnapshotMethods:
 
     def get_snapshot(self, timestamp: str) -> AnalysisResult | None:
         """Load a single snapshot by timestamp. Returns analysis dict or None."""
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT id, timestamp, summary_json, ds_channels_json, us_channels_json, analysis_meta_json, raw_json FROM snapshots WHERE timestamp = ?",
                 (timestamp,),
@@ -207,7 +206,7 @@ class SnapshotMethods:
 
     def get_snapshot_raw_data(self, timestamp: str) -> dict | None:
         """Return the raw driver payload stored with a snapshot, if available."""
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT raw_json FROM snapshots WHERE timestamp = ?",
                 (timestamp,),
@@ -217,7 +216,7 @@ class SnapshotMethods:
     def get_range_data(self, start_ts: str, end_ts: str) -> list[dict]:
         """Get all snapshots between two ISO timestamps (inclusive)."""
         anchor_start = _unwrap_anchor_start(end_ts)
-        with self._connect() as conn:
+        with self._read() as conn:
             anchor_rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? AND timestamp < ? ORDER BY timestamp",
@@ -257,7 +256,7 @@ class SnapshotMethods:
         """
         start_utc, end_utc = local_date_to_utc_range(date, self.tz_name)
         anchor_start = _unwrap_anchor_start(end_utc)
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp",
@@ -303,7 +302,7 @@ class SnapshotMethods:
         """Get summary snapshots from the last N hours."""
         cutoff = utc_cutoff(hours=hours)
         anchor_start = utc_cutoff(hours=_UNWRAP_ANCHOR_DAYS * 24)
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? ORDER BY timestamp",
@@ -319,7 +318,7 @@ class SnapshotMethods:
         range_start, _ = local_date_to_utc_range(start_date, self.tz_name)
         _, range_end = local_date_to_utc_range(end_date, self.tz_name)
         anchor_start = _unwrap_anchor_start(range_end)
-        with self._connect() as conn:
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT timestamp, summary_json FROM snapshots "
                 "WHERE timestamp >= ? AND timestamp <= ? "
@@ -342,7 +341,7 @@ class SnapshotMethods:
         start_ts = (center - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
         end_ts = (center + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
         ts_param = center.strftime("%Y-%m-%dT%H:%M:%SZ")
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 """SELECT timestamp, summary_json, ds_channels_json, us_channels_json
                    FROM snapshots
@@ -364,7 +363,7 @@ class SnapshotMethods:
         """Return DS and US channels from the latest snapshot."""
         from app.channel_selector import attach_channel_selectors
 
-        with self._connect() as conn:
+        with self._read() as conn:
             row = conn.execute(
                 "SELECT ds_channels_json, us_channels_json FROM snapshots ORDER BY timestamp DESC LIMIT 1"
             ).fetchone()

--- a/app/storage/sqlite.py
+++ b/app/storage/sqlite.py
@@ -1,6 +1,15 @@
-"""Shared SQLite connection helpers."""
+"""Single owner for SQLite connection policy and transaction boundaries.
 
+Production callers use the managed context managers below.  ``connect_sqlite``
+remains the compatibility seam for external modules and intentionally keeps its
+original timeout, busy-timeout, and tuple-row behavior.
+"""
+
+from collections.abc import Iterable, Iterator, Sequence
+from contextlib import contextmanager
 import sqlite3
+from pathlib import Path
+import threading
 from typing import Any
 
 DEFAULT_SQLITE_TIMEOUT_SECONDS = 30
@@ -13,3 +22,135 @@ def connect_sqlite(db_path: str, **kwargs: Any) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path, **kwargs)
     conn.execute(f"PRAGMA busy_timeout={DEFAULT_SQLITE_BUSY_TIMEOUT_MS}")
     return conn
+
+
+_transaction_state = threading.local()
+
+
+def _managed_timeout(timeout: float | None) -> tuple[float, int]:
+    seconds = DEFAULT_SQLITE_TIMEOUT_SECONDS if timeout is None else timeout
+    return seconds, max(0, int(seconds * 1000))
+
+
+def _apply_common_policy(conn: sqlite3.Connection, busy_timeout_ms: int) -> None:
+    conn.row_factory = sqlite3.Row
+    conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+    conn.execute("PRAGMA foreign_keys=ON")
+
+
+@contextmanager
+def open_read(
+    db_path: str, *, timeout: float | None = None
+) -> Iterator[sqlite3.Connection]:
+    """Yield a query-only managed connection and always close it."""
+    seconds, busy_timeout_ms = _managed_timeout(timeout)
+    conn = connect_sqlite(db_path, timeout=seconds, autocommit=True)
+    try:
+        _apply_common_policy(conn, busy_timeout_ms)
+        conn.execute("PRAGMA query_only=ON")
+        yield conn
+    finally:
+        conn.close()
+
+
+@contextmanager
+def open_readonly(
+    db_path: str, *, timeout: float = DEFAULT_SQLITE_TIMEOUT_SECONDS
+) -> Iterator[sqlite3.Connection]:
+    """Open an existing database through SQLite's true read-only URI mode."""
+    uri = Path(db_path).expanduser().resolve().as_uri() + "?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=timeout, autocommit=True)
+    try:
+        _apply_common_policy(conn, max(0, int(timeout * 1000)))
+        yield conn
+    finally:
+        conn.close()
+
+
+@contextmanager
+def write_transaction(
+    db_path: str, *, timeout: float | None = None
+) -> Iterator[sqlite3.Connection]:
+    """Run one immediate transaction with explicit commit/rollback ownership."""
+    resolved_path = str(Path(db_path).expanduser().resolve())
+    active_paths = getattr(_transaction_state, "active_paths", None)
+    if active_paths:
+        raise RuntimeError(f"nested write_transaction on {resolved_path}")
+    if active_paths is None:
+        active_paths = set()
+        _transaction_state.active_paths = active_paths
+    active_paths.add(resolved_path)
+
+    conn = None
+    try:
+        seconds, busy_timeout_ms = _managed_timeout(timeout)
+        # Explicit BEGIN/commit ownership requires legacy transaction control
+        # with implicit transactions disabled.  In sqlite3, commit() is a no-op
+        # when autocommit=True, even after an explicit BEGIN.
+        conn = connect_sqlite(
+            db_path,
+            timeout=seconds,
+            autocommit=sqlite3.LEGACY_TRANSACTION_CONTROL,
+            isolation_level=None,
+        )
+        _apply_common_policy(conn, busy_timeout_ms)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+        except BaseException:
+            conn.rollback()
+            raise
+        else:
+            try:
+                conn.commit()
+            except BaseException:
+                conn.rollback()
+                raise
+    finally:
+        active_paths.discard(resolved_path)
+        if conn is not None:
+            conn.close()
+
+
+def bulk_write(
+    db_path: str,
+    sql: str,
+    rows: Iterable[Sequence[Any]],
+    *,
+    chunk_size: int = 0,
+) -> int:
+    """Execute materialized rows atomically and return affected-row count."""
+    materialized = list(rows)
+    if not materialized:
+        return 0
+
+    total = 0
+    with write_transaction(db_path) as conn:
+        if chunk_size > 0:
+            chunks = (
+                materialized[offset:offset + chunk_size]
+                for offset in range(0, len(materialized), chunk_size)
+            )
+        else:
+            chunks = (materialized,)
+        for chunk in chunks:
+            cursor = conn.executemany(sql, chunk)
+            total += cursor.rowcount
+    return total
+
+
+def consistent_copy(src_db_path: str, dest_path: str) -> None:
+    """Create a consistent SQLite copy using a parameterized VACUUM INTO."""
+    conn = connect_sqlite(src_db_path, autocommit=True)
+    try:
+        conn.execute("VACUUM INTO ?", (dest_path,))
+    finally:
+        conn.close()
+
+
+def verify_database(db_path: str) -> str:
+    """Return the result of SQLite's full integrity check."""
+    with open_readonly(db_path) as conn:
+        row = conn.execute("PRAGMA integrity_check").fetchone()
+    return str(row[0]) if row else ""

--- a/app/storage/tokens.py
+++ b/app/storage/tokens.py
@@ -1,7 +1,6 @@
 """API token management mixin."""
 
 import secrets
-import sqlite3
 from datetime import datetime, timedelta, timezone
 
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -39,7 +38,7 @@ class TokenMethods:
         prefix = plaintext[:_TOKEN_PREFIX_LENGTH]
         token_hash = generate_password_hash(plaintext)
         created_at = utc_now()
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "INSERT INTO api_tokens (name, token_hash, token_prefix, created_at) VALUES (?, ?, ?, ?)",
                 (name, token_hash, prefix, created_at),
@@ -49,8 +48,7 @@ class TokenMethods:
     def validate_api_token(self, token):
         """Validate a Bearer token. Returns token info dict or None."""
         prefix = (token or "")[:_TOKEN_PREFIX_LENGTH]
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(
                 """
                 SELECT id, name, token_hash, token_prefix, created_at, last_used_at
@@ -59,23 +57,26 @@ class TokenMethods:
                 """,
                 (prefix,),
             ).fetchall()
-            for row in rows:
-                if check_password_hash(row["token_hash"], token):
-                    now = utc_now()
-                    if _should_refresh_last_used(row["last_used_at"], now):
-                        conn.execute("UPDATE api_tokens SET last_used_at = ? WHERE id = ?", (now, row["id"]))
-                    return {
-                        "id": row["id"],
-                        "name": row["name"],
-                        "token_prefix": row["token_prefix"],
-                        "created_at": row["created_at"],
-                    }
+        for row in rows:
+            if check_password_hash(row["token_hash"], token):
+                now = utc_now()
+                if _should_refresh_last_used(row["last_used_at"], now):
+                    with self._write() as conn:
+                        conn.execute(
+                            "UPDATE api_tokens SET last_used_at = ? WHERE id = ?",
+                            (now, row["id"]),
+                        )
+                return {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "token_prefix": row["token_prefix"],
+                    "created_at": row["created_at"],
+                }
         return None
 
     def get_api_tokens(self):
         """Return list of all tokens (without hashes) for UI display."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
+        with self._read() as conn:
             rows = conn.execute(
                 "SELECT id, name, token_prefix, created_at, last_used_at, revoked FROM api_tokens ORDER BY created_at DESC"
             ).fetchall()
@@ -83,7 +84,7 @@ class TokenMethods:
 
     def revoke_api_token(self, token_id):
         """Soft-revoke a token. Returns True if a token was revoked."""
-        with self._connect() as conn:
+        with self._write() as conn:
             cur = conn.execute(
                 "UPDATE api_tokens SET revoked = 1 WHERE id = ? AND revoked = 0",
                 (token_id,),

--- a/tests/sqlite_helpers.py
+++ b/tests/sqlite_helpers.py
@@ -1,0 +1,80 @@
+"""Shared assertions for SQLite infrastructure tests."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+
+
+class CountingConnection(sqlite3.Connection):
+    """Connection subclass exposing transaction and bulk-call counts."""
+
+    instances: list["CountingConnection"] = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.commit_calls = 0
+        self.rollback_calls = 0
+        self.executemany_calls = 0
+        type(self).instances.append(self)
+
+    def commit(self):
+        self.commit_calls += 1
+        return super().commit()
+
+    def rollback(self):
+        self.rollback_calls += 1
+        return super().rollback()
+
+    def executemany(self, sql, parameters, /):
+        self.executemany_calls += 1
+        return super().executemany(sql, parameters)
+
+
+def install_counting_connect(monkeypatch, sqlite_module):
+    """Patch an infrastructure module so new connections are countable."""
+    original = sqlite_module.sqlite3.connect
+    CountingConnection.instances.clear()
+
+    def connect(*args, **kwargs):
+        kwargs.setdefault("factory", CountingConnection)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite_module.sqlite3, "connect", connect)
+    return CountingConnection.instances
+
+
+def schema_digest(db_path: str | Path) -> str:
+    """Hash normalized user-visible schema SQL."""
+    with sqlite3.connect(str(db_path)) as conn:
+        rows = conn.execute(
+            "SELECT type, name, tbl_name, sql FROM sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+        ).fetchall()
+    normalized = "\n".join(
+        "|".join("" if value is None else " ".join(str(value).split()) for value in row)
+        for row in rows
+    )
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def data_digest(db_path: str | Path, *, exclude: set[str] | None = None) -> tuple[dict[str, int], str]:
+    """Return per-table counts and a stable hash over ordered row tuples."""
+    excluded = {"sqlite_sequence", "_docsight_migrations", *(exclude or set())}
+    with sqlite3.connect(str(db_path)) as conn:
+        tables = [
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            )
+            if row[0] not in excluded
+        ]
+        counts = {}
+        payload = []
+        for table in tables:
+            quoted = table.replace('"', '""')
+            rows = conn.execute(f'SELECT * FROM "{quoted}" ORDER BY rowid').fetchall()
+            counts[table] = len(rows)
+            payload.append((table, rows))
+    return counts, hashlib.sha256(repr(payload).encode()).hexdigest()

--- a/tests/test_backup_restore_verified.py
+++ b/tests/test_backup_restore_verified.py
@@ -1,0 +1,129 @@
+"""Verified staged database restore contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import sqlite3
+import tarfile
+import tempfile
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from app.modules.backup.backup import FORMAT_VERSION, MAGIC, restore_backup
+from app.storage.sqlite import verify_database
+
+
+def _archive(files: dict[str, bytes]) -> io.BytesIO:
+    meta = json.dumps({"magic": MAGIC, "format_version": FORMAT_VERSION}).encode()
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as tar:
+        for name, content in {"backup_meta.json": meta, **files}.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    payload.seek(0)
+    return payload
+
+
+def _database_bytes(tmp_path, rows):
+    handle = tempfile.NamedTemporaryFile(dir=tmp_path, suffix=".db", delete=False)
+    path = Path(handle.name)
+    handle.close()
+    with closing(sqlite3.connect(path)) as conn:
+        conn.execute("CREATE TABLE records (value TEXT)")
+        conn.executemany("INSERT INTO records VALUES (?)", [(row,) for row in rows])
+        conn.commit()
+    payload = path.read_bytes()
+    path.unlink()
+    return payload
+
+
+def test_restore_verifies_then_atomically_publishes_and_removes_sidecars(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    live = data_dir / "docsis_history.db"
+    live.write_bytes(_database_bytes(tmp_path, ["old"]))
+    (data_dir / "docsis_history.db-wal").write_bytes(b"stale wal")
+    (data_dir / "docsis_history.db-shm").write_bytes(b"stale shm")
+    replacement = _database_bytes(tmp_path, ["new", "second"])
+
+    from app.modules.backup import backup as backup_module
+
+    real_replace = backup_module.os.replace
+    replacements = []
+
+    def checked_replace(source, destination):
+        source = Path(source)
+        destination = Path(destination)
+        assert source.parent == data_dir
+        assert destination == live
+        assert verify_database(str(source)) == "ok"
+        replacements.append((source, destination))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(backup_module.os, "replace", checked_replace)
+    result = restore_backup(_archive({"docsis_history.db": replacement}), str(data_dir))
+
+    assert result["restored_files"] == ["docsis_history.db"]
+    assert len(replacements) == 1
+    assert verify_database(str(live)) == "ok"
+    with sqlite3.connect(live) as conn:
+        assert conn.execute("SELECT value FROM records ORDER BY rowid").fetchall() == [
+            ("new",), ("second",)
+        ]
+    assert not (data_dir / "docsis_history.db-wal").exists()
+    assert not (data_dir / "docsis_history.db-shm").exists()
+    assert not list(data_dir.glob(".docsight-restore-*"))
+
+
+def test_corrupt_staged_database_leaves_live_database_byte_identical(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    live = data_dir / "docsis_history.db"
+    live.write_bytes(_database_bytes(tmp_path, ["retained"]))
+    before = hashlib.sha256(live.read_bytes()).hexdigest()
+
+    with pytest.raises(ValueError, match="database|integrity|malformed|encrypted"):
+        restore_backup(_archive({"docsis_history.db": b"not a sqlite database"}), str(data_dir))
+
+    assert hashlib.sha256(live.read_bytes()).hexdigest() == before
+    with sqlite3.connect(live) as conn:
+        assert conn.execute("SELECT value FROM records").fetchall() == [("retained",)]
+    assert not list(data_dir.glob(".docsight-restore-*"))
+
+
+def test_all_databases_are_verified_before_any_database_is_published(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    main = data_dir / "docsis_history.db"
+    monitor = data_dir / "connection_monitor.db"
+    main.write_bytes(_database_bytes(tmp_path, ["main-old"]))
+    monitor.write_bytes(_database_bytes(tmp_path, ["monitor-old"]))
+    main_before = main.read_bytes()
+    monitor_before = monitor.read_bytes()
+
+    from app.modules.backup import backup as backup_module
+
+    replace_calls = []
+    monkeypatch.setattr(
+        backup_module.os,
+        "replace",
+        lambda *args: replace_calls.append(args),
+    )
+
+    with pytest.raises(ValueError):
+        restore_backup(
+            _archive({
+                "docsis_history.db": _database_bytes(tmp_path, ["main-new"]),
+                "connection_monitor.db": b"corrupt",
+            }),
+            str(data_dir),
+        )
+
+    assert replace_calls == []
+    assert main.read_bytes() == main_before
+    assert monitor.read_bytes() == monitor_before

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -213,7 +213,7 @@ class TestBQMStorage:
         def boom(*args, **kwargs):
             raise sqlite3.OperationalError("database is locked")
 
-        monkeypatch.setattr("app.modules.bqm.storage.sqlite3.connect", boom)
+        monkeypatch.setattr("app.storage.sqlite.sqlite3.connect", boom)
 
         with pytest.raises(sqlite3.OperationalError, match="database is locked"):
             bqm_storage.store_csv_data(sample_csv_rows)

--- a/tests/test_bulk_benchmark.py
+++ b/tests/test_bulk_benchmark.py
@@ -1,0 +1,40 @@
+"""Structural bulk-write benchmark; timing is evidence, not a gate."""
+
+from __future__ import annotations
+
+import time
+import tracemalloc
+
+from app.storage import SnapshotStorage
+from app.storage import sqlite as sqlite_owner
+from tests.sqlite_helpers import install_counting_connect
+
+
+def test_five_thousand_rows_use_one_transaction_and_one_executemany(tmp_path, monkeypatch):
+    db_path = tmp_path / "benchmark.db"
+    storage = SnapshotStorage(str(db_path), max_days=7)
+    instances = install_counting_connect(monkeypatch, sqlite_owner)
+    rows = [
+        {
+            "timestamp": f"2026-01-01T00:{index % 60:02d}:{index % 60:02d}Z",
+            "severity": "info",
+            "event_type": "benchmark",
+            "message": f"event-{index}",
+            "details": None,
+        }
+        for index in range(5_000)
+    ]
+
+    tracemalloc.start()
+    started = time.perf_counter()
+    count = storage.save_events(rows)
+    elapsed = time.perf_counter() - started
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    print(f"bulk_5000 wall_s={elapsed:.6f} peak_kb={peak // 1024}")
+    assert count == 5_000
+    assert len(instances) == 1
+    assert instances[0].commit_calls == 1
+    assert instances[0].executemany_calls == 1
+    assert storage.get_event_count() == 5_000

--- a/tests/test_migrations_registry.py
+++ b/tests/test_migrations_registry.py
@@ -1,0 +1,402 @@
+"""Ordered, shape-aware SQLite migration contracts."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sqlite3
+
+import pytest
+
+from tests.sqlite_helpers import data_digest, schema_digest
+
+
+def _migrations_module():
+    return importlib.import_module("app.storage.migrations")
+
+
+def _registry_ids(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT id FROM _docsight_migrations ORDER BY applied_at, id"
+            )
+        ]
+
+
+def test_generic_migrations_run_in_order_and_second_run_is_noop(tmp_path):
+    migrations = _migrations_module()
+    db_path = tmp_path / "ordered.db"
+    observed = []
+
+    def apply_first(conn):
+        observed.append("first")
+        conn.execute("CREATE TABLE first_table (value TEXT)")
+
+    def apply_second(conn):
+        observed.append("second")
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name='first_table'"
+        ).fetchone()
+        conn.execute("CREATE TABLE second_table (value TEXT)")
+
+    sequence = (
+        migrations.Migration("test-0001", apply_first, lambda conn: False),
+        migrations.Migration("test-0002", apply_second, lambda conn: False),
+    )
+
+    assert migrations.run_migrations(str(db_path), sequence) == ["test-0001", "test-0002"]
+    first_digest = schema_digest(db_path)
+    assert migrations.run_migrations(str(db_path), sequence) == []
+    assert schema_digest(db_path) == first_digest
+    assert observed == ["first", "second"]
+    assert _registry_ids(db_path) == ["test-0001", "test-0002"]
+
+
+def test_completed_migration_set_does_not_open_an_empty_write_transaction(
+    tmp_path, monkeypatch
+):
+    migrations = _migrations_module()
+    db_path = tmp_path / "complete.db"
+    sequence = (
+        migrations.Migration(
+            "test-0001-complete",
+            lambda conn: conn.execute("CREATE TABLE completed (value TEXT)"),
+            lambda conn: False,
+        ),
+    )
+    migrations.run_migrations(str(db_path), sequence)
+
+    monkeypatch.setattr(
+        migrations,
+        "write_transaction",
+        lambda *args, **kwargs: pytest.fail("completed migrations must not take a write lock"),
+    )
+    assert migrations.run_migrations(str(db_path), sequence) == []
+
+
+def test_shape_probe_stamps_without_applying(tmp_path):
+    migrations = _migrations_module()
+    db_path = tmp_path / "adopt.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE already_current (value TEXT)")
+    called = False
+
+    def forbidden(conn):
+        nonlocal called
+        called = True
+
+    migration = migrations.Migration(
+        "test-0001-adopt", forbidden,
+        lambda conn: conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name='already_current'"
+        ).fetchone() is not None,
+    )
+
+    assert migrations.run_migrations(str(db_path), [migration]) == ["test-0001-adopt"]
+    assert called is False
+    assert _registry_ids(db_path) == ["test-0001-adopt"]
+
+
+def test_failed_migration_rolls_back_shape_and_registry_then_retries(tmp_path):
+    migrations = _migrations_module()
+    db_path = tmp_path / "retry.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE retained (value TEXT)")
+        conn.execute("INSERT INTO retained VALUES ('kept')")
+    before_data = data_digest(db_path)
+
+    def fail(conn):
+        conn.execute("CREATE TABLE partial (value TEXT)")
+        conn.execute("INSERT INTO retained VALUES ('discarded')")
+        raise RuntimeError("injected migration failure")
+
+    failed = migrations.Migration("test-0001-retry", fail, lambda conn: False)
+    with pytest.raises(RuntimeError, match="injected migration failure"):
+        migrations.run_migrations(str(db_path), [failed])
+
+    assert data_digest(db_path) == before_data
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name='partial'"
+        ).fetchone() is None
+        assert conn.execute(
+            "SELECT 1 FROM _docsight_migrations WHERE id='test-0001-retry'"
+        ).fetchone() is None
+
+    successful = migrations.Migration(
+        "test-0001-retry",
+        lambda conn: conn.execute("CREATE TABLE completed (value TEXT)"),
+        lambda conn: False,
+    )
+    assert migrations.run_migrations(str(db_path), [successful]) == ["test-0001-retry"]
+
+
+def test_fresh_core_reaches_head_and_preserves_schema_version(tmp_path):
+    migrations = _migrations_module()
+    db_path = tmp_path / "fresh.db"
+
+    applied = migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS)
+    assert applied == [migration.migration_id for migration in migrations.CORE_MIGRATIONS]
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT value FROM _docsight_meta WHERE key='schema_version'"
+        ).fetchone() == ("2",)
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(snapshots)")}
+        assert {"is_demo", "raw_json", "analysis_meta_json"} <= columns
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    assert migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS) == []
+
+
+def test_unversioned_current_tables_replay_idempotent_schema_to_restore_indexes(tmp_path):
+    migrations = _migrations_module()
+    db_path = tmp_path / "missing-indexes.db"
+
+    with sqlite3.connect(db_path) as conn:
+        for statement in migrations.CORE_SCHEMA:
+            if not statement.lstrip().upper().startswith("CREATE INDEX"):
+                conn.execute(statement)
+        for statement in migrations.SEGMENT_SCHEMA:
+            if not statement.lstrip().upper().startswith("CREATE UNIQUE INDEX"):
+                conn.execute(statement)
+
+    migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS)
+    migrations.run_migrations(str(db_path), migrations.SEGMENT_MIGRATIONS)
+
+    with sqlite3.connect(db_path) as conn:
+        indexes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+    assert {
+        "idx_snapshots_ts",
+        "idx_events_ts",
+        "idx_events_ack",
+        "idx_events_type_ts",
+        "idx_snapshots_ts_id",
+        "idx_weather_ts",
+        "idx_pwa_push_subscriptions_updated",
+        "idx_sc_exec_status",
+        "idx_sc_exec_created",
+        "idx_segment_util_ts",
+        "idx_segment_util_events_key",
+    } <= indexes
+
+
+def test_legacy_snapshot_shape_is_upgraded_without_data_change(tmp_path):
+    migrations = _migrations_module()
+    db_path = tmp_path / "legacy-snapshot.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE snapshots (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL, "
+            "summary_json TEXT NOT NULL, ds_channels_json TEXT NOT NULL, us_channels_json TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO snapshots VALUES (1, '2026-01-01T00:00:00Z', '{}', '[]', '[]')"
+        )
+
+    migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS)
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT id, timestamp, summary_json, ds_channels_json, us_channels_json FROM snapshots"
+        ).fetchall() == [(1, "2026-01-01T00:00:00Z", "{}", "[]", "[]")]
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(snapshots)")}
+        assert {"is_demo", "raw_json", "analysis_meta_json"} <= columns
+
+
+def test_exact_legacy_incidents_shape_is_copied_transactionally(tmp_path):
+    migrations = _migrations_module()
+    db_path = tmp_path / "legacy-journal.db"
+    attachment = b"\x00legacy\xff"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE incidents (id INTEGER PRIMARY KEY, date TEXT NOT NULL, title TEXT NOT NULL, "
+            "description TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE incident_attachments (id INTEGER PRIMARY KEY, incident_id INTEGER NOT NULL, "
+            "filename TEXT NOT NULL, mime_type TEXT NOT NULL, data BLOB NOT NULL, created_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO incidents VALUES (7, '2026-01-01', 'Legacy', NULL, 'created', 'updated')"
+        )
+        conn.execute(
+            "INSERT INTO incident_attachments VALUES (9, 7, 'proof.bin', 'application/octet-stream', ?, 'created')",
+            (attachment,),
+        )
+
+    migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS)
+    with sqlite3.connect(db_path) as conn:
+        entry = conn.execute(
+            "SELECT id, date, title, description, created_at, updated_at FROM journal_entries"
+        ).fetchone()
+        copied = conn.execute(
+            "SELECT id, entry_id, filename, mime_type, data, created_at FROM journal_attachments"
+        ).fetchone()
+        assert entry == (7, "2026-01-01", "Legacy", None, "created", "updated")
+        assert copied == (9, 7, "proof.bin", "application/octet-stream", attachment, "created")
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='incident_attachments'"
+        ).fetchone() is None
+
+
+def test_legacy_incident_orphans_do_not_block_startup_or_lose_attachment_data(
+    tmp_path, caplog
+):
+    migrations = _migrations_module()
+    db_path = tmp_path / "legacy-journal-orphan.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE incidents (id INTEGER PRIMARY KEY, date TEXT NOT NULL, title TEXT NOT NULL, "
+            "description TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE incident_attachments (id INTEGER PRIMARY KEY, incident_id INTEGER NOT NULL, "
+            "filename TEXT NOT NULL, mime_type TEXT NOT NULL, data BLOB NOT NULL, created_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO incidents VALUES (7, '2026-01-01', 'Legacy', NULL, 'created', 'updated')"
+        )
+        conn.executemany(
+            "INSERT INTO incident_attachments VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (9, 7, "valid.bin", "application/octet-stream", b"valid", "created"),
+                (10, 999, "orphan.bin", "application/octet-stream", b"orphan", "created"),
+            ],
+        )
+
+    with caplog.at_level(logging.WARNING):
+        migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS)
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT id, entry_id, data FROM journal_attachments"
+        ).fetchall() == [(9, 7, b"valid")]
+        assert conn.execute(
+            "SELECT id, incident_id, data FROM incident_attachments ORDER BY id"
+        ).fetchall() == [(9, 7, b"valid"), (10, 999, b"orphan")]
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    assert "orphaned row" in caplog.text.lower()
+    assert migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS) == []
+
+
+def test_hybrid_incidents_shape_is_warned_stamped_and_untouched(tmp_path, caplog):
+    migrations = _migrations_module()
+    db_path = tmp_path / "hybrid.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE incidents (id INTEGER PRIMARY KEY, title TEXT NOT NULL, is_demo INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE journal_entries (id INTEGER PRIMARY KEY, title TEXT NOT NULL, is_demo INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute("INSERT INTO incidents VALUES (1, 'old', 0)")
+        conn.execute("INSERT INTO journal_entries VALUES (2, 'new', 0)")
+    before = data_digest(db_path)
+
+    with caplog.at_level(logging.WARNING):
+        migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS)
+
+    after = data_digest(db_path, exclude={"_docsight_meta", "snapshots", "device_state", "events", "weather_data", "api_tokens", "pwa_push_subscriptions", "smart_capture_executions"})
+    before_counts, before_hash = before
+    after_counts, after_hash = after
+    assert after_counts["incidents"] == before_counts["incidents"]
+    assert after_counts["journal_entries"] == before_counts["journal_entries"]
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT * FROM incidents").fetchall() == [(1, "old", 0)]
+        assert conn.execute("SELECT * FROM journal_entries").fetchall() == [(2, "new", 0)]
+    assert "hybrid" in caplog.text.lower()
+    assert "core-0002-incidents-to-journal" in _registry_ids(db_path)
+
+
+def test_unknown_incidents_shape_is_warned_stamped_and_not_renamed(tmp_path, caplog):
+    migrations = _migrations_module()
+    db_path = tmp_path / "unknown-incidents.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE incidents (id INTEGER PRIMARY KEY, title TEXT NOT NULL, payload BLOB)"
+        )
+        conn.execute("INSERT INTO incidents VALUES (1, 'unknown', ?)", (b"kept",))
+
+    with caplog.at_level(logging.WARNING):
+        migrations.run_migrations(str(db_path), migrations.CORE_MIGRATIONS)
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT id, title, payload FROM incidents"
+        ).fetchall() == [(1, "unknown", b"kept")]
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='journal_entries'"
+        ).fetchone() is None
+    assert "unknown incidents schema" in caplog.text.lower()
+    assert "core-0002-incidents-to-journal" in _registry_ids(db_path)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "legacy_sql", "table", "required_columns"),
+    [
+        (
+            "weather",
+            "CREATE TABLE weather_data (timestamp TEXT PRIMARY KEY, temperature REAL NOT NULL)",
+            "weather_data",
+            {"is_demo"},
+        ),
+        (
+            "journal",
+            "CREATE TABLE journal_entries (id INTEGER PRIMARY KEY, is_demo INTEGER DEFAULT 0);"
+            "CREATE TABLE journal_attachments (id INTEGER PRIMARY KEY);"
+            "CREATE TABLE incidents (id INTEGER PRIMARY KEY, name TEXT)",
+            "incidents",
+            {"is_demo"},
+        ),
+        (
+            "speedtest",
+            "CREATE TABLE speedtest_results (id INTEGER PRIMARY KEY, timestamp TEXT NOT NULL);"
+            "CREATE TABLE speedtest_meta (key TEXT PRIMARY KEY, value TEXT)",
+            "speedtest_results",
+            {"server_id", "server_name", "is_demo", "result_url", "external_ip"},
+        ),
+        (
+            "bqm",
+            "CREATE TABLE bqm_graphs (id INTEGER PRIMARY KEY, date TEXT, timestamp TEXT, image_blob BLOB)",
+            "bqm_graphs",
+            {"is_demo"},
+        ),
+        (
+            "bnetz",
+            "CREATE TABLE bnetz_measurements (id INTEGER PRIMARY KEY, date TEXT, timestamp TEXT)",
+            "bnetz_measurements",
+            {"source", "is_demo"},
+        ),
+        (
+            "connection_monitor",
+            "CREATE TABLE connection_targets (id INTEGER PRIMARY KEY, label TEXT, host TEXT, created_at REAL)",
+            "connection_targets",
+            {"is_demo"},
+        ),
+    ],
+)
+def test_evidenced_module_legacy_shapes_reach_head_idempotently(
+    tmp_path, module_name, legacy_sql, table, required_columns
+):
+    migrations = _migrations_module()
+    module_migrations = importlib.import_module(
+        f"app.modules.{module_name}.migrations"
+    ).MIGRATIONS
+    db_path = tmp_path / f"{module_name}.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(legacy_sql)
+
+    applied = migrations.run_migrations(str(db_path), module_migrations)
+    first_digest = schema_digest(db_path)
+
+    assert applied == [migration.migration_id for migration in module_migrations]
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        assert required_columns <= columns
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    assert migrations.run_migrations(str(db_path), module_migrations) == []
+    assert schema_digest(db_path) == first_digest

--- a/tests/test_sqlite_bulk.py
+++ b/tests/test_sqlite_bulk.py
@@ -1,0 +1,90 @@
+"""Bulk write correctness and atomicity contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from app.storage import sqlite as sqlite_owner
+from tests.sqlite_helpers import install_counting_connect
+
+
+def _create_table(db_path):
+    with sqlite_owner.connect_sqlite(str(db_path)) as conn:
+        conn.execute(
+            "CREATE TABLE records (id INTEGER PRIMARY KEY, text_value TEXT, int_value INTEGER, "
+            "real_value REAL, blob_value BLOB, null_value TEXT)"
+        )
+
+
+def test_empty_bulk_does_not_open_connection(tmp_path, monkeypatch):
+    calls = []
+
+    def forbidden(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("empty input opened a connection")
+
+    monkeypatch.setattr(sqlite_owner, "write_transaction", forbidden, raising=False)
+    assert sqlite_owner.bulk_write(str(tmp_path / "unused.db"), "INSERT INTO x VALUES (?)", []) == 0
+    assert sqlite_owner.bulk_write(str(tmp_path / "unused.db"), "INSERT INTO x VALUES (?)", iter(())) == 0
+    assert calls == []
+
+
+def test_bulk_preserves_types_and_consumes_generator_once(tmp_path):
+    db_path = tmp_path / "types.db"
+    _create_table(db_path)
+    yielded = []
+
+    def rows():
+        yielded.append(1)
+        yield (1, "text", 7, 1.25, b"bytes", None)
+
+    count = sqlite_owner.bulk_write(
+        str(db_path),
+        "INSERT INTO records VALUES (?, ?, ?, ?, ?, ?)",
+        rows(),
+    )
+
+    assert count == 1
+    assert yielded == [1]
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT text_value, int_value, real_value, blob_value, null_value, "
+            "typeof(text_value), typeof(int_value), typeof(real_value), typeof(blob_value), typeof(null_value) "
+            "FROM records"
+        ).fetchone()
+    assert row == ("text", 7, 1.25, b"bytes", None, "text", "integer", "real", "blob", "null")
+
+
+def test_bulk_is_atomic_when_one_row_is_invalid(tmp_path):
+    db_path = tmp_path / "atomic.db"
+    _create_table(db_path)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        sqlite_owner.bulk_write(
+            str(db_path),
+            "INSERT INTO records (id, text_value) VALUES (?, ?)",
+            [(1, "first"), (1, "duplicate"), (2, "never")],
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM records").fetchone()[0] == 0
+
+
+def test_bulk_reports_affected_rows_and_uses_one_transaction(tmp_path, monkeypatch):
+    db_path = tmp_path / "count.db"
+    _create_table(db_path)
+    instances = install_counting_connect(monkeypatch, sqlite_owner)
+
+    count = sqlite_owner.bulk_write(
+        str(db_path),
+        "INSERT OR IGNORE INTO records (id, text_value) VALUES (?, ?)",
+        [(1, "first"), (1, "ignored"), (2, "second"), (3, "third")],
+        chunk_size=2,
+    )
+
+    assert count == 3
+    assert len(instances) == 1
+    assert instances[0].commit_calls == 1
+    assert instances[0].executemany_calls == 2

--- a/tests/test_sqlite_busy_timeout.py
+++ b/tests/test_sqlite_busy_timeout.py
@@ -2,7 +2,11 @@
 
 from app.modules.bqm.storage import BqmStorage
 from app.storage import SnapshotStorage
-from app.storage.sqlite import DEFAULT_SQLITE_BUSY_TIMEOUT_MS, connect_sqlite
+from app.storage.sqlite import (
+    DEFAULT_SQLITE_BUSY_TIMEOUT_MS,
+    connect_sqlite,
+    open_read,
+)
 
 
 def test_shared_sqlite_helper_sets_busy_timeout(tmp_path):
@@ -15,7 +19,7 @@ def test_shared_sqlite_helper_sets_busy_timeout(tmp_path):
 def test_core_storage_connections_set_busy_timeout(tmp_path):
     storage = SnapshotStorage(str(tmp_path / "core.db"), max_days=7)
 
-    with storage._connect() as conn:
+    with storage._read() as conn:
         value = conn.execute("PRAGMA busy_timeout").fetchone()[0]
 
     assert value == DEFAULT_SQLITE_BUSY_TIMEOUT_MS
@@ -24,7 +28,7 @@ def test_core_storage_connections_set_busy_timeout(tmp_path):
 def test_module_storage_connections_use_shared_busy_timeout(tmp_path):
     storage = BqmStorage(str(tmp_path / "bqm.db"))
 
-    with connect_sqlite(storage.db_path) as conn:
+    with open_read(storage.db_path) as conn:
         value = conn.execute("PRAGMA busy_timeout").fetchone()[0]
 
     assert value == DEFAULT_SQLITE_BUSY_TIMEOUT_MS

--- a/tests/test_sqlite_connection_policy.py
+++ b/tests/test_sqlite_connection_policy.py
@@ -1,0 +1,88 @@
+"""Managed SQLite connection policy contracts."""
+
+from __future__ import annotations
+
+import inspect
+import sqlite3
+
+import pytest
+
+from app.storage import sqlite as sqlite_owner
+
+
+def _closed(conn):
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
+
+
+def test_connect_sqlite_compatibility_seam(tmp_path):
+    signature = inspect.signature(sqlite_owner.connect_sqlite)
+    assert list(signature.parameters) == ["db_path", "kwargs"]
+    with sqlite_owner.connect_sqlite(str(tmp_path / "compat.db")) as conn:
+        assert conn.row_factory is None
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 30_000
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+
+
+def test_open_read_applies_policy_rejects_writes_and_closes(tmp_path):
+    db_path = str(tmp_path / "managed.db")
+    with sqlite_owner.connect_sqlite(db_path) as setup:
+        setup.execute("CREATE TABLE records (value TEXT)")
+
+    with sqlite_owner.open_read(db_path) as conn:
+        assert conn.row_factory is sqlite3.Row
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 30_000
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO records VALUES ('blocked')")
+
+    _closed(conn)
+
+
+def test_open_read_closes_after_exception(tmp_path):
+    db_path = str(tmp_path / "exception.db")
+    with sqlite_owner.connect_sqlite(db_path):
+        pass
+
+    with pytest.raises(RuntimeError, match="injected"):
+        with sqlite_owner.open_read(db_path) as conn:
+            raise RuntimeError("injected")
+
+    _closed(conn)
+
+
+def test_open_readonly_handles_spaces_never_creates_and_closes(tmp_path):
+    db_path = tmp_path / "directory with spaces" / "read only.db"
+    db_path.parent.mkdir()
+    with sqlite_owner.connect_sqlite(str(db_path)) as setup:
+        setup.execute("CREATE TABLE records (value TEXT)")
+        setup.execute("INSERT INTO records VALUES ('kept')")
+
+    with sqlite_owner.open_readonly(str(db_path), timeout=2) as conn:
+        assert conn.row_factory is sqlite3.Row
+        assert conn.execute("SELECT value FROM records").fetchone()[0] == "kept"
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 2_000
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO records VALUES ('blocked')")
+
+    _closed(conn)
+    missing = tmp_path / "missing.db"
+    with pytest.raises(sqlite3.OperationalError):
+        with sqlite_owner.open_readonly(str(missing)):
+            pass
+    assert not missing.exists()
+
+
+def test_consistent_copy_parameterizes_destination_with_quote(tmp_path):
+    source = tmp_path / "source.db"
+    destination = tmp_path / "copy's database.db"
+    with sqlite_owner.connect_sqlite(str(source)) as conn:
+        conn.execute("CREATE TABLE records (value TEXT)")
+        conn.execute("INSERT INTO records VALUES ('kept')")
+
+    sqlite_owner.consistent_copy(str(source), str(destination))
+
+    assert sqlite_owner.verify_database(str(destination)) == "ok"
+    with sqlite3.connect(destination) as conn:
+        assert conn.execute("SELECT value FROM records").fetchall() == [("kept",)]

--- a/tests/test_sqlite_ownership_contract.py
+++ b/tests/test_sqlite_ownership_contract.py
@@ -1,0 +1,157 @@
+"""Static ownership guard for production SQLite policy and schema code."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "app"
+SQLITE_OWNER = Path("app/storage/sqlite.py")
+MIGRATION_OWNER = Path("app/storage/migrations.py")
+DDL_OWNERS = {
+    Path("app/storage/schema.py"),
+    MIGRATION_OWNER,
+    *(Path(f"app/modules/{name}/migrations.py") for name in (
+        "weather", "journal", "speedtest", "bqm", "bnetz", "connection_monitor"
+    )),
+}
+DDL_PATTERN = re.compile(
+    r"(?:^|;)\s*(?:CREATE\s+TABLE|ALTER\s+TABLE|CREATE\s+(?:UNIQUE\s+)?INDEX|DROP\s+TABLE)\b",
+    re.I | re.M,
+)
+POLICY_PATTERN = re.compile(
+    r"\bPRAGMA\s+(?:busy_timeout|foreign_keys|query_only)\b|"
+    r"\bPRAGMA\s+journal_mode\s*=|\bVACUUM\s+INTO\b",
+    re.I,
+)
+
+
+def _production_trees():
+    for path in APP.rglob("*.py"):
+        relative = path.relative_to(ROOT)
+        yield relative, ast.parse(path.read_text(encoding="utf-8"), filename=str(relative))
+
+
+def _static_string(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            else:
+                parts.append("{}")
+        return "".join(parts)
+    return None
+
+
+def _call_owners(tree):
+    sqlite_aliases = {"sqlite3"}
+    direct_connects = set()
+    shared_connects = {"connect_sqlite"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "sqlite3":
+                    sqlite_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "sqlite3":
+            for alias in node.names:
+                if alias.name == "connect":
+                    direct_connects.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module in {
+            "app.storage.sqlite", "storage.sqlite", "sqlite"
+        }:
+            for alias in node.names:
+                if alias.name == "connect_sqlite":
+                    shared_connects.add(alias.asname or alias.name)
+
+    findings = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id in sqlite_aliases
+            and func.attr == "connect"
+        ) or (isinstance(func, ast.Name) and func.id in direct_connects):
+            findings.append(("sqlite3.connect", node.lineno))
+        elif isinstance(func, ast.Name) and func.id in shared_connects:
+            findings.append(("connect_sqlite", node.lineno))
+        elif isinstance(func, ast.Attribute) and func.attr in {"commit", "rollback", "executemany"}:
+            findings.append((func.attr, node.lineno))
+    return findings
+
+
+def test_connection_transaction_and_bulk_ownership():
+    violations = []
+    required = {"sqlite3.connect", "commit", "rollback", "executemany"}
+    observed = set()
+    for relative, tree in _production_trees():
+        for marker, line in _call_owners(tree):
+            if relative == SQLITE_OWNER:
+                observed.add(marker)
+            else:
+                violations.append(f"{relative}:{line}: {marker}")
+    assert observed >= required
+    assert violations == []
+
+
+def test_policy_pragma_and_vacuum_ownership_ignores_comments_and_non_sql_strings():
+    violations = []
+    owner_markers = []
+    for relative, tree in _production_trees():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "execute" or not node.args:
+                continue
+            sql_node = node.args[0]
+            if isinstance(sql_node, ast.Constant) and isinstance(sql_node.value, str):
+                sql = sql_node.value
+            elif isinstance(sql_node, ast.JoinedStr):
+                sql = "".join(
+                    value.value
+                    for value in sql_node.values
+                    if isinstance(value, ast.Constant) and isinstance(value.value, str)
+                )
+            else:
+                continue
+            if not POLICY_PATTERN.search(sql):
+                continue
+            if relative == SQLITE_OWNER:
+                owner_markers.append(sql)
+            else:
+                violations.append(f"{relative}:{node.lineno}")
+    assert owner_markers
+    assert violations == []
+
+
+def test_ddl_ownership_uses_exact_allowlist():
+    missing = sorted(str(path) for path in DDL_OWNERS if not (ROOT / path).is_file())
+    assert missing == []
+
+    violations = []
+    observed = set()
+    for relative, tree in _production_trees():
+        parents = {
+            child: parent
+            for parent in ast.walk(tree)
+            for child in ast.iter_child_nodes(parent)
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(parents.get(node), ast.JoinedStr):
+                continue
+            sql = _static_string(node)
+            if sql is not None and DDL_PATTERN.search(sql):
+                if relative in DDL_OWNERS:
+                    observed.add(relative)
+                else:
+                    violations.append(f"{relative}:{getattr(node, 'lineno', '?')}")
+    assert observed == DDL_OWNERS
+    assert violations == []

--- a/tests/test_sqlite_transactions.py
+++ b/tests/test_sqlite_transactions.py
@@ -1,0 +1,75 @@
+"""Write transaction ownership and failure contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from app.storage import sqlite as sqlite_owner
+from tests.sqlite_helpers import install_counting_connect
+
+
+def _create_table(db_path):
+    with sqlite_owner.connect_sqlite(str(db_path)) as conn:
+        conn.execute("CREATE TABLE records (value TEXT UNIQUE)")
+
+
+def test_write_transaction_commits_exactly_once_and_closes(tmp_path, monkeypatch):
+    db_path = tmp_path / "success.db"
+    _create_table(db_path)
+    instances = install_counting_connect(monkeypatch, sqlite_owner)
+
+    with sqlite_owner.write_transaction(str(db_path)) as conn:
+        conn.execute("INSERT INTO records VALUES ('kept')")
+
+    assert len(instances) == 1
+    assert instances[0].commit_calls == 1
+    assert instances[0].rollback_calls == 0
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
+
+
+def test_write_transaction_rolls_back_fully_and_closes(tmp_path, monkeypatch):
+    db_path = tmp_path / "rollback.db"
+    _create_table(db_path)
+    instances = install_counting_connect(monkeypatch, sqlite_owner)
+
+    with pytest.raises(RuntimeError, match="injected"):
+        with sqlite_owner.write_transaction(str(db_path)) as conn:
+            conn.execute("INSERT INTO records VALUES ('discarded')")
+            raise RuntimeError("injected")
+
+    assert instances[0].commit_calls == 0
+    assert instances[0].rollback_calls == 1
+    with sqlite3.connect(db_path) as check:
+        assert check.execute("SELECT COUNT(*) FROM records").fetchone()[0] == 0
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
+
+
+@pytest.mark.parametrize("same_path", [True, False])
+def test_nested_write_transactions_are_rejected(tmp_path, same_path):
+    first = tmp_path / "first.db"
+    second = first if same_path else tmp_path / "second.db"
+    with sqlite_owner.write_transaction(str(first)):
+        with pytest.raises(RuntimeError, match="nested write_transaction"):
+            with sqlite_owner.write_transaction(str(second)):
+                pass
+
+
+def test_busy_failure_happens_at_begin_and_recovers_after_release(tmp_path):
+    db_path = tmp_path / "busy.db"
+    _create_table(db_path)
+    holder = sqlite3.connect(db_path, autocommit=True)
+    holder.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            with sqlite_owner.write_transaction(str(db_path), timeout=0.05):
+                pytest.fail("a busy transaction must not yield")
+    finally:
+        holder.rollback()
+        holder.close()
+
+    with sqlite_owner.write_transaction(str(db_path), timeout=0.05) as conn:
+        conn.execute("INSERT INTO records VALUES ('after-release')")


### PR DESCRIPTION
## Summary

- centralize SQLite connection policy and explicit read/write transaction ownership
- add atomic bulk writes and migrate core plus module storage callers to the shared contract
- introduce ordered, shape-aware migrations for fresh, current, legacy, hybrid, and unknown database shapes
- harden backup and restore with consistent copies, staged integrity checks, atomic publication, and WAL/SHM cleanup
- enforce ownership boundaries with focused policy, transaction, migration, restore, and static contract tests

## Validation

- `python -m pytest tests/ -q --tb=short --ignore=tests/e2e` — 3797 passed, 2 skipped
- Chromium E2E, isolated file batches — 531 passed with exact 531-test denominator
- focused migration, storage, backup, and ownership tests — 92 passed
- 5,000-event bulk benchmark — one commit, one `executemany`, 0.027s wall time, 513 KiB peak memory
- `python -m compileall -q app tests`
- `git diff HEAD^ HEAD --check`

## Compatibility

Existing storage method signatures and the `connect_sqlite` compatibility seam remain unchanged. The migration registry is additive, the existing UTC migration remains separate, and no dependency, retention, synchronous-policy, or user-facing schema change is included.
