### PR TITLE
Centralize report and evidence period aggregation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -609,6 +609,31 @@ Return JSON { success: true, analysis: {...} }
 
 ---
 
+### Period aggregation layer
+
+Stored DOCSIS snapshots are reduced through
+`app.aggregation.aggregate_snapshot_period()`. The entry point is pure: callers
+supply inclusive UTC bounds and an independent threshold context, and receive a
+deterministically ordered, JSON-serializable aggregate with coverage,
+provenance-aware diagnostics, averages, totals, worst values, and channel
+drivers. Equal timestamps use a stable content digest as a tiebreaker while
+preserving duplicate multiplicity.
+
+Report PDFs, incident reports, complaint text, before/after comparison, and the
+evidence checklist share this contract. Storage queries remain in their route
+adapters. The evidence checklist loads snapshots once and requests its remaining
+timeline sources without modem data; BQM and Connection Monitor remain explicit
+external evidence adapters.
+
+Threshold resolution remains analyzer-owned. The analyzer exposes copied plain
+threshold data and pure resolution functions; the aggregation layer may call
+only those resolution functions, and the analyzer has no dependency on
+aggregation.
+
+Transition detection, latest-analysis home displays, local-calendar modulation
+analysis, storage trend queries, and journal incident-date windows intentionally
+retain their distinct scopes and semantics.
+
 ## Storage Layer
 
 **Database:** SQLite (`/data/docsis_history.db`) with WAL mode for concurrent access

--- a/app/aggregation/__init__.py
+++ b/app/aggregation/__init__.py
@@ -1,0 +1,28 @@
+"""Deterministic snapshot-period aggregation domain API."""
+
+from .contract import (
+    AGGREGATION_SCHEMA_VERSION,
+    Coverage,
+    PeriodAggregate,
+    ThresholdContext,
+    Window,
+)
+from .period import aggregate_snapshot_period
+from .provenance import derive_diagnostic_notes, derive_historical
+from .sources import select_preferred_bnetz, source_coverage
+from .window import canonical_utc_timestamp, report_bounds
+
+__all__ = [
+    "AGGREGATION_SCHEMA_VERSION",
+    "Coverage",
+    "PeriodAggregate",
+    "ThresholdContext",
+    "Window",
+    "aggregate_snapshot_period",
+    "canonical_utc_timestamp",
+    "derive_diagnostic_notes",
+    "derive_historical",
+    "report_bounds",
+    "select_preferred_bnetz",
+    "source_coverage",
+]

--- a/app/aggregation/contract.py
+++ b/app/aggregation/contract.py
@@ -1,0 +1,95 @@
+"""Plain-data contracts for deterministic snapshot-period aggregation."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, TypedDict
+
+AGGREGATION_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class Window:
+    """Inclusive UTC bounds supplied by the storage adapter."""
+
+    start: str
+    end: str
+
+
+class Coverage(TypedDict):
+    """Exhaustive source-value states within all snapshots in a period."""
+
+    samples: int
+    nulls: int
+    unsupported: int
+    invalid: int
+    missing: int
+    total: int
+
+
+@dataclass(frozen=True)
+class ThresholdContext:
+    """Independent active-threshold data and its profile provenance."""
+
+    raw: Mapping[str, Any]
+    profile_id: str | None
+    profile_version: str | None
+
+    @classmethod
+    def from_analyzer_snapshot(cls, snapshot: Mapping[str, Any]) -> ThresholdContext:
+        """Build an isolated context from :func:`app.analyzer.threshold_snapshot`."""
+        raw = snapshot.get("thresholds")
+        copied = copy.deepcopy(raw) if isinstance(raw, Mapping) else {}
+        profile = snapshot.get("profile")
+        profile = profile if isinstance(profile, Mapping) else {}
+        return cls(
+            raw=MappingProxyType(copied),
+            profile_id=profile.get("id"),
+            profile_version=profile.get("version"),
+        )
+
+
+class ThresholdProfileProvenance(TypedDict):
+    id: str | None
+    version: str | None
+
+
+class AnalyzerProvenanceEntry(TypedDict):
+    analyzer_schema: int | str | None
+    app_version: str | None
+    threshold_profile: ThresholdProfileProvenance
+    count: int
+
+
+class SnapshotAnalyzerProvenance(TypedDict):
+    legacy_no_metadata: int
+    metadata: list[AnalyzerProvenanceEntry]
+
+
+class AggregateProvenance(TypedDict):
+    source: str
+    active_threshold_profile: ThresholdProfileProvenance
+    stored_snapshot_analyzers: SnapshotAnalyzerProvenance
+
+
+class PeriodAggregate(TypedDict):
+    """JSON-serializable deterministic projection of a snapshot period."""
+
+    schema_version: int
+    window: dict[str, str]
+    snapshot_count: int
+    first_observed_at: str | None
+    last_observed_at: str | None
+    latest_snapshot: Mapping[str, Any] | None
+    provenance: AggregateProvenance
+    health_distribution: dict[Any, int]
+    worst: dict[str, Any]
+    metric_coverage: dict[str, Coverage]
+    averages: dict[str, float | None]
+    totals: dict[str, Any]
+    worst_channels: dict[str, list[tuple[Any, int]]]
+    samples: list[dict[str, Any]]
+    diagnostic_notes: list[dict[str, Any]]

--- a/app/aggregation/period.py
+++ b/app/aggregation/period.py
@@ -1,0 +1,326 @@
+"""Deterministic aggregation of stored DOCSIS snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from app.analyzer import resolve_snr_thresholds
+from app.docsis_utils import classify_channel_family
+
+from .contract import (
+    AGGREGATION_SCHEMA_VERSION,
+    Coverage,
+    PeriodAggregate,
+    ThresholdContext,
+    Window,
+)
+from .provenance import aggregate_provenance, derive_historical
+from .window import canonical_utc_timestamp
+
+_AVERAGE_FIELDS = {
+    "ds_power": "ds_power_avg",
+    "ds_snr": "ds_snr_avg",
+    "us_power": "us_power_avg",
+}
+_RAW_WORST_FIELDS = {
+    "ds_power_max": "ds_power_max",
+    "ds_power_min": "ds_power_min",
+    "us_power_max": "us_power_max",
+    "ds_snr_min": "ds_snr_min",
+    "ds_uncorrectable_max": "ds_uncorrectable_errors",
+    "ds_correctable_max": "ds_correctable_errors",
+}
+_COUNTER_FIELDS = {"ds_uncorrectable_max", "ds_correctable_max"}
+_WORST_FIELDS = (*_RAW_WORST_FIELDS, "ds_snr_warn_min")
+
+
+def _content_digest(snapshot: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        snapshot,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _ordered_snapshots(
+    snapshots: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    return sorted(
+        snapshots,
+        key=lambda snapshot: (
+            canonical_utc_timestamp(snapshot.get("timestamp")),
+            _content_digest(snapshot),
+        ),
+    )
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _empty_coverage(total: int) -> Coverage:
+    return {
+        "samples": 0,
+        "nulls": 0,
+        "unsupported": 0,
+        "invalid": 0,
+        "missing": 0,
+        "total": total,
+    }
+
+
+def _full_coverage(total: int) -> Coverage:
+    coverage = _empty_coverage(total)
+    coverage["samples"] = total
+    return coverage
+
+
+def _value_state(
+    values: Mapping[str, Any], key: str, *, unsupported: bool = False
+) -> str:
+    if unsupported:
+        return "unsupported"
+    if key not in values:
+        return "missing"
+    value = values[key]
+    if value is None:
+        return "nulls"
+    return "samples" if _number(value) is not None else "invalid"
+
+
+def _snr_warning_threshold(
+    snapshot: Mapping[str, Any], numeric_snr: float, thresholds: ThresholdContext
+) -> tuple[str, Any]:
+    """Classify a derived threshold without treating its source SNR as a sample.
+
+    Null/invalid/absent source SNR states are propagated by the caller. A valid
+    source is counted as a derived sample only when a matching channel yields a
+    finite warning threshold; otherwise the derived value is missing/invalid.
+    """
+    for channel in snapshot.get("ds_channels") or []:
+        if not isinstance(channel, Mapping) or _number(channel.get("snr")) != numeric_snr:
+            continue
+        family = channel.get("channel_family") or classify_channel_family("ds", channel)
+        spec = resolve_snr_thresholds(
+            channel.get("modulation"),
+            channel_family=family,
+            thresholds=thresholds.raw,
+        )
+        raw_warning = spec.get("warn_min")
+        if _number(raw_warning) is not None:
+            return "samples", raw_warning
+        return "invalid", None
+    return "missing", None
+
+
+def _bad_channels(
+    ordered: Sequence[Mapping[str, Any]], direction: str
+) -> list[tuple[Any, int]]:
+    counts: dict[Any, int] = {}
+    key = "ds_channels" if direction == "ds" else "us_channels"
+    for snapshot in ordered:
+        for channel in snapshot.get(key) or []:
+            if channel.get("health") in ("good", "tolerated"):
+                continue
+            channel_id = channel.get("channel_id", 0)
+            counts[channel_id] = counts.get(channel_id, 0) + 1
+    return sorted(counts.items(), key=lambda item: item[1], reverse=True)[:5]
+
+
+def aggregate_snapshot_period(
+    snapshots: Sequence[Mapping[str, Any]],
+    *,
+    window: Window,
+    thresholds: ThresholdContext,
+) -> PeriodAggregate:
+    """Aggregate stored snapshots deterministically within inclusive UTC bounds.
+
+    The caller owns storage filtering. This pure function preserves duplicate
+    multiplicity, orders equal timestamps by a content digest, keeps semantic
+    nulls distinct from numeric zero, and never mutates snapshots or thresholds.
+    """
+    ordered = _ordered_snapshots(list(snapshots or []))
+    total = len(ordered)
+    worst: dict[str, Any] = {
+        "ds_power_max": None,
+        "ds_power_min": None,
+        "us_power_max": None,
+        "ds_snr_min": None,
+        "ds_snr_warn_min": None,
+        "ds_uncorrectable_max": None,
+        "ds_correctable_max": None,
+        "health_critical_count": 0,
+        "health_marginal_count": 0,
+        "health_tolerated_count": 0,
+        "total_snapshots": total,
+    }
+    metric_coverage = {
+        key: _empty_coverage(total)
+        for key in (*_AVERAGE_FIELDS, *_WORST_FIELDS)
+    }
+    average_values: dict[str, list[float]] = {
+        "ds_power": [],
+        "ds_snr": [],
+        "us_power": [],
+    }
+    counter_totals = {"ds_correctable_errors": 0, "ds_uncorrectable_errors": 0}
+    counter_supported = {"ds_correctable_errors": False, "ds_uncorrectable_errors": False}
+    health_distribution: dict[Any, int] = {}
+    samples: list[dict[str, Any]] = []
+
+    for snapshot in ordered:
+        raw_summary = snapshot.get("summary")
+        summary = raw_summary if isinstance(raw_summary, Mapping) else {}
+        errors_supported = bool(summary.get("errors_supported", True))
+
+        for output_key, summary_key in _AVERAGE_FIELDS.items():
+            state = _value_state(summary, summary_key)
+            metric_coverage[output_key][state] += 1
+        for output_key, summary_key in _RAW_WORST_FIELDS.items():
+            state = _value_state(
+                summary,
+                summary_key,
+                unsupported=output_key in _COUNTER_FIELDS and not errors_supported,
+            )
+            metric_coverage[output_key][state] += 1
+
+        snr_source_state = _value_state(summary, "ds_snr_min")
+        derived_warning = None
+        if snr_source_state == "samples":
+            numeric_snr = _number(summary.get("ds_snr_min"))
+            assert numeric_snr is not None
+            warning_state, derived_warning = _snr_warning_threshold(
+                snapshot, numeric_snr, thresholds
+            )
+        else:
+            warning_state = snr_source_state
+        metric_coverage["ds_snr_warn_min"][warning_state] += 1
+
+        health = summary.get("health", "unknown")
+        health_distribution[health] = health_distribution.get(health, 0) + 1
+        if health == "critical":
+            worst["health_critical_count"] += 1
+        elif health == "marginal":
+            worst["health_marginal_count"] += 1
+        elif health == "tolerated":
+            worst["health_tolerated_count"] += 1
+
+        for output_key, summary_key in _AVERAGE_FIELDS.items():
+            value = _number(summary.get(summary_key))
+            if value is not None:
+                average_values[output_key].append(value)
+
+        for key in ("ds_power_max", "ds_power_min"):
+            raw = summary.get(key)
+            numeric = _number(raw)
+            if numeric is None:
+                continue
+            current = worst[key]
+            if current is None or abs(numeric) > abs(float(current)):
+                worst[key] = raw
+
+        raw = summary.get("us_power_max")
+        numeric = _number(raw)
+        if numeric is not None:
+            current = _number(worst["us_power_max"])
+            if current is None or numeric > current:
+                worst["us_power_max"] = raw
+
+        raw_snr = summary.get("ds_snr_min")
+        numeric_snr = _number(raw_snr)
+        if numeric_snr is not None:
+            current_snr = _number(worst["ds_snr_min"])
+            if current_snr is None or numeric_snr < current_snr:
+                worst["ds_snr_min"] = raw_snr
+                worst["ds_snr_warn_min"] = None
+            if (
+                numeric_snr == _number(worst["ds_snr_min"])
+                and worst["ds_snr_warn_min"] is None
+                and derived_warning is not None
+            ):
+                worst["ds_snr_warn_min"] = derived_warning
+
+        for summary_key, worst_key in (
+            ("ds_uncorrectable_errors", "ds_uncorrectable_max"),
+            ("ds_correctable_errors", "ds_correctable_max"),
+        ):
+            raw_counter = summary.get(summary_key) if errors_supported else None
+            numeric_counter = _number(raw_counter)
+            if numeric_counter is None:
+                continue
+            current = _number(worst[worst_key])
+            if current is None or numeric_counter > current:
+                worst[worst_key] = raw_counter
+            counter_supported[summary_key] = True
+            counter_totals[summary_key] += (
+                raw_counter
+                if isinstance(raw_counter, (int, float)) and not isinstance(raw_counter, bool)
+                else numeric_counter
+            )
+
+        uncorr = summary.get("ds_uncorrectable_errors") if errors_supported else None
+        if _number(uncorr) is None:
+            uncorr = None
+        samples.append({
+            "timestamp": canonical_utc_timestamp(snapshot.get("timestamp")),
+            "ds_power_avg": summary.get("ds_power_avg") if _number(summary.get("ds_power_avg")) is not None else None,
+            "ds_snr_avg": summary.get("ds_snr_avg") if _number(summary.get("ds_snr_avg")) is not None else None,
+            "us_power_avg": summary.get("us_power_avg") if _number(summary.get("us_power_avg")) is not None else None,
+            "uncorr_errors": uncorr,
+            "health": health,
+        })
+
+    historical = derive_historical(ordered, thresholds=thresholds)
+    metric_coverage.update({
+        "health_critical_count": _full_coverage(total),
+        "health_marginal_count": _full_coverage(total),
+        "health_tolerated_count": _full_coverage(total),
+        "total_snapshots": _full_coverage(total),
+    })
+    return {
+        "schema_version": AGGREGATION_SCHEMA_VERSION,
+        "window": {"start": window.start, "end": window.end},
+        "snapshot_count": total,
+        "first_observed_at": samples[0]["timestamp"] if samples else None,
+        "last_observed_at": samples[-1]["timestamp"] if samples else None,
+        "latest_snapshot": ordered[-1] if ordered else None,
+        "provenance": aggregate_provenance(ordered, thresholds=thresholds),
+        "health_distribution": health_distribution,
+        "worst": worst,
+        "metric_coverage": metric_coverage,
+        "averages": {
+            key: (sum(values) / len(values) if values else None)
+            for key, values in average_values.items()
+        },
+        "totals": {
+            "ds_correctable_errors": (
+                counter_totals["ds_correctable_errors"]
+                if counter_supported["ds_correctable_errors"] else None
+            ),
+            "ds_uncorrectable_errors": (
+                counter_totals["ds_uncorrectable_errors"]
+                if counter_supported["ds_uncorrectable_errors"] else None
+            ),
+            "correctable_supported": counter_supported["ds_correctable_errors"],
+            "uncorrectable_supported": counter_supported["ds_uncorrectable_errors"],
+            "errors_supported": any(counter_supported.values()),
+        },
+        "worst_channels": {
+            "ds": _bad_channels(ordered, "ds"),
+            "us": _bad_channels(ordered, "us"),
+        },
+        "samples": samples,
+        "diagnostic_notes": historical["diagnostic_notes"],
+    }

--- a/app/aggregation/provenance.py
+++ b/app/aggregation/provenance.py
@@ -1,0 +1,439 @@
+"""Provenance-aware historical diagnostic derivation."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from app.analyzer import resolve_ds_power_thresholds, resolve_snr_thresholds
+from app.docsis_utils import (
+    channel_type_label as _channel_type_label,
+)
+from app.docsis_utils import (
+    classify_channel_family as _classify_channel_family,
+)
+from app.docsis_utils import (
+    modulation_threshold_key as _modulation_threshold_key,
+)
+from app.threshold_profiles import BUILTIN_THRESHOLD_PROFILES
+
+from .contract import AggregateProvenance, ThresholdContext
+from .window import canonical_utc_timestamp
+
+_INVALID_METADATA_VALUE = "invalid"
+
+
+def _metadata_token(value: Any) -> str | None:
+    """Project a controlled metadata token without copying arbitrary payloads."""
+    if isinstance(value, str) or value is None:
+        return value
+    return _INVALID_METADATA_VALUE
+
+
+def _analyzer_schema(value: Any) -> int | str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return _INVALID_METADATA_VALUE
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and math.isfinite(value) and value.is_integer():
+        return int(value)
+    return _INVALID_METADATA_VALUE
+
+
+def aggregate_provenance(
+    snapshots: Sequence[Mapping[str, Any]], *, thresholds: ThresholdContext
+) -> AggregateProvenance:
+    """Return counted, deterministic, metadata-only aggregate provenance."""
+    counts: dict[tuple[int | str | None, str | None, str | None, str | None], int] = {}
+    legacy_no_metadata = 0
+    for snapshot in snapshots:
+        meta = snapshot.get("analysis_meta")
+        if not isinstance(meta, Mapping) or not any(
+            key in meta for key in ("analyzer_schema", "app_version", "threshold_profile")
+        ):
+            legacy_no_metadata += 1
+            continue
+
+        profile = meta.get("threshold_profile")
+        if isinstance(profile, Mapping):
+            profile_id = _metadata_token(profile.get("id"))
+            profile_version = _metadata_token(profile.get("version"))
+        elif profile is None:
+            profile_id = None
+            profile_version = None
+        else:
+            profile_id = _INVALID_METADATA_VALUE
+            profile_version = _INVALID_METADATA_VALUE
+        identity = (
+            _analyzer_schema(meta.get("analyzer_schema")),
+            _metadata_token(meta.get("app_version")),
+            profile_id,
+            profile_version,
+        )
+        counts[identity] = counts.get(identity, 0) + 1
+
+    metadata = [
+        {
+            "analyzer_schema": identity[0],
+            "app_version": identity[1],
+            "threshold_profile": {"id": identity[2], "version": identity[3]},
+            "count": count,
+        }
+        for identity, count in sorted(
+            counts.items(),
+            key=lambda item: tuple(
+                (type(value).__name__, str(value)) for value in item[0]
+            ),
+        )
+    ]
+    return {
+        "source": "stored_snapshots",
+        "active_threshold_profile": {
+            "id": _metadata_token(thresholds.profile_id),
+            "version": _metadata_token(thresholds.profile_version),
+        },
+        "stored_snapshot_analyzers": {
+            "legacy_no_metadata": legacy_no_metadata,
+            "metadata": metadata,
+        },
+    }
+
+def _historical_builtin_thresholds(snapshot):
+    """Return immutable built-in thresholds only for an exact provenance match."""
+    meta = snapshot.get("analysis_meta")
+    profile_ref = meta.get("threshold_profile") if isinstance(meta, dict) else None
+    if not isinstance(profile_ref, dict):
+        return None
+
+    profile_id = profile_ref.get("id")
+    profile_version = profile_ref.get("version")
+    for profile in BUILTIN_THRESHOLD_PROFILES:
+        if profile.get("id") != profile_id or profile.get("version") != profile_version:
+            continue
+        thresholds = profile.get("thresholds")
+        return thresholds if isinstance(thresholds, dict) else None
+    return None
+
+
+def _has_analyzer_snapshot_semantics(snapshot):
+    """Return whether sparse metric-health keys use analyzer-era semantics."""
+    meta = snapshot.get("analysis_meta")
+    if not isinstance(meta, dict):
+        return False
+
+    schema = meta.get("analyzer_schema")
+    if isinstance(schema, bool):
+        return False
+    if isinstance(schema, int):
+        return schema >= 1
+    if isinstance(schema, float):
+        return math.isfinite(schema) and schema.is_integer() and schema >= 1
+    return False
+
+
+def _historical_power_bounds(thresholds, direction, channel, family):
+    if thresholds is None:
+        return None
+    section_name = "upstream_power" if direction == "us" else "downstream_power"
+    section = thresholds.get(section_name)
+    if not isinstance(section, dict):
+        return None
+
+    if direction == "us":
+        key = "ofdma" if family == "ofdma" else "sc_qam"
+    elif family == "ofdm":
+        key = "ofdm"
+    else:
+        key = _modulation_threshold_key(channel.get("modulation"), section)
+    spec = section.get(key)
+    critical = spec.get("critical") if isinstance(spec, dict) else None
+    if not isinstance(critical, (list, tuple)) or len(critical) != 2:
+        return None
+    try:
+        return float(critical[0]), float(critical[1])
+    except (TypeError, ValueError):
+        return None
+
+
+def _historical_snr_min(thresholds, channel, family):
+    if thresholds is None:
+        return None
+    section = thresholds.get("snr")
+    if not isinstance(section, dict):
+        return None
+    key = "ofdm" if family == "ofdm" else _modulation_threshold_key(
+        channel.get("modulation"), section
+    )
+    spec = section.get(key)
+    if not isinstance(spec, dict) or "critical_min" not in spec:
+        return None
+    try:
+        return float(spec["critical_min"])
+    except (TypeError, ValueError):
+        return None
+
+
+def _stored_metric_direction(channel, metric):
+    """Read the analyzer's stored critical direction without reclassification."""
+    detail = str(channel.get("health_detail") or "").lower()
+    if metric == "snr" and "snr critical" in detail:
+        return "low"
+    if f"{metric} critical high" in detail:
+        return "high"
+    if f"{metric} critical low" in detail:
+        return "low"
+    return None
+
+
+def _diagnostic_note(
+    *, note_type, channel, channel_label, metric, value, boundary=None,
+    boundary_key=None, extreme_pct=50,
+):
+    note = {
+        "type": note_type,
+        "channel_id": channel.get("channel_id", "?"),
+        "channel_type": channel_label,
+        "metric": metric,
+        "value": value,
+        "unit": "dB" if metric == "SNR/MER" else "dBmV",
+        "severity": "critical",
+    }
+    if boundary is None or boundary_key is None:
+        return note
+
+    if boundary_key == "spec_max":
+        distance = value - boundary
+    else:
+        distance = boundary - value
+    if distance <= 0:
+        # The stored critical classification remains authoritative even when a
+        # supposedly matching profile is internally inconsistent with it.
+        return note
+
+    deviation = round(distance / max(abs(boundary), 1) * 100)
+    note.update({boundary_key: boundary, "deviation_pct": deviation})
+    note["severity"] = "extreme" if deviation > extreme_pct else "critical"
+    return note
+
+
+def _snapshot_diagnostic_notes(current_analysis, thresholds):
+    """Build critical notes without reinterpreting stored analyzer output.
+
+    Analyzer-era metric-health keys are sparse, so an absent key means good.
+    Exact numeric claims are reconstructed only from a built-in profile whose
+    stored id and version both match. Legacy snapshots without a key retain
+    the active-threshold behavior used before provenance was persisted.
+    """
+    if not current_analysis:
+        return []
+
+    notes = []
+    analyzer_snapshot = _has_analyzer_snapshot_semantics(current_analysis)
+    us_thresholds = (
+        {} if analyzer_snapshot else thresholds.raw.get("upstream_power", {})
+    )
+    historical_thresholds = _historical_builtin_thresholds(current_analysis)
+
+    for ch in current_analysis.get("us_channels", []):
+        power = ch.get("power")
+        if power is None:
+            continue
+        family = _classify_channel_family("us", ch)
+        key = "ofdma" if family == "ofdma" else "sc_qam"
+        channel_label = _channel_type_label("us", ch) or (ch.get("modulation") or key.upper())
+        if "power_health" in ch:
+            if ch.get("power_health") != "critical":
+                continue
+            bounds = _historical_power_bounds(historical_thresholds, "us", ch, family)
+            stored_direction = _stored_metric_direction(ch, "power")
+            if stored_direction is None and bounds is not None:
+                if power > bounds[1]:
+                    stored_direction = "high"
+                elif power < bounds[0]:
+                    stored_direction = "low"
+            if stored_direction == "high":
+                notes.append(_diagnostic_note(
+                    note_type="us_power_high", channel=ch, channel_label=channel_label,
+                    metric="upstream power", value=power,
+                    boundary=bounds[1] if bounds else None, boundary_key="spec_max",
+                ))
+            elif stored_direction == "low":
+                notes.append(_diagnostic_note(
+                    note_type="us_power_low", channel=ch, channel_label=channel_label,
+                    metric="upstream power", value=power,
+                    boundary=bounds[0] if bounds else None, boundary_key="spec_min",
+                ))
+            continue
+        if analyzer_snapshot:
+            continue
+
+        # Explicit legacy behavior: only snapshots predating analyzer schema
+        # provenance use the currently active analyzer profile.
+        spec = us_thresholds.get(key, {})
+        crit = spec.get("critical", [35.0, 53.0])
+        if power > crit[1]:
+            notes.append(_diagnostic_note(
+                note_type="us_power_high", channel=ch, channel_label=channel_label,
+                metric="upstream power", value=power,
+                boundary=crit[1], boundary_key="spec_max",
+            ))
+        elif power < crit[0]:
+            notes.append(_diagnostic_note(
+                note_type="us_power_low", channel=ch, channel_label=channel_label,
+                metric="upstream power", value=power,
+                boundary=crit[0], boundary_key="spec_min",
+            ))
+
+    for ch in current_analysis.get("ds_channels", []):
+        mod = (ch.get("modulation") or "256QAM").upper()
+        family = ch.get("channel_family") or _classify_channel_family("ds", ch)
+        channel_label = _channel_type_label("ds", ch) or mod
+        power = ch.get("power")
+        if power is not None:
+            if "power_health" in ch:
+                if ch.get("power_health") == "critical":
+                    bounds = _historical_power_bounds(historical_thresholds, "ds", ch, family)
+                    stored_direction = _stored_metric_direction(ch, "power")
+                    if stored_direction is None and bounds is not None:
+                        if power > bounds[1]:
+                            stored_direction = "high"
+                        elif power < bounds[0]:
+                            stored_direction = "low"
+                    if stored_direction == "high":
+                        notes.append(_diagnostic_note(
+                            note_type="ds_power_high", channel=ch, channel_label=channel_label,
+                            metric="downstream power", value=power,
+                            boundary=bounds[1] if bounds else None, boundary_key="spec_max",
+                        ))
+                    elif stored_direction == "low":
+                        notes.append(_diagnostic_note(
+                            note_type="ds_power_low", channel=ch, channel_label=channel_label,
+                            metric="downstream power", value=power,
+                            boundary=bounds[0] if bounds else None, boundary_key="spec_min",
+                        ))
+            elif not analyzer_snapshot:
+                spec = resolve_ds_power_thresholds(mod, channel_family=family, thresholds=thresholds.raw)
+                if power > spec["crit_max"]:
+                    notes.append(_diagnostic_note(
+                        note_type="ds_power_high", channel=ch, channel_label=channel_label,
+                        metric="downstream power", value=power,
+                        boundary=spec["crit_max"], boundary_key="spec_max",
+                    ))
+                elif power < spec["crit_min"]:
+                    notes.append(_diagnostic_note(
+                        note_type="ds_power_low", channel=ch, channel_label=channel_label,
+                        metric="downstream power", value=power,
+                        boundary=spec["crit_min"], boundary_key="spec_min",
+                    ))
+
+        snr = ch.get("snr")
+        if snr is not None:
+            if "snr_health" in ch:
+                if ch.get("snr_health") == "critical":
+                    snr_crit = _historical_snr_min(historical_thresholds, ch, family)
+                    if _stored_metric_direction(ch, "snr") == "low":
+                        notes.append(_diagnostic_note(
+                            note_type="snr_low", channel=ch, channel_label=channel_label,
+                            metric="SNR/MER", value=snr, boundary=snr_crit,
+                            boundary_key="spec_min", extreme_pct=30,
+                        ))
+            elif not analyzer_snapshot:
+                snr_spec = resolve_snr_thresholds(mod, channel_family=family, thresholds=thresholds.raw)
+                snr_crit = snr_spec["crit_min"]
+                if snr < snr_crit:
+                    notes.append(_diagnostic_note(
+                        note_type="snr_low", channel=ch, channel_label=channel_label,
+                        metric="SNR/MER", value=snr, boundary=snr_crit,
+                        boundary_key="spec_min", extreme_pct=30,
+                    ))
+
+    return notes
+
+
+_DIAGNOSTIC_TYPE_ORDER = {
+    "us_power_high": 0,
+    "us_power_low": 1,
+    "ds_power_high": 2,
+    "ds_power_low": 3,
+    "snr_low": 4,
+}
+
+
+_canonical_snapshot_timestamp = canonical_utc_timestamp
+
+def _stable_channel_identity(note):
+    channel_id = note.get("channel_id")
+    try:
+        return 0, int(channel_id)
+    except (TypeError, ValueError):
+        return 1, str(channel_id or "")
+
+
+def _derive_historical(snapshots, *, thresholds: ThresholdContext):
+    """Derive latest status and one deterministic worst diagnostic per type."""
+    prepared = []
+    candidates = []
+    for snapshot in snapshots or []:
+        observed_at = _canonical_snapshot_timestamp(snapshot.get("timestamp"))
+        prepared.append((observed_at, snapshot))
+        for note in _snapshot_diagnostic_notes(snapshot, thresholds):
+            candidate = dict(note)
+            candidate["observed_at"] = observed_at
+            candidates.append(candidate)
+
+    latest_snapshot = None
+    if prepared:
+        latest_snapshot = max(prepared, key=lambda item: item[0])[1]
+
+    selected = {}
+    for note in candidates:
+        note_type = note.get("type")
+        if note_type not in _DIAGNOSTIC_TYPE_ORDER:
+            continue
+        numeric_provenance = "deviation_pct" in note
+        if numeric_provenance:
+            try:
+                evidence_rank = -float(note["deviation_pct"])
+            except (TypeError, ValueError):
+                numeric_provenance = False
+        if not numeric_provenance:
+            try:
+                raw_value = float(note.get("value"))
+            except (TypeError, ValueError):
+                raw_value = 0.0
+            evidence_rank = -raw_value if note_type.endswith("_high") else raw_value
+
+        # Exact numeric provenance is preferred because its deviations are
+        # historically comparable. Neutral stored-critical evidence is ranked
+        # only by its direction-aware raw value; no percentage is fabricated.
+        rank = (
+            0 if numeric_provenance else 1,
+            evidence_rank,
+            note["observed_at"],
+            _stable_channel_identity(note),
+            str(note.get("channel_type") or ""),
+            _DIAGNOSTIC_TYPE_ORDER[note_type],
+        )
+        existing = selected.get(note_type)
+        if existing is None or rank < existing[0]:
+            selected[note_type] = (rank, note)
+
+    notes = [
+        selected[note_type][1]
+        for note_type in sorted(selected, key=_DIAGNOSTIC_TYPE_ORDER.get)
+    ]
+    return {"latest_snapshot": latest_snapshot, "diagnostic_notes": notes}
+
+
+
+def derive_historical(snapshots, *, thresholds: ThresholdContext):
+    """Derive latest status and deterministic diagnostic notes for a period."""
+    return _derive_historical(snapshots, thresholds=thresholds)
+
+
+def derive_diagnostic_notes(ordered_snapshots, thresholds: ThresholdContext):
+    """Derive deterministic provenance-aware notes for ordered snapshots."""
+    return _derive_historical(ordered_snapshots, thresholds=thresholds)["diagnostic_notes"]

--- a/app/aggregation/sources.py
+++ b/app/aggregation/sources.py
@@ -1,0 +1,42 @@
+"""Small pure projections for non-snapshot evidence sources."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from .window import canonical_utc_timestamp
+
+
+def source_coverage(
+    rows: Iterable[Mapping[str, Any]], timestamp_key: str = "timestamp"
+) -> dict[str, Any]:
+    """Return additive row count and latest valid timestamp for a source."""
+    count = 0
+    latest: tuple[str, Any] | None = None
+    for row in rows:
+        raw_count = row.get("sample_count") or row.get("count") or 1
+        try:
+            count += int(raw_count)
+        except (TypeError, ValueError):
+            count += 1
+        raw_timestamp = row.get(timestamp_key)
+        canonical = canonical_utc_timestamp(raw_timestamp)
+        if not raw_timestamp or len(canonical) != 20 or not canonical.endswith("Z"):
+            continue
+        if latest is None or canonical > latest[0]:
+            latest = canonical, raw_timestamp
+    return {
+        "count": count,
+        "last_observed_at": latest[1] if latest else None,
+    }
+
+
+def select_preferred_bnetz(
+    rows: Sequence[Mapping[str, Any]] | None,
+) -> Mapping[str, Any] | None:
+    """Select the newest deviation measurement, otherwise the newest row."""
+    for row in reversed(rows or []):
+        if row.get("verdict_download") == "deviation" or row.get("verdict_upload") == "deviation":
+            return row
+    return rows[-1] if rows else None

--- a/app/aggregation/window.py
+++ b/app/aggregation/window.py
@@ -1,0 +1,39 @@
+"""UTC window normalization for snapshot aggregation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from .contract import Window
+
+
+def canonical_utc_timestamp(value: Any) -> str:
+    """Normalize a timestamp to second-resolution UTC, preserving invalid input."""
+    raw = str(value or "").strip()
+    normalized = raw[:-1] + "+00:00" if raw.endswith(("Z", "z")) else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except (TypeError, ValueError):
+        return str(value or "")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def report_bounds(
+    snapshots: Sequence[Mapping[str, Any]] | None,
+    *,
+    window: Window | None = None,
+) -> tuple[str, str]:
+    """Return requested inclusive bounds or deterministic observed extremes."""
+    timestamps = sorted(
+        canonical_utc_timestamp(snapshot.get("timestamp"))
+        for snapshot in snapshots or []
+    )
+    start = window.start if window and window.start else (timestamps[0] if timestamps else "-")
+    end = window.end if window and window.end else (timestamps[-1] if timestamps else "-")
+    return start, end

--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -6,12 +6,18 @@ community threshold profiles loaded through the module system.
 
 from __future__ import annotations
 
+import copy
 import logging
-from typing import Literal
+from collections.abc import Mapping
+from typing import Any, Literal
 
 from .docsis_utils import (
     classify_channel_family as _shared_classify_channel_family,
+)
+from .docsis_utils import (
     modulation_threshold_key as _modulation_threshold_key,
+)
+from .docsis_utils import (
     parse_qam_order as _parse_qam_order,
 )
 from .error_counters import (
@@ -20,7 +26,7 @@ from .error_counters import (
     uncorrectable_percentage,
 )
 from .types import AnalysisResult, DocsisData, SignalFamilyHealthCause
-from .tz import utc_now, _parse_utc
+from .tz import _parse_utc, utc_now
 
 log = logging.getLogger("docsis.analyzer")
 
@@ -95,9 +101,14 @@ def _resolve_modulation(modulation, section):
     return _modulation_threshold_key(modulation, section)
 
 
-def _get_ds_power_thresholds(modulation=None, *, channel_family: str | None = None):
-    """Get DS power thresholds for a given modulation."""
-    ds = _t().get("downstream_power", {})
+def resolve_ds_power_thresholds(
+    modulation=None,
+    *,
+    channel_family: str | None = None,
+    thresholds: Mapping[str, Any],
+):
+    """Resolve downstream power thresholds from an explicit plain-data mapping."""
+    ds = thresholds.get("downstream_power", {})
     if channel_family == "ofdm" and "ofdm" in ds:
         t = ds["ofdm"]
     else:
@@ -114,6 +125,13 @@ def _get_ds_power_thresholds(modulation=None, *, channel_family: str | None = No
         "crit_min": crit[0],
         "crit_max": crit[1],
     }
+
+
+def _get_ds_power_thresholds(modulation=None, *, channel_family: str | None = None):
+    """Get DS power thresholds for a given modulation."""
+    return resolve_ds_power_thresholds(
+        modulation, channel_family=channel_family, thresholds=_t()
+    )
 
 
 def _get_us_power_thresholds(channel_type=None):
@@ -138,9 +156,14 @@ def _get_us_power_thresholds(channel_type=None):
     }
 
 
-def _get_snr_thresholds(modulation=None, *, channel_family: str | None = None):
-    """Get SNR thresholds for a given modulation."""
-    snr = _t().get("snr", {})
+def resolve_snr_thresholds(
+    modulation=None,
+    *,
+    channel_family: str | None = None,
+    thresholds: Mapping[str, Any],
+):
+    """Resolve downstream SNR thresholds from an explicit plain-data mapping."""
+    snr = thresholds.get("snr", {})
     if not isinstance(snr, dict):
         snr = {}
     if channel_family == "ofdm" and "ofdm" in snr:
@@ -153,6 +176,13 @@ def _get_snr_thresholds(modulation=None, *, channel_family: str | None = None):
         "warn_min": t.get("warning_min", t.get("good_min", 33.0)),
         "crit_min": t.get("critical_min", 29.0),
     }
+
+
+def _get_snr_thresholds(modulation=None, *, channel_family: str | None = None):
+    """Get SNR thresholds for a given modulation."""
+    return resolve_snr_thresholds(
+        modulation, channel_family=channel_family, thresholds=_t()
+    )
 
 
 def _get_us_modulation_thresholds():
@@ -478,6 +508,14 @@ def get_thresholds():
             return obj
         return {k: _strip(v) for k, v in obj.items() if not k.startswith("_")}
     return _strip(_t())
+
+
+def threshold_snapshot() -> dict[str, Any]:
+    """Return an independent plain-data capture of active thresholds and provenance."""
+    return {
+        "thresholds": copy.deepcopy(_t()),
+        "profile": copy.deepcopy(_threshold_profile),
+    }
 
 
 def _parse_float(val, default=None):

--- a/app/modules/comparison/routes.py
+++ b/app/modules/comparison/routes.py
@@ -1,7 +1,15 @@
 """Before/After Comparison module routes."""
 
-from flask import Blueprint, request, jsonify
-from app.web import require_auth, get_storage
+from flask import Blueprint, jsonify, request
+
+from app.aggregation import (
+    ThresholdContext,
+    Window,
+    aggregate_snapshot_period,
+    report_bounds,
+)
+from app.analyzer import threshold_snapshot
+from app.web import get_storage, require_auth
 
 bp = Blueprint("comparison_module", __name__)
 
@@ -10,78 +18,37 @@ def _get_storage():
     return get_storage()
 
 
-def _aggregate_period(snapshots):
-    """Aggregate a list of snapshots into period summary."""
-    if not snapshots:
-        return {
-            "snapshots": 0,
-            "avg": {"ds_power": None, "ds_snr": None, "us_power": None},
-            "total": {"corr_errors": None, "uncorr_errors": None},
-            "errors_supported": False,
-            "corr_errors_supported": False,
-            "uncorr_errors_supported": False,
-            "health_distribution": {},
-            "timeseries": [],
-        }
-
-    ds_power = []
-    ds_snr = []
-    us_power = []
-    corr_total = 0
-    uncorr_total = 0
-    corr_errors_supported = False
-    uncorr_errors_supported = False
-    health_counts = {}
-    timeseries = []
-
-    for snap in snapshots:
-        s = snap.get("summary", {})
-        if s.get("ds_power_avg") is not None:
-            ds_power.append(s["ds_power_avg"])
-        if s.get("ds_snr_avg") is not None:
-            ds_snr.append(s["ds_snr_avg"])
-        if s.get("us_power_avg") is not None:
-            us_power.append(s["us_power_avg"])
-        errors_supported = s.get("errors_supported", True)
-        corr_errors = s.get("ds_correctable_errors") if errors_supported else None
-        uncorr_errors = s.get("ds_uncorrectable_errors") if errors_supported else None
-        if corr_errors is not None:
-            corr_errors_supported = True
-            corr_total += corr_errors
-        if uncorr_errors is not None:
-            uncorr_errors_supported = True
-            uncorr_total += uncorr_errors
-        h = s.get("health", "unknown")
-        health_counts[h] = health_counts.get(h, 0) + 1
-        timeseries.append({
-            "timestamp": snap.get("timestamp", ""),
-            "ds_power_avg": s.get("ds_power_avg"),
-            "ds_snr_avg": s.get("ds_snr_avg"),
-            "us_power_avg": s.get("us_power_avg"),
-            "uncorr_errors": uncorr_errors,
-            "health": h,
-        })
-
-    def avg(lst):
-        return round(sum(lst) / len(lst), 2) if lst else None
-
+def _comparison_view(aggregate):
+    """Map the shared aggregate to the established comparison response shape."""
+    totals = aggregate["totals"]
     return {
-        "snapshots": len(snapshots),
+        "snapshots": aggregate["snapshot_count"],
         "avg": {
-            "ds_power": avg(ds_power),
-            "ds_snr": avg(ds_snr),
-            "us_power": avg(us_power),
+            key: (round(value, 2) if value is not None else None)
+            for key, value in aggregate["averages"].items()
         },
         "total": {
-            "corr_errors": corr_total if corr_errors_supported else None,
-            "uncorr_errors": uncorr_total if uncorr_errors_supported else None,
+            "corr_errors": totals["ds_correctable_errors"],
+            "uncorr_errors": totals["ds_uncorrectable_errors"],
         },
-        "errors_supported": corr_errors_supported or uncorr_errors_supported,
-        "corr_errors_supported": corr_errors_supported,
-        "uncorr_errors_supported": uncorr_errors_supported,
-        "health_distribution": health_counts,
-        "timeseries": timeseries,
+        "errors_supported": totals["errors_supported"],
+        "corr_errors_supported": totals["correctable_supported"],
+        "uncorr_errors_supported": totals["uncorrectable_supported"],
+        "health_distribution": aggregate["health_distribution"],
+        "timeseries": aggregate["samples"],
     }
+
+
+def _comparison_period(snapshots):
+    """Compatibility adapter for comparison helper callers."""
+    bounds = report_bounds(snapshots)
+    thresholds = ThresholdContext.from_analyzer_snapshot(threshold_snapshot())
+    aggregate = aggregate_snapshot_period(
+        snapshots,
+        window=Window(*bounds),
+        thresholds=thresholds,
+    )
+    return _comparison_view(aggregate)
 
 
 def _compute_delta(period_a, period_b):
@@ -139,8 +106,19 @@ def compare_periods(storage, from_a, to_a, from_b, to_b):
     snapshots_a = storage.get_range_data(from_a, to_a)
     snapshots_b = storage.get_range_data(from_b, to_b)
 
-    period_a = _aggregate_period(snapshots_a)
-    period_b = _aggregate_period(snapshots_b)
+    thresholds = ThresholdContext.from_analyzer_snapshot(threshold_snapshot())
+    aggregate_a = aggregate_snapshot_period(
+        snapshots_a,
+        window=Window(from_a, to_a),
+        thresholds=thresholds,
+    )
+    aggregate_b = aggregate_snapshot_period(
+        snapshots_b,
+        window=Window(from_b, to_b),
+        thresholds=thresholds,
+    )
+    period_a = _comparison_view(aggregate_a)
+    period_b = _comparison_view(aggregate_b)
     period_a["from"] = from_a
     period_a["to"] = to_a
     period_b["from"] = from_b

--- a/app/modules/evidence/checklist.py
+++ b/app/modules/evidence/checklist.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
-from typing import Any, Iterable
+from typing import Any
+
+from app.aggregation import source_coverage
 
 PRESENT = "present"
 STALE = "stale"
@@ -34,15 +37,7 @@ def _parse_ts(value: str | None) -> datetime | None:
 
 
 def _latest_ts(rows: Iterable[dict[str, Any]], timestamp_key: str = "timestamp") -> str | None:
-    latest: datetime | None = None
-    latest_raw: str | None = None
-    for row in rows:
-        raw = row.get(timestamp_key)
-        parsed = _parse_ts(raw)
-        if parsed is not None and (latest is None or parsed > latest):
-            latest = parsed
-            latest_raw = raw
-    return latest_raw
+    return source_coverage(rows, timestamp_key)["last_observed_at"]
 
 
 def _is_stale(last_ts: str | None, window_end: str | None, hours: int) -> bool:
@@ -84,14 +79,28 @@ def _source_rows(timeline: Iterable[dict[str, Any]], *sources: str) -> list[dict
 
 
 def _row_count(rows: Iterable[dict[str, Any]]) -> int:
-    total = 0
-    for row in rows:
-        count = row.get("sample_count") or row.get("count") or 1
-        try:
-            total += int(count)
-        except (TypeError, ValueError):
-            total += 1
-    return total
+    return source_coverage(rows)["count"]
+
+
+def _evidence_status_values(
+    count: int,
+    last_ts: str | None,
+    *,
+    configured: bool = True,
+    applicable: bool = True,
+    optional_when_unconfigured: bool = True,
+    window_end: str | None,
+    stale_key: str | None = None,
+) -> tuple[str, str | None]:
+    if not applicable:
+        return NOT_APPLICABLE, None
+    if not configured and count == 0:
+        return (OPTIONAL if optional_when_unconfigured else MISSING), None
+    if count == 0:
+        return MISSING, None
+    if stale_key and _is_stale(last_ts, window_end, _STALE_HOURS[stale_key]):
+        return STALE, last_ts
+    return PRESENT, last_ts
 
 
 def _evidence_status(
@@ -103,16 +112,16 @@ def _evidence_status(
     window_end: str | None,
     stale_key: str | None = None,
 ) -> tuple[str, str | None]:
-    if not applicable:
-        return NOT_APPLICABLE, None
-    if not configured and not rows:
-        return (OPTIONAL if optional_when_unconfigured else MISSING), None
-    if not rows:
-        return MISSING, None
-    last_ts = _latest_ts(rows)
-    if stale_key and _is_stale(last_ts, window_end, _STALE_HOURS[stale_key]):
-        return STALE, last_ts
-    return PRESENT, last_ts
+    coverage = source_coverage(rows)
+    return _evidence_status_values(
+        coverage["count"],
+        coverage["last_observed_at"],
+        configured=configured,
+        applicable=applicable,
+        optional_when_unconfigured=optional_when_unconfigured,
+        window_end=window_end,
+        stale_key=stale_key,
+    )
 
 
 def _latency_item(
@@ -189,6 +198,7 @@ def build_checklist(
     bqm_rows: list[dict[str, Any]] | None,
     connection_latency_rows: list[dict[str, Any]] | None = None,
     capabilities: dict[str, Any] | None = None,
+    snapshot_aggregate: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Build the stateless evidence checklist for an incident or selected window."""
     capabilities = capabilities or {}
@@ -205,12 +215,24 @@ def build_checklist(
     event_rows = _source_rows(timeline, "event", "events")
     bnetz_rows = _source_rows(timeline, "bnetz")
 
-    signal_status, signal_last = _evidence_status(
-        signal_rows,
-        applicable=docsis_supported,
-        window_end=window_end,
-        stale_key="signal",
-    )
+    if snapshot_aggregate is None:
+        signal_count = len(signal_rows)
+        signal_status, signal_last = _evidence_status(
+            signal_rows,
+            applicable=docsis_supported,
+            window_end=window_end,
+            stale_key="signal",
+        )
+    else:
+        signal_count = int(snapshot_aggregate.get("snapshot_count") or 0)
+        signal_last = snapshot_aggregate.get("last_observed_at")
+        signal_status, signal_last = _evidence_status_values(
+            signal_count,
+            signal_last,
+            applicable=docsis_supported,
+            window_end=window_end,
+            stale_key="signal",
+        )
     speed_status, speed_last = _evidence_status(
         speedtest_rows,
         configured=speedtest_configured,
@@ -230,7 +252,7 @@ def build_checklist(
     bnetz_last = _latest_ts(bnetz_rows)
 
     items = [
-        _item("signal", signal_status, len(signal_rows), signal_last, {"view": "correlation"}, demo=demo),
+        _item("signal", signal_status, signal_count, signal_last, {"view": "correlation"}, demo=demo),
         _item("speedtest", speed_status, len(speedtest_rows), speed_last, {"view": "speedtest"}, demo=demo),
         _latency_item(
             bqm_rows=bqm_rows,

--- a/app/modules/evidence/routes.py
+++ b/app/modules/evidence/routes.py
@@ -5,17 +5,23 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
-
-from app.storage.sqlite import open_read
 from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from flask import Blueprint, jsonify, request
 
-from app.tz import get_tz_name, local_date_to_utc_range, local_to_utc, local_today
-from app.web import require_auth, get_config_manager, get_storage
+from app.aggregation import (
+    ThresholdContext,
+    Window,
+    aggregate_snapshot_period,
+    canonical_utc_timestamp,
+)
+from app.analyzer import threshold_snapshot
 from app.modules.journal.storage import JournalStorage
+from app.storage.sqlite import open_read
+from app.tz import get_tz_name, local_date_to_utc_range, local_to_utc, local_today
+from app.web import get_config_manager, get_storage, require_auth
 
 from .checklist import build_checklist, summarize_checklist
 
@@ -39,10 +45,8 @@ def _get_tz_name() -> str:
 
 
 def _utc_datetime(value: str) -> datetime:
-    normalized = value.replace("Z", "+00:00")
+    normalized = canonical_utc_timestamp(value).replace("Z", "+00:00")
     parsed = datetime.fromisoformat(normalized)
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
 
 
@@ -89,6 +93,7 @@ def _get_journal_entries_for_window(db_path: str, start_ts: str, end_ts: str) ->
 
 
 def _get_bqm_rows(db_path: str, start_ts: str, end_ts: str) -> list[dict[str, Any]] | None:
+    """Load BQM rows through the external latency-source adapter."""
     try:
         from app.modules.bqm.storage import BqmStorage
         tz_name = _get_tz_name()
@@ -135,7 +140,7 @@ def _get_connection_monitor_db_path() -> str:
 
 
 def _get_connection_latency_rows(start_ts: str, end_ts: str) -> list[dict[str, Any]]:
-    """Return compact Connection Monitor latency evidence rows for a UTC window."""
+    """Load compact rows through the external Connection Monitor source adapter."""
     db_path = _get_connection_monitor_db_path()
     if not os.path.exists(db_path):
         return []
@@ -293,7 +298,18 @@ def api_evidence_checklist():
             return jsonify({"error": "from/to must be valid ISO timestamps"}), 400
         journal_entries = _get_journal_entries_for_window(core.db_path, window["from"], window["to"])
 
-    timeline = core.get_correlation_timeline(window["from"], window["to"])
+    snapshots = core.get_range_data(window["from"], window["to"])
+    thresholds = ThresholdContext.from_analyzer_snapshot(threshold_snapshot())
+    snapshot_aggregate = aggregate_snapshot_period(
+        snapshots,
+        window=Window(window["from"], window["to"]),
+        thresholds=thresholds,
+    )
+    timeline = core.get_correlation_timeline(
+        window["from"],
+        window["to"],
+        sources={"speedtest", "events", "bnetz", "segment", "capture"},
+    )
     bqm_rows = _get_bqm_rows(core.db_path, window["from"], window["to"])
     connection_latency_rows = _get_connection_latency_rows(window["from"], window["to"])
     config_manager = get_config_manager()
@@ -305,6 +321,7 @@ def api_evidence_checklist():
         bqm_rows=bqm_rows,
         connection_latency_rows=connection_latency_rows,
         capabilities=capabilities,
+        snapshot_aggregate=snapshot_aggregate,
     )
     return jsonify({
         "window": window,

--- a/app/modules/reports/report.py
+++ b/app/modules/reports/report.py
@@ -3,19 +3,21 @@
 import io
 import json
 import logging
-import math
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 
 from fpdf import FPDF
 
-from app.analyzer import _get_ds_power_thresholds, _get_snr_thresholds, get_thresholds
-from app.docsis_utils import (
-    channel_type_label as _channel_type_label,
-    classify_channel_family as _classify_channel_family,
-    modulation_threshold_key as _modulation_threshold_key,
+from app.aggregation import (
+    ThresholdContext,
+    Window,
+    aggregate_snapshot_period,
+    canonical_utc_timestamp,
+    derive_historical,
+    report_bounds,
+    select_preferred_bnetz,
 )
-from app.threshold_profiles import BUILTIN_THRESHOLD_PROFILES
+from app.analyzer import get_thresholds, threshold_snapshot
 
 log = logging.getLogger("docsis.report")
 
@@ -99,344 +101,30 @@ def _default_warn_thresholds(ds_snr_warn_min=None):
     }
 
 
-def _historical_builtin_thresholds(snapshot):
-    """Return immutable built-in thresholds only for an exact provenance match."""
-    meta = snapshot.get("analysis_meta")
-    profile_ref = meta.get("threshold_profile") if isinstance(meta, dict) else None
-    if not isinstance(profile_ref, dict):
-        return None
-
-    profile_id = profile_ref.get("id")
-    profile_version = profile_ref.get("version")
-    for profile in BUILTIN_THRESHOLD_PROFILES:
-        if profile.get("id") != profile_id or profile.get("version") != profile_version:
-            continue
-        thresholds = profile.get("thresholds")
-        return thresholds if isinstance(thresholds, dict) else None
-    return None
-
-
-def _has_analyzer_snapshot_semantics(snapshot):
-    """Return whether sparse metric-health keys use analyzer-era semantics."""
-    meta = snapshot.get("analysis_meta")
-    if not isinstance(meta, dict):
-        return False
-
-    schema = meta.get("analyzer_schema")
-    if isinstance(schema, bool):
-        return False
-    if isinstance(schema, int):
-        return schema >= 1
-    if isinstance(schema, float):
-        return math.isfinite(schema) and schema.is_integer() and schema >= 1
-    return False
-
-
-def _historical_power_bounds(thresholds, direction, channel, family):
-    if thresholds is None:
-        return None
-    section_name = "upstream_power" if direction == "us" else "downstream_power"
-    section = thresholds.get(section_name)
-    if not isinstance(section, dict):
-        return None
-
-    if direction == "us":
-        key = "ofdma" if family == "ofdma" else "sc_qam"
-    elif family == "ofdm":
-        key = "ofdm"
-    else:
-        key = _modulation_threshold_key(channel.get("modulation"), section)
-    spec = section.get(key)
-    critical = spec.get("critical") if isinstance(spec, dict) else None
-    if not isinstance(critical, (list, tuple)) or len(critical) != 2:
-        return None
-    try:
-        return float(critical[0]), float(critical[1])
-    except (TypeError, ValueError):
-        return None
-
-
-def _historical_snr_min(thresholds, channel, family):
-    if thresholds is None:
-        return None
-    section = thresholds.get("snr")
-    if not isinstance(section, dict):
-        return None
-    key = "ofdm" if family == "ofdm" else _modulation_threshold_key(
-        channel.get("modulation"), section
-    )
-    spec = section.get(key)
-    if not isinstance(spec, dict) or "critical_min" not in spec:
-        return None
-    try:
-        return float(spec["critical_min"])
-    except (TypeError, ValueError):
-        return None
-
-
-def _stored_metric_direction(channel, metric):
-    """Read the analyzer's stored critical direction without reclassification."""
-    detail = str(channel.get("health_detail") or "").lower()
-    if metric == "snr" and "snr critical" in detail:
-        return "low"
-    if f"{metric} critical high" in detail:
-        return "high"
-    if f"{metric} critical low" in detail:
-        return "low"
-    return None
-
-
-def _diagnostic_note(
-    *, note_type, channel, channel_label, metric, value, boundary=None,
-    boundary_key=None, extreme_pct=50,
-):
-    note = {
-        "type": note_type,
-        "channel_id": channel.get("channel_id", "?"),
-        "channel_type": channel_label,
-        "metric": metric,
-        "value": value,
-        "severity": "critical",
-    }
-    if boundary is None or boundary_key is None:
-        return note
-
-    if boundary_key == "spec_max":
-        distance = value - boundary
-    else:
-        distance = boundary - value
-    if distance <= 0:
-        # The stored critical classification remains authoritative even when a
-        # supposedly matching profile is internally inconsistent with it.
-        return note
-
-    deviation = round(distance / max(abs(boundary), 1) * 100)
-    note.update({boundary_key: boundary, "deviation_pct": deviation})
-    note["severity"] = "extreme" if deviation > extreme_pct else "critical"
-    return note
-
-
-def _build_diagnostic_notes(current_analysis):
-    """Build critical notes without reinterpreting stored analyzer output.
-
-    Analyzer-era metric-health keys are sparse, so an absent key means good.
-    Exact numeric claims are reconstructed only from a built-in profile whose
-    stored id and version both match. Legacy snapshots without a key retain
-    the active-threshold behavior used before provenance was persisted.
-    """
-    if not current_analysis:
-        return []
-
-    notes = []
-    analyzer_snapshot = _has_analyzer_snapshot_semantics(current_analysis)
-    us_thresholds = (
-        {} if analyzer_snapshot else get_thresholds().get("upstream_power", {})
-    )
-    historical_thresholds = _historical_builtin_thresholds(current_analysis)
-
-    for ch in current_analysis.get("us_channels", []):
-        power = ch.get("power")
-        if power is None:
-            continue
-        family = _classify_channel_family("us", ch)
-        key = "ofdma" if family == "ofdma" else "sc_qam"
-        channel_label = _channel_type_label("us", ch) or (ch.get("modulation") or key.upper())
-        if "power_health" in ch:
-            if ch.get("power_health") != "critical":
-                continue
-            bounds = _historical_power_bounds(historical_thresholds, "us", ch, family)
-            stored_direction = _stored_metric_direction(ch, "power")
-            if stored_direction is None and bounds is not None:
-                if power > bounds[1]:
-                    stored_direction = "high"
-                elif power < bounds[0]:
-                    stored_direction = "low"
-            if stored_direction == "high":
-                notes.append(_diagnostic_note(
-                    note_type="us_power_high", channel=ch, channel_label=channel_label,
-                    metric="upstream power", value=power,
-                    boundary=bounds[1] if bounds else None, boundary_key="spec_max",
-                ))
-            elif stored_direction == "low":
-                notes.append(_diagnostic_note(
-                    note_type="us_power_low", channel=ch, channel_label=channel_label,
-                    metric="upstream power", value=power,
-                    boundary=bounds[0] if bounds else None, boundary_key="spec_min",
-                ))
-            continue
-        if analyzer_snapshot:
-            continue
-
-        # Explicit legacy behavior: only snapshots predating analyzer schema
-        # provenance use the currently active analyzer profile.
-        spec = us_thresholds.get(key, {})
-        crit = spec.get("critical", [35.0, 53.0])
-        if power > crit[1]:
-            notes.append(_diagnostic_note(
-                note_type="us_power_high", channel=ch, channel_label=channel_label,
-                metric="upstream power", value=power,
-                boundary=crit[1], boundary_key="spec_max",
-            ))
-        elif power < crit[0]:
-            notes.append(_diagnostic_note(
-                note_type="us_power_low", channel=ch, channel_label=channel_label,
-                metric="upstream power", value=power,
-                boundary=crit[0], boundary_key="spec_min",
-            ))
-
-    for ch in current_analysis.get("ds_channels", []):
-        mod = (ch.get("modulation") or "256QAM").upper()
-        family = ch.get("channel_family") or _classify_channel_family("ds", ch)
-        channel_label = _channel_type_label("ds", ch) or mod
-        power = ch.get("power")
-        if power is not None:
-            if "power_health" in ch:
-                if ch.get("power_health") == "critical":
-                    bounds = _historical_power_bounds(historical_thresholds, "ds", ch, family)
-                    stored_direction = _stored_metric_direction(ch, "power")
-                    if stored_direction is None and bounds is not None:
-                        if power > bounds[1]:
-                            stored_direction = "high"
-                        elif power < bounds[0]:
-                            stored_direction = "low"
-                    if stored_direction == "high":
-                        notes.append(_diagnostic_note(
-                            note_type="ds_power_high", channel=ch, channel_label=channel_label,
-                            metric="downstream power", value=power,
-                            boundary=bounds[1] if bounds else None, boundary_key="spec_max",
-                        ))
-                    elif stored_direction == "low":
-                        notes.append(_diagnostic_note(
-                            note_type="ds_power_low", channel=ch, channel_label=channel_label,
-                            metric="downstream power", value=power,
-                            boundary=bounds[0] if bounds else None, boundary_key="spec_min",
-                        ))
-            elif not analyzer_snapshot:
-                spec = _get_ds_power_thresholds(mod, channel_family=family)
-                if power > spec["crit_max"]:
-                    notes.append(_diagnostic_note(
-                        note_type="ds_power_high", channel=ch, channel_label=channel_label,
-                        metric="downstream power", value=power,
-                        boundary=spec["crit_max"], boundary_key="spec_max",
-                    ))
-                elif power < spec["crit_min"]:
-                    notes.append(_diagnostic_note(
-                        note_type="ds_power_low", channel=ch, channel_label=channel_label,
-                        metric="downstream power", value=power,
-                        boundary=spec["crit_min"], boundary_key="spec_min",
-                    ))
-
-        snr = ch.get("snr")
-        if snr is not None:
-            if "snr_health" in ch:
-                if ch.get("snr_health") == "critical":
-                    snr_crit = _historical_snr_min(historical_thresholds, ch, family)
-                    if _stored_metric_direction(ch, "snr") == "low":
-                        notes.append(_diagnostic_note(
-                            note_type="snr_low", channel=ch, channel_label=channel_label,
-                            metric="SNR/MER", value=snr, boundary=snr_crit,
-                            boundary_key="spec_min", extreme_pct=30,
-                        ))
-            elif not analyzer_snapshot:
-                snr_spec = _get_snr_thresholds(mod, channel_family=family)
-                snr_crit = snr_spec["crit_min"]
-                if snr < snr_crit:
-                    notes.append(_diagnostic_note(
-                        note_type="snr_low", channel=ch, channel_label=channel_label,
-                        metric="SNR/MER", value=snr, boundary=snr_crit,
-                        boundary_key="spec_min", extreme_pct=30,
-                    ))
-
-    return notes
-
-
-_DIAGNOSTIC_TYPE_ORDER = {
-    "us_power_high": 0,
-    "us_power_low": 1,
-    "ds_power_high": 2,
-    "ds_power_low": 3,
-    "snr_low": 4,
-}
-
-
 def _canonical_snapshot_timestamp(value):
-    """Return a canonical UTC timestamp for deterministic report rendering."""
-    raw = str(value or "").strip()
-    if raw.endswith(("Z", "z")):
-        raw = raw[:-1] + "+00:00"
-    try:
-        parsed = datetime.fromisoformat(raw)
-    except ValueError:
-        return str(value or "")
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc).replace(microsecond=0).strftime(
-        "%Y-%m-%dT%H:%M:%SZ"
-    )
-
-
-def _stable_channel_identity(note):
-    channel_id = note.get("channel_id")
-    try:
-        return 0, int(channel_id)
-    except (TypeError, ValueError):
-        return 1, str(channel_id or "")
+    """Compatibility delegate for deterministic report timestamp rendering."""
+    return canonical_utc_timestamp(value)
 
 
 def derive_historical_report_data(snapshots):
-    """Derive latest status and one deterministic worst diagnostic per type."""
-    prepared = []
-    candidates = []
-    for snapshot in snapshots or []:
-        observed_at = _canonical_snapshot_timestamp(snapshot.get("timestamp"))
-        prepared.append((observed_at, snapshot))
-        for note in _build_diagnostic_notes(snapshot):
-            candidate = dict(note)
-            candidate["observed_at"] = observed_at
-            candidates.append(candidate)
+    """Derive latest status and deterministic diagnostics with active thresholds."""
+    thresholds = ThresholdContext.from_analyzer_snapshot(threshold_snapshot())
+    historical = derive_historical(snapshots, thresholds=thresholds)
+    return {
+        "latest_snapshot": historical["latest_snapshot"],
+        "diagnostic_notes": [
+            {key: value for key, value in note.items() if key != "unit"}
+            for note in historical["diagnostic_notes"]
+        ],
+    }
 
-    latest_snapshot = None
-    if prepared:
-        latest_snapshot = max(prepared, key=lambda item: item[0])[1]
 
-    selected = {}
-    for note in candidates:
-        note_type = note.get("type")
-        if note_type not in _DIAGNOSTIC_TYPE_ORDER:
-            continue
-        numeric_provenance = "deviation_pct" in note
-        if numeric_provenance:
-            try:
-                evidence_rank = -float(note["deviation_pct"])
-            except (TypeError, ValueError):
-                numeric_provenance = False
-        if not numeric_provenance:
-            try:
-                raw_value = float(note.get("value"))
-            except (TypeError, ValueError):
-                raw_value = 0.0
-            evidence_rank = -raw_value if note_type.endswith("_high") else raw_value
-
-        # Exact numeric provenance is preferred because its deviations are
-        # historically comparable. Neutral stored-critical evidence is ranked
-        # only by its direction-aware raw value; no percentage is fabricated.
-        rank = (
-            0 if numeric_provenance else 1,
-            evidence_rank,
-            note["observed_at"],
-            _stable_channel_identity(note),
-            str(note.get("channel_type") or ""),
-            _DIAGNOSTIC_TYPE_ORDER[note_type],
-        )
-        existing = selected.get(note_type)
-        if existing is None or rank < existing[0]:
-            selected[note_type] = (rank, note)
-
-    notes = [
-        selected[note_type][1]
-        for note_type in sorted(selected, key=_DIAGNOSTIC_TYPE_ORDER.get)
+def _build_diagnostic_notes(current_analysis):
+    """Compatibility delegate for report helper callers."""
+    return [
+        {key: value for key, value in note.items() if key != "observed_at"}
+        for note in derive_historical_report_data([current_analysis])["diagnostic_notes"]
     ]
-    return {"latest_snapshot": latest_snapshot, "diagnostic_notes": notes}
 
 
 def _format_diagnostic_note(note, s):
@@ -662,104 +350,33 @@ def _format_optional_measurement(value):
     return "N/A" if value is None else str(value)
 
 
-def _compute_worst_values(snapshots):
-    """Compute worst values across all snapshots in the range."""
-    worst = {
-        "ds_power_max": None,
-        "ds_power_min": None,
-        "us_power_max": None,
-        "ds_snr_min": None,
-        "ds_snr_warn_min": None,
-        "ds_uncorrectable_max": None,
-        "ds_correctable_max": None,
-        "health_critical_count": 0,
-        "health_marginal_count": 0,
-        "health_tolerated_count": 0,
-        "total_snapshots": len(snapshots),
-    }
-    for snap in snapshots:
-        s = snap["summary"]
-        ds_power_max = s.get("ds_power_max")
-        if ds_power_max is not None and (
-            worst["ds_power_max"] is None
-            or abs(ds_power_max) > abs(worst["ds_power_max"])
-        ):
-            worst["ds_power_max"] = ds_power_max
-        ds_power_min = s.get("ds_power_min")
-        if ds_power_min is not None and (
-            worst["ds_power_min"] is None
-            or abs(ds_power_min) > abs(worst["ds_power_min"])
-        ):
-            worst["ds_power_min"] = ds_power_min
-        us_power_max = s.get("us_power_max")
-        if us_power_max is not None and (
-            worst["us_power_max"] is None or us_power_max > worst["us_power_max"]
-        ):
-            worst["us_power_max"] = us_power_max
-        ds_snr_min = s.get("ds_snr_min")
-        if ds_snr_min is not None and (
-            worst["ds_snr_min"] is None or ds_snr_min < worst["ds_snr_min"]
-        ):
-            worst["ds_snr_min"] = ds_snr_min
-            worst["ds_snr_warn_min"] = None
-        if (
-            ds_snr_min is not None
-            and ds_snr_min == worst["ds_snr_min"]
-            and worst["ds_snr_warn_min"] is None
-        ):
-            try:
-                target_snr = float(ds_snr_min)
-            except (TypeError, ValueError):
-                target_snr = None
-            if target_snr is not None:
-                for ch in snap.get("ds_channels") or []:
-                    try:
-                        channel_snr = float(ch.get("snr"))
-                    except (TypeError, ValueError):
-                        continue
-                    if channel_snr != target_snr:
-                        continue
-                    family = ch.get("channel_family") or _classify_channel_family("ds", ch)
-                    snr_spec = _get_snr_thresholds(ch.get("modulation"), channel_family=family)
-                    worst["ds_snr_warn_min"] = snr_spec["warn_min"]
-                    break
-        errors_supported = s.get("errors_supported", True)
-        uncorr_errors = s.get("ds_uncorrectable_errors") if errors_supported else None
-        corr_errors = s.get("ds_correctable_errors") if errors_supported else None
-        if uncorr_errors is not None and (
-            worst["ds_uncorrectable_max"] is None or uncorr_errors > worst["ds_uncorrectable_max"]
-        ):
-            worst["ds_uncorrectable_max"] = uncorr_errors
-        if corr_errors is not None and (
-            worst["ds_correctable_max"] is None or corr_errors > worst["ds_correctable_max"]
-        ):
-            worst["ds_correctable_max"] = corr_errors
-        health = s.get("health", "good")
-        if health == "critical":
-            worst["health_critical_count"] += 1
-        elif health == "marginal":
-            worst["health_marginal_count"] += 1
-        elif health == "tolerated":
-            worst["health_tolerated_count"] += 1
-    return worst
+def _aggregate_report_period(snapshots, report_start=None, report_end=None):
+    requested = Window(report_start or "", report_end or "")
+    start, end = report_bounds(snapshots, window=requested)
+    thresholds = ThresholdContext.from_analyzer_snapshot(threshold_snapshot())
+    aggregate = aggregate_snapshot_period(
+        snapshots,
+        window=Window(start, end),
+        thresholds=thresholds,
+    )
+    return aggregate, start, end
 
 
-def _find_worst_channels(snapshots):
-    """Find channels that were most frequently in bad health."""
-    ds_issues = {}
-    us_issues = {}
-    for snap in snapshots:
-        for ch in snap.get("ds_channels", []):
-            cid = ch.get("channel_id", 0)
-            if ch.get("health") not in ("good", "tolerated"):
-                ds_issues[cid] = ds_issues.get(cid, 0) + 1
-        for ch in snap.get("us_channels", []):
-            cid = ch.get("channel_id", 0)
-            if ch.get("health") not in ("good", "tolerated"):
-                us_issues[cid] = us_issues.get(cid, 0) + 1
-    ds_sorted = sorted(ds_issues.items(), key=lambda x: x[1], reverse=True)[:5]
-    us_sorted = sorted(us_issues.items(), key=lambda x: x[1], reverse=True)[:5]
-    return ds_sorted, us_sorted
+def _legacy_worst_values(snapshots):
+    """Compatibility adapter for existing report-helper callers."""
+    aggregate, _, _ = _aggregate_report_period(snapshots)
+    return aggregate["worst"]
+
+
+def _legacy_worst_channels(snapshots):
+    """Compatibility adapter for existing report-helper callers."""
+    aggregate, _, _ = _aggregate_report_period(snapshots)
+    channels = aggregate["worst_channels"]
+    return channels["ds"], channels["us"]
+
+
+_compute_worst_values = _legacy_worst_values
+_find_worst_channels = _legacy_worst_channels
 
 
 def _comparison_label(s, key):
@@ -852,13 +469,11 @@ def _format_customer_closing(s, customer_name="", customer_number="", customer_a
 
 
 def _report_bounds(snapshots, report_start=None, report_end=None):
-    timestamps = sorted(
-        _canonical_snapshot_timestamp(snapshot.get("timestamp"))
-        for snapshot in snapshots or []
+    """Compatibility delegate for inclusive report labeling bounds."""
+    return report_bounds(
+        snapshots,
+        window=Window(report_start or "", report_end or ""),
     )
-    start = report_start or (timestamps[0] if timestamps else "-")
-    end = report_end or (timestamps[-1] if timestamps else "-")
-    return start, end
 
 
 def generate_report(
@@ -895,10 +510,11 @@ def generate_report(
     config = config or {}
     connection_info = connection_info or {}
     s = _get_report_strings(lang)
-    report_start, report_end = _report_bounds(snapshots, report_start, report_end)
-    historical = derive_historical_report_data(snapshots)
-    latest_snapshot = historical["latest_snapshot"]
-    diag_notes = historical["diagnostic_notes"]
+    period_aggregate, report_start, report_end = _aggregate_report_period(
+        snapshots, report_start, report_end
+    )
+    latest_snapshot = period_aggregate["latest_snapshot"]
+    diag_notes = period_aggregate["diagnostic_notes"]
     pdf = IncidentReport(lang=lang)
     pdf.alias_nb_pages()
     pdf.add_page()
@@ -1012,7 +628,7 @@ def generate_report(
     if snapshots:
         pdf.add_page()
         pdf._section_title(s["section_historical"])
-        worst = _compute_worst_values(snapshots)
+        worst = period_aggregate["worst"]
 
         pdf._key_value(s["total_measurements"], str(worst["total_snapshots"]))
         pdf._key_value(s["measurements_critical"], str(worst["health_critical_count"]), bold_value=True)
@@ -1033,7 +649,8 @@ def generate_report(
         pdf.ln(3)
 
         # Worst channels
-        ds_worst, us_worst = _find_worst_channels(snapshots)
+        ds_worst = period_aggregate["worst_channels"]["ds"]
+        us_worst = period_aggregate["worst_channels"]["us"]
         if ds_worst:
             pdf.set_font("dejavu", "B", 10)
             pdf.cell(0, 6, s["worst_ds_channels"], new_x="LMARGIN", new_y="NEXT")
@@ -1070,7 +687,7 @@ def generate_report(
     complaint_closing = _format_customer_closing(s, customer_name, customer_number, customer_address)
 
     if snapshots:
-        worst = _compute_worst_values(snapshots)
+        worst = period_aggregate["worst"]
         warn = _default_warn_thresholds(worst["ds_snr_warn_min"])
         start = report_start[:10]
         end = report_end[:10]
@@ -1136,6 +753,7 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
     config = config or {}
     connection_info = connection_info or {}
     s = _get_report_strings(lang)
+    period_aggregate, _, _ = _aggregate_report_period(snapshots)
     pdf = IncidentReport(lang=lang)
     # Override the header title for incident reports
     pdf._s = dict(pdf._s)
@@ -1191,7 +809,7 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
     if snapshots:
         pdf.add_page()
         pdf._section_title(s["section_historical"])
-        worst = _compute_worst_values(snapshots)
+        worst = period_aggregate["worst"]
 
         pdf._key_value(s["total_measurements"], str(worst["total_snapshots"]))
         pdf._key_value(s["measurements_critical"], str(worst["health_critical_count"]), bold_value=True)
@@ -1212,7 +830,8 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
         pdf.ln(3)
 
         # Worst channels
-        ds_worst, us_worst = _find_worst_channels(snapshots)
+        ds_worst = period_aggregate["worst_channels"]["ds"]
+        us_worst = period_aggregate["worst_channels"]["us"]
         if ds_worst:
             pdf.set_font("dejavu", "B", 10)
             pdf.cell(0, 6, s["worst_ds_channels"], new_x="LMARGIN", new_y="NEXT")
@@ -1363,10 +982,10 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
     pdf.set_font("dejavu", "", 9)
 
     if snapshots:
-        worst = _compute_worst_values(snapshots)
+        worst = period_aggregate["worst"]
         warn = _default_warn_thresholds(worst["ds_snr_warn_min"])
-        start = snapshots[0]["timestamp"][:10]
-        end = snapshots[-1]["timestamp"][:10]
+        start = period_aggregate["first_observed_at"][:10]
+        end = period_aggregate["last_observed_at"][:10]
         poor_pct = round(worst['health_critical_count'] / max(worst['total_snapshots'], 1) * 100)
         complaint = (
             f"{s['complaint_subject']}\n\n"
@@ -1393,14 +1012,7 @@ def generate_incident_report(incident, entries, snapshots, speedtests, bnetz_lis
 
     # Add BNetzA reference if measurements exist
     if bnetz_list:
-        # Pick best measurement (prefer deviation)
-        bnetz_data = None
-        for m in reversed(bnetz_list):
-            if m.get("verdict_download") == "deviation" or m.get("verdict_upload") == "deviation":
-                bnetz_data = m
-                break
-        if not bnetz_data:
-            bnetz_data = bnetz_list[-1]
+        bnetz_data = select_preferred_bnetz(bnetz_list)
 
         dl_max = round(bnetz_data.get("download_max_tariff") or 0)
         dl_avg = round(bnetz_data.get("download_measured_avg") or 0)
@@ -1457,9 +1069,10 @@ def generate_complaint_text(snapshots, config=None, connection_info=None, lang="
     config = config or {}
     s = _get_report_strings(lang)
     isp = config.get("isp_name", "Unknown ISP")
-    report_start, report_end = _report_bounds(snapshots, report_start, report_end)
-    historical = derive_historical_report_data(snapshots)
-    diag_notes = historical["diagnostic_notes"]
+    period_aggregate, report_start, report_end = _aggregate_report_period(
+        snapshots, report_start, report_end
+    )
+    diag_notes = period_aggregate["diagnostic_notes"]
 
     # Build closing with actual customer data
     closing_lines = []
@@ -1507,7 +1120,7 @@ def generate_complaint_text(snapshots, config=None, connection_info=None, lang="
     comparison_section = _format_comparison_evidence(comparison_data, s)
 
     if snapshots:
-        worst = _compute_worst_values(snapshots)
+        worst = period_aggregate["worst"]
         warn = _default_warn_thresholds(worst["ds_snr_warn_min"])
         start = report_start[:10]
         end = report_end[:10]

--- a/app/modules/reports/routes.py
+++ b/app/modules/reports/routes.py
@@ -3,13 +3,16 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
-from flask import Blueprint, request, jsonify, make_response
+from flask import Blueprint, jsonify, make_response, request
 
-from app.tz import utc_now, utc_cutoff
+from app.aggregation import select_preferred_bnetz
+from app.tz import utc_cutoff, utc_now
 from app.web import (
-    require_auth,
-    get_storage, get_config_manager, get_state,
     _get_lang,
+    get_config_manager,
+    get_state,
+    get_storage,
+    require_auth,
 )
 
 from .report import generate_complaint_text, generate_report
@@ -211,13 +214,7 @@ def api_complaint():
                 bnetz_data = next((m for m in all_bnetz if m["id"] == bnetz_id), None)
             else:
                 in_range = _bnetz_storage.get_bnetz_in_range(start_ts, end_ts)
-                # Prefer most recent with deviation
-                for m in reversed(in_range):
-                    if m.get("verdict_download") == "deviation" or m.get("verdict_upload") == "deviation":
-                        bnetz_data = m
-                        break
-                if not bnetz_data and in_range:
-                    bnetz_data = in_range[-1]
+                bnetz_data = select_preferred_bnetz(in_range)
         except (ImportError, Exception):
             pass  # BNetzA module not available
 

--- a/tests/aggregation/test_determinism.py
+++ b/tests/aggregation/test_determinism.py
@@ -1,0 +1,36 @@
+import hashlib
+import json
+import random
+
+from app.aggregation import ThresholdContext, Window, aggregate_snapshot_period
+
+
+def _digest(value):
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def test_one_hundred_seeded_permutations_have_one_digest_and_do_not_mutate_context():
+    snapshots = [
+        {
+            "timestamp": f"2026-05-01T00:00:0{index % 3}Z",
+            "summary": {"health": "good", "ds_power_avg": index, "ds_uncorrectable_errors": 0},
+            "ds_channels": [],
+            "us_channels": [],
+        }
+        for index in range(6)
+    ]
+    context = ThresholdContext.from_analyzer_snapshot({
+        "thresholds": {"downstream_power": {}, "upstream_power": {}, "snr": {}},
+        "profile": {"id": "test", "version": "1"},
+    })
+    before = _digest(dict(context.raw))
+    window = Window("2026-05-01T00:00:00Z", "2026-05-01T23:59:59Z")
+    digests = set()
+    for seed in range(100):
+        shuffled = list(snapshots)
+        random.Random(seed).shuffle(shuffled)
+        digests.add(_digest(aggregate_snapshot_period(shuffled, window=window, thresholds=context)))
+
+    assert len(digests) == 1
+    assert _digest(dict(context.raw)) == before

--- a/tests/aggregation/test_period_aggregate.py
+++ b/tests/aggregation/test_period_aggregate.py
@@ -1,0 +1,180 @@
+from app.aggregation import ThresholdContext, Window, aggregate_snapshot_period
+
+WINDOW = Window("2026-05-01T00:00:00Z", "2026-05-05T00:00:00Z")
+
+
+def _thresholds():
+    return ThresholdContext.from_analyzer_snapshot({
+        "thresholds": {
+            "downstream_power": {},
+            "upstream_power": {},
+            "snr": {
+                "_default": "256QAM",
+                "256QAM": {"good_min": 33, "warning_min": 31, "critical_min": 29},
+                "ofdm": {"good_min": 27, "warning_min": 25.5, "critical_min": 24.5},
+            },
+        },
+        "profile": {"id": "test", "version": "1"},
+    })
+
+
+def _snapshot(timestamp, **summary):
+    return {
+        "timestamp": timestamp,
+        "summary": {"health": "good", **summary},
+        "ds_channels": [],
+        "us_channels": [],
+    }
+
+
+def test_semantic_nulls_supported_zero_and_metric_coverage_are_distinct():
+    snapshots = [
+        _snapshot(
+            "2026-05-01T00:00:00Z",
+            ds_power_avg=0,
+            ds_power_max=0,
+            ds_uncorrectable_errors=0,
+            ds_correctable_errors=0,
+        ),
+        _snapshot(
+            "2026-05-02T00:00:00Z",
+            ds_power_avg=None,
+            ds_power_max=None,
+            ds_uncorrectable_errors=None,
+            ds_correctable_errors=None,
+        ),
+        _snapshot(
+            "2026-05-03T00:00:00Z",
+            errors_supported=False,
+            ds_uncorrectable_errors=99,
+            ds_correctable_errors=99,
+        ),
+        _snapshot(
+            "2026-05-04T00:00:00Z",
+            ds_power_avg="invalid",
+            ds_power_max="invalid",
+            ds_uncorrectable_errors="invalid",
+            ds_correctable_errors=float("inf"),
+        ),
+        _snapshot("2026-05-05T00:00:00Z"),
+    ]
+
+    aggregate = aggregate_snapshot_period(snapshots, window=WINDOW, thresholds=_thresholds())
+
+    assert aggregate["averages"]["ds_power"] == 0
+    assert aggregate["worst"]["ds_power_max"] == 0
+    assert aggregate["worst"]["ds_uncorrectable_max"] == 0
+    assert aggregate["metric_coverage"]["ds_power"] == {
+        "samples": 1,
+        "nulls": 1,
+        "unsupported": 0,
+        "invalid": 1,
+        "missing": 2,
+        "total": 5,
+    }
+    assert aggregate["metric_coverage"]["ds_power_max"] == {
+        "samples": 1,
+        "nulls": 1,
+        "unsupported": 0,
+        "invalid": 1,
+        "missing": 2,
+        "total": 5,
+    }
+    assert aggregate["metric_coverage"]["ds_uncorrectable_max"] == {
+        "samples": 1,
+        "nulls": 1,
+        "unsupported": 1,
+        "invalid": 1,
+        "missing": 1,
+        "total": 5,
+    }
+    assert aggregate["samples"][2]["uncorr_errors"] is None
+
+    state_keys = {"samples", "nulls", "unsupported", "invalid", "missing"}
+    raw_metrics = {
+        "ds_power",
+        "ds_snr",
+        "us_power",
+        "ds_power_max",
+        "ds_power_min",
+        "us_power_max",
+        "ds_snr_min",
+        "ds_uncorrectable_max",
+        "ds_correctable_max",
+    }
+    assert raw_metrics <= aggregate["metric_coverage"].keys()
+    for coverage in aggregate["metric_coverage"].values():
+        assert set(coverage) == state_keys | {"total"}
+        assert all(type(coverage[key]) is int for key in coverage)
+        assert sum(coverage[key] for key in state_keys) == coverage["total"] == 5
+
+
+def test_abs_magnitude_worst_and_supplying_channel_warning_threshold_are_preserved():
+    first = _snapshot(
+        "2026-05-01T00:00:00Z", ds_power_max=10, ds_power_min=-4, ds_snr_min=30
+    )
+    first["ds_channels"] = [{
+        "channel_id": 3,
+        "modulation": "256QAM",
+        "snr": 30,
+        "health": "critical",
+    }]
+    second = _snapshot(
+        "2026-05-02T00:00:00Z", ds_power_max=-12, ds_power_min=8, ds_snr_min=32
+    )
+
+    aggregate = aggregate_snapshot_period([second, first], window=WINDOW, thresholds=_thresholds())
+
+    assert aggregate["worst"]["ds_power_max"] == -12
+    assert aggregate["worst"]["ds_power_min"] == 8
+    assert aggregate["worst"]["ds_snr_min"] == 30
+    assert aggregate["worst"]["ds_snr_warn_min"] == 31
+    assert aggregate["worst_channels"]["ds"] == [(3, 1)]
+
+
+def test_duplicate_timestamps_keep_multiplicity_and_content_tiebreak_selects_latest():
+    first = _snapshot("2026-05-02T00:00:00Z", ds_power_avg=1, health="good")
+    second = _snapshot("2026-05-02T00:00:00Z", ds_power_avg=2, health="critical")
+
+    left = aggregate_snapshot_period([first, second, first], window=WINDOW, thresholds=_thresholds())
+    right = aggregate_snapshot_period([first, first, second], window=WINDOW, thresholds=_thresholds())
+
+    assert left == right
+    assert left["snapshot_count"] == 3
+    assert sum(left["health_distribution"].values()) == 3
+    assert left["latest_snapshot"] in (first, second)
+
+
+def test_good_period_average_keeps_the_stored_critical_channel_as_diagnostic_driver():
+    snapshot = _snapshot(
+        "2026-05-01T00:00:00Z",
+        health="good",
+        ds_power_avg=0.0,
+    )
+    snapshot["analysis_meta"] = {
+        "analyzer_schema": 3,
+        "app_version": "2026.7-test",
+        "threshold_profile": {"id": "unavailable", "version": "1"},
+    }
+    snapshot["ds_channels"] = [{
+        "channel_id": 41,
+        "channel_family": "sc_qam",
+        "modulation": "256QAM",
+        "power": 12.0,
+        "power_health": "critical",
+        "health": "critical",
+        "health_detail": "power critical high",
+    }]
+
+    aggregate = aggregate_snapshot_period([snapshot], window=WINDOW, thresholds=_thresholds())
+
+    assert aggregate["health_distribution"] == {"good": 1}
+    assert aggregate["averages"]["ds_power"] == 0.0
+    assert len(aggregate["diagnostic_notes"]) == 1
+    driver = aggregate["diagnostic_notes"][0]
+    assert driver["type"] == "ds_power_high"
+    assert driver["channel_id"] == 41
+    assert driver["metric"] == "downstream power"
+    assert driver["value"] == 12.0
+    assert driver["unit"] == "dBmV"
+    assert driver["severity"] == "critical"

--- a/tests/aggregation/test_provenance.py
+++ b/tests/aggregation/test_provenance.py
@@ -1,0 +1,156 @@
+import hashlib
+import json
+import random
+
+from app.aggregation import (
+    ThresholdContext,
+    Window,
+    aggregate_snapshot_period,
+    derive_historical,
+)
+
+
+def _context(ds_critical):
+    return ThresholdContext.from_analyzer_snapshot({
+        "thresholds": {
+            "downstream_power": {
+                "_default": "256QAM",
+                "256QAM": {
+                    "good": list(ds_critical),
+                    "warning": list(ds_critical),
+                    "critical": list(ds_critical),
+                },
+            },
+            "upstream_power": {},
+            "snr": {},
+        },
+        "profile": {"id": "injected", "version": "1"},
+    })
+
+
+def _snapshot(*, analyzer_meta=False):
+    snapshot = {
+        "timestamp": "2026-05-01T00:00:00Z",
+        "summary": {"health": "critical"},
+        "ds_channels": [{
+            "channel_id": 7,
+            "modulation": "256QAM",
+            "power": 12.0,
+            "health": "critical",
+        }],
+        "us_channels": [],
+    }
+    if analyzer_meta:
+        snapshot["analysis_meta"] = {
+            "analyzer_schema": 3,
+            "threshold_profile": {"id": "missing", "version": "1"},
+        }
+        snapshot["ds_channels"][0].update({
+            "power_health": "critical",
+            "health_detail": "power critical high",
+        })
+    return snapshot
+
+
+def test_legacy_fallback_uses_only_the_injected_threshold_context():
+    permissive = derive_historical([_snapshot()], thresholds=_context((-20, 20)))
+    restrictive = derive_historical([_snapshot()], thresholds=_context((-5, 5)))
+
+    assert permissive["diagnostic_notes"] == []
+    assert restrictive["diagnostic_notes"][0]["type"] == "ds_power_high"
+
+
+def test_analyzer_era_snapshot_does_not_fall_back_to_active_thresholds():
+    first = derive_historical([_snapshot(analyzer_meta=True)], thresholds=_context((-20, 20)))
+    second = derive_historical([_snapshot(analyzer_meta=True)], thresholds=_context((-5, 5)))
+
+    assert first == second
+    assert "deviation_pct" not in first["diagnostic_notes"][0]
+
+
+def test_aggregate_provenance_is_counted_sanitized_and_permutation_stable():
+    shared_meta = {
+        "analyzer_schema": 3,
+        "app_version": "2026.7-test",
+        "threshold_profile": {"id": "builtin.default", "version": "1.1.0"},
+        "locale": "private-locale",
+    }
+    snapshots = [
+        {
+            "timestamp": "2026-05-01T00:00:00Z",
+            "summary": {"health": "good"},
+            "analysis_meta": shared_meta,
+            "raw_data": {"password": "secret"},
+            "ds_channels": [],
+            "us_channels": [],
+        },
+        {
+            "timestamp": "2026-05-02T00:00:00Z",
+            "summary": {"health": "good"},
+            "analysis_meta": dict(shared_meta),
+            "ds_channels": [],
+            "us_channels": [],
+        },
+        {
+            "timestamp": "2026-05-03T00:00:00Z",
+            "summary": {"health": "good"},
+            "analysis_meta": {
+                "analyzer_schema": 2,
+                "app_version": "2026.6-test",
+                "threshold_profile": {"id": "builtin.legacy", "version": "1.0.0"},
+            },
+            "ds_channels": [],
+            "us_channels": [],
+        },
+        {
+            "timestamp": "2026-05-04T00:00:00Z",
+            "summary": {"health": "good"},
+            "analysis_meta": None,
+            "ds_channels": [],
+            "us_channels": [],
+        },
+    ]
+    context = _context((-20, 20))
+    window = Window("2026-05-01T00:00:00Z", "2026-05-04T00:00:00Z")
+
+    digests = set()
+    provenance = None
+    for seed in range(25):
+        shuffled = list(snapshots)
+        random.Random(seed).shuffle(shuffled)
+        aggregate = aggregate_snapshot_period(shuffled, window=window, thresholds=context)
+        provenance = aggregate["provenance"]
+        encoded = json.dumps(provenance, sort_keys=True, separators=(",", ":")).encode()
+        digests.add(hashlib.sha256(encoded).hexdigest())
+
+    assert len(digests) == 1
+    assert provenance == {
+        "source": "stored_snapshots",
+        "active_threshold_profile": {"id": "injected", "version": "1"},
+        "stored_snapshot_analyzers": {
+            "legacy_no_metadata": 1,
+            "metadata": [
+                {
+                    "analyzer_schema": 2,
+                    "app_version": "2026.6-test",
+                    "threshold_profile": {"id": "builtin.legacy", "version": "1.0.0"},
+                    "count": 1,
+                },
+                {
+                    "analyzer_schema": 3,
+                    "app_version": "2026.7-test",
+                    "threshold_profile": {"id": "builtin.default", "version": "1.1.0"},
+                    "count": 2,
+                },
+            ],
+        },
+    }
+    analyzer_summary = provenance["stored_snapshot_analyzers"]
+    assert analyzer_summary["legacy_no_metadata"] + sum(
+        item["count"] for item in analyzer_summary["metadata"]
+    ) == len(snapshots)
+    serialized = json.dumps(provenance)
+    assert "raw_data" not in serialized
+    assert "secret" not in serialized
+    assert "locale" not in serialized
+    assert "private-locale" not in serialized

--- a/tests/aggregation/test_threshold_context.py
+++ b/tests/aggregation/test_threshold_context.py
@@ -1,0 +1,49 @@
+import json
+
+from app import analyzer
+from app.aggregation import ThresholdContext
+
+
+def test_public_resolvers_are_equivalent_to_existing_analyzer_helpers(monkeypatch):
+    thresholds = {
+        "downstream_power": {
+            "_default": "64QAM",
+            "64QAM": {"good": [-7, 7], "warning": [-9, 9], "critical": [-11, 11]},
+            "ofdm": {"good": [-5, 5], "warning": [-8, 8], "critical": [-12, 12]},
+        },
+        "snr": {
+            "_default": "64QAM",
+            "64QAM": {"good_min": 29, "warning_min": 27, "critical_min": 25},
+            "ofdm": {"good_min": 30, "warning_min": 28, "critical_min": 26},
+        },
+    }
+    monkeypatch.setattr(analyzer, "_thresholds", thresholds)
+
+    for modulation, family in ((None, None), ("64QAM", "sc_qam"), ("OFDM", "ofdm")):
+        assert analyzer.resolve_ds_power_thresholds(
+            modulation, channel_family=family, thresholds=thresholds
+        ) == analyzer._get_ds_power_thresholds(modulation, channel_family=family)
+        assert analyzer.resolve_snr_thresholds(
+            modulation, channel_family=family, thresholds=thresholds
+        ) == analyzer._get_snr_thresholds(modulation, channel_family=family)
+
+
+def test_threshold_snapshot_and_context_are_independent_deep_copies(monkeypatch):
+    source = {
+        "downstream_power": {
+            "_default": "256QAM",
+            "256QAM": {"critical": [-8.0, 16.0]},
+        }
+    }
+    monkeypatch.setattr(analyzer, "_thresholds", source)
+    monkeypatch.setattr(analyzer, "_threshold_profile", {"id": "test", "version": "1"})
+
+    snapshot = analyzer.threshold_snapshot()
+    context = ThresholdContext.from_analyzer_snapshot(snapshot)
+    before = json.dumps(dict(context.raw), sort_keys=True)
+    source["downstream_power"]["256QAM"]["critical"][1] = 99
+    snapshot["thresholds"]["downstream_power"]["256QAM"]["critical"][0] = -99
+
+    assert json.dumps(dict(context.raw), sort_keys=True) == before
+    assert context.profile_id == "test"
+    assert context.profile_version == "1"

--- a/tests/aggregation/test_window.py
+++ b/tests/aggregation/test_window.py
@@ -1,0 +1,38 @@
+from app.aggregation import Window, canonical_utc_timestamp, report_bounds
+from app.tz import local_date_to_utc_range
+
+
+def test_canonicalization_is_identity_on_stored_format():
+    assert canonical_utc_timestamp("2026-05-01T01:02:03Z") == "2026-05-01T01:02:03Z"
+
+
+def test_canonicalization_normalizes_offsets_naive_values_and_microseconds():
+    assert canonical_utc_timestamp("2026-05-01T03:02:03+02:00") == "2026-05-01T01:02:03Z"
+    assert canonical_utc_timestamp("2026-05-01T01:02:03") == "2026-05-01T01:02:03Z"
+    assert canonical_utc_timestamp("2026-05-01T01:02:03.999Z") == "2026-05-01T01:02:03Z"
+    assert canonical_utc_timestamp("not-a-timestamp") == "not-a-timestamp"
+
+
+def test_report_bounds_use_requested_inclusive_window_or_observed_extremes():
+    snapshots = [
+        {"timestamp": "2026-05-02T00:00:00Z"},
+        {"timestamp": "2026-05-01T00:00:00Z"},
+    ]
+    assert report_bounds(snapshots) == (
+        "2026-05-01T00:00:00Z",
+        "2026-05-02T00:00:00Z",
+    )
+    window = Window("2026-04-30T00:00:00Z", "2026-05-03T00:00:00Z")
+    assert report_bounds(snapshots, window=window) == (window.start, window.end)
+    assert report_bounds([]) == ("-", "-")
+
+
+def test_existing_berlin_dst_day_windows_remain_inclusive():
+    assert local_date_to_utc_range("2026-03-29", "Europe/Berlin") == (
+        "2026-03-28T23:00:00Z",
+        "2026-03-29T21:59:59Z",
+    )
+    assert local_date_to_utc_range("2026-10-25", "Europe/Berlin") == (
+        "2026-10-24T22:00:00Z",
+        "2026-10-25T22:59:59Z",
+    )

--- a/tests/test_aggregation_entry_static.py
+++ b/tests/test_aggregation_entry_static.py
@@ -1,0 +1,118 @@
+"""Architecture guards for the deterministic period aggregation boundary."""
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AGGREGATION = ROOT / "app" / "aggregation"
+
+
+def _tree(path):
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def test_consumers_do_not_reintroduce_private_period_aggregators():
+    forbidden = {"_compute_worst_values", "_find_worst_channels", "_aggregate_period"}
+    paths = [
+        ROOT / "app" / "modules" / "reports" / "report.py",
+        ROOT / "app" / "modules" / "comparison" / "routes.py",
+        ROOT / "app" / "modules" / "evidence" / "routes.py",
+    ]
+    definitions = {
+        node.name
+        for path in paths
+        for node in ast.walk(_tree(path))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert definitions.isdisjoint(forbidden)
+
+
+def test_aggregation_imports_stay_pure_and_analyzer_boundary_is_narrow():
+    forbidden_roots = {"flask", "sqlite3", "fpdf"}
+    forbidden_app = {"app.storage", "app.web"}
+    analyzer_names = set()
+    for path in AGGREGATION.glob("*.py"):
+        for node in ast.walk(_tree(path)):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name.split(".")[0] not in forbidden_roots
+                    assert not any(alias.name.startswith(name) for name in forbidden_app)
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                assert module.split(".")[0] not in forbidden_roots
+                assert not any(module.startswith(name) for name in forbidden_app)
+                if module == "app.analyzer":
+                    analyzer_names.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.Call):
+                called = node.func
+                if isinstance(called, ast.Name):
+                    assert called.id != "utc_now"
+                elif isinstance(called, ast.Attribute):
+                    assert not (
+                        isinstance(called.value, ast.Name)
+                        and called.value.id == "datetime"
+                        and called.attr == "now"
+                    )
+    assert analyzer_names <= {"resolve_ds_power_thresholds", "resolve_snr_thresholds"}
+
+
+def test_analyzer_never_imports_aggregation():
+    for node in ast.walk(_tree(ROOT / "app" / "analyzer.py")):
+        if isinstance(node, ast.Import):
+            assert all("aggregation" not in alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            assert "aggregation" not in (node.module or "")
+
+
+def test_threshold_context_raw_is_not_mutated_inside_aggregation():
+    def contains_raw_access(node):
+        return any(
+            isinstance(child, ast.Attribute) and child.attr == "raw"
+            for child in ast.walk(node)
+        )
+
+    forbidden_methods = {"update", "pop", "popitem", "clear", "setdefault"}
+    for path in AGGREGATION.glob("*.py"):
+        for node in ast.walk(_tree(path)):
+            if isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign, ast.Delete)):
+                targets = list(getattr(node, "targets", []))
+                target = getattr(node, "target", None)
+                if target is not None:
+                    targets.append(target)
+                assert not any(contains_raw_access(candidate) for candidate in targets)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                assert not (
+                    node.func.attr in forbidden_methods
+                    and isinstance(node.func.value, ast.Attribute)
+                    and node.func.value.attr == "raw"
+                )
+
+
+def test_documented_aggregation_api_and_entry_point_are_pinned():
+    import app.aggregation as aggregation
+
+    expected = {
+        "AGGREGATION_SCHEMA_VERSION",
+        "Coverage",
+        "PeriodAggregate",
+        "ThresholdContext",
+        "Window",
+        "aggregate_snapshot_period",
+        "canonical_utc_timestamp",
+        "derive_diagnostic_notes",
+        "derive_historical",
+        "report_bounds",
+        "select_preferred_bnetz",
+        "source_coverage",
+    }
+    assert set(aggregation.__all__) == expected
+    definitions = []
+    for path in (ROOT / "app").rglob("*.py"):
+        definitions.extend(
+            (path, node)
+            for node in ast.walk(_tree(path))
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "aggregate_snapshot_period"
+        )
+    assert len(definitions) == 1
+    assert definitions[0][0] == AGGREGATION / "period.py"

--- a/tests/test_comparison_module.py
+++ b/tests/test_comparison_module.py
@@ -204,12 +204,12 @@ class TestCompareEndpoint:
 
 
 class TestAggregatePeriod:
-    """Unit tests for the _aggregate_period function."""
+    """Unit tests for the _comparison_period function."""
 
     def test_empty_snapshots(self):
-        from app.modules.comparison.routes import _aggregate_period
+        from app.modules.comparison.routes import _comparison_period
 
-        result = _aggregate_period([])
+        result = _comparison_period([])
         assert result["snapshots"] == 0
         assert result["avg"]["ds_power"] is None
         assert result["errors_supported"] is False
@@ -217,9 +217,9 @@ class TestAggregatePeriod:
         assert result["total"]["uncorr_errors"] is None
 
     def test_single_snapshot(self):
-        from app.modules.comparison.routes import _aggregate_period
+        from app.modules.comparison.routes import _comparison_period
 
-        result = _aggregate_period([SNAPSHOT_A])
+        result = _comparison_period([SNAPSHOT_A])
         assert result["snapshots"] == 1
         assert result["avg"]["ds_power"] == 3.1
         assert result["avg"]["ds_snr"] == 34.2
@@ -227,18 +227,18 @@ class TestAggregatePeriod:
         assert result["total"]["uncorr_errors"] == 0
 
     def test_multiple_snapshots_averages(self):
-        from app.modules.comparison.routes import _aggregate_period
+        from app.modules.comparison.routes import _comparison_period
 
-        result = _aggregate_period([SNAPSHOT_A, SNAPSHOT_B])
+        result = _comparison_period([SNAPSHOT_A, SNAPSHOT_B])
         assert result["snapshots"] == 2
         assert result["avg"]["ds_power"] == pytest.approx(3.65)
         assert result["avg"]["ds_snr"] == pytest.approx(32.85)
         assert result["total"]["corr_errors"] == 300
 
     def test_unsupported_error_counters_remain_none(self):
-        from app.modules.comparison.routes import _aggregate_period
+        from app.modules.comparison.routes import _comparison_period
 
-        result = _aggregate_period([UNSUPPORTED_ERRORS_SNAPSHOT])
+        result = _comparison_period([UNSUPPORTED_ERRORS_SNAPSHOT])
 
         assert result["errors_supported"] is False
         assert result["corr_errors_supported"] is False
@@ -248,7 +248,7 @@ class TestAggregatePeriod:
         assert result["timeseries"][0]["uncorr_errors"] is None
 
     def test_errors_supported_false_zero_counters_remain_unsupported(self):
-        from app.modules.comparison.routes import _aggregate_period
+        from app.modules.comparison.routes import _comparison_period
 
         legacy_zero_snapshot = {
             **UNSUPPORTED_ERRORS_SNAPSHOT,
@@ -259,7 +259,7 @@ class TestAggregatePeriod:
                 "ds_uncorrectable_errors": 0,
             },
         }
-        result = _aggregate_period([legacy_zero_snapshot])
+        result = _comparison_period([legacy_zero_snapshot])
 
         assert result["errors_supported"] is False
         assert result["corr_errors_supported"] is False
@@ -269,9 +269,9 @@ class TestAggregatePeriod:
         assert result["timeseries"][0]["uncorr_errors"] is None
 
     def test_zero_error_counters_stay_supported_zeroes(self):
-        from app.modules.comparison.routes import _aggregate_period
+        from app.modules.comparison.routes import _comparison_period
 
-        result = _aggregate_period([SNAPSHOT_A])
+        result = _comparison_period([SNAPSHOT_A])
 
         assert result["errors_supported"] is True
         assert result["corr_errors_supported"] is True
@@ -280,7 +280,7 @@ class TestAggregatePeriod:
         assert result["total"]["uncorr_errors"] == 0
 
     def test_partially_supported_error_counters_do_not_invent_zeroes(self):
-        from app.modules.comparison.routes import _aggregate_period
+        from app.modules.comparison.routes import _comparison_period
 
         partial = {
             **UNSUPPORTED_ERRORS_SNAPSHOT,
@@ -290,7 +290,7 @@ class TestAggregatePeriod:
                 "ds_uncorrectable_errors": None,
             },
         }
-        result = _aggregate_period([partial])
+        result = _comparison_period([partial])
 
         assert result["errors_supported"] is True
         assert result["corr_errors_supported"] is True
@@ -323,10 +323,10 @@ class TestComputeDelta:
     """Unit tests for the _compute_delta function."""
 
     def test_basic_delta(self):
-        from app.modules.comparison.routes import _aggregate_period, _compute_delta
+        from app.modules.comparison.routes import _comparison_period, _compute_delta
 
-        pa = _aggregate_period([SNAPSHOT_A])
-        pb = _aggregate_period([SNAPSHOT_B])
+        pa = _comparison_period([SNAPSHOT_A])
+        pb = _comparison_period([SNAPSHOT_B])
         delta = _compute_delta(pa, pb)
         assert delta["ds_power"] == pytest.approx(1.1)
         assert delta["ds_snr"] == pytest.approx(-2.7)
@@ -334,29 +334,29 @@ class TestComputeDelta:
         assert delta["uncorr_errors"] == 127
 
     def test_delta_with_empty_period(self):
-        from app.modules.comparison.routes import _aggregate_period, _compute_delta
+        from app.modules.comparison.routes import _comparison_period, _compute_delta
 
-        pa = _aggregate_period([])
-        pb = _aggregate_period([SNAPSHOT_B])
+        pa = _comparison_period([])
+        pb = _comparison_period([SNAPSHOT_B])
         delta = _compute_delta(pa, pb)
         assert delta["ds_power"] is None
         assert delta["ds_snr"] is None
 
     def test_both_periods_empty(self):
-        from app.modules.comparison.routes import _aggregate_period, _compute_delta
+        from app.modules.comparison.routes import _comparison_period, _compute_delta
 
-        pa = _aggregate_period([])
-        pb = _aggregate_period([])
+        pa = _comparison_period([])
+        pb = _comparison_period([])
         delta = _compute_delta(pa, pb)
         assert delta["ds_power"] is None
         assert delta["uncorr_errors"] is None
         assert delta["verdict"] == "unchanged"
 
     def test_delta_ignores_unsupported_error_counters(self):
-        from app.modules.comparison.routes import _aggregate_period, _compute_delta
+        from app.modules.comparison.routes import _comparison_period, _compute_delta
 
-        unsupported_a = _aggregate_period([UNSUPPORTED_ERRORS_SNAPSHOT])
-        unsupported_b = _aggregate_period([
+        unsupported_a = _comparison_period([UNSUPPORTED_ERRORS_SNAPSHOT])
+        unsupported_b = _comparison_period([
             {**UNSUPPORTED_ERRORS_SNAPSHOT, "timestamp": "2026-03-08T06:00:00Z"}
         ])
 
@@ -367,7 +367,7 @@ class TestComputeDelta:
 
     def test_extreme_snr_improvement(self):
         """Large SNR jump should be classified as improved."""
-        from app.modules.comparison.routes import _aggregate_period, _compute_delta
+        from app.modules.comparison.routes import _comparison_period, _compute_delta
 
         great = {
             "timestamp": "2026-03-08T06:00:00Z",
@@ -382,8 +382,8 @@ class TestComputeDelta:
             "ds_channels": [],
             "us_channels": [],
         }
-        pa = _aggregate_period([SNAPSHOT_A])
-        pb = _aggregate_period([great])
+        pa = _comparison_period([SNAPSHOT_A])
+        pb = _comparison_period([great])
         delta = _compute_delta(pa, pb)
         assert delta["verdict"] == "improved"
 

--- a/tests/test_evidence_api.py
+++ b/tests/test_evidence_api.py
@@ -8,15 +8,59 @@ from app.runtime import current_runtime
 class FakeCoreStorage:
     db_path = ":memory:"
 
-    def get_correlation_timeline(self, start_ts, end_ts):
+    def __init__(self):
+        self.snapshot_loads = 0
+        self.timeline_sources = None
+
+    def get_range_data(self, start_ts, end_ts):
+        self.snapshot_loads += 1
+        return [{
+            "timestamp": end_ts,
+            "summary": {"health": "critical"},
+            "ds_channels": [],
+            "us_channels": [],
+        }]
+
+    def get_correlation_timeline(self, start_ts, end_ts, sources=None):
         self.requested_range = (start_ts, end_ts)
-        return [
+        self.timeline_sources = sources
+        rows = [
             {"timestamp": end_ts, "source": "modem", "health": "critical"},
             {"timestamp": end_ts, "source": "event", "severity": "critical"},
         ]
+        if sources is None:
+            return rows
+        return [row for row in rows if row["source"] != "modem"]
 
 
 class TestEvidenceChecklistApi:
+    def test_checklist_loads_snapshots_exactly_once_and_skips_modem_timeline(self):
+        from app.modules.evidence import routes
+
+        core = FakeCoreStorage()
+        config = Mock()
+        config.get.side_effect = lambda key, default=None: {"modem_type": "fritzbox"}.get(key, default)
+        config.is_speedtest_configured.return_value = False
+        config.is_bqm_configured.return_value = False
+        config.is_demo_mode.return_value = False
+
+        with app.test_request_context(
+            "/api/evidence/checklist?from=2026-06-10T18:00:00Z&to=2026-06-10T23:00:00Z"
+        ):
+            with patch.object(routes, "get_storage", return_value=core), \
+                 patch.object(routes, "get_config_manager", return_value=config), \
+                 patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
+                 patch.object(routes, "_get_bqm_rows", return_value=[]), \
+                 patch.object(routes, "_get_connection_latency_rows", return_value=[]):
+                response = getattr(routes.api_evidence_checklist, "__wrapped__")()
+
+        assert core.snapshot_loads == 1
+        assert core.timeline_sources is not None
+        assert "modem" not in core.timeline_sources
+        signal = next(item for item in response.get_json()["items"] if item["key"] == "signal")
+        assert signal["count"] == 1
+        assert signal["status"] == "present"
+
     def test_requires_incident_or_time_range(self):
         from app.modules.evidence import routes
 

--- a/tests/test_evidence_checklist.py
+++ b/tests/test_evidence_checklist.py
@@ -157,3 +157,26 @@ def test_build_checklist_marks_demo_mode_on_payload():
     )
 
     assert all(item["demo"] is True for item in payload)
+
+
+def test_snapshot_aggregate_preserves_the_existing_signal_item_json():
+    legacy = build_checklist(
+        WINDOW,
+        timeline=[{"timestamp": "2026-06-10T22:55:00Z", "source": "modem"}],
+        journal_entries=[],
+        bqm_rows=[],
+        capabilities={"docsis_supported": True, "speedtest_configured": False, "bqm_configured": False},
+    )
+    aggregated = build_checklist(
+        WINDOW,
+        timeline=[],
+        journal_entries=[],
+        bqm_rows=[],
+        capabilities={"docsis_supported": True, "speedtest_configured": False, "bqm_configured": False},
+        snapshot_aggregate={
+            "snapshot_count": 1,
+            "last_observed_at": "2026-06-10T22:55:00Z",
+        },
+    )
+
+    assert aggregated == legacy

--- a/tests/test_report_period.py
+++ b/tests/test_report_period.py
@@ -499,7 +499,7 @@ def test_empty_pdf_prints_requested_window_zero_count_and_neutral_text():
     assert "No stored DOCSIS measurements are available for the requested report period." in text
 
 
-def test_pdf_and_text_complaint_share_one_historical_note_set_per_artifact():
+def test_pdf_and_text_complaint_use_one_period_aggregate_per_artifact():
     from app.modules.reports import report
 
     snapshots = [_snapshot(
@@ -515,27 +515,27 @@ def test_pdf_and_text_complaint_share_one_historical_note_set_per_artifact():
         }],
     )]
     snapshots[0]["analysis_meta"] = _builtin_analysis_meta()
-    real_derive = report.derive_historical_report_data
+    real_aggregate = report.aggregate_snapshot_period
 
     with patch.object(
-        report, "derive_historical_report_data", wraps=real_derive
-    ) as derive:
+        report, "aggregate_snapshot_period", wraps=real_aggregate
+    ) as aggregate:
         pdf_text = _pdf_text(report.generate_report(
             snapshots,
             report_start="2026-05-01T00:00:00Z",
             report_end="2026-05-02T00:00:00Z",
         ))
-    assert derive.call_count == 1
+    assert aggregate.call_count == 1
 
     with patch.object(
-        report, "derive_historical_report_data", wraps=real_derive
-    ) as derive:
+        report, "aggregate_snapshot_period", wraps=real_aggregate
+    ) as aggregate:
         complaint = report.generate_complaint_text(
             snapshots,
             report_start="2026-05-01T00:00:00Z",
             report_end="2026-05-02T00:00:00Z",
         )
-    assert derive.call_count == 1
+    assert aggregate.call_count == 1
 
     expected = (
         "Channel 4 (SC-QAM): downstream power of 30.0 dBmV exceeds expected "


### PR DESCRIPTION
## What changed

- add one pure, deterministic period aggregation contract for stored DOCSIS snapshots
- preserve duplicate multiplicity and distinguish numeric samples, nulls, unsupported counters, invalid values, and missing samples
- retain stored analyzer and threshold provenance while keeping legacy fallback explicit
- migrate PDF reports, incident reports, complaint text, comparison, and Evidence to the shared aggregate
- load Evidence snapshots once and keep BQM and Connection Monitor as explicit source adapters
- document the dependency boundary and add architecture, determinism, provenance, coverage, and compatibility guards

## Compatibility

Existing report, complaint, comparison, and Evidence response shapes remain unchanged. A representative mixed SC-QAM and OFDM fixture produced identical complaint text and normalized PDF text before and after the refactor. There are no database, snapshot, authentication, threshold, locale, or UI migrations.

## Validation

- `3818 passed, 2 skipped` in the full non-E2E Python suite
- `531 passed` in the complete Playwright E2E suite under UTC
- `191 passed` in the final focused report, Evidence, comparison, aggregation, and browser gate
- `9 passed` in the JavaScript suite
- all 69 locale files validated
- workflow YAML, Python compilation, diff checks, and production dependency audit passed
- deterministic fault proof failed with 8 distinct digests when the same-timestamp content tiebreak was removed, then passed after restoration
- all three representative PDF pages were rasterized and checked for clipping, overlap, overflow, ordering, and null rendering
