### PR TITLE
refactor: remove obsolete compatibility shims

### DIFF
--- a/app/module_config_registry.py
+++ b/app/module_config_registry.py
@@ -78,15 +78,6 @@ def evaluate_module_secret_ownership(
     return reserved, owners, errors
 
 
-def reserve_module_secrets(modules: list[ModuleInfo]) -> None:
-    """Compatibility adapter for applying preflighted secret ownership."""
-    reserved, owners, errors = evaluate_module_secret_ownership(modules)
-    for module in modules:
-        if module.id in errors:
-            module.error = errors[module.id]
-    _cfg.set_module_secret_registry(reserved, owners)
-
-
 def evaluate_module_config_ownership(modules: list[ModuleInfo]) -> dict[str, str]:
     """Return redacted errors for ambiguous community config ownership."""
     protected = set(_cfg.CORE_CONFIG_KEYS)

--- a/app/module_loader.py
+++ b/app/module_loader.py
@@ -6,22 +6,19 @@ import os  # Compatibility: callers patch the shared filesystem module here.
 # Public imports below intentionally preserve the legacy module-loader facade.
 from app import module_registry as _module_registry
 from app.builtin_modules import BUILTIN_MODULE_DIRS, BUILTIN_PYTHON_CONTRIBUTIONS
-from app.manifest_contract import ID_PATTERN, REQUIRED_FIELDS, VALID_CONTRIBUTES, VALID_TYPES
+from app.manifest_contract import ID_PATTERN, VALID_CONTRIBUTES
 from app.module_config_registry import (
     evaluate_module_config_ownership,
     evaluate_module_secret_ownership,
     register_module_config,
-    reserve_module_secrets,
 )
 from app.module_contributions import (
-    REQUIRED_THEME_SECTIONS, REQUIRED_THRESHOLD_SECTIONS,
     _PROTECTED_API_PREFIXES, _PROTECTED_ROUTES,
-    _load_module_class, _load_symbol,
-    _read_json_contribution, _redacted_resolution,
+    _read_json_contribution,
     attach_builtin_python_contributions, load_module_collector,
     load_module_publisher, load_module_routes, merge_module_i18n,
-    module_static_endpoint, module_static_url, plan_module_static,
-    resolve_module_contribution, resolve_module_i18n, resolve_module_routes,
+    module_static_endpoint, module_static_url,
+    resolve_module_contribution,
     setup_module_static, setup_module_templates, validate_theme,
     validate_thresholds,
 )
@@ -32,11 +29,10 @@ from app.module_registry import (
     discover_modules,
     validate_manifest,
 )
-from app.path_safety import safe_manifest_ref, safe_manifest_subpath
 from app.registration import (
-    ModuleContribution, PlannedBlueprint, PlannedRule, RegistrationError,
-    RegistrationPlan, apply_module_i18n, apply_plan, existing_rules,
-    probe_blueprint, register_plan, validate_plan,
+    RegistrationError,
+    RegistrationPlan, existing_rules,
+    register_plan, validate_plan,
 )
 from app.theme_registry import BUILTIN_THEMES
 from app.threshold_profiles import BUILTIN_THRESHOLD_PROFILES

--- a/app/modules/reports/report.py
+++ b/app/modules/reports/report.py
@@ -468,14 +468,6 @@ def _format_customer_closing(s, customer_name="", customer_number="", customer_a
     return "\n".join([label, name, number, *address_lines])
 
 
-def _report_bounds(snapshots, report_start=None, report_end=None):
-    """Compatibility delegate for inclusive report labeling bounds."""
-    return report_bounds(
-        snapshots,
-        window=Window(report_start or "", report_end or ""),
-    )
-
-
 def generate_report(
     snapshots,
     current_analysis=None,


### PR DESCRIPTION
## Summary

- remove an unused report-period compatibility delegate
- remove an unreferenced module-secret reservation adapter
- trim unreferenced legacy module-loader re-exports while preserving the live facade

## Verification

- `238 passed` focused Python tests
- `3860 passed, 2 skipped` complete non-browser Python suite
- `9 passed` JavaScript contract tests
- 69 locale catalogs validated against `en.json`
- `531 passed` browser E2E cases across the canonical four shards
- maintenance budget: application Python −21 LOC, application functions −2, application tree −1,031 bytes; test and all other independent ledgers unchanged

## Risk

Low. Every removed symbol had no in-repository or official community-module consumer, and the complete non-browser suite stayed green when the dead callable bodies were replaced with failing probes before deletion. No tests, workflows, documentation, dependencies, or user-visible behavior changed.
