### PR TITLE
feat(i18n): add Charter/Spectrum to the ISP presets

### DIFF
--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Тарифа",
   "max_downstream": "Макс надолу по веригата",

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarif",
   "max_downstream": "Max po proudu",

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Takst",
   "max_downstream": "Max Downstream",

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarif",
   "max_downstream": "Max Downstream",

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Τιμολόγιο",
   "max_downstream": "Max Downstream",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tariff",
   "max_downstream": "Max Downstream",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -221,7 +221,8 @@
     "Euskaltel",
     "R",
     "Telecable",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarifa",
   "max_downstream": "Bajada máxima",

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tariif",
   "max_downstream": "Max allavoolu",

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tariffi",
   "max_downstream": "Max alavirtaan",

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -218,7 +218,8 @@
   "isp_select": "Choisir un fournisseur",
   "isp_options": [
     "SFR",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Forfait",
   "max_downstream": "Débit descendant max",

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Taraif",
   "max_downstream": "Max Downstream",

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarifa",
   "max_downstream": "Maks nizvodno",

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Díjszabás",
   "max_downstream": "Max Downstream",

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tariffa",
   "max_downstream": "Max a valle",

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarifas",
   "max_downstream": "Max pasroviui",

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarifs",
   "max_downstream": "Max lejup pa straumi",

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tariff",
   "max_downstream": "Maks nedstrøms",

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarief",
   "max_downstream": "Max stroomafwaarts",

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Taryfa",
   "max_downstream": "Maksymalny spadek",

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarifa",
   "max_downstream": "Máximo a jusante",

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarif",
   "max_downstream": "Max în aval",

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarifa",
   "max_downstream": "Max po prúde",

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tarifa",
   "max_downstream": "Max Downstream",

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -226,7 +226,8 @@
     "NetCologne",
     "M-net",
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
   ],
   "tariff": "Tariff",
   "max_downstream": "Max nedströms",


### PR DESCRIPTION
## Summary

Adds **Charter/Spectrum** to the `isp_options` preset list in Settings → Connection.

Spectrum is the second-largest US cable ISP. The list already carries `Comcast/Xfinity`, so this follows the same `Parent/Brand` naming and sits directly after it.

```diff
     "Wilhelm.tel",
-    "Comcast/Xfinity"
+    "Comcast/Xfinity",
+    "Charter/Spectrum"
```

## Notes

- Applied to all 24 core locales, since `isp_options` is provider names rather than translated copy. The two locales that carry their own regional list keep it — `es` stays `Vodafone, Euskaltel, R, Telecable, …` and `fr` stays `SFR, …`, each simply gaining the new entry.
- `python scripts/i18n_check.py --validate` passes: *All 69 language file(s) are in sync with en.json*.
- Users can already reach this via the "Other" free-text field, so this only saves a manual entry for a large provider — happy to drop it if the preset list is meant to stay German-market-focused.

Separate from #800 (SB8200 CBN driver) to keep that PR to one change. Opened without a prior issue, so happy to move it to a discussion or have it closed.
