### PR TITLE
Fix correlation timestamps across time zones

### DIFF
--- a/app/blueprints/analysis_bp.py
+++ b/app/blueprints/analysis_bp.py
@@ -255,5 +255,4 @@ def api_correlation():
                 entry["modem_ds_snr_min"] = closest.get("ds_snr_min")
                 entry["modem_ds_power_avg"] = closest.get("ds_power_avg")
 
-    _localize_timestamps(timeline)
     return jsonify(timeline)

--- a/app/tz.py
+++ b/app/tz.py
@@ -6,7 +6,7 @@ Conversion to local time happens only at the display boundary (web/charts/report
 
 import os
 from datetime import datetime, timedelta, timezone
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # Canonical UTC format used throughout the application
 _UTC_FMT = "%Y-%m-%dT%H:%M:%SZ"
@@ -121,22 +121,49 @@ def get_tz_name(config_manager=None):
     return guess_iana_timezone()
 
 
+def _valid_iana_timezone(value):
+    """Return a normalized, loadable ZoneInfo key or an empty string."""
+    if not isinstance(value, str):
+        return ""
+    candidate = value.strip()
+    if candidate.startswith(":"):
+        candidate = candidate[1:]
+    if not candidate:
+        return ""
+    try:
+        ZoneInfo(candidate)
+    except (OSError, UnicodeError, ValueError, ZoneInfoNotFoundError):
+        return ""
+    return candidate
+
+
 def guess_iana_timezone():
     """Best-effort guess of the current IANA timezone from the system.
 
     Returns an IANA name like 'Europe/Berlin' or '' if detection fails.
     No Flask dependency — safe to call from main.py or storage.py.
     """
+    tz_env = _valid_iana_timezone(os.environ.get("TZ", ""))
+    if tz_env:
+        return tz_env
+
     try:
         link = os.readlink("/etc/localtime")
         for marker in ("/zoneinfo/",):
             if marker in link:
-                return link.split(marker, 1)[1]
+                localtime_tz = _valid_iana_timezone(link.split(marker, 1)[1])
+                if localtime_tz:
+                    return localtime_tz
     except (OSError, ValueError):
         pass
-    tz_env = os.environ.get("TZ", "")
-    if "/" in tz_env:
-        return tz_env
+
+    try:
+        with open("/etc/timezone", encoding="utf-8") as timezone_file:
+            timezone_tz = _valid_iana_timezone(timezone_file.read())
+            if timezone_tz:
+                return timezone_tz
+    except (OSError, UnicodeError):
+        pass
     return ""
 
 

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -4,19 +4,19 @@ import json
 import sqlite3
 import pytest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 from app.storage import SnapshotStorage
 from app.modules.speedtest.storage import SpeedtestStorage
-from app.tz import to_local, utc_now, utc_cutoff
-from app.web import update_state, _get_tz_name
+from app.tz import utc_now, utc_cutoff
+from app.web import update_state
 from app.config import ConfigManager
 from app.runtime import current_runtime
 
 
 def _api_response_date(utc_ts: str) -> str:
-    """Return the date part expected from APIs that localize UTC timestamps."""
-    tz_name = _get_tz_name()
-    return (to_local(utc_ts, tz_name) if tz_name else utc_ts.rstrip("Z"))[:10]
+    """Return the UTC date part expected from the correlation API."""
+    return utc_ts[:10]
 
 
 @pytest.fixture
@@ -293,6 +293,51 @@ class TestCorrelationAPI:
         sources = set(e["source"] for e in data)
         assert "modem" in sources
         assert "speedtest" in sources
+
+    def test_correlation_preserves_utc_timestamps_with_configured_timezone(
+        self, client_with_storage, config_mgr, storage
+    ):
+        """Machine-readable correlation timestamps remain UTC across a DST boundary."""
+        config_mgr.save({"timezone": "Europe/Berlin"})
+        timeline = [
+            {
+                "timestamp": "2026-10-25T00:30:00Z",
+                "source": "modem",
+                "health": "good",
+                "ds_snr_min": 38.0,
+                "ds_power_avg": 1.0,
+            },
+            {
+                "timestamp": "2026-10-25T00:45:00Z",
+                "source": "speedtest",
+                "download_mbps": 500.0,
+            },
+            {
+                "timestamp": "2026-10-25T01:00:00Z",
+                "source": "event",
+                "severity": "warning",
+                "event_type": "health_change",
+                "message": "Health changed",
+            },
+            {
+                "timestamp": "2026-10-25T01:15:00Z",
+                "source": "capture",
+                "status": "completed",
+                "trigger_type": "health_change",
+                "action_type": "capture",
+            },
+        ]
+        expected_timestamps = {
+            entry["source"]: entry["timestamp"] for entry in timeline
+        }
+
+        with patch.object(storage, "get_correlation_timeline", return_value=timeline):
+            response = client_with_storage.get("/api/correlation?hours=24")
+
+        assert response.status_code == 200
+        assert {
+            entry["source"]: entry["timestamp"] for entry in response.get_json()
+        } == expected_timestamps
 
     def test_correlation_source_filter(self, client_with_storage, storage, sample_analysis):
         """Correlation endpoint respects sources filter."""

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -3,7 +3,7 @@
 import os
 import pytest
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 from zoneinfo import ZoneInfo
 
 from app.tz import (
@@ -190,25 +190,84 @@ class TestLocalDateToUtcRange:
 
 
 class TestGuessIanaTimezone:
-    def test_from_tz_env(self):
-        with patch.dict(os.environ, {"TZ": "Europe/Berlin"}):
-            with patch("os.readlink", side_effect=OSError):
-                result = guess_iana_timezone()
-                assert result == "Europe/Berlin"
+    @pytest.mark.parametrize("tz_env", ["Europe/Berlin", "Etc/UTC"])
+    def test_valid_tz_env_wins_over_localtime(self, tz_env):
+        localtime = "Etc/UTC" if tz_env == "Europe/Berlin" else "Europe/Berlin"
+        with patch.dict(os.environ, {"TZ": tz_env}, clear=True):
+            with patch("os.readlink", return_value=f"/usr/share/zoneinfo/{localtime}") as readlink:
+                with patch("builtins.open", mock_open(read_data="America/New_York\n")) as timezone_file:
+                    assert guess_iana_timezone() == tz_env
+        readlink.assert_not_called()
+        timezone_file.assert_not_called()
 
-    def test_non_iana_tz(self):
-        with patch.dict(os.environ, {"TZ": "CET"}):
-            with patch("os.readlink", side_effect=OSError):
-                result = guess_iana_timezone()
-                assert result == ""  # CET has no slash
+    def test_leading_colon_tz_env(self):
+        with patch.dict(os.environ, {"TZ": ":Europe/Berlin"}, clear=True):
+            with patch("os.readlink") as readlink:
+                with patch("builtins.open") as timezone_file:
+                    assert guess_iana_timezone() == "Europe/Berlin"
+        readlink.assert_not_called()
+        timezone_file.assert_not_called()
 
-    def test_from_localtime_symlink(self):
-        with patch("os.readlink", return_value="/usr/share/zoneinfo/Europe/Berlin"):
-            result = guess_iana_timezone()
-            assert result == "Europe/Berlin"
+    def test_zoneinfo_key_without_slash(self):
+        with patch.dict(os.environ, {"TZ": "UTC"}, clear=True):
+            with patch("os.readlink") as readlink:
+                with patch("builtins.open") as timezone_file:
+                    assert guess_iana_timezone() == "UTC"
+        readlink.assert_not_called()
+        timezone_file.assert_not_called()
 
-    def test_no_detection(self):
-        with patch.dict(os.environ, {"TZ": ""}, clear=False):
+    @pytest.mark.parametrize(
+        "tz_env",
+        [
+            "Foo/Bar",
+            "/usr/share/zoneinfo/Europe/Berlin",
+            "CET-1CEST,M3.5.0/2,M10.5.0/3",
+        ],
+    )
+    def test_invalid_tz_env_falls_back_without_raising(self, tz_env):
+        with patch.dict(os.environ, {"TZ": tz_env}, clear=True):
+            with patch("os.readlink", return_value="/usr/share/zoneinfo/Etc/UTC"):
+                with patch("builtins.open") as timezone_file:
+                    assert guess_iana_timezone() == "Etc/UTC"
+        timezone_file.assert_not_called()
+
+    def test_invalid_tz_env_with_no_valid_fallback_returns_empty(self):
+        with patch.dict(os.environ, {"TZ": "Foo/Bar"}, clear=True):
             with patch("os.readlink", side_effect=OSError):
-                result = guess_iana_timezone()
-                assert result == ""
+                with patch("builtins.open", mock_open(read_data="Also/Invalid\n")):
+                    assert guess_iana_timezone() == ""
+
+    @pytest.mark.parametrize("tz_env", [None, ""])
+    def test_missing_or_empty_tz_falls_back_to_localtime_symlink(self, tz_env):
+        environ = {} if tz_env is None else {"TZ": tz_env}
+        with patch.dict(os.environ, environ, clear=True):
+            with patch("os.readlink", return_value="/usr/share/zoneinfo/Europe/Berlin"):
+                with patch("builtins.open") as timezone_file:
+                    assert guess_iana_timezone() == "Europe/Berlin"
+        timezone_file.assert_not_called()
+
+    def test_invalid_localtime_symlink_falls_back_to_etc_timezone(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("os.readlink", return_value="/usr/share/zoneinfo/Foo/Bar"):
+                with patch("builtins.open", mock_open(read_data="Europe/Berlin\n")) as timezone_file:
+                    assert guess_iana_timezone() == "Europe/Berlin"
+        timezone_file.assert_called_once_with("/etc/timezone", encoding="utf-8")
+
+    def test_etc_timezone_used_when_localtime_is_not_a_zoneinfo_symlink(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("os.readlink", side_effect=OSError):
+                with patch("builtins.open", mock_open(read_data="Europe/Berlin\n")):
+                    assert guess_iana_timezone() == "Europe/Berlin"
+
+    @pytest.mark.parametrize("timezone_value", ["Foo/Bar\n", "/etc/localtime\n"])
+    def test_invalid_etc_timezone_fails_closed(self, timezone_value):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("os.readlink", side_effect=OSError):
+                with patch("builtins.open", mock_open(read_data=timezone_value)):
+                    assert guess_iana_timezone() == ""
+
+    def test_unreadable_etc_timezone_fails_closed(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("os.readlink", side_effect=OSError):
+                with patch("builtins.open", side_effect=OSError):
+                    assert guess_iana_timezone() == ""


### PR DESCRIPTION
## Summary
- keep correlation API timestamps in unambiguous UTC with a `Z` suffix
- prefer a valid explicit `TZ` value over system timezone files
- validate timezone candidates and safely fall back to `/etc/localtime` or `/etc/timezone`
- cover DST-boundary correlation data and timezone precedence regressions

## Validation
- Python test suite
- JavaScript unit tests
- browser E2E suite
- translation catalog validation

Fixes #802
