### PR TITLE
Fix CM3000 OFDM error counter mapping

### DIFF
--- a/app/drivers/cm3000.py
+++ b/app/drivers/cm3000.py
@@ -40,14 +40,6 @@ log = logging.getLogger("docsis.driver.cm3000")
 
 _STATUS_PATH = "/DocsisStatus.htm"
 
-# Match the single-quoted live tagValueList in each function.
-# Commented-out examples use double quotes or /* */ blocks, so
-# targeting single quotes skips them reliably.
-# Uses .*? (lazy) instead of [^}]*? to support nested braces in
-# function bodies (e.g. if-blocks in some firmware versions).
-_RE_FUNCTION_START = re.compile(r"function\s+(?P<name>\w+)\s*\(\)\s*\{", re.DOTALL)
-_RE_SINGLE_QUOTED = re.compile(r"'([^'\\]*(?:\\.[^'\\]*)*)'", re.DOTALL)
-_RE_DOUBLE_QUOTED = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"', re.DOTALL)
 _LOGIN_MARKERS = (
     "login.htm",
     "login.html",
@@ -63,13 +55,6 @@ _RE_FORM_BLOCK = re.compile(
 )
 _RE_INPUT = re.compile(r"<input\b(?P<attrs>[^>]*)>", re.IGNORECASE | re.DOTALL)
 _RE_ATTR = re.compile(r"(?P<name>[A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*['\"](?P<value>[^'\"]*)['\"]")
-
-# Fields per channel for each section (after the leading count value).
-_DS_QAM_FIELDS = 9   # num|lock|mod|chID|freq|power|snr|corrErr|uncorrErr
-_US_ATDMA_FIELDS = 7  # num|lock|type|chID|symbolRate|freq|power
-_DS_OFDM_FIELDS = 11  # num|lock|profiles|chID|freq|power|snr|subcarriers|corrErr|uncorrErr|unknown
-_US_OFDMA_FIELDS = 6  # num|lock|profiles|chID|freq|power
-_RE_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
 
 
 class CM3000Driver(ModemDriver):

--- a/app/drivers/formats/javascript.py
+++ b/app/drivers/formats/javascript.py
@@ -250,11 +250,13 @@ def _parse_cm3000_lane(html: str, function_name: str) -> ParseResult[list[RawCha
                     "multiplex": channel[2].upper() if channel[2] else "",
                 })
             elif function_name == "InitDsOfdmTableTagValue":
+                # number|lock|profiles|channel ID|frequency|power|SNR/MER|
+                # active subcarriers|unerrored|correctable|uncorrectable
                 result.append({
                     "channelID": int(channel[3]), "type": "OFDM",
                     "frequency": hz_to_mhz(channel[4]), "powerLevel": parse_number(channel[5]),
                     "mer": parse_number(channel[6]), "mse": None,
-                    "corrErrors": int(channel[8]), "nonCorrErrors": int(channel[9]),
+                    "corrErrors": int(channel[9]), "nonCorrErrors": int(channel[10]),
                 })
             else:
                 result.append({

--- a/tests/drivers/driver_format_cases.py
+++ b/tests/drivers/driver_format_cases.py
@@ -333,7 +333,7 @@ TG_SUCCESS = """<script>json_dsData = [{"ChannelID":"7","ChannelType":"SC-QAM","
 CM3000_SUCCESS = _cm3000_html(
     "1|1|Locked|QAM256|7|591000000 Hz|-2.5|40.0|1234|5|",
     "1|1|Locked|ATDMA|3|5120 Ksym/sec|29200000 Hz|43.5 dBmV|",
-    "1|1|Locked|0 ,1 ,2 ,3|193|690000000 Hz|-0.32 dBmV|41.8 dB|388 ~ 3707|9|1|0|",
+    "1|1|Locked|0 ,1 ,2 ,3|193|690000000 Hz|-0.32 dBmV|41.8 dB|388 ~ 3707|9000|9|1|",
     "1|1|Locked|12 ,13|41|36200000 Hz|36.5 dBmV|",
 )
 

--- a/tests/test_cm3000_driver.py
+++ b/tests/test_cm3000_driver.py
@@ -1,8 +1,13 @@
 """Tests for Netgear CM3000 modem driver."""
 
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
+from app.analyzer import ANALYZER_SCHEMA_VERSION, analyze, apply_cumulative_error_baseline
 from app.drivers.cm3000 import CM3000Driver
+from app.event_detector import EventDetector
 
 
 # -- Embedded tagValueList strings from real CM3000 HAR capture --
@@ -441,8 +446,9 @@ class TestDownstreamOFDM:
         assert ch["powerLevel"] == -0.32
         assert ch["mer"] == 41.8
         assert ch["mse"] is None
-        assert ch["corrErrors"] == 21375387957
-        assert ch["nonCorrErrors"] == 10237586972
+        assert ch["corrErrors"] == 10237586972
+        assert ch["nonCorrErrors"] == 18675397
+        assert 21375387957 not in (ch["corrErrors"], ch["nonCorrErrors"])
 
     def test_second_channel_fields(self, mock_status):
         data = mock_status.get_docsis_data()
@@ -451,6 +457,44 @@ class TestDownstreamOFDM:
         assert ch["frequency"] == "957 MHz"
         assert ch["powerLevel"] == -5.92
         assert ch["mer"] == 38.6
+        assert ch["corrErrors"] == 19395421307
+        assert ch["nonCorrErrors"] == 378
+        assert 21728350102 not in (ch["corrErrors"], ch["nonCorrErrors"])
+
+    def test_issue_815_mapping_transition_starts_fresh_counter_baseline(self, mock_status):
+        current_data = mock_status.get_docsis_data()
+        previous_data = deepcopy(current_data)
+        old_ofdm_counters = {
+            193: (21375387957, 10237586972),
+            194: (21728350102, 19395421307),
+        }
+        for channel in previous_data["channelDs"]["docsis31"]:
+            channel["corrErrors"], channel["nonCorrErrors"] = old_ofdm_counters[
+                channel["channelID"]
+            ]
+
+        previous = analyze(previous_data)
+        previous["analysis_meta"] = {"analyzer_schema": ANALYZER_SCHEMA_VERSION}
+        current = analyze(current_data)
+
+        apply_cumulative_error_baseline(current, previous)
+
+        baseline = current["summary"]["error_baseline"]
+        assert baseline["schema_baseline"] is False
+        assert baseline["comparable_counter_reset"] is True
+        assert baseline["raw_uncorrectable_counter_reset"] is True
+        assert baseline["ds_comparable_correctable_recent_delta"] == 0
+        assert baseline["ds_comparable_uncorrectable_recent_delta"] == 0
+        assert baseline["ds_comparable_correctable_delta"] == 0
+        assert baseline["ds_comparable_uncorrectable_delta"] == 0
+        assert baseline["ds_raw_uncorrectable_recent_delta"] == 0
+        assert baseline["ds_raw_uncorrectable_delta"] == 0
+
+        detector = EventDetector()
+        detector.seed(previous)
+        event_types = {event["event_type"] for event in detector.check(current)}
+        assert "error_spike" not in event_types
+        assert "modem_restart_detected" not in event_types
 
 
 # -- Upstream OFDMA --


### PR DESCRIPTION
## Summary

- map CM3000 downstream OFDM correctable and uncorrectable codewords to their actual payload fields
- add real-capture, format-characterization, and upgrade-boundary regression coverage
- remove stale duplicate CM3000 parser definitions from the device adapter

## Historical data

CM3000 OFDM snapshots collected before this fix may contain incorrect error-counter values: unerrored codewords were stored as correctable, correctable codewords were stored as uncorrectable, and the true uncorrectable value was not retained. Those historical values cannot be reconstructed safely. The first corrected sample starts a fresh local counter baseline without emitting a false error spike or modem-restart event.

## Checks

- Python non-E2E suite: 4041 passed, 2 skipped
- JavaScript suite: 16 passed
- focused parser, characterization, baseline, event, golden, and architecture regressions

Closes #815
