### PR TITLE
Route CI checks by changed paths

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,21 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+    # GitHub does not evaluate path filters for tag pushes, so v* builds
+    # remain unconditional while main pushes stay limited to image inputs.
+    paths:
+      - 'app/**'
+      - 'tools/**'
+      - 'requirements.txt'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'entrypoint.sh'
+      - '.github/workflows/docker.yml'
   workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 env:
   REGISTRY: ghcr.io
@@ -38,6 +52,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
             type=ref,event=tag
+            type=sha,enable=${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4

--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -21,6 +21,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: full-e2e-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: >-
+    ${{
+      github.event_name == 'pull_request' &&
+      (
+        github.event.action != 'labeled' ||
+        github.event.label.name == 'full-e2e'
+      )
+    }}
+
 jobs:
   changes:
     if: github.event_name == 'pull_request'
@@ -40,6 +51,12 @@ jobs:
               - 'app/static/**'
               - 'app/modules/**'
               - 'app/web.py'
+              - 'app/blueprints/**'
+              - 'app/tz.py'
+              - 'app/i18n/**'
+              - 'app/app_factory.py'
+              - 'app/base_path.py'
+              - 'app/glossary.py'
               - 'tests/e2e/**'
               - 'tests/test_e2e_harness.py'
               - 'tests/test_e2e_shards.py'
@@ -57,8 +74,19 @@ jobs:
       (
         github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch' ||
-        contains(github.event.pull_request.labels.*.name, 'full-e2e') ||
-        needs.changes.outputs.browser == 'true'
+        (
+          github.event_name == 'pull_request' &&
+          (
+            (github.event.action == 'labeled' && github.event.label.name == 'full-e2e') ||
+            (
+              github.event.action != 'labeled' &&
+              (
+                contains(github.event.pull_request.labels.*.name, 'full-e2e') ||
+                needs.changes.outputs.browser == 'true'
+              )
+            )
+          )
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.single_process && 35 || 18 }}
@@ -154,8 +182,19 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          contains(github.event.pull_request.labels.*.name, 'full-e2e') ||
-          needs.changes.outputs.browser == 'true'
+          (
+            github.event_name == 'pull_request' &&
+            (
+              (github.event.action == 'labeled' && github.event.label.name == 'full-e2e') ||
+              (
+                github.event.action != 'labeled' &&
+                (
+                  contains(github.event.pull_request.labels.*.name, 'full-e2e') ||
+                  needs.changes.outputs.browser == 'true'
+                )
+              )
+            )
+          )
         }}
       SHARD_JOB_RESULT: ${{ needs.e2e-shards.result }}
       CHANGE_DETECTION_RESULT: ${{ needs.changes.result }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,143 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "23 4 * * 1"
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      python: ${{ steps.filter.outputs.python }}
+      windows: ${{ steps.filter.outputs.windows }}
+      browser: ${{ steps.filter.outputs.browser }}
+      js: ${{ steps.filter.outputs.js }}
+      i18n: ${{ steps.filter.outputs.i18n }}
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Filter test-relevant changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: some-with-excludes
+          filters: |
+            docs:
+              - '*.md'
+              - 'docs/**'
+              - 'packaging/windows/*.md'
+            python:
+              - 'app/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'tools/**'
+              - 'packaging/windows/**'
+              - '!packaging/windows/*.md'
+              - 'requirements.txt'
+              - 'requirements-test.txt'
+              - 'pytest.ini'
+              - '.github/workflows/*.yml'
+            windows:
+              - 'app/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'tools/**'
+              - 'packaging/windows/**'
+              - '!packaging/windows/*.md'
+              - 'requirements.txt'
+              - 'requirements-test.txt'
+              - 'packaging/windows/requirements-runtime-windows.txt'
+              - 'packaging/windows/requirements-test-windows.txt'
+              - 'pytest.ini'
+              - '.github/workflows/*.yml'
+            browser:
+              - 'app/templates/**'
+              - 'app/static/**'
+              - 'app/modules/**'
+              - 'app/web.py'
+              - 'app/blueprints/**'
+              - 'app/tz.py'
+              - 'app/i18n/**'
+              - 'app/app_factory.py'
+              - 'app/base_path.py'
+              - 'app/glossary.py'
+              - 'tests/e2e/**'
+              - 'tests/test_e2e_harness.py'
+              - 'tests/test_e2e_shards.py'
+              - 'scripts/e2e_shards.py'
+              - 'requirements.txt'
+              - 'requirements-test.txt'
+              - '.github/workflows/full-e2e.yml'
+              - '.github/workflows/test.yml'
+            js:
+              - 'package.json'
+              - 'package-lock.json'
+              - 'app/static/js/**'
+              - 'app/static/sw.js'
+              - 'app/static/vendor/**'
+              - 'tests/js/**'
+              - '.github/workflows/test.yml'
+            i18n:
+              - 'app/i18n/**'
+              - 'app/modules/**/i18n/**'
+              - 'scripts/i18n_check.py'
+              - 'tests/test_i18n_check.py'
+              - '.github/workflows/test.yml'
+            deps:
+              - 'requirements.txt'
+              - '.github/workflows/test.yml'
+
+  docs:
+    needs: changes
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-test.txt
+
+      - name: Install dependencies
+        run: |
+          pip install --require-hashes -r requirements.txt
+          pip install --require-hashes -r requirements-test.txt
+
+      - name: Run documentation contract tests
+        run: >-
+          python -m pytest -q
+          tests/test_public_launch_surface.py
+          tests/test_defensive_review_docs.py
+          tests/test_windows_packaging.py
+
   test:
+    needs: changes
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -45,6 +176,12 @@ jobs:
         run: python -m pytest tests/ -v --tb=short --ignore=tests/e2e
 
   test-js:
+    needs: changes
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.js == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -65,6 +202,12 @@ jobs:
         run: npm test
 
   test-windows:
+    needs: changes
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.windows == 'true'
     runs-on: windows-latest
 
     steps:
@@ -89,6 +232,12 @@ jobs:
         run: python -m pytest tests/ -v --tb=short --ignore=tests/e2e -m "not linux_only"
 
   mobile-e2e:
+    needs: changes
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.browser == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -115,6 +264,17 @@ jobs:
         run: TZ=UTC python -m pytest -q tests/e2e/test_mobile_quality_gate.py --tb=short
 
   audit:
+    needs: changes
+    if: >-
+      always() &&
+      !cancelled() &&
+      (
+        github.event_name == 'schedule' ||
+        (
+          needs.changes.result == 'success' &&
+          needs.changes.outputs.deps == 'true'
+        )
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -129,6 +289,12 @@ jobs:
           inputs: requirements.txt
 
   i18n:
+    needs: changes
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.i18n == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -142,3 +308,67 @@ jobs:
 
       - name: Validate translations
         run: python scripts/i18n_check.py --validate
+
+  tests-summary:
+    name: tests-summary
+    needs: [changes, docs, test, test-windows, mobile-e2e, test-js, i18n, audit]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify routed test results
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          DOCS_CHANGED: ${{ needs.changes.outputs.docs }}
+          PYTHON_CHANGED: ${{ needs.changes.outputs.python }}
+          WINDOWS_CHANGED: ${{ needs.changes.outputs.windows }}
+          BROWSER_CHANGED: ${{ needs.changes.outputs.browser }}
+          JS_CHANGED: ${{ needs.changes.outputs.js }}
+          I18N_CHANGED: ${{ needs.changes.outputs.i18n }}
+          DEPS_CHANGED: ${{ needs.changes.outputs.deps }}
+          DOCS_RESULT: ${{ needs.docs.result }}
+          PYTHON_RESULT: ${{ needs.test.result }}
+          WINDOWS_RESULT: ${{ needs.test-windows.result }}
+          BROWSER_RESULT: ${{ needs.mobile-e2e.result }}
+          JS_RESULT: ${{ needs.test-js.result }}
+          I18N_RESULT: ${{ needs.i18n.result }}
+          DEPS_RESULT: ${{ needs.audit.result }}
+        run: |
+          python - <<'PY'
+          import os
+
+          event_name = os.environ["EVENT_NAME"]
+          changes_result = os.environ["CHANGES_RESULT"]
+          routes = {
+              "docs": (os.environ["DOCS_CHANGED"], os.environ["DOCS_RESULT"]),
+              "python": (os.environ["PYTHON_CHANGED"], os.environ["PYTHON_RESULT"]),
+              "windows": (os.environ["WINDOWS_CHANGED"], os.environ["WINDOWS_RESULT"]),
+              "browser": (os.environ["BROWSER_CHANGED"], os.environ["BROWSER_RESULT"]),
+              "js": (os.environ["JS_CHANGED"], os.environ["JS_RESULT"]),
+              "i18n": (os.environ["I18N_CHANGED"], os.environ["I18N_RESULT"]),
+              "deps": (os.environ["DEPS_CHANGED"], os.environ["DEPS_RESULT"]),
+          }
+
+          failed = [name for name, (_, result) in routes.items()
+                    if result in {"failure", "cancelled"}]
+          if failed:
+              raise SystemExit(f"Failed or cancelled jobs: {', '.join(failed)}")
+
+          if event_name == "schedule":
+              if routes["deps"][1] != "success":
+                  raise SystemExit("Scheduled dependency audit did not succeed")
+              raise SystemExit(0)
+
+          if changes_result != "success":
+              raise SystemExit(
+                  f"Change detection did not succeed: {changes_result}"
+              )
+
+          for name, (changed, result) in routes.items():
+              if changed not in {"true", "false"}:
+                  raise SystemExit(f"Missing detector output for {name}: {changed!r}")
+              if changed == "true" and result != "success":
+                  raise SystemExit(
+                      f"{name} changes require a successful job; result was {result}"
+                  )
+          PY

--- a/tests/drivers/surfboard/test_auth.py
+++ b/tests/drivers/surfboard/test_auth.py
@@ -4,7 +4,7 @@ import hashlib
 import hmac
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import call, patch, MagicMock
 from app.drivers.surfboard import SurfboardDriver, _HNAP_PRELOGIN_KEY
 from ._data import HNAP_LOGIN_PHASE1, HNAP_LOGIN_PHASE2
 
@@ -109,9 +109,13 @@ class TestLogin:
         def mock_post(action, body, **kwargs):
             return {"LoginResponse": {"Challenge": "", "PublicKey": "", "Cookie": ""}}
 
-        with patch.object(driver, "_hnap_post", side_effect=mock_post):
+        with patch.object(driver, "_hnap_post", side_effect=mock_post) as hnap_post, \
+             patch("app.drivers.surfboard.time") as mock_time:
             with pytest.raises(RuntimeError, match="no challenge received"):
                 driver.login()
+
+        assert hnap_post.call_count == 3
+        assert mock_time.sleep.call_args_list == [call(5), call(15)]
 
     def test_login_retries_on_connection_error(self, driver):
         import requests as req
@@ -416,4 +420,3 @@ class TestHnapAuth:
 
 
 # -- Downstream SC-QAM --
-

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -1,0 +1,342 @@
+"""Contracts for path-routed CI workflows.
+
+PyYAML follows YAML 1.1 and may parse the unquoted GitHub Actions ``on`` key
+as boolean ``True``.  The loader below normalizes that quirk before assertions.
+"""
+
+from pathlib import Path
+import re
+
+import pytest
+
+yaml = pytest.importorskip(
+    "yaml",
+    reason="CI workflow contracts run where the YAML test dependency is installed",
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+E2E_BROWSER_PATHS = [
+    "app/templates/**",
+    "app/static/**",
+    "app/modules/**",
+    "app/web.py",
+    "app/blueprints/**",
+    "app/tz.py",
+    "app/i18n/**",
+    "app/app_factory.py",
+    "app/base_path.py",
+    "app/glossary.py",
+    "tests/e2e/**",
+    "tests/test_e2e_harness.py",
+    "tests/test_e2e_shards.py",
+    "scripts/e2e_shards.py",
+    "requirements.txt",
+    "requirements-test.txt",
+    ".github/workflows/full-e2e.yml",
+]
+
+DOCKER_PATHS = [
+    "app/**",
+    "tools/**",
+    "requirements.txt",
+    "Dockerfile",
+    ".dockerignore",
+    "entrypoint.sh",
+    ".github/workflows/docker.yml",
+]
+
+TEST_FILTERS = {
+    "docs": [
+        "*.md",
+        "docs/**",
+        "packaging/windows/*.md",
+    ],
+    "python": [
+        "app/**",
+        "tests/**",
+        "scripts/**",
+        "tools/**",
+        "packaging/windows/**",
+        "!packaging/windows/*.md",
+        "requirements.txt",
+        "requirements-test.txt",
+        "pytest.ini",
+        ".github/workflows/*.yml",
+    ],
+    "windows": [
+        "app/**",
+        "tests/**",
+        "scripts/**",
+        "tools/**",
+        "packaging/windows/**",
+        "!packaging/windows/*.md",
+        "requirements.txt",
+        "requirements-test.txt",
+        "packaging/windows/requirements-runtime-windows.txt",
+        "packaging/windows/requirements-test-windows.txt",
+        "pytest.ini",
+        ".github/workflows/*.yml",
+    ],
+    "browser": E2E_BROWSER_PATHS + [".github/workflows/test.yml"],
+    "js": [
+        "package.json",
+        "package-lock.json",
+        "app/static/js/**",
+        "app/static/sw.js",
+        "app/static/vendor/**",
+        "tests/js/**",
+        ".github/workflows/test.yml",
+    ],
+    "i18n": [
+        "app/i18n/**",
+        "app/modules/**/i18n/**",
+        "scripts/i18n_check.py",
+        "tests/test_i18n_check.py",
+        ".github/workflows/test.yml",
+    ],
+    "deps": ["requirements.txt", ".github/workflows/test.yml"],
+}
+
+
+def load_workflow(name):
+    workflow = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    if "on" not in workflow and True in workflow:
+        workflow["on"] = workflow.pop(True)
+    return workflow
+
+
+def parsed_filters(workflow):
+    filter_step = next(
+        step for step in workflow["jobs"]["changes"]["steps"]
+        if step.get("id") == "filter"
+    )
+    return yaml.safe_load(filter_step["with"]["filters"]), filter_step
+
+
+def compact(expression):
+    return re.sub(r"\s+", " ", expression).strip()
+
+
+def e2e_required(event_name, action=None, event_label=None, labels=(), browser=False):
+    """Readable model of the exact predicate asserted against the workflow."""
+    if event_name in {"schedule", "workflow_dispatch"}:
+        return True
+    if event_name != "pull_request":
+        return False
+    if action == "labeled":
+        return event_label == "full-e2e"
+    return "full-e2e" in labels or browser
+
+
+def test_full_e2e_paths_concurrency_and_summary_contract():
+    workflow = load_workflow("full-e2e.yml")
+    filters, filter_step = parsed_filters(workflow)
+
+    assert filters == {"browser": E2E_BROWSER_PATHS}
+    assert re.fullmatch(r"dorny/paths-filter@[0-9a-f]{40}", filter_step["uses"])
+    assert workflow["concurrency"]["group"] == (
+        "full-e2e-${{ github.event.pull_request.number || github.run_id }}"
+    )
+    cancel_in_progress = compact(workflow["concurrency"]["cancel-in-progress"])
+    assert cancel_in_progress == compact("""
+        ${{
+          github.event_name == 'pull_request' &&
+          (
+            github.event.action != 'labeled' ||
+            github.event.label.name == 'full-e2e'
+          )
+        }}
+    """)
+    assert workflow["jobs"]["full-e2e"]["name"] == "full-e2e"
+
+    required = compact(workflow["jobs"]["full-e2e"]["env"]["E2E_REQUIRED"])
+    expected = compact("""
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          (
+            github.event_name == 'pull_request' &&
+            (
+              (github.event.action == 'labeled' && github.event.label.name == 'full-e2e') ||
+              (
+                github.event.action != 'labeled' &&
+                (
+                  contains(github.event.pull_request.labels.*.name, 'full-e2e') ||
+                  needs.changes.outputs.browser == 'true'
+                )
+              )
+            )
+          )
+        }}
+    """)
+    assert required == expected
+
+    shard_if = compact(workflow["jobs"]["e2e-shards"]["if"])
+    required_body = required.removeprefix("${{ ").removesuffix(" }}")
+    assert "always() && !cancelled()" in shard_if
+    assert "needs.changes.result == 'success'" in shard_if
+    assert required_body in shard_if
+    summarize = next(
+        step for step in workflow["jobs"]["full-e2e"]["steps"]
+        if step["name"].startswith("Verify complete successful")
+    )["run"]
+    assert "--expected-total 549" in summarize
+
+
+@pytest.mark.parametrize(
+    ("event_name", "action", "event_label", "labels", "browser", "expected"),
+    [
+        ("pull_request", "labeled", "documentation", (), True, False),
+        ("pull_request", "labeled", "documentation", ("full-e2e",), False, False),
+        ("pull_request", "labeled", "full-e2e", (), False, True),
+        ("pull_request", "synchronize", None, (), True, True),
+        ("pull_request", "synchronize", None, ("full-e2e",), False, True),
+        ("pull_request", "synchronize", None, (), False, False),
+        ("pull_request", "opened", None, ("full-e2e",), False, True),
+        ("pull_request", "reopened", None, (), True, True),
+        ("schedule", None, None, (), False, True),
+        ("workflow_dispatch", None, None, (), False, True),
+    ],
+)
+def test_full_e2e_requirement_truth_table(
+    event_name, action, event_label, labels, browser, expected
+):
+    assert e2e_required(event_name, action, event_label, labels, browser) is expected
+
+
+def test_docker_paths_tags_manual_and_concurrency_contract():
+    workflow = load_workflow("docker.yml")
+    triggers = workflow["on"]
+
+    assert triggers["push"] == {
+        "branches": ["main"],
+        "tags": ["v*"],
+        "paths": DOCKER_PATHS,
+    }
+    assert triggers["workflow_dispatch"] is None
+    assert workflow["concurrency"] == {
+        "group": "docker-${{ github.ref }}",
+        "cancel-in-progress": "${{ github.ref == 'refs/heads/main' }}",
+    }
+    metadata_tags = next(
+        step["with"]["tags"]
+        for step in workflow["jobs"]["build-and-push"]["steps"]
+        if step.get("id") == "meta"
+    )
+    assert "type=ref,event=tag" in metadata_tags
+    assert "type=sha,enable=${{ github.event_name == 'workflow_dispatch'" in metadata_tags
+
+
+def test_test_workflow_detector_schedule_and_exact_path_contracts():
+    workflow = load_workflow("test.yml")
+    triggers = workflow["on"]
+    filters, filter_step = parsed_filters(workflow)
+
+    assert triggers["schedule"] == [{"cron": "23 4 * * 1"}]
+    assert "paths-ignore" not in triggers["push"]
+    assert "paths-ignore" not in triggers["pull_request"]
+    assert workflow["jobs"]["changes"]["if"] == "github.event_name != 'schedule'"
+    assert workflow["jobs"]["changes"]["permissions"] == {
+        "contents": "read",
+        "pull-requests": "read",
+    }
+    assert set(workflow["jobs"]["changes"]["outputs"]) == set(TEST_FILTERS)
+    assert filters == TEST_FILTERS
+    assert re.fullmatch(r"dorny/paths-filter@[0-9a-f]{40}", filter_step["uses"])
+    assert filter_step["with"]["predicate-quantifier"] == "some-with-excludes"
+
+    docs_run = next(
+        step["run"] for step in workflow["jobs"]["docs"]["steps"]
+        if step["name"] == "Run documentation contract tests"
+    )
+    for test_file in (
+        "tests/test_public_launch_surface.py",
+        "tests/test_defensive_review_docs.py",
+        "tests/test_windows_packaging.py",
+    ):
+        assert test_file in docs_run
+
+
+def test_test_workflow_jobs_are_routed_through_the_detector():
+    jobs = load_workflow("test.yml")["jobs"]
+    routes = {
+        "docs": "docs",
+        "test": "python",
+        "test-windows": "windows",
+        "mobile-e2e": "browser",
+        "test-js": "js",
+        "i18n": "i18n",
+    }
+
+    for job_name, output in routes.items():
+        condition = compact(jobs[job_name]["if"])
+        assert jobs[job_name]["needs"] == "changes"
+        assert condition.startswith("always() && !cancelled() &&")
+        assert "needs.changes.result == 'success'" in condition
+        assert f"needs.changes.outputs.{output} == 'true'" in condition
+
+    audit_if = compact(jobs["audit"]["if"])
+    assert jobs["audit"]["needs"] == "changes"
+    assert audit_if.startswith("always() && !cancelled() &&")
+    assert "github.event_name == 'schedule'" in audit_if
+    assert "needs.changes.result == 'success'" in audit_if
+    assert "needs.changes.outputs.deps == 'true'" in audit_if
+
+
+def test_tests_summary_is_always_present_and_fails_closed():
+    summary = load_workflow("test.yml")["jobs"]["tests-summary"]
+    assert summary["name"] == "tests-summary"
+    assert set(summary["needs"]) == {
+        "changes",
+        "docs",
+        "test",
+        "test-windows",
+        "mobile-e2e",
+        "test-js",
+        "i18n",
+        "audit",
+    }
+    assert summary["if"] == "always()"
+
+    step = summary["steps"][0]
+    script = step["run"]
+    assert set(step["env"]) == {
+        "EVENT_NAME",
+        "CHANGES_RESULT",
+        "DOCS_CHANGED",
+        "PYTHON_CHANGED",
+        "WINDOWS_CHANGED",
+        "BROWSER_CHANGED",
+        "JS_CHANGED",
+        "I18N_CHANGED",
+        "DEPS_CHANGED",
+        "DOCS_RESULT",
+        "PYTHON_RESULT",
+        "WINDOWS_RESULT",
+        "BROWSER_RESULT",
+        "JS_RESULT",
+        "I18N_RESULT",
+        "DEPS_RESULT",
+    }
+    assert 'result in {"failure", "cancelled"}' in script
+    assert 'event_name == "schedule"' in script
+    assert 'routes["deps"][1] != "success"' in script
+    assert 'changes_result != "success"' in script
+    assert 'changed not in {"true", "false"}' in script
+    assert 'changed == "true" and result != "success"' in script
+
+
+@pytest.mark.parametrize("name", ["full-e2e.yml", "docker.yml", "test.yml"])
+def test_changed_workflows_keep_every_action_sha_pinned(name):
+    workflow = load_workflow(name)
+    uses = [
+        step["uses"]
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if "uses" in step
+    ]
+    assert uses
+    assert all(re.fullmatch(r"[^@]+@[0-9a-f]{40}", action) for action in uses)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -186,6 +186,19 @@ class TestEventStorage:
         assert events[0]["timestamp"] == ts2
         assert events[1]["timestamp"] == ts1
 
+    def test_get_events_limit(self, storage):
+        for index in range(3):
+            storage.save_event(
+                f"2026-01-0{index + 1}T00:00:00Z",
+                "info",
+                "channel_change",
+                f"Event {index}",
+            )
+
+        events = storage.get_events(limit=2)
+
+        assert [event["message"] for event in events] == ["Event 2", "Event 1"]
+
     def test_save_events_empty_list(self, storage):
         assert storage.save_events([]) == 0
 
@@ -332,9 +345,27 @@ class TestEventExportApi:
         assert resp.status_code == 401
         assert resp.get_json() == {"error": "Authentication required"}
 
-    def test_events_export_csv_sets_truncation_header_when_limited(self, events_client, storage):
-        for index in range(10001):
-            storage.save_event(f"2026-04-29T22:{index % 60:02d}:26Z", "info", "channel_change", f"Event {index}")
+    def test_events_export_csv_sets_truncation_header_when_limited(
+        self, events_client, storage, monkeypatch
+    ):
+        requested_limits = []
+
+        def get_events(**kwargs):
+            requested_limits.append(kwargs["limit"])
+            return [
+                {
+                    "id": index + 1,
+                    "timestamp": f"2026-04-29T22:{index % 60:02d}:26Z",
+                    "severity": "info",
+                    "event_type": "channel_change",
+                    "message": f"Event {index}",
+                    "details": {"channel_count": 32, "sequence": index},
+                    "acknowledged": index % 2,
+                }
+                for index in range(kwargs["limit"])
+            ]
+
+        monkeypatch.setattr(storage, "get_events", get_events)
 
         resp = events_client.get("/api/events/export.csv")
 
@@ -343,6 +374,7 @@ class TestEventExportApi:
         assert resp.headers["X-DOCSight-Export-Truncated"] == "true"
         rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
         assert len(rows) == 10000
+        assert requested_limits == [10001]
 
 
 # ── EventDetector Tests ──


### PR DESCRIPTION
## Summary

- route documentation, Python, Windows, browser, JavaScript, translation, and dependency checks by changed paths
- keep stable fail-closed summary checks while avoiding unrelated full E2E and Docker work
- prevent stale `latest` image races and preserve unconditional tag/manual builds
- remove real wait and bulk-insert costs from two existing tests without reducing their contracts

## Checks

- 4,060 non-E2E Python tests passed
- 173 focused workflow, event, and SURFboard tests passed
- 16 JavaScript tests passed
- 92 translation catalogs validated
- workflow syntax and action lint checks passed
- workflow mutation checks rejected five weakened routing variants
