### PR TITLE
Preserve browser gate status across label events

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -177,6 +177,9 @@ jobs:
     needs: [changes, e2e-shards]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: read
     env:
       E2E_REQUIRED: >-
         ${{
@@ -207,6 +210,42 @@ jobs:
             echo "Browser change detection result was $CHANGE_DETECTION_RESULT"
             exit 1
           fi
+
+      - name: Preserve prior browser gate on unrelated labels
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.action == 'labeled' &&
+          github.event.label.name != 'full-e2e'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const ref = context.payload.pull_request.head.sha;
+            const {data} = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref,
+              check_name: 'full-e2e',
+              filter: 'all',
+              per_page: 100,
+            });
+            const previous = data.check_runs
+              .filter(run =>
+                run.status === 'completed' &&
+                run.app?.slug === 'github-actions'
+              )
+              .sort((left, right) =>
+                new Date(right.completed_at) - new Date(left.completed_at)
+              )[0];
+            if (!previous) {
+              core.setFailed('No completed browser gate exists for this commit.');
+            } else if (previous.conclusion !== 'success') {
+              core.setFailed(
+                `Previous browser gate concluded ${previous.conclusion}.`
+              );
+            } else {
+              core.info('Previous browser gate succeeded; preserving that result.');
+            }
 
       - name: Checkout
         if: env.E2E_REQUIRED == 'true'

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -151,6 +151,10 @@ def test_full_e2e_paths_concurrency_and_summary_contract():
         }}
     """)
     assert workflow["jobs"]["full-e2e"]["name"] == "full-e2e"
+    assert workflow["jobs"]["full-e2e"]["permissions"] == {
+        "contents": "read",
+        "checks": "read",
+    }
 
     required = compact(workflow["jobs"]["full-e2e"]["env"]["E2E_REQUIRED"])
     expected = compact("""
@@ -184,6 +188,26 @@ def test_full_e2e_paths_concurrency_and_summary_contract():
         if step["name"].startswith("Verify complete successful")
     )["run"]
     assert "--expected-total 549" in summarize
+
+    preserve = next(
+        step for step in workflow["jobs"]["full-e2e"]["steps"]
+        if step["name"] == "Preserve prior browser gate on unrelated labels"
+    )
+    preserve_if = compact(preserve["if"])
+    assert "github.event.action == 'labeled'" in preserve_if
+    assert "github.event.label.name != 'full-e2e'" in preserve_if
+    assert re.fullmatch(r"actions/github-script@[0-9a-f]{40}", preserve["uses"])
+    preserve_script = preserve["with"]["script"]
+    for contract in (
+        "check_name: 'full-e2e'",
+        "filter: 'all'",
+        "run.status === 'completed'",
+        "run.app?.slug === 'github-actions'",
+        "if (!previous)",
+        "previous.conclusion !== 'success'",
+        "core.setFailed",
+    ):
+        assert contract in preserve_script
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- preserve the latest completed browser-gate result when an unrelated pull request label is added
- fail closed when no trustworthy prior gate result exists or the prior result was unsuccessful
- keep unrelated labels from rerunning the full browser suite

## Tests

- `4060 passed, 2 skipped` in the full non-browser suite
- `34 passed` in the workflow and E2E contract suite
- workflow YAML validation and `actionlint`
- mutation checks for prior-failure handling and check-read permissions
