### PR TITLE
refactor: move dashboard surfaces into modules

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -264,7 +264,7 @@ jobs:
           pattern: full-e2e-shard-*
           path: shard-artifacts
 
-      - name: Verify complete successful 549-case union
+      - name: Verify complete successful 551-case union
         if: env.E2E_REQUIRED == 'true'
         run: |
           if [ "$SHARD_JOB_RESULT" != "success" ]; then
@@ -273,7 +273,7 @@ jobs:
           fi
           python scripts/e2e_shards.py summarize \
             --results-root shard-artifacts \
-            --expected-total 549
+            --expected-total 551
 
       - name: Browser gate not required for this change
         if: env.E2E_REQUIRED != 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,20 @@ preflight. An unresolved route, static directory, template, catalog, class, or
 JSON contribution rejects the module's complete plan; no partial contribution
 is registered.
 
+Modules declare dashboard content with `contributes.tab` and dialogs with
+`contributes.dialogs`, each pointing to a module template such as
+`templates/example_tab.html` or `templates/example_dialogs.html`. Empty rendered
+tabs receive no view wrapper. Dialogs render outside hidden views, so an enabled
+integration can keep its setup dialog available before it is configured. Missing
+or unsafe dialog templates reject the complete module contribution plan.
+
+The module static directory's `main.js` loads automatically, with a versioned URL,
+on both Dashboard and Settings when the module is enabled. Top-level execution
+must tolerate missing dashboard elements and globals. Expose an idempotent view
+initialization hook (for example `window.initExampleView`) and wire it into the
+existing dashboard routing convention. Guard absent view elements and ensure
+repeated activation does not accumulate listeners, timers, or fetch loops.
+
 Server-side module code should import the established accessors it needs from
 `app.web`, such as `get_config_manager()`, `get_storage()`, `get_state()`, or
 `get_module_loader()`. These accessors resolve the active application's typed

--- a/app/manifest_contract.py
+++ b/app/manifest_contract.py
@@ -24,6 +24,7 @@ VALID_CONTRIBUTES = frozenset(
         "routes",
         "settings",
         "tab",
+        "dialogs",
         "card",
         "i18n",
         "static",

--- a/app/module_contributions.py
+++ b/app/module_contributions.py
@@ -268,7 +268,7 @@ def setup_module_templates(
 ) -> dict[str, str]:
     """Resolve declared template files for Jinja includes."""
     resolved = {}
-    for key in {"tab", "card", "settings"}:
+    for key in {"tab", "card", "settings", "dialogs"}:
         rel_path = contributes.get(key)
         if not rel_path:
             continue
@@ -383,7 +383,7 @@ def resolve_module_contribution(
         "template", lambda: setup_module_templates(mod.id, mod.path, contributes)
     )
     declared_templates = {
-        key for key in ("tab", "card", "settings") if key in contributes
+        key for key in ("tab", "card", "settings", "dialogs") if key in contributes
     }
     if declared_templates != set(template_paths):
         missing_kind = sorted(declared_templates - set(template_paths))[0]

--- a/app/modules/bqm/manifest.json
+++ b/app/modules/bqm/manifest.json
@@ -11,7 +11,9 @@
     "routes": "routes.py",
     "settings": "templates/bqm_settings.html",
     "static": "static/",
-    "i18n": "i18n/"
+    "i18n": "i18n/",
+    "tab": "templates/bqm_tab.html",
+    "dialogs": "templates/bqm_dialogs.html"
   },
   "config": {
     "bqm_url": "",

--- a/app/modules/bqm/static/main.js
+++ b/app/modules/bqm/static/main.js
@@ -8,7 +8,7 @@ if (typeof BQMChart === 'undefined') {
 }
 
 /* ── BQM State ── */
-var bqmDate = todayStr();
+var bqmDate = typeof todayStr === 'function' ? todayStr() : null;
 var _bqmAvailableDates = new Set();
 var _bqmCsvDates = new Set();
 var _bqmPngDates = new Set();
@@ -843,7 +843,9 @@ function deleteBqmImages() {
 }
 
 /* ── BQM View Init (called from switchView) ── */
-function initBqmView() {
+window.initBqmView = function() {
+    if (!document.getElementById('view-bqm')) return;
+    if (!bqmDate) bqmDate = todayStr();
     // Cross-view date linking (Phase 4)
     if (window._selectedDateRange) {
         _bqmRangeStart = window._selectedDateRange.start;
@@ -865,4 +867,4 @@ function initBqmView() {
     } else {
         loadBqmGraph(bqmDate);
     }
-}
+};

--- a/app/modules/bqm/templates/bqm_dialogs.html
+++ b/app/modules/bqm/templates/bqm_dialogs.html
@@ -1,0 +1,79 @@
+<!-- ═══ BQM Import Modal ═══ -->
+<dialog class="modal-overlay" id="bqm-import-modal" role="dialog" aria-modal="true" aria-labelledby="bqm-import-modal-title" onclick="if(event.target===this)closeBqmImportModal()" oncancel="event.preventDefault(); closeBqmImportModal()">
+    <div class="modal" style="max-width:800px;">
+        <div class="modal-header">
+            <h2 id="bqm-import-modal-title">{{ t.bqm_import_title }}</h2>
+            <button class="modal-close" onclick="closeBqmImportModal()" aria-label="{{ t.close }}">&times;</button>
+        </div>
+        <div class="modal-body" style="overflow-y:auto;">
+            <!-- Drop zone -->
+            <div id="bqm-import-dropzone" class="import-upload-zone bqm-import-dropzone">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:48px;height:48px;color:var(--muted);">
+                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                    <polyline points="17 8 12 3 7 8"/>
+                    <line x1="12" y1="3" x2="12" y2="15"/>
+                </svg>
+                <p>{{ t.bqm_import_drop }}</p>
+                <p style="font-size:0.8em;color:var(--muted);">{{ t.bqm_import_formats }}</p>
+                <button type="button" class="btn btn-muted import-browse-btn" onclick="event.stopPropagation(); document.getElementById('bqm-import-file-input').click();">{{ t.get('bqm_import_browse', 'Browse BQM images') }}</button>
+                <input type="file" id="bqm-import-file-input" style="display:none;" accept="image/png,image/jpeg,.png,.jpg,.jpeg" multiple>
+            </div>
+            <div id="bqm-import-validation-state" class="import-validation-state" role="status" aria-live="polite"></div>
+            <!-- Options: overwrite + date offset -->
+            <div id="bqm-import-options" style="display:none; margin:10px 0;">
+                <div style="display:flex;align-items:center;gap:16px;flex-wrap:wrap;">
+                    <label style="display:flex;align-items:center;gap:8px;font-size:0.9em;cursor:pointer;">
+                        <input type="checkbox" id="bqm-import-overwrite">
+                        {{ t.bqm_import_overwrite }}
+                    </label>
+                    <label style="display:flex;align-items:center;gap:8px;font-size:0.9em;">
+                        {{ t.bqm_import_offset }}:
+                        <input type="number" id="bqm-import-offset" class="bqm-offset-input" min="-30" max="30" value="0" step="1">
+                    </label>
+                </div>
+            </div>
+            <!-- Status line -->
+            <div id="bqm-import-status" class="import-info" style="display:none;"></div>
+            <!-- Preview table -->
+            <div id="bqm-import-preview" style="display:none;">
+                <div class="import-table-wrap">
+                    <table class="bqm-import-table">
+                        <thead><tr>
+                            <th style="width:70px;"></th>
+                            <th>{{ t.incident_title }}</th>
+                            <th style="width:160px;">{{ t.incident_date }}</th>
+                            <th style="width:36px;"></th>
+                        </tr></thead>
+                        <tbody id="bqm-import-tbody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="incident-modal-footer" id="bqm-import-footer" style="display:none;">
+            <div class="modal-footer-left"></div>
+            <div style="display:flex; gap:10px;">
+                <button class="btn btn-muted" onclick="closeBqmImportModal()">{{ t.cancel }}</button>
+                <button class="btn btn-accent" id="bqm-import-confirm-btn" onclick="executeBqmImport()" disabled>{{ t.bqm_import }}</button>
+            </div>
+        </div>
+    </div>
+</dialog>
+
+<!-- BQM Setup Modal -->
+<dialog class="modal-overlay" id="bqm-setup-modal" role="dialog" aria-modal="true" aria-labelledby="bqm-setup-modal-title">
+    <div class="modal modal-wide setup-guide-modal">
+        <div class="modal-header">
+            <h2 id="bqm-setup-modal-title">📈 {{ t.get('bqm_setup_guided_title', 'ThinkBroadband BQM setup') }}</h2>
+            <button class="modal-close" onclick="closeBqmSetupModal()" aria-label="{{ t.close }}">&times;</button>
+        </div>
+        <p class="modal-hint">{{ t.get('bqm_setup_guided_intro', 'Link an existing ThinkBroadband Broadband Quality Monitor so DOCSight can show latency and packet loss beside modem evidence.') }}</p>
+        <div class="modal-body setup-guide-body">
+            <section class="setup-guide-card"><h3>{{ t.get('setup_why_title', 'Why connect it') }}</h3><ul><li>{{ t.get('bqm_setup_benefit_1', 'Track latency, packet loss, and outages') }}</li><li>{{ t.get('bqm_setup_benefit_2', 'Compare external reachability with modem signal state') }}</li><li>{{ t.get('bqm_setup_benefit_3', 'Attach graphs to ISP evidence packages') }}</li></ul></section>
+            <section class="setup-guide-card"><h3>{{ t.get('setup_requirements_title', 'Requirements') }}</h3><ul><li>{{ t.get('bqm_setup_requirement_monitor', 'A ThinkBroadband CSV Yesterday share URL') }}</li><li>{{ t.get('bqm_setup_requirement_static_ip', 'A stable public IP or DDNS target monitored by BQM') }}</li></ul></section>
+            <section class="setup-guide-card setup-guide-command"><h3>{{ t.get('setup_configure_title', 'Configure') }}</h3><p>{{ t.get('bqm_setup_configure_text', 'Create or open your BQM monitor, copy the CSV Yesterday share URL, then save it in Settings. CSV Live is for spot checks only.') }}</p><code id="bqm-setup-url">https://www.thinkbroadband.com/broadband/monitoring/quality/share/abc123def456789012345678901234567890abcd-2-y.csv</code><button class="btn btn-secondary" onclick="copySetupSnippet('bqm-setup-url', 'bqm-setup-status')">{{ t.get('bqm_setup_copy_url', 'Copy example URL format') }}</button></section>
+            <section class="setup-guide-card"><h3>{{ t.get('setup_validate_title', 'Validate') }}</h3><p>{{ t.get('bqm_setup_validate_text', 'After saving a CSV Yesterday URL, DOCSight performs one initial fetch. Use CSV bulk import for up to 12 months of history or longer gaps.') }}</p><button class="btn btn-muted" onclick="validateSetupGuidance('bqm-setup-status', 'bqm')">{{ t.get('setup_validate_source', 'Review validation path') }}</button></section>
+        </div>
+        <div id="bqm-setup-status" class="setup-validation-status" role="status" aria-live="polite"></div>
+        <div class="modal-footer"><button class="btn btn-muted" onclick="closeBqmSetupModal()">{{ t.close }}</button><a class="btn btn-accent" href="{{ url_for('settings', _anchor='mod-docsight_bqm') }}">⚙ {{ t.get('bqm_setup_open_settings', 'Open BQM settings') }}</a></div>
+    </div>
+</dialog>

--- a/app/modules/bqm/templates/bqm_tab.html
+++ b/app/modules/bqm/templates/bqm_tab.html
@@ -1,0 +1,76 @@
+{% if bqm_configured %}
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.bqm_title }}</h2>
+        </div>
+        <!-- BQM Toolbar: quick-jump + month nav -->
+        <div id="bqm-toolbar" class="view-page-actions bqm-toolbar">
+        <button class="trend-tab bqm-quick" id="bqm-today-btn">{{ t.bqm_today }}</button>
+        <button class="trend-tab bqm-quick" id="bqm-yesterday-btn">{{ t.bqm_yesterday }}</button>
+        <button class="trend-tab bqm-quick" id="bqm-7d-btn">{{ t.bqm_range_7d or '7d' }}</button>
+        <button class="trend-tab bqm-quick" id="bqm-30d-btn">{{ t.bqm_range_30d or '30d' }}</button>
+        <div class="bqm-month-nav">
+            <button id="bqm-month-prev" class="bqm-nav-btn" aria-label="{{ t.get('previous_month', 'Previous month') }}">&#8249;</button>
+            <span id="bqm-month-label" class="bqm-month-label"></span>
+            <button id="bqm-month-next" class="bqm-nav-btn" aria-label="{{ t.get('next_month', 'Next month') }}">&#8250;</button>
+        </div>
+        <button class="bqm-nav-btn bqm-import-btn" onclick="openBqmImportModal()" title="{{ t.bqm_import_title }}" aria-label="{{ t.bqm_import_title }}">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14" style="display:block;">
+                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
+            </svg>
+        </button>
+        <button class="bqm-nav-btn bqm-import-btn" onclick="var s=document.getElementById('bqm-csv-import-section');s.style.display=s.style.display==='none'?'':'none'" title="{{ t.get('bqm_csv_import', 'Import CSV') }}" aria-label="{{ t.get('bqm_csv_import', 'Import CSV') }}">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14" style="display:block;">
+                <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>
+            </svg>
+        </button>
+        <button class="bqm-nav-btn bqm-import-btn bqm-delete-btn" onclick="deleteBqmImages()" title="{{ t.bqm_delete }}" aria-label="{{ t.bqm_delete }}">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14" style="display:block;">
+                <polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
+            </svg>
+        </button>
+        </div>
+    </div>
+    <!-- Calendar grid -->
+    <div id="bqm-calendar" class="bqm-calendar">
+        <div class="bqm-weekday-header">
+            <span>{{ t.weekday_mo }}</span><span>{{ t.weekday_tu }}</span><span>{{ t.weekday_we }}</span><span>{{ t.weekday_th }}</span><span>{{ t.weekday_fr }}</span><span>{{ t.weekday_sa }}</span><span>{{ t.weekday_su }}</span>
+        </div>
+        <div id="bqm-calendar-grid" class="bqm-calendar-grid"></div>
+    </div>
+    <span id="bqm-range-label" class="bqm-range-label"></span>
+    <div id="bqm-content">
+        <div id="bqm-card" class="bqm-card" style="display:none;">
+            <div class="chart-card-header">
+                <div class="chart-header-content">
+                    <svg class="chart-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M3 3v18h18"/>
+                        <path d="M7 12l4-4 4 4 4-4"/>
+                    </svg>
+                    <div class="chart-label">{{ t.bqm_title }}</div>
+                    <span id="bqm-live-badge" class="bqm-live-badge" style="display:none;">{{ t.bqm_live }}</span>
+                    <span id="bqm-last-updated" class="bqm-last-updated" style="display:none;"></span>
+                </div>
+                <div id="bqm-view-toggle" class="trend-tabs" style="display:none;">
+                    <button class="trend-tab active" id="bqm-toggle-uplot">uPlot</button>
+                    <button class="trend-tab" id="bqm-toggle-png">PNG</button>
+                </div>
+            </div>
+            <div id="bqm-chart-container" class="bqm-chart-container" style="display:none;"></div>
+            <div id="bqm-image-wrap" style="text-align:center;">
+                <img id="bqm-image" style="max-width:100%; border-radius:8px;" alt="BQM Graph">
+            </div>
+        </div>
+        <div id="bqm-no-data" class="no-data-msg" style="display:none;"></div>
+    </div>
+
+    <!-- BQM CSV Import (inline, below calendar) -->
+    <div id="bqm-csv-import-section" class="bqm-csv-import" style="display:none; margin:16px auto; max-width:480px; text-align:center;">
+        <div style="display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:center;">
+            <input type="file" id="bqm-csv-file" accept=".csv" style="font-size:0.85em;">
+            <button class="btn btn-primary btn-sm" id="bqm-csv-import-btn" onclick="importBqmCsv()">{{ t.get('bqm_csv_import', 'Import CSV') }}</button>
+        </div>
+        <div id="bqm-csv-import-status" class="bqm-csv-status" style="margin-top:8px; font-size:0.85em;"></div>
+    </div>
+
+{% endif %}

--- a/app/modules/evidence/static/main.js
+++ b/app/modules/evidence/static/main.js
@@ -159,9 +159,11 @@ function _evidenceRenderItems(items) {
         var sources = _evidenceRenderSourceBreakdown(item);
         var last = item.last_ts ? '<span class="evidence-muted">' + _evidenceEscape(item.last_ts) + '</span>' : '';
         var action = '';
-        if (item.action && item.action.view) {
+        if (item.action && item.action.view && document.getElementById(
+            item.action.view === 'live' ? 'view-dashboard' : 'view-' + item.action.view
+        )) {
             action = '<button class="evidence-action" type="button" data-evidence-view="' + _evidenceEscape(item.action.view) + '">' + _evidenceEscape(_evidenceActionLabel(item)) + '</button>';
-        } else if (item.action && item.action.action) {
+        } else if (item.action && item.action.action === 'report') {
             action = '<button class="evidence-action" type="button" data-evidence-action="' + _evidenceEscape(item.action.action) + '">' + _evidenceEscape(_evidenceActionLabel(item)) + '</button>';
         }
         return '<article class="evidence-item evidence-status-' + status + '">' +

--- a/app/modules/journal/manifest.json
+++ b/app/modules/journal/manifest.json
@@ -9,7 +9,9 @@
   "contributes": {
     "routes": "routes.py",
     "static": "static/",
-    "i18n": "i18n/"
+    "i18n": "i18n/",
+    "tab": "templates/journal_tab.html",
+    "dialogs": "templates/journal_dialogs.html"
   },
   "menu": {
     "label_key": "docsight.journal.incident_journal",

--- a/app/modules/journal/static/main.js
+++ b/app/modules/journal/static/main.js
@@ -1,4 +1,4 @@
-/* ── journal.js ─────────────────────────────────────────────
+/* ── Journal module ─────────────────────────────────────────────
    Incident Journal, Incident Containers, Timeline, Import,
    Bulk Selection, Search, Export
    Extracted from the IIFE in index.html (Issue #119)
@@ -12,6 +12,13 @@ var _activeIncidentFilter = null; // null=all, 0=unassigned, N=incident id
 var _selectedEntryIds = []; // bulk selection state
 var _bulkMode = false;
 var _incidentsData = []; // cached incident containers
+
+window.initJournalView = function() {
+    if (!document.getElementById('view-journal')) return;
+    if (_timelineActive) closeIncidentTimeline();
+    loadIncidents();
+    loadJournal();
+};
 
 var INCIDENT_ICONS = [
     {keys: ['telefon', 'anruf', 'hotline', 'telefonat', 'angerufen', 'rückruf', 'callcenter'], icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="incident-icon"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z"/></svg>', label: 'phone'},

--- a/app/modules/journal/templates/journal_dialogs.html
+++ b/app/modules/journal/templates/journal_dialogs.html
@@ -1,0 +1,189 @@
+<!-- ═══ Entry Modal ═══ -->
+<dialog class="modal-overlay" id="entry-modal" role="dialog" aria-modal="true" aria-labelledby="entry-modal-title" onclick="if(event.target===this)closeEntryModal()">
+    <div class="modal" style="max-width:640px;">
+        <div class="modal-header">
+            <div style="display:flex;align-items:center;gap:10px;">
+                <span id="entry-modal-icon" class="incident-modal-icon"></span>
+                <h2 id="entry-modal-title"></h2>
+            </div>
+            <button class="modal-close" onclick="closeEntryModal()" aria-label="{{ t.close }}">&times;</button>
+        </div>
+        <div class="modal-body" style="overflow-y:auto;">
+            <p class="incident-modal-intro">{{ t.get('entry_modal_intro', 'Capture what happened and link the evidence DOCSight can turn into an ISP-ready timeline.') }}</p>
+            <input type="hidden" id="entry-id">
+            <div class="incident-form-group">
+                <label for="entry-date">{{ t.incident_date }}</label>
+                <input type="date" id="entry-date">
+            </div>
+            <div class="incident-form-group">
+                <label for="entry-title-input">{{ t.incident_title }}</label>
+                <input type="text" id="entry-title-input" maxlength="200" placeholder="{{ t.incident_title }}">
+            </div>
+            <div class="incident-form-group">
+                <label>{{ t.icon }}</label>
+                <p class="incident-field-hint">{{ t.get('entry_icon_hint', 'Choose a visible category such as outage, packet loss, speed degradation, maintenance, or contact with your ISP.') }}</p>
+                <input type="hidden" id="entry-icon-value">
+                <div class="icon-picker" id="entry-icon-picker"></div>
+            </div>
+            <div class="incident-form-group">
+                <label for="entry-desc">{{ t.incident_description }}</label>
+                <p class="incident-field-hint">{{ t.get('entry_description_hint', 'Add concrete symptoms, times, support references, modem states, or what changed for the connection.') }}</p>
+                <textarea id="entry-desc" maxlength="10000" placeholder="{{ t.incident_description }}"></textarea>
+            </div>
+            <div class="incident-form-group">
+                <label for="entry-incident-select">{{ t.incident_assign }}</label>
+                <select id="entry-incident-select" class="entry-incident-select">
+                    <option value="">{{ t.incident_none }}</option>
+                </select>
+            </div>
+            <div class="incident-form-group" id="entry-attachments-section">
+                <label>{{ t.attachments }}</label>
+                <p class="incident-field-hint">{{ t.get('entry_evidence_hint', 'Evidence can include modem screenshots, BQM images, Speedtest results, SmokePing charts, or support letters.') }}</p>
+                <div class="attachment-list" id="entry-attachment-list"></div>
+                <button class="btn-upload" id="entry-upload-btn" onclick="document.getElementById('entry-file-input').click()">
+                    &#128206; {{ t.upload_file }}
+                </button>
+                <p class="incident-field-hint" id="entry-upload-hint"></p>
+                <span id="entry-upload-spinner" style="display:none;"><span class="upload-spinner"></span></span>
+                <input type="file" id="entry-file-input" style="display:none;" multiple
+                       accept="image/png,image/jpeg,image/gif,image/webp,application/pdf,text/plain"
+                       onchange="handleEntryFileUpload(this)">
+            </div>
+        </div>
+        <div class="incident-modal-footer">
+            <div class="modal-footer-left">
+                <button class="btn-danger" id="entry-delete-btn" onclick="deleteEntry()" style="display:none;">{{ t.delete_incident }}</button>
+            </div>
+            <div style="display:flex; gap:10px;">
+                <button class="btn btn-muted" onclick="closeEntryModal()">{{ t.cancel }}</button>
+                <button class="btn btn-accent" id="entry-save-btn" onclick="saveEntry()">{{ t.get('entry_create_action', 'Create entry') }}</button>
+            </div>
+        </div>
+    </div>
+</dialog>
+
+<!-- ═══ Incident Container Modal ═══ -->
+<dialog class="modal-overlay" id="incident-container-modal" role="dialog" aria-modal="true" aria-labelledby="incident-container-modal-title" onclick="if(event.target===this)closeIncidentModal()">
+    <div class="modal incident-container-modal" style="max-width:560px;">
+        <div class="modal-header">
+            <h2 id="incident-container-modal-title"></h2>
+            <button class="modal-close" onclick="closeIncidentModal()" aria-label="{{ t.close }}">&times;</button>
+        </div>
+        <div class="modal-body" style="overflow-y:auto;">
+            <p class="incident-modal-intro">{{ t.get('incident_modal_intro', 'Group related entries and evidence so DOCSight can build one clear incident timeline and report path.') }}</p>
+            <input type="hidden" id="incident-container-id">
+            <div class="incident-form-group">
+                <label for="incident-container-name">{{ t.incident_name }}</label>
+                <input type="text" id="incident-container-name" maxlength="200" placeholder="{{ t.incident_name }}">
+            </div>
+            <div class="incident-form-group">
+                <label for="incident-container-status">{{ t.incident_status }}</label>
+                <select id="incident-container-status">
+                    <option value="open">{{ t.incident_status_open }}</option>
+                    <option value="resolved">{{ t.incident_status_resolved }}</option>
+                    <option value="escalated">{{ t.incident_status_escalated }}</option>
+                </select>
+            </div>
+            <div class="incident-form-group" style="display:flex;gap:12px;">
+                <div style="flex:1;">
+                    <label for="incident-container-start">{{ t.incident_start_date }}</label>
+                    <input type="date" id="incident-container-start">
+                </div>
+                <div style="flex:1;">
+                    <label for="incident-container-end">{{ t.incident_end_date }}</label>
+                    <input type="date" id="incident-container-end">
+                </div>
+            </div>
+            <div class="incident-form-group">
+                <label>{{ t.icon }}</label>
+                <p class="incident-field-hint">{{ t.get('incident_icon_hint', 'Pick the category users will recognize later in filters, timelines, and exports.') }}</p>
+                <input type="hidden" id="incident-container-icon-value">
+                <div class="icon-picker" id="incident-container-icon-picker"></div>
+            </div>
+            <div class="incident-form-group">
+                <label for="incident-container-desc">{{ t.incident_description }}</label>
+                <textarea id="incident-container-desc" maxlength="5000" placeholder="{{ t.incident_description }}"></textarea>
+            </div>
+            <div class="incident-form-group" id="incident-container-entry-count-section" style="display:none;">
+                <label>{{ t.get('incident_linked_evidence', 'Linked evidence') }}</label>
+                <div class="incident-evidence-summary">
+                    <span id="incident-container-entry-count" style="font-weight:600;"></span>
+                    <span>{{ t.get('incident_linked_entries_hint', 'journal entries linked to this incident') }}</span>
+                </div>
+                <button type="button" class="btn-small btn-accent" id="incident-container-report-btn" onclick="openIncidentReportFromModal()">{{ t.get('incident_build_report', 'Build report') }}</button>
+            </div>
+            <div class="incident-form-group" id="incident-container-empty-evidence-section">
+                <label>{{ t.get('incident_linked_evidence', 'Linked evidence') }}</label>
+                <p class="incident-field-hint">{{ t.get('incident_empty_evidence_hint', 'Assign journal entries, screenshots, modem snapshots, BQM images, Speedtest results, or SmokePing charts as the incident develops.') }}</p>
+            </div>
+        </div>
+        <div class="incident-modal-footer">
+            <div class="modal-footer-left">
+                <button class="btn-danger" id="incident-container-delete-btn" onclick="deleteIncident()" style="display:none;">{{ t.delete }}</button>
+            </div>
+            <div style="display:flex; gap:10px;">
+                <button class="btn btn-muted" onclick="closeIncidentModal()">{{ t.cancel }}</button>
+                <button class="btn btn-accent" id="incident-container-save-btn" onclick="saveIncident()">{{ t.get('incident_create_action', 'Create incident') }}</button>
+            </div>
+        </div>
+    </div>
+</dialog>
+
+<!-- ═══ Import Modal ═══ -->
+<dialog class="modal-overlay" id="import-modal" role="dialog" aria-modal="true" aria-labelledby="import-modal-title" onclick="if(event.target===this)closeImportModal()">
+    <div class="modal" style="max-width:900px;">
+        <div class="modal-header">
+            <h2 id="import-modal-title">{{ t.import_incidents }}</h2>
+            <button class="modal-close" onclick="closeImportModal()" aria-label="{{ t.close }}">&times;</button>
+        </div>
+        <div class="modal-body" style="overflow-y:auto;">
+            <!-- Upload zone -->
+            <div id="import-upload-zone" class="import-upload-zone">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:48px;height:48px;color:var(--muted);">
+                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                    <polyline points="17 8 12 3 7 8"/>
+                    <line x1="12" y1="3" x2="12" y2="15"/>
+                </svg>
+                <p>{{ t.import_upload_hint }}</p>
+                <p style="font-size:0.8em;color:var(--muted);">{{ t.import_file_types }}</p>
+                <button type="button" class="btn btn-muted import-browse-btn" onclick="event.stopPropagation(); document.getElementById('import-file-input').click();">{{ t.get('import_browse_file', 'Browse CSV or Excel file') }}</button>
+                <input type="file" id="import-file-input" style="display:none;" accept=".xlsx,.csv" onchange="handleImportFile(this)">
+            </div>
+            <div id="import-validation-state" class="import-validation-state" role="status" aria-live="polite"></div>
+            <!-- Loading -->
+            <div id="import-loading" style="display:none;text-align:center;padding:20px;">
+                <div class="spinner"></div>
+                <p style="margin-top:10px;color:var(--muted);">{{ t.import_parsing }}</p>
+            </div>
+            <!-- Preview -->
+            <div id="import-preview" style="display:none;">
+                <div class="import-info" id="import-info"></div>
+                <div class="import-controls">
+                    <label class="import-select-all">
+                        <input type="checkbox" id="import-select-all" checked onchange="toggleImportAll(this.checked)">
+                        {{ t.import_select_all }}
+                    </label>
+                </div>
+                <div class="import-table-wrap">
+                    <table class="import-table" id="import-table">
+                        <thead><tr>
+                            <th style="width:40px;"></th>
+                            <th style="width:36px;"></th>
+                            <th>{{ t.incident_date }}</th>
+                            <th>{{ t.incident_title }}</th>
+                            <th class="journal-hide-mobile">{{ t.incident_description }}</th>
+                        </tr></thead>
+                        <tbody id="import-tbody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="incident-modal-footer" id="import-footer" style="display:none;">
+            <div class="modal-footer-left"></div>
+            <div style="display:flex; gap:10px;">
+                <button class="btn btn-muted" onclick="closeImportModal()">{{ t.cancel }}</button>
+                <button class="btn btn-accent" id="import-confirm-btn" onclick="confirmImport()">{{ t.import_selected }}</button>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/app/modules/journal/templates/journal_tab.html
+++ b/app/modules/journal/templates/journal_tab.html
@@ -1,0 +1,126 @@
+    <div class="view-page-header journal-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.incident_journal }}</h2>
+        </div>
+        <div class="view-page-actions journal-header-actions">
+            <button class="btn-new-entry" onclick="openEntryModal()">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
+                    <path d="M12 5v14m-7-7h14"/>
+                </svg>
+                {{ t.new_entry }}
+            </button>
+            <button class="btn-new-entry btn-import" onclick="openImportModal()">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
+                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                    <polyline points="17 8 12 3 7 8"/>
+                    <line x1="12" y1="3" x2="12" y2="15"/>
+                </svg>
+                {{ t.import }}
+            </button>
+            <div class="journal-export-wrapper" style="position:relative;display:inline-block;">
+                <button class="btn-new-entry btn-import" onclick="toggleExportDropdown(event)">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
+                        <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                        <polyline points="7 10 12 15 17 10"/>
+                        <line x1="12" y1="15" x2="12" y2="3"/>
+                    </svg>
+                    {{ t.export_journal }}
+                </button>
+                <div class="journal-export-dropdown" id="journal-export-dropdown">
+                    <button onclick="exportJournal('csv')">CSV</button>
+                    <button onclick="exportJournal('json')">JSON</button>
+                    <button onclick="exportJournal('md')">Markdown</button>
+                </div>
+            </div>
+            <button class="btn-danger btn-delete-all" id="btn-delete-all-entries" onclick="deleteAllEntries()" style="display:none;">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
+                    <polyline points="3 6 5 6 21 6"/>
+                    <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
+                </svg>
+                {{ t.delete_all }}
+            </button>
+        </div>
+    </div>
+    <div class="incident-filter-bar" id="incident-filter-bar" style="display:none;"></div>
+    <div class="incident-summary" id="incident-summary" style="display:none;"></div>
+    <div class="journal-bulk-bar" id="journal-bulk-bar" style="display:none;">
+        <span class="journal-bulk-count" id="journal-bulk-count"></span>
+        <select id="journal-bulk-incident-select" class="journal-bulk-select">
+            <option value="" disabled selected>{{ t.incident_assign }}…</option>
+        </select>
+        <button class="btn-small btn-accent" onclick="bulkAssign()">{{ t.bulk_assign }}</button>
+        <button class="btn-small btn-muted" onclick="bulkUnassign()">{{ t.bulk_unassign }}</button>
+        <span class="journal-bulk-sep"></span>
+        <button class="btn-small btn-ghost" onclick="clearBulkSelection()">{{ t.bulk_deselect }}</button>
+    </div>
+    <div class="journal-search-wrap" id="journal-search-wrap" style="display:none;">
+        <div class="journal-search-box">
+            <svg class="journal-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="11" cy="11" r="8"/>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+            <input type="text" id="journal-search-input" placeholder="{{ t.search_placeholder }}" autocomplete="off" spellcheck="false">
+            <button class="journal-search-clear" id="journal-search-clear" onclick="clearJournalSearch()" style="display:none;">&times;</button>
+        </div>
+        <span class="journal-search-count" id="journal-search-count"></span>
+    </div>
+    <div id="journal-loading" class="waiting" style="display:none;">
+        <div class="skeleton skel-row"></div>
+        <div class="skeleton skel-row"></div>
+        <div class="skeleton skel-row"></div>
+        <div class="skeleton skel-row"></div>
+    </div>
+    <div id="journal-empty" class="journal-empty" style="display:none;"></div>
+
+    <!-- Phase 4.5: Card wrapper for journal table -->
+    <div id="journal-table-card" class="table-card" style="display:none;">
+        <div class="table-card-header">
+            <div class="table-card-title">
+                <svg class="table-card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M19 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V5a2 2 0 00-2-2z"/>
+                    <path d="M16 2v4M8 2v4M3 10h18"/>
+                </svg>
+                <span>{{ t.incident_journal }}</span>
+            </div>
+            <button class="btn-bulk-toggle" id="btn-bulk-toggle" onclick="toggleBulkMode()" style="display:none;">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;">
+                    <polyline points="9 11 12 14 22 4"/>
+                    <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
+                </svg>
+                <span id="btn-bulk-toggle-label">{{ t.bulk_select }}</span>
+            </button>
+        </div>
+        <table id="journal-table">
+            <thead><tr id="journal-thead-row">
+                <th style="width:36px;"></th>
+                <th data-col="date">{{ t.incident_date }}<span class="sort-indicator"></span></th>
+                <th data-col="title">{{ t.incident_title }}<span class="sort-indicator"></span></th>
+                <th data-col="description" class="journal-hide-mobile">{{ t.incident_description }}<span class="sort-indicator"></span></th>
+                <th>&#128206;</th>
+            </tr></thead>
+            <tbody id="journal-tbody"></tbody>
+        </table>
+    </div>
+
+    <!-- ═══ Incident Timeline View (replaces journal table) ═══ -->
+    <div id="incident-timeline-view" style="display:none;">
+        <button class="incident-timeline-back" onclick="closeIncidentTimeline()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;">
+                <polyline points="15 18 9 12 15 6"/>
+            </svg>
+            <span data-i18n="incident_back_journal">{{ t.incident_back_journal }}</span>
+        </button>
+        <div id="incident-timeline-header" class="incident-timeline-card"></div>
+        <div id="incident-timeline-entries" class="incident-timeline-card"></div>
+        <div id="incident-timeline-chart-card" class="incident-timeline-card">
+            <div class="incident-timeline-section-title">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+                <span data-i18n="incident_signal_timeline">{{ t.incident_signal_timeline }}</span>
+            </div>
+            <div class="incident-timeline-chart-wrap">
+                <canvas id="incident-timeline-canvas"></canvas>
+            </div>
+        </div>
+        <div id="incident-timeline-signals" class="incident-timeline-card"></div>
+        <div id="incident-timeline-bnetz" class="incident-timeline-card" style="display:none;"></div>
+    </div>

--- a/app/modules/speedtest/manifest.json
+++ b/app/modules/speedtest/manifest.json
@@ -11,7 +11,9 @@
     "routes": "routes.py",
     "settings": "templates/speedtest_settings.html",
     "static": "static/",
-    "i18n": "i18n/"
+    "i18n": "i18n/",
+    "tab": "templates/speedtest_tab.html",
+    "dialogs": "templates/speedtest_dialogs.html"
   },
   "config": {
     "speedtest_tracker_url": "",

--- a/app/modules/speedtest/static/main.js
+++ b/app/modules/speedtest/static/main.js
@@ -8,6 +8,11 @@ var _speedtestSortDir = 'desc';
 var _signalCache = {};
 var _enrichedCache = {};
 
+window.initSpeedtestView = function() {
+    if (!document.getElementById('view-speedtest')) return;
+    loadSpeedtestHistory();
+};
+
 function formatSpeedtestTimestamp(ts) {
     if (!ts) return '';
     var d = new Date(ts);

--- a/app/modules/speedtest/templates/speedtest_dialogs.html
+++ b/app/modules/speedtest/templates/speedtest_dialogs.html
@@ -1,0 +1,43 @@
+<!-- Speedtest Setup Modal -->
+<dialog class="modal-overlay" id="speedtest-setup-modal" role="dialog" aria-modal="true" aria-labelledby="speedtest-setup-modal-title">
+    <div class="modal modal-wide setup-guide-modal">
+        <div class="modal-header">
+            <h2 id="speedtest-setup-modal-title">⚡ {{ t.get('speedtest_setup_guided_title', 'Speedtest Tracker setup') }}</h2>
+            <button class="modal-close" onclick="closeSpeedtestSetupModal()" aria-label="{{ t.close }}">&times;</button>
+        </div>
+        <p class="modal-hint">{{ t.get('speedtest_setup_guided_intro', 'Connect your existing Speedtest Tracker instance so DOCSight can correlate real throughput with modem signal health.') }}</p>
+        <div class="modal-body setup-guide-body">
+            <section class="setup-guide-card">
+                <h3>{{ t.get('setup_why_title', 'Why connect it') }}</h3>
+                <ul>
+                    <li>{{ t.get('speedtest_setup_benefit_1', 'Correlate speed tests with DOCSIS signal levels') }}</li>
+                    <li>{{ t.get('speedtest_setup_benefit_2', 'Spot peak-hour performance drops') }}</li>
+                    <li>{{ t.get('speedtest_setup_benefit_3', 'Add throughput evidence to reports') }}</li>
+                </ul>
+            </section>
+            <section class="setup-guide-card">
+                <h3>{{ t.get('setup_requirements_title', 'Requirements') }}</h3>
+                <ul>
+                    <li>{{ t.get('speedtest_setup_requirement_url', 'A reachable Speedtest Tracker URL') }}</li>
+                    <li>{{ t.get('speedtest_setup_requirement_api', 'API access enabled in Speedtest Tracker') }}</li>
+                </ul>
+            </section>
+            <section class="setup-guide-card setup-guide-command">
+                <h3>{{ t.get('setup_configure_title', 'Configure') }}</h3>
+                <p>{{ t.get('speedtest_setup_configure_text', 'Paste the Speedtest Tracker base URL in Settings, then save the integration.') }}</p>
+                <code id="speedtest-setup-command">docker run --name speedtest-tracker -p 8080:80 lscr.io/linuxserver/speedtest-tracker:latest</code>
+                <button class="btn btn-secondary" onclick="copySetupSnippet('speedtest-setup-command', 'speedtest-setup-status')">{{ t.get('speedtest_setup_copy_command', 'Copy Docker command') }}</button>
+            </section>
+            <section class="setup-guide-card">
+                <h3>{{ t.get('setup_validate_title', 'Validate') }}</h3>
+                <p>{{ t.get('speedtest_setup_validate_text', 'Use Settings to save the URL, then confirm DOCSight can read recent speed test results.') }}</p>
+                <button class="btn btn-muted" onclick="validateSetupGuidance('speedtest-setup-status', 'speedtest')">{{ t.get('speedtest_setup_test_guidance', 'Review validation path') }}</button>
+            </section>
+        </div>
+        <div id="speedtest-setup-status" class="setup-validation-status" role="status" aria-live="polite"></div>
+        <div class="modal-footer">
+            <button class="btn btn-muted" onclick="closeSpeedtestSetupModal()">{{ t.close }}</button>
+            <a class="btn btn-accent" href="{{ url_for('settings', _anchor='mod-docsight_speedtest') }}">⚙ {{ t.get('speedtest_setup_open_settings', 'Open Speedtest settings') }}</a>
+        </div>
+    </div>
+</dialog>

--- a/app/modules/speedtest/templates/speedtest_tab.html
+++ b/app/modules/speedtest/templates/speedtest_tab.html
@@ -1,0 +1,73 @@
+{% if speedtest_configured %}
+    <div class="view-page-header">
+        <div class="view-page-header-left">
+            <h2 class="view-page-title">{{ t.speedtest_tracker }}</h2>
+        </div>
+        <div class="view-page-actions speedtest-controls">
+            <div class="trend-tabs" id="speedtest-tabs">
+                <button class="trend-tab" data-value="1" onclick="selectPill(this, filterSpeedtestData)">1d</button>
+                <button class="trend-tab active" data-value="7" onclick="selectPill(this, filterSpeedtestData)">7d</button>
+                <button class="trend-tab" data-value="14" onclick="selectPill(this, filterSpeedtestData)">14d</button>
+                <button class="trend-tab" data-value="30" onclick="selectPill(this, filterSpeedtestData)">30d</button>
+                <button class="trend-tab" data-value="90" onclick="selectPill(this, filterSpeedtestData)">90d</button>
+                <button class="trend-tab" data-value="all" onclick="selectPill(this, filterSpeedtestData)">{{ t.fetch_all }}</button>
+            </div>
+            {% if not demo_mode %}<button class="btn btn-primary btn-sm" id="speedtest-run-btn" onclick="runSpeedtest()"><i data-lucide="play"></i> {{ t.run_speedtest }}</button>{% endif %}
+            <button class="refresh-btn" id="speedtest-refresh-btn" title="{{ t.refresh }}" onclick="loadSpeedtestHistory()"><i data-lucide="refresh-cw"></i></button>
+        </div>
+    </div>
+    <div id="speedtest-loading" class="waiting" style="display:none;">
+        <div class="skeleton skel-chart"></div>
+    </div>
+    <div id="speedtest-no-data" class="no-data-msg speedtest-empty-state" style="display:none;">
+        <i data-lucide="wifi-off" style="width:40px;height:40px;color:var(--text-muted);margin-bottom:12px;"></i>
+        <div class="speedtest-empty-title">{{ t.speedtest_empty_title or 'No speedtest results yet' }}</div>
+        <div class="speedtest-empty-desc">{{ t.speedtest_empty_desc or 'Automated tests will appear here once the schedule runs. You can also start a manual test.' }}</div>
+        {% if not demo_mode %}<button class="btn btn-primary btn-sm" onclick="runSpeedtest()" style="margin-top:12px;"><i data-lucide="play"></i> {{ t.run_speedtest }}</button>{% endif %}
+    </div>
+    <div id="speedtest-chart-container" style="display:none;">
+        <!-- Phase 4.2: Modern card wrapper for speedtest chart -->
+        <div class="speedtest-chart-card">
+            <div class="chart-card-header">
+                <div class="chart-header-content">
+                    <svg class="chart-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="12" cy="12" r="10"/>
+                        <path d="M12 6v6l4 2"/>
+                    </svg>
+                    <div class="chart-label">{{ t.speedtest_history }}</div>
+                </div>
+            </div>
+            <div class="speedtest-chart-wrap">
+                <canvas id="speedtest-chart"></canvas>
+                <div class="speedtest-chart-tooltip" id="speedtest-chart-tooltip"></div>
+                <div class="speedtest-chart-legend">
+                    <span class="legend-dl">{{ t.legend_download }}</span>
+                    <span class="legend-ul">{{ t.legend_upload }}</span>
+                    <span class="legend-ping">{{ t.legend_ping }}</span>
+                    <span class="legend-thresh">{{ t.legend_threshold }}</span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Phase 4.2: Table card wrapper -->
+    <div id="speedtest-table-wrap" class="table-card">
+        <table id="speedtest-table" class="sortable" style="display:none;">
+            <thead><tr>
+                <th class="st-expand-col"></th>
+                <th data-col="timestamp">{{ t.timestamp }}<span class="sort-indicator">▼</span></th>
+                <th data-col="server_id">{{ t.server or 'Server' }}<span class="sort-indicator"></span></th>
+                <th data-col="download_mbps">{{ t.download }}<span class="sort-indicator"></span></th>
+                <th data-col="upload_mbps">{{ t.upload }}<span class="sort-indicator"></span></th>
+                <th data-col="ping_ms">{{ t.ping }}<span class="sort-indicator"></span></th>
+                <th data-col="jitter_ms">{{ t.jitter }}<span class="sort-indicator"></span></th>
+                <th data-col="packet_loss_pct">{{ t.packet_loss }}<span class="sort-indicator"></span></th>
+                <th class="st-sc-col"></th>
+            </tr></thead>
+            <tbody id="speedtest-tbody"></tbody>
+        </table>
+        <div id="speedtest-show-more" style="text-align:center; padding:12px; display:none;">
+            <button class="btn btn-muted" id="speedtest-more-btn" onclick="showMoreSpeedtest()"></button>
+        </div>
+    </div>
+
+{% endif %}

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -75,7 +75,7 @@ var CORRELATION_CM_AVAILABLE = dashboardBootstrap.connectionMonitorAvailable;
     /* currentView is global — defined in chart-engine.js */
     /* charts registry is global — defined in chart-engine.js */
     /* _trendRange → trends.js */
-    /* BQM state variables → bqm.js */
+    /* BQM state variables → BQM module */
     /* todayStr, pad, formatDateDE → chart-engine.js */
 
     /* ── Sortable Tables ── */
@@ -276,6 +276,14 @@ var CORRELATION_CM_AVAILABLE = dashboardBootstrap.connectionMonitorAvailable;
     };
 
     function switchView(view, skipHash) {
+        var targetId = view === 'live' ? 'view-dashboard' : 'view-' + view;
+        var target = document.getElementById(targetId);
+        if (!target) {
+            view = 'live';
+            target = document.getElementById('view-dashboard');
+            history.replaceState(null, '', location.pathname + location.search);
+            skipHash = true;
+        }
         currentView = view;
         if (!skipHash) location.hash = view === 'live' ? '' : view;
         syncNavActiveState(view);
@@ -283,8 +291,6 @@ var CORRELATION_CM_AVAILABLE = dashboardBootstrap.connectionMonitorAvailable;
         document.querySelectorAll('.main-content > .view').forEach(function(v) {
             v.classList.remove('active');
         });
-        var targetId = view === 'live' ? 'view-dashboard' : 'view-' + view;
-        var target = document.getElementById(targetId);
         if (target) target.classList.add('active');
 
         stopAutoRefresh();
@@ -294,15 +300,13 @@ var CORRELATION_CM_AVAILABLE = dashboardBootstrap.connectionMonitorAvailable;
         if (view === 'live') {
             startAutoRefresh();
         } else if (view === 'bqm') {
-            if (typeof initBqmView === 'function') initBqmView();
+            if (typeof window.initBqmView === 'function') window.initBqmView();
         } else if (view === 'smokeping') {
             if (typeof loadSmokepingGraphs === 'function') loadSmokepingGraphs();
         } else if (view === 'speedtest') {
-            loadSpeedtestHistory();
+            if (typeof window.initSpeedtestView === 'function') window.initSpeedtestView();
         } else if (view === 'journal') {
-            if (typeof _timelineActive !== 'undefined' && _timelineActive && typeof closeIncidentTimeline === 'function') closeIncidentTimeline();
-            if (typeof loadIncidents === 'function') loadIncidents();
-            if (typeof loadJournal === 'function') loadJournal();
+            if (typeof window.initJournalView === 'function') window.initJournalView();
         } else if (view === 'events') {
             if (typeof loadEvents === 'function') loadEvents();
         } else if (view === 'channels') {
@@ -342,21 +346,20 @@ var CORRELATION_CM_AVAILABLE = dashboardBootstrap.connectionMonitorAvailable;
     /* ── Hash-based view routing ── */
     function viewFromHash() {
         var h = location.hash.replace('#', '');
-        if (!h) return null;
+        if (!h) return 'live';
         // Strip query params (e.g. #channels?mode=timeline → channels)
         var view = h.split('?')[0];
-        // Accept any view that exists in DOM (supports module views)
-        var el = document.getElementById('view-' + view) || (view === 'live' && document.getElementById('view-dashboard'));
-        return el ? view : null;
+        return view;
     }
     window.addEventListener('hashchange', function() {
         var v = viewFromHash();
-        if (v && v !== currentView) switchView(v, true);
+        var targetId = v === 'live' ? 'view-dashboard' : 'view-' + v;
+        if (v !== currentView || !document.getElementById(targetId)) switchView(v, true);
     });
 
     /* BNetzA Breitbandmessung → integrations.js */
 
-    /* BQM Calendar, Live → bqm.js */
+    /* BQM Calendar, Live → BQM module */
 
     /* ── Auto Refresh with Countdown ── */
     var refreshTimer = null;
@@ -540,9 +543,9 @@ var CORRELATION_CM_AVAILABLE = dashboardBootstrap.connectionMonitorAvailable;
 
     /* Trend Charts, expand buttons, zoom shortcuts → trends.js */
 
-    /* BQM keyboard shortcuts → bqm.js */
+    /* BQM keyboard shortcuts → BQM module */
 
-    /* BQM Graph + Import → bqm.js */
+    /* BQM Graph + Import → BQM module */
 
     /* Smokeping Graphs → integrations.js */
 
@@ -552,7 +555,7 @@ var CORRELATION_CM_AVAILABLE = dashboardBootstrap.connectionMonitorAvailable;
     window._pendingView = (_initHash && _initHash !== 'live') ? _initHash : null;
 
 
-    /* ── Incident Journal, Incidents, Timeline, Import, Bulk, Search → journal.js ── */
+    /* ── Incident Journal, Incidents, Timeline, Import, Bulk, Search → Journal module ── */
 
 
     // Sidebar resize handler (clean up state on viewport change)

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v88';
+var CACHE_VERSION = 'v89';
 var REGISTRATION_SCOPE = new URL(self.registration.scope);
 
 if (REGISTRATION_SCOPE.origin !== self.location.origin || REGISTRATION_SCOPE.pathname.slice(-1) !== '/') {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,3 +1,12 @@
+{% set builtin_module_views = {
+    'docsight.journal': 'journal',
+    'docsight.bqm': 'bqm',
+    'docsight.speedtest': 'speedtest',
+    'docsight.modulation': 'modulation',
+    'docsight.comparison': 'comparison',
+    'docsight.connection_monitor': 'connection-monitor',
+    'docsight.evidence': 'evidence'
+} %}
 <!DOCTYPE html>
 <html lang="{{ lang }}" data-theme="{{ theme|default('dark') }}">
 <head>
@@ -225,7 +234,7 @@
             </div>
         </div>
         {% set tab_modules = [] %}
-        {% for mod in modules if mod.template_paths.get('tab') and mod.id not in ('docsight.modulation', 'docsight.comparison', 'docsight.connection_monitor', 'docsight.evidence') %}
+        {% for mod in modules if mod.template_paths.get('tab') and mod.id not in builtin_module_views %}
             {% if tab_modules.append(mod) %}{% endif %}
         {% endfor %}
         {% if tab_modules %}
@@ -1466,146 +1475,6 @@
     </div>
 </div>
 
-<!-- ═══ View: BQM Graphs ═══ -->
-{% if bqm_configured %}
-<div id="view-bqm" class="view">
-    <div class="view-page-header">
-        <div class="view-page-header-left">
-            <h2 class="view-page-title">{{ t.bqm_title }}</h2>
-        </div>
-        <!-- BQM Toolbar: quick-jump + month nav -->
-        <div id="bqm-toolbar" class="view-page-actions bqm-toolbar">
-        <button class="trend-tab bqm-quick" id="bqm-today-btn">{{ t.bqm_today }}</button>
-        <button class="trend-tab bqm-quick" id="bqm-yesterday-btn">{{ t.bqm_yesterday }}</button>
-        <button class="trend-tab bqm-quick" id="bqm-7d-btn">{{ t.bqm_range_7d or '7d' }}</button>
-        <button class="trend-tab bqm-quick" id="bqm-30d-btn">{{ t.bqm_range_30d or '30d' }}</button>
-        <div class="bqm-month-nav">
-            <button id="bqm-month-prev" class="bqm-nav-btn" aria-label="{{ t.get('previous_month', 'Previous month') }}">&#8249;</button>
-            <span id="bqm-month-label" class="bqm-month-label"></span>
-            <button id="bqm-month-next" class="bqm-nav-btn" aria-label="{{ t.get('next_month', 'Next month') }}">&#8250;</button>
-        </div>
-        <button class="bqm-nav-btn bqm-import-btn" onclick="openBqmImportModal()" title="{{ t.bqm_import_title }}" aria-label="{{ t.bqm_import_title }}">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14" style="display:block;">
-                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
-            </svg>
-        </button>
-        <button class="bqm-nav-btn bqm-import-btn" onclick="var s=document.getElementById('bqm-csv-import-section');s.style.display=s.style.display==='none'?'':'none'" title="{{ t.get('bqm_csv_import', 'Import CSV') }}" aria-label="{{ t.get('bqm_csv_import', 'Import CSV') }}">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14" style="display:block;">
-                <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>
-            </svg>
-        </button>
-        <button class="bqm-nav-btn bqm-import-btn bqm-delete-btn" onclick="deleteBqmImages()" title="{{ t.bqm_delete }}" aria-label="{{ t.bqm_delete }}">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14" style="display:block;">
-                <polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
-            </svg>
-        </button>
-        </div>
-    </div>
-    <!-- Calendar grid -->
-    <div id="bqm-calendar" class="bqm-calendar">
-        <div class="bqm-weekday-header">
-            <span>{{ t.weekday_mo }}</span><span>{{ t.weekday_tu }}</span><span>{{ t.weekday_we }}</span><span>{{ t.weekday_th }}</span><span>{{ t.weekday_fr }}</span><span>{{ t.weekday_sa }}</span><span>{{ t.weekday_su }}</span>
-        </div>
-        <div id="bqm-calendar-grid" class="bqm-calendar-grid"></div>
-    </div>
-    <span id="bqm-range-label" class="bqm-range-label"></span>
-    <div id="bqm-content">
-        <div id="bqm-card" class="bqm-card" style="display:none;">
-            <div class="chart-card-header">
-                <div class="chart-header-content">
-                    <svg class="chart-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M3 3v18h18"/>
-                        <path d="M7 12l4-4 4 4 4-4"/>
-                    </svg>
-                    <div class="chart-label">{{ t.bqm_title }}</div>
-                    <span id="bqm-live-badge" class="bqm-live-badge" style="display:none;">{{ t.bqm_live }}</span>
-                    <span id="bqm-last-updated" class="bqm-last-updated" style="display:none;"></span>
-                </div>
-                <div id="bqm-view-toggle" class="trend-tabs" style="display:none;">
-                    <button class="trend-tab active" id="bqm-toggle-uplot">uPlot</button>
-                    <button class="trend-tab" id="bqm-toggle-png">PNG</button>
-                </div>
-            </div>
-            <div id="bqm-chart-container" class="bqm-chart-container" style="display:none;"></div>
-            <div id="bqm-image-wrap" style="text-align:center;">
-                <img id="bqm-image" style="max-width:100%; border-radius:8px;" alt="BQM Graph">
-            </div>
-        </div>
-        <div id="bqm-no-data" class="no-data-msg" style="display:none;"></div>
-    </div>
-</div>
-{% endif %}
-
-<!-- ═══ BQM Import Modal ═══ -->
-<dialog class="modal-overlay" id="bqm-import-modal" role="dialog" aria-modal="true" aria-labelledby="bqm-import-modal-title" onclick="if(event.target===this)closeBqmImportModal()" oncancel="event.preventDefault(); closeBqmImportModal()">
-    <div class="modal" style="max-width:800px;">
-        <div class="modal-header">
-            <h2 id="bqm-import-modal-title">{{ t.bqm_import_title }}</h2>
-            <button class="modal-close" onclick="closeBqmImportModal()" aria-label="{{ t.close }}">&times;</button>
-        </div>
-        <div class="modal-body" style="overflow-y:auto;">
-            <!-- Drop zone -->
-            <div id="bqm-import-dropzone" class="import-upload-zone bqm-import-dropzone">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:48px;height:48px;color:var(--muted);">
-                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                    <polyline points="17 8 12 3 7 8"/>
-                    <line x1="12" y1="3" x2="12" y2="15"/>
-                </svg>
-                <p>{{ t.bqm_import_drop }}</p>
-                <p style="font-size:0.8em;color:var(--muted);">{{ t.bqm_import_formats }}</p>
-                <button type="button" class="btn btn-muted import-browse-btn" onclick="event.stopPropagation(); document.getElementById('bqm-import-file-input').click();">{{ t.get('bqm_import_browse', 'Browse BQM images') }}</button>
-                <input type="file" id="bqm-import-file-input" style="display:none;" accept="image/png,image/jpeg,.png,.jpg,.jpeg" multiple>
-            </div>
-            <div id="bqm-import-validation-state" class="import-validation-state" role="status" aria-live="polite"></div>
-            <!-- Options: overwrite + date offset -->
-            <div id="bqm-import-options" style="display:none; margin:10px 0;">
-                <div style="display:flex;align-items:center;gap:16px;flex-wrap:wrap;">
-                    <label style="display:flex;align-items:center;gap:8px;font-size:0.9em;cursor:pointer;">
-                        <input type="checkbox" id="bqm-import-overwrite">
-                        {{ t.bqm_import_overwrite }}
-                    </label>
-                    <label style="display:flex;align-items:center;gap:8px;font-size:0.9em;">
-                        {{ t.bqm_import_offset }}:
-                        <input type="number" id="bqm-import-offset" class="bqm-offset-input" min="-30" max="30" value="0" step="1">
-                    </label>
-                </div>
-            </div>
-            <!-- Status line -->
-            <div id="bqm-import-status" class="import-info" style="display:none;"></div>
-            <!-- Preview table -->
-            <div id="bqm-import-preview" style="display:none;">
-                <div class="import-table-wrap">
-                    <table class="bqm-import-table">
-                        <thead><tr>
-                            <th style="width:70px;"></th>
-                            <th>{{ t.incident_title }}</th>
-                            <th style="width:160px;">{{ t.incident_date }}</th>
-                            <th style="width:36px;"></th>
-                        </tr></thead>
-                        <tbody id="bqm-import-tbody"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-        <div class="incident-modal-footer" id="bqm-import-footer" style="display:none;">
-            <div class="modal-footer-left"></div>
-            <div style="display:flex; gap:10px;">
-                <button class="btn btn-muted" onclick="closeBqmImportModal()">{{ t.cancel }}</button>
-                <button class="btn btn-accent" id="bqm-import-confirm-btn" onclick="executeBqmImport()" disabled>{{ t.bqm_import }}</button>
-            </div>
-        </div>
-    </div>
-</dialog>
-
-<!-- BQM CSV Import (inline, below calendar) -->
-<div id="bqm-csv-import-section" class="bqm-csv-import" style="display:none; margin:16px auto; max-width:480px; text-align:center;">
-    <div style="display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:center;">
-        <input type="file" id="bqm-csv-file" accept=".csv" style="font-size:0.85em;">
-        <button class="btn btn-primary btn-sm" id="bqm-csv-import-btn" onclick="importBqmCsv()">{{ t.get('bqm_csv_import', 'Import CSV') }}</button>
-    </div>
-    <div id="bqm-csv-import-status" class="bqm-csv-status" style="margin-top:8px; font-size:0.85em;"></div>
-</div>
-
 <!-- ═══ View: Smokeping Graphs ═══ -->
 {% if modules|selectattr('id', 'equalto', 'docsight.smokeping')|list and smokeping_configured %}
 <div id="view-smokeping" class="view">
@@ -1714,136 +1583,6 @@
     </div>
 </div>
 {% endif %}
-
-<!-- ═══ View: Incident Journal ═══ -->
-<div id="view-journal" class="view">
-    <div class="view-page-header journal-header">
-        <div class="view-page-header-left">
-            <h2 class="view-page-title">{{ t.incident_journal }}</h2>
-        </div>
-        <div class="view-page-actions journal-header-actions">
-            <button class="btn-new-entry" onclick="openEntryModal()">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
-                    <path d="M12 5v14m-7-7h14"/>
-                </svg>
-                {{ t.new_entry }}
-            </button>
-            <button class="btn-new-entry btn-import" onclick="openImportModal()">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
-                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                    <polyline points="17 8 12 3 7 8"/>
-                    <line x1="12" y1="3" x2="12" y2="15"/>
-                </svg>
-                {{ t.import }}
-            </button>
-            <div class="journal-export-wrapper" style="position:relative;display:inline-block;">
-                <button class="btn-new-entry btn-import" onclick="toggleExportDropdown(event)">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
-                        <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                        <polyline points="7 10 12 15 17 10"/>
-                        <line x1="12" y1="15" x2="12" y2="3"/>
-                    </svg>
-                    {{ t.export_journal }}
-                </button>
-                <div class="journal-export-dropdown" id="journal-export-dropdown">
-                    <button onclick="exportJournal('csv')">CSV</button>
-                    <button onclick="exportJournal('json')">JSON</button>
-                    <button onclick="exportJournal('md')">Markdown</button>
-                </div>
-            </div>
-            <button class="btn-danger btn-delete-all" id="btn-delete-all-entries" onclick="deleteAllEntries()" style="display:none;">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:16px;height:16px;">
-                    <polyline points="3 6 5 6 21 6"/>
-                    <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
-                </svg>
-                {{ t.delete_all }}
-            </button>
-        </div>
-    </div>
-    <div class="incident-filter-bar" id="incident-filter-bar" style="display:none;"></div>
-    <div class="incident-summary" id="incident-summary" style="display:none;"></div>
-    <div class="journal-bulk-bar" id="journal-bulk-bar" style="display:none;">
-        <span class="journal-bulk-count" id="journal-bulk-count"></span>
-        <select id="journal-bulk-incident-select" class="journal-bulk-select">
-            <option value="" disabled selected>{{ t.incident_assign }}…</option>
-        </select>
-        <button class="btn-small btn-accent" onclick="bulkAssign()">{{ t.bulk_assign }}</button>
-        <button class="btn-small btn-muted" onclick="bulkUnassign()">{{ t.bulk_unassign }}</button>
-        <span class="journal-bulk-sep"></span>
-        <button class="btn-small btn-ghost" onclick="clearBulkSelection()">{{ t.bulk_deselect }}</button>
-    </div>
-    <div class="journal-search-wrap" id="journal-search-wrap" style="display:none;">
-        <div class="journal-search-box">
-            <svg class="journal-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="11" cy="11" r="8"/>
-                <line x1="21" y1="21" x2="16.65" y2="16.65"/>
-            </svg>
-            <input type="text" id="journal-search-input" placeholder="{{ t.search_placeholder }}" autocomplete="off" spellcheck="false">
-            <button class="journal-search-clear" id="journal-search-clear" onclick="clearJournalSearch()" style="display:none;">&times;</button>
-        </div>
-        <span class="journal-search-count" id="journal-search-count"></span>
-    </div>
-    <div id="journal-loading" class="waiting" style="display:none;">
-        <div class="skeleton skel-row"></div>
-        <div class="skeleton skel-row"></div>
-        <div class="skeleton skel-row"></div>
-        <div class="skeleton skel-row"></div>
-    </div>
-    <div id="journal-empty" class="journal-empty" style="display:none;"></div>
-
-    <!-- Phase 4.5: Card wrapper for journal table -->
-    <div id="journal-table-card" class="table-card" style="display:none;">
-        <div class="table-card-header">
-            <div class="table-card-title">
-                <svg class="table-card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M19 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V5a2 2 0 00-2-2z"/>
-                    <path d="M16 2v4M8 2v4M3 10h18"/>
-                </svg>
-                <span>{{ t.incident_journal }}</span>
-            </div>
-            <button class="btn-bulk-toggle" id="btn-bulk-toggle" onclick="toggleBulkMode()" style="display:none;">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;">
-                    <polyline points="9 11 12 14 22 4"/>
-                    <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
-                </svg>
-                <span id="btn-bulk-toggle-label">{{ t.bulk_select }}</span>
-            </button>
-        </div>
-        <table id="journal-table">
-            <thead><tr id="journal-thead-row">
-                <th style="width:36px;"></th>
-                <th data-col="date">{{ t.incident_date }}<span class="sort-indicator"></span></th>
-                <th data-col="title">{{ t.incident_title }}<span class="sort-indicator"></span></th>
-                <th data-col="description" class="journal-hide-mobile">{{ t.incident_description }}<span class="sort-indicator"></span></th>
-                <th>&#128206;</th>
-            </tr></thead>
-            <tbody id="journal-tbody"></tbody>
-        </table>
-    </div>
-
-    <!-- ═══ Incident Timeline View (replaces journal table) ═══ -->
-    <div id="incident-timeline-view" style="display:none;">
-        <button class="incident-timeline-back" onclick="closeIncidentTimeline()">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;">
-                <polyline points="15 18 9 12 15 6"/>
-            </svg>
-            <span data-i18n="incident_back_journal">{{ t.incident_back_journal }}</span>
-        </button>
-        <div id="incident-timeline-header" class="incident-timeline-card"></div>
-        <div id="incident-timeline-entries" class="incident-timeline-card"></div>
-        <div id="incident-timeline-chart-card" class="incident-timeline-card">
-            <div class="incident-timeline-section-title">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
-                <span data-i18n="incident_signal_timeline">{{ t.incident_signal_timeline }}</span>
-            </div>
-            <div class="incident-timeline-chart-wrap">
-                <canvas id="incident-timeline-canvas"></canvas>
-            </div>
-        </div>
-        <div id="incident-timeline-signals" class="incident-timeline-card"></div>
-        <div id="incident-timeline-bnetz" class="incident-timeline-card" style="display:none;"></div>
-    </div>
-</div>
 
 <!-- ═══ View: Glossary ═══ -->
 <div id="view-glossary" class="view glossary-app-view">
@@ -2081,272 +1820,6 @@
     </div>
 </div>
 
-<!-- ═══ Entry Modal ═══ -->
-<dialog class="modal-overlay" id="entry-modal" role="dialog" aria-modal="true" aria-labelledby="entry-modal-title" onclick="if(event.target===this)closeEntryModal()">
-    <div class="modal" style="max-width:640px;">
-        <div class="modal-header">
-            <div style="display:flex;align-items:center;gap:10px;">
-                <span id="entry-modal-icon" class="incident-modal-icon"></span>
-                <h2 id="entry-modal-title"></h2>
-            </div>
-            <button class="modal-close" onclick="closeEntryModal()" aria-label="{{ t.close }}">&times;</button>
-        </div>
-        <div class="modal-body" style="overflow-y:auto;">
-            <p class="incident-modal-intro">{{ t.get('entry_modal_intro', 'Capture what happened and link the evidence DOCSight can turn into an ISP-ready timeline.') }}</p>
-            <input type="hidden" id="entry-id">
-            <div class="incident-form-group">
-                <label for="entry-date">{{ t.incident_date }}</label>
-                <input type="date" id="entry-date">
-            </div>
-            <div class="incident-form-group">
-                <label for="entry-title-input">{{ t.incident_title }}</label>
-                <input type="text" id="entry-title-input" maxlength="200" placeholder="{{ t.incident_title }}">
-            </div>
-            <div class="incident-form-group">
-                <label>{{ t.icon }}</label>
-                <p class="incident-field-hint">{{ t.get('entry_icon_hint', 'Choose a visible category such as outage, packet loss, speed degradation, maintenance, or contact with your ISP.') }}</p>
-                <input type="hidden" id="entry-icon-value">
-                <div class="icon-picker" id="entry-icon-picker"></div>
-            </div>
-            <div class="incident-form-group">
-                <label for="entry-desc">{{ t.incident_description }}</label>
-                <p class="incident-field-hint">{{ t.get('entry_description_hint', 'Add concrete symptoms, times, support references, modem states, or what changed for the connection.') }}</p>
-                <textarea id="entry-desc" maxlength="10000" placeholder="{{ t.incident_description }}"></textarea>
-            </div>
-            <div class="incident-form-group">
-                <label for="entry-incident-select">{{ t.incident_assign }}</label>
-                <select id="entry-incident-select" class="entry-incident-select">
-                    <option value="">{{ t.incident_none }}</option>
-                </select>
-            </div>
-            <div class="incident-form-group" id="entry-attachments-section">
-                <label>{{ t.attachments }}</label>
-                <p class="incident-field-hint">{{ t.get('entry_evidence_hint', 'Evidence can include modem screenshots, BQM images, Speedtest results, SmokePing charts, or support letters.') }}</p>
-                <div class="attachment-list" id="entry-attachment-list"></div>
-                <button class="btn-upload" id="entry-upload-btn" onclick="document.getElementById('entry-file-input').click()">
-                    &#128206; {{ t.upload_file }}
-                </button>
-                <p class="incident-field-hint" id="entry-upload-hint"></p>
-                <span id="entry-upload-spinner" style="display:none;"><span class="upload-spinner"></span></span>
-                <input type="file" id="entry-file-input" style="display:none;" multiple
-                       accept="image/png,image/jpeg,image/gif,image/webp,application/pdf,text/plain"
-                       onchange="handleEntryFileUpload(this)">
-            </div>
-        </div>
-        <div class="incident-modal-footer">
-            <div class="modal-footer-left">
-                <button class="btn-danger" id="entry-delete-btn" onclick="deleteEntry()" style="display:none;">{{ t.delete_incident }}</button>
-            </div>
-            <div style="display:flex; gap:10px;">
-                <button class="btn btn-muted" onclick="closeEntryModal()">{{ t.cancel }}</button>
-                <button class="btn btn-accent" id="entry-save-btn" onclick="saveEntry()">{{ t.get('entry_create_action', 'Create entry') }}</button>
-            </div>
-        </div>
-    </div>
-</dialog>
-
-<!-- ═══ Incident Container Modal ═══ -->
-<dialog class="modal-overlay" id="incident-container-modal" role="dialog" aria-modal="true" aria-labelledby="incident-container-modal-title" onclick="if(event.target===this)closeIncidentModal()">
-    <div class="modal incident-container-modal" style="max-width:560px;">
-        <div class="modal-header">
-            <h2 id="incident-container-modal-title"></h2>
-            <button class="modal-close" onclick="closeIncidentModal()" aria-label="{{ t.close }}">&times;</button>
-        </div>
-        <div class="modal-body" style="overflow-y:auto;">
-            <p class="incident-modal-intro">{{ t.get('incident_modal_intro', 'Group related entries and evidence so DOCSight can build one clear incident timeline and report path.') }}</p>
-            <input type="hidden" id="incident-container-id">
-            <div class="incident-form-group">
-                <label for="incident-container-name">{{ t.incident_name }}</label>
-                <input type="text" id="incident-container-name" maxlength="200" placeholder="{{ t.incident_name }}">
-            </div>
-            <div class="incident-form-group">
-                <label for="incident-container-status">{{ t.incident_status }}</label>
-                <select id="incident-container-status">
-                    <option value="open">{{ t.incident_status_open }}</option>
-                    <option value="resolved">{{ t.incident_status_resolved }}</option>
-                    <option value="escalated">{{ t.incident_status_escalated }}</option>
-                </select>
-            </div>
-            <div class="incident-form-group" style="display:flex;gap:12px;">
-                <div style="flex:1;">
-                    <label for="incident-container-start">{{ t.incident_start_date }}</label>
-                    <input type="date" id="incident-container-start">
-                </div>
-                <div style="flex:1;">
-                    <label for="incident-container-end">{{ t.incident_end_date }}</label>
-                    <input type="date" id="incident-container-end">
-                </div>
-            </div>
-            <div class="incident-form-group">
-                <label>{{ t.icon }}</label>
-                <p class="incident-field-hint">{{ t.get('incident_icon_hint', 'Pick the category users will recognize later in filters, timelines, and exports.') }}</p>
-                <input type="hidden" id="incident-container-icon-value">
-                <div class="icon-picker" id="incident-container-icon-picker"></div>
-            </div>
-            <div class="incident-form-group">
-                <label for="incident-container-desc">{{ t.incident_description }}</label>
-                <textarea id="incident-container-desc" maxlength="5000" placeholder="{{ t.incident_description }}"></textarea>
-            </div>
-            <div class="incident-form-group" id="incident-container-entry-count-section" style="display:none;">
-                <label>{{ t.get('incident_linked_evidence', 'Linked evidence') }}</label>
-                <div class="incident-evidence-summary">
-                    <span id="incident-container-entry-count" style="font-weight:600;"></span>
-                    <span>{{ t.get('incident_linked_entries_hint', 'journal entries linked to this incident') }}</span>
-                </div>
-                <button type="button" class="btn-small btn-accent" id="incident-container-report-btn" onclick="openIncidentReportFromModal()">{{ t.get('incident_build_report', 'Build report') }}</button>
-            </div>
-            <div class="incident-form-group" id="incident-container-empty-evidence-section">
-                <label>{{ t.get('incident_linked_evidence', 'Linked evidence') }}</label>
-                <p class="incident-field-hint">{{ t.get('incident_empty_evidence_hint', 'Assign journal entries, screenshots, modem snapshots, BQM images, Speedtest results, or SmokePing charts as the incident develops.') }}</p>
-            </div>
-        </div>
-        <div class="incident-modal-footer">
-            <div class="modal-footer-left">
-                <button class="btn-danger" id="incident-container-delete-btn" onclick="deleteIncident()" style="display:none;">{{ t.delete }}</button>
-            </div>
-            <div style="display:flex; gap:10px;">
-                <button class="btn btn-muted" onclick="closeIncidentModal()">{{ t.cancel }}</button>
-                <button class="btn btn-accent" id="incident-container-save-btn" onclick="saveIncident()">{{ t.get('incident_create_action', 'Create incident') }}</button>
-            </div>
-        </div>
-    </div>
-</dialog>
-
-<!-- ═══ Import Modal ═══ -->
-<dialog class="modal-overlay" id="import-modal" role="dialog" aria-modal="true" aria-labelledby="import-modal-title" onclick="if(event.target===this)closeImportModal()">
-    <div class="modal" style="max-width:900px;">
-        <div class="modal-header">
-            <h2 id="import-modal-title">{{ t.import_incidents }}</h2>
-            <button class="modal-close" onclick="closeImportModal()" aria-label="{{ t.close }}">&times;</button>
-        </div>
-        <div class="modal-body" style="overflow-y:auto;">
-            <!-- Upload zone -->
-            <div id="import-upload-zone" class="import-upload-zone">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:48px;height:48px;color:var(--muted);">
-                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                    <polyline points="17 8 12 3 7 8"/>
-                    <line x1="12" y1="3" x2="12" y2="15"/>
-                </svg>
-                <p>{{ t.import_upload_hint }}</p>
-                <p style="font-size:0.8em;color:var(--muted);">{{ t.import_file_types }}</p>
-                <button type="button" class="btn btn-muted import-browse-btn" onclick="event.stopPropagation(); document.getElementById('import-file-input').click();">{{ t.get('import_browse_file', 'Browse CSV or Excel file') }}</button>
-                <input type="file" id="import-file-input" style="display:none;" accept=".xlsx,.csv" onchange="handleImportFile(this)">
-            </div>
-            <div id="import-validation-state" class="import-validation-state" role="status" aria-live="polite"></div>
-            <!-- Loading -->
-            <div id="import-loading" style="display:none;text-align:center;padding:20px;">
-                <div class="spinner"></div>
-                <p style="margin-top:10px;color:var(--muted);">{{ t.import_parsing }}</p>
-            </div>
-            <!-- Preview -->
-            <div id="import-preview" style="display:none;">
-                <div class="import-info" id="import-info"></div>
-                <div class="import-controls">
-                    <label class="import-select-all">
-                        <input type="checkbox" id="import-select-all" checked onchange="toggleImportAll(this.checked)">
-                        {{ t.import_select_all }}
-                    </label>
-                </div>
-                <div class="import-table-wrap">
-                    <table class="import-table" id="import-table">
-                        <thead><tr>
-                            <th style="width:40px;"></th>
-                            <th style="width:36px;"></th>
-                            <th>{{ t.incident_date }}</th>
-                            <th>{{ t.incident_title }}</th>
-                            <th class="journal-hide-mobile">{{ t.incident_description }}</th>
-                        </tr></thead>
-                        <tbody id="import-tbody"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-        <div class="incident-modal-footer" id="import-footer" style="display:none;">
-            <div class="modal-footer-left"></div>
-            <div style="display:flex; gap:10px;">
-                <button class="btn btn-muted" onclick="closeImportModal()">{{ t.cancel }}</button>
-                <button class="btn btn-accent" id="import-confirm-btn" onclick="confirmImport()">{{ t.import_selected }}</button>
-            </div>
-        </div>
-    </div>
-</dialog>
-
-<!-- ═══ View: Speedtest ═══ -->
-{% if speedtest_configured %}
-<div id="view-speedtest" class="view">
-    <div class="view-page-header">
-        <div class="view-page-header-left">
-            <h2 class="view-page-title">{{ t.speedtest_tracker }}</h2>
-        </div>
-        <div class="view-page-actions speedtest-controls">
-            <div class="trend-tabs" id="speedtest-tabs">
-                <button class="trend-tab" data-value="1" onclick="selectPill(this, filterSpeedtestData)">1d</button>
-                <button class="trend-tab active" data-value="7" onclick="selectPill(this, filterSpeedtestData)">7d</button>
-                <button class="trend-tab" data-value="14" onclick="selectPill(this, filterSpeedtestData)">14d</button>
-                <button class="trend-tab" data-value="30" onclick="selectPill(this, filterSpeedtestData)">30d</button>
-                <button class="trend-tab" data-value="90" onclick="selectPill(this, filterSpeedtestData)">90d</button>
-                <button class="trend-tab" data-value="all" onclick="selectPill(this, filterSpeedtestData)">{{ t.fetch_all }}</button>
-            </div>
-            {% if not demo_mode %}<button class="btn btn-primary btn-sm" id="speedtest-run-btn" onclick="runSpeedtest()"><i data-lucide="play"></i> {{ t.run_speedtest }}</button>{% endif %}
-            <button class="refresh-btn" id="speedtest-refresh-btn" title="{{ t.refresh }}" onclick="loadSpeedtestHistory()"><i data-lucide="refresh-cw"></i></button>
-        </div>
-    </div>
-    <div id="speedtest-loading" class="waiting" style="display:none;">
-        <div class="skeleton skel-chart"></div>
-    </div>
-    <div id="speedtest-no-data" class="no-data-msg speedtest-empty-state" style="display:none;">
-        <i data-lucide="wifi-off" style="width:40px;height:40px;color:var(--text-muted);margin-bottom:12px;"></i>
-        <div class="speedtest-empty-title">{{ t.speedtest_empty_title or 'No speedtest results yet' }}</div>
-        <div class="speedtest-empty-desc">{{ t.speedtest_empty_desc or 'Automated tests will appear here once the schedule runs. You can also start a manual test.' }}</div>
-        {% if not demo_mode %}<button class="btn btn-primary btn-sm" onclick="runSpeedtest()" style="margin-top:12px;"><i data-lucide="play"></i> {{ t.run_speedtest }}</button>{% endif %}
-    </div>
-    <div id="speedtest-chart-container" style="display:none;">
-        <!-- Phase 4.2: Modern card wrapper for speedtest chart -->
-        <div class="speedtest-chart-card">
-            <div class="chart-card-header">
-                <div class="chart-header-content">
-                    <svg class="chart-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="12" cy="12" r="10"/>
-                        <path d="M12 6v6l4 2"/>
-                    </svg>
-                    <div class="chart-label">{{ t.speedtest_history }}</div>
-                </div>
-            </div>
-            <div class="speedtest-chart-wrap">
-                <canvas id="speedtest-chart"></canvas>
-                <div class="speedtest-chart-tooltip" id="speedtest-chart-tooltip"></div>
-                <div class="speedtest-chart-legend">
-                    <span class="legend-dl">{{ t.legend_download }}</span>
-                    <span class="legend-ul">{{ t.legend_upload }}</span>
-                    <span class="legend-ping">{{ t.legend_ping }}</span>
-                    <span class="legend-thresh">{{ t.legend_threshold }}</span>
-                </div>
-            </div>
-        </div>
-    </div>
-    <!-- Phase 4.2: Table card wrapper -->
-    <div id="speedtest-table-wrap" class="table-card">
-        <table id="speedtest-table" class="sortable" style="display:none;">
-            <thead><tr>
-                <th class="st-expand-col"></th>
-                <th data-col="timestamp">{{ t.timestamp }}<span class="sort-indicator">▼</span></th>
-                <th data-col="server_id">{{ t.server or 'Server' }}<span class="sort-indicator"></span></th>
-                <th data-col="download_mbps">{{ t.download }}<span class="sort-indicator"></span></th>
-                <th data-col="upload_mbps">{{ t.upload }}<span class="sort-indicator"></span></th>
-                <th data-col="ping_ms">{{ t.ping }}<span class="sort-indicator"></span></th>
-                <th data-col="jitter_ms">{{ t.jitter }}<span class="sort-indicator"></span></th>
-                <th data-col="packet_loss_pct">{{ t.packet_loss }}<span class="sort-indicator"></span></th>
-                <th class="st-sc-col"></th>
-            </tr></thead>
-            <tbody id="speedtest-tbody"></tbody>
-        </table>
-        <div id="speedtest-show-more" style="text-align:center; padding:12px; display:none;">
-            <button class="btn btn-muted" id="speedtest-more-btn" onclick="showMoreSpeedtest()"></button>
-        </div>
-    </div>
-</div>
-{% endif %}
-
 {% if gaming_quality_enabled %}
 <div id="view-gaming" class="view">
     <div class="view-page-header">
@@ -2507,77 +1980,21 @@
    MODULE VIEWS - Dynamically rendered from enabled modules with tab template
    ══════════════════════════════════════════════════════════════════════════ #}
 {% for mod in modules if mod.template_paths.get('tab') %}
-<div id="{% if mod.id == 'docsight.modulation' %}view-modulation{% elif mod.id == 'docsight.comparison' %}view-comparison{% elif mod.id == 'docsight.connection_monitor' %}view-connection-monitor{% elif mod.id == 'docsight.evidence' %}view-evidence{% else %}view-mod-{{ mod.id|replace('.', '-') }}{% endif %}" class="view">
-    {% include mod.template_paths['tab'] %}
+{% set tab_content %}{% include mod.template_paths['tab'] %}{% endset %}
+{% if tab_content|trim %}
+<div id="view-{{ builtin_module_views.get(mod.id, 'mod-' ~ mod.id|replace('.', '-')) }}" class="view">
+    {{ tab_content }}
 </div>
+{% endif %}
 {% endfor %}
 
 </div><!-- /main-content -->
 </main><!-- /app-main -->
 </div><!-- /app-layout -->
 
-<!-- Speedtest Setup Modal -->
-<dialog class="modal-overlay" id="speedtest-setup-modal" role="dialog" aria-modal="true" aria-labelledby="speedtest-setup-modal-title">
-    <div class="modal modal-wide setup-guide-modal">
-        <div class="modal-header">
-            <h2 id="speedtest-setup-modal-title">⚡ {{ t.get('speedtest_setup_guided_title', 'Speedtest Tracker setup') }}</h2>
-            <button class="modal-close" onclick="closeSpeedtestSetupModal()" aria-label="{{ t.close }}">&times;</button>
-        </div>
-        <p class="modal-hint">{{ t.get('speedtest_setup_guided_intro', 'Connect your existing Speedtest Tracker instance so DOCSight can correlate real throughput with modem signal health.') }}</p>
-        <div class="modal-body setup-guide-body">
-            <section class="setup-guide-card">
-                <h3>{{ t.get('setup_why_title', 'Why connect it') }}</h3>
-                <ul>
-                    <li>{{ t.get('speedtest_setup_benefit_1', 'Correlate speed tests with DOCSIS signal levels') }}</li>
-                    <li>{{ t.get('speedtest_setup_benefit_2', 'Spot peak-hour performance drops') }}</li>
-                    <li>{{ t.get('speedtest_setup_benefit_3', 'Add throughput evidence to reports') }}</li>
-                </ul>
-            </section>
-            <section class="setup-guide-card">
-                <h3>{{ t.get('setup_requirements_title', 'Requirements') }}</h3>
-                <ul>
-                    <li>{{ t.get('speedtest_setup_requirement_url', 'A reachable Speedtest Tracker URL') }}</li>
-                    <li>{{ t.get('speedtest_setup_requirement_api', 'API access enabled in Speedtest Tracker') }}</li>
-                </ul>
-            </section>
-            <section class="setup-guide-card setup-guide-command">
-                <h3>{{ t.get('setup_configure_title', 'Configure') }}</h3>
-                <p>{{ t.get('speedtest_setup_configure_text', 'Paste the Speedtest Tracker base URL in Settings, then save the integration.') }}</p>
-                <code id="speedtest-setup-command">docker run --name speedtest-tracker -p 8080:80 lscr.io/linuxserver/speedtest-tracker:latest</code>
-                <button class="btn btn-secondary" onclick="copySetupSnippet('speedtest-setup-command', 'speedtest-setup-status')">{{ t.get('speedtest_setup_copy_command', 'Copy Docker command') }}</button>
-            </section>
-            <section class="setup-guide-card">
-                <h3>{{ t.get('setup_validate_title', 'Validate') }}</h3>
-                <p>{{ t.get('speedtest_setup_validate_text', 'Use Settings to save the URL, then confirm DOCSight can read recent speed test results.') }}</p>
-                <button class="btn btn-muted" onclick="validateSetupGuidance('speedtest-setup-status', 'speedtest')">{{ t.get('speedtest_setup_test_guidance', 'Review validation path') }}</button>
-            </section>
-        </div>
-        <div id="speedtest-setup-status" class="setup-validation-status" role="status" aria-live="polite"></div>
-        <div class="modal-footer">
-            <button class="btn btn-muted" onclick="closeSpeedtestSetupModal()">{{ t.close }}</button>
-            <a class="btn btn-accent" href="{{ url_for('settings', _anchor='mod-docsight_speedtest') }}">⚙ {{ t.get('speedtest_setup_open_settings', 'Open Speedtest settings') }}</a>
-        </div>
-    </div>
-</dialog>
-
-<!-- BQM Setup Modal -->
-<dialog class="modal-overlay" id="bqm-setup-modal" role="dialog" aria-modal="true" aria-labelledby="bqm-setup-modal-title">
-    <div class="modal modal-wide setup-guide-modal">
-        <div class="modal-header">
-            <h2 id="bqm-setup-modal-title">📈 {{ t.get('bqm_setup_guided_title', 'ThinkBroadband BQM setup') }}</h2>
-            <button class="modal-close" onclick="closeBqmSetupModal()" aria-label="{{ t.close }}">&times;</button>
-        </div>
-        <p class="modal-hint">{{ t.get('bqm_setup_guided_intro', 'Link an existing ThinkBroadband Broadband Quality Monitor so DOCSight can show latency and packet loss beside modem evidence.') }}</p>
-        <div class="modal-body setup-guide-body">
-            <section class="setup-guide-card"><h3>{{ t.get('setup_why_title', 'Why connect it') }}</h3><ul><li>{{ t.get('bqm_setup_benefit_1', 'Track latency, packet loss, and outages') }}</li><li>{{ t.get('bqm_setup_benefit_2', 'Compare external reachability with modem signal state') }}</li><li>{{ t.get('bqm_setup_benefit_3', 'Attach graphs to ISP evidence packages') }}</li></ul></section>
-            <section class="setup-guide-card"><h3>{{ t.get('setup_requirements_title', 'Requirements') }}</h3><ul><li>{{ t.get('bqm_setup_requirement_monitor', 'A ThinkBroadband CSV Yesterday share URL') }}</li><li>{{ t.get('bqm_setup_requirement_static_ip', 'A stable public IP or DDNS target monitored by BQM') }}</li></ul></section>
-            <section class="setup-guide-card setup-guide-command"><h3>{{ t.get('setup_configure_title', 'Configure') }}</h3><p>{{ t.get('bqm_setup_configure_text', 'Create or open your BQM monitor, copy the CSV Yesterday share URL, then save it in Settings. CSV Live is for spot checks only.') }}</p><code id="bqm-setup-url">https://www.thinkbroadband.com/broadband/monitoring/quality/share/abc123def456789012345678901234567890abcd-2-y.csv</code><button class="btn btn-secondary" onclick="copySetupSnippet('bqm-setup-url', 'bqm-setup-status')">{{ t.get('bqm_setup_copy_url', 'Copy example URL format') }}</button></section>
-            <section class="setup-guide-card"><h3>{{ t.get('setup_validate_title', 'Validate') }}</h3><p>{{ t.get('bqm_setup_validate_text', 'After saving a CSV Yesterday URL, DOCSight performs one initial fetch. Use CSV bulk import for up to 12 months of history or longer gaps.') }}</p><button class="btn btn-muted" onclick="validateSetupGuidance('bqm-setup-status', 'bqm')">{{ t.get('setup_validate_source', 'Review validation path') }}</button></section>
-        </div>
-        <div id="bqm-setup-status" class="setup-validation-status" role="status" aria-live="polite"></div>
-        <div class="modal-footer"><button class="btn btn-muted" onclick="closeBqmSetupModal()">{{ t.close }}</button><a class="btn btn-accent" href="{{ url_for('settings', _anchor='mod-docsight_bqm') }}">⚙ {{ t.get('bqm_setup_open_settings', 'Open BQM settings') }}</a></div>
-    </div>
-</dialog>
+{% for mod in modules if mod.template_paths.get('dialogs') %}
+{% include mod.template_paths['dialogs'] %}
+{% endfor %}
 
 <!-- Smokeping Setup Modal -->
 {% if modules|selectattr('id', 'equalto', 'docsight.smokeping')|list %}
@@ -2805,11 +2222,9 @@
 <script src="{{ url_for('static', filename='js/browser-contracts.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/dashboard.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/modals.js', v=version) }}"></script>
-<script src="{{ url_for('static', filename='js/journal.js', v=version) }}"></script>
 {% if modules|selectattr('id', 'equalto', 'docsight.bqm')|list %}
 <script src="{{ module_static_url('docsight.bqm', 'js/bqm-chart.js', v=version) }}"></script>
 {% endif %}
-<script src="{{ url_for('static', filename='js/bqm.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/trends.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/channels.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/integrations.js', v=version) }}"></script>
@@ -2817,7 +2232,6 @@
 <script src="{{ url_for('static', filename='js/utils.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/notices.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/demo-banner.js', v=version) }}"></script>
-<script src="{{ url_for('static', filename='js/speedtest.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/correlation.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/segment-utilization.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/glossary-page.js', v=version) }}"></script>

--- a/scripts/e2e_shards.py
+++ b/scripts/e2e_shards.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover - Windows can validate manifests only
 ROOT = Path(__file__).resolve().parents[1]
 E2E_DIR = ROOT / "tests" / "e2e"
 DEFAULT_MANIFEST = E2E_DIR / "shards.json"
-EXPECTED_TOTAL = 549
+EXPECTED_TOTAL = 551
 
 
 class ManifestError(ValueError):

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -1,15 +1,16 @@
 {
   "version": 1,
-  "expected_total": 549,
+  "expected_total": 551,
   "baseline_cpu_seconds": 1534.372,
   "shards": [
     {
       "id": 1,
-      "collected_cases": 80,
+      "collected_cases": 82,
       "files": [
         "test_connection_monitor.py",
         "test_event_log_redesign.py",
         "test_i18n.py",
+        "test_module_views.py",
         "test_path_prefix_browser.py",
         "test_real_proxy_path_prefix.py",
         "test_segment_utilization.py"

--- a/tests/e2e/test_module_views.py
+++ b/tests/e2e/test_module_views.py
@@ -1,0 +1,131 @@
+"""Module ownership, routing and dialog behavior in the browser."""
+
+import pytest
+from playwright.sync_api import expect
+
+from tests.e2e.conftest import _new_target
+from tests.e2e.support.lifecycle import running_processes
+from tests.e2e.support.profiles import ServerProfile
+
+
+@pytest.fixture
+def root_module_servers(tmp_path_factory):
+    """Keep the three delivery states in the root journey only."""
+    targets, specs = {}, []
+    for state in ("configured", "unconfigured", "disabled"):
+        profile = ServerProfile(
+            "module-views-" + state, configured=True,
+            demo_mode=state != "unconfigured",
+            disabled_modules="docsight.journal,docsight.bqm,docsight.speedtest" if state == "disabled" else "",
+        )
+        target, spec = _new_target("module-views-" + state,
+                                   tmp_path_factory.mktemp("module-views-" + state), profile)
+        targets[state] = target.base_url
+        specs.append(spec)
+    with running_processes(specs):
+        yield targets
+
+
+@pytest.fixture
+def prefixed_module_server(tmp_path_factory):
+    profile = ServerProfile(
+        "module-views-docsight", configured=True, demo_mode=True,
+        mount_path="/docsight",
+    )
+    target, spec = _new_target(
+        "module-views-docsight",
+        tmp_path_factory.mktemp("module-views-docsight"), profile,
+    )
+    with running_processes([spec]):
+        yield target.base_url
+
+
+def test_root_module_views_settings_disabled_actions_and_mobile_setup(page, root_module_servers):
+    errors = []
+    page.on("pageerror", lambda error: errors.append(str(error)))
+    base = root_module_servers["configured"]
+    for view in ("journal", "bqm", "speedtest"):
+        page.goto(base + "/#" + view)
+        expect(page.locator("#view-" + view)).to_be_visible()
+        page.evaluate("view => { switchView('live'); switchView(view); switchView(view); }", view)
+        expect(page.locator("#view-" + view)).to_be_visible()
+        expect(page.locator(".main-content > .view.active")).to_have_count(1)
+    page.goto(base + "/settings")
+    page.wait_for_load_state("networkidle")
+    for view in ("journal", "bqm", "speedtest"):
+        expect(page.locator(f'script[src*="/modules/docsight.{view}/static/main.js?v="]')).to_have_count(1)
+
+    base = root_module_servers["disabled"]
+    page.goto(base + "/#journal")
+    expect(page.locator("#view-dashboard")).to_be_visible()
+    expect(page.locator(".main-content > .view.active")).to_have_count(1)
+    expect(page).to_have_url(base + "/")
+    for view in ("journal", "bqm", "speedtest", "unknown"):
+        expect(page.locator("#view-" + view)).to_have_count(0)
+        expect(page.locator(f'.nav-item[data-view="{view}"]')).to_have_count(0)
+        expect(page.locator(f'.nav-item[onclick="open{view.title()}SetupModal()"]')).to_have_count(0)
+        expect(page.locator(f'script[src*="/modules/docsight.{view}/static/main.js"]')).to_have_count(0)
+    for view in ("bqm", "speedtest", "unknown"):
+        page.evaluate("view => switchView(view)", view)
+        expect(page.locator("#view-dashboard")).to_be_visible()
+        expect(page.locator(".main-content > .view.active")).to_have_count(1)
+        expect(page).to_have_url(base + "/")
+    page.evaluate("switchView('evidence')")
+    page.evaluate(
+        """
+        _evidenceRenderItems(['journal', 'bqm', 'speedtest'].map((key) => ({
+            key: key,
+            status: 'unavailable',
+            hint_key: 'missing',
+            action: key === 'journal' ? {view: 'journal', action: 'add_note'} : {view: key}
+        })))
+        """
+    )
+    expect(page.locator("#evidence-items .evidence-item").first).to_be_visible()
+    expect(page.locator('[data-evidence-view="journal"], [data-evidence-view="bqm"], [data-evidence-view="speedtest"]')).to_have_count(0)
+    expect(page.locator('[data-evidence-action="add_note"]')).to_have_count(0)
+
+    page.set_viewport_size({"width": 390, "height": 844})
+    page.goto(root_module_servers["unconfigured"])
+    sidebar = page.locator("#sidebar")
+    for view, hook in (("bqm", "Bqm"), ("speedtest", "Speedtest")):
+        expect(page.locator("#view-" + view)).to_have_count(0)
+        page.locator("#hamburger").click()
+        expect(sidebar).to_have_attribute("aria-hidden", "false")
+        trigger = page.locator(f'.nav-item[onclick="open{hook}SetupModal()"]')
+        expect(trigger).to_be_visible()
+        trigger.focus()
+        expect(trigger).to_be_focused()
+        trigger.press("Enter")
+        dialog = page.locator(f"#{view}-setup-modal")
+        expect(dialog).to_be_visible()
+        close_button = dialog.locator(".modal-close")
+        close_button.focus()
+        expect(close_button).to_be_focused()
+        close_button.press("Enter")
+        expect(dialog).not_to_be_visible()
+        page.evaluate("closeSidebar()")
+        expect(sidebar).to_have_attribute("aria-hidden", "true")
+    assert errors == []
+
+
+def test_prefixed_module_hash_navigation_and_script_urls(page, prefixed_module_server):
+    """Leave other delivery states to the root journey and Python ownership tests."""
+    errors = []
+    page.on("pageerror", lambda error: errors.append(str(error)))
+    base = prefixed_module_server
+    page.goto(base + "/#journal")
+    expect(page.locator("#view-journal")).to_be_visible()
+    expect(page.locator(".main-content > .view.active")).to_have_count(1)
+    expect(page).to_have_url(base + "/#journal")
+    for view in ("journal", "bqm", "speedtest"):
+        expect(page.locator(f'script[src^="/docsight/modules/docsight.{view}/static/main.js?v="]')).to_have_count(1)
+    for view in ("live", "bqm", "speedtest", "journal"):
+        page.locator(f'.nav-item[data-view="{view}"]').click()
+        view_id = "dashboard" if view == "live" else view
+        expect(page.locator("#view-" + view_id)).to_be_visible()
+        expect(page.locator(".main-content > .view.active")).to_have_count(1)
+        expected_hash = "#" if view == "live" else "#" + view
+        expect(page).to_have_url(base + "/" + expected_hash)
+        assert errors == []
+    assert errors == []

--- a/tests/js/module-views.test.js
+++ b/tests/js/module-views.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const test = require('node:test');
+const root = path.resolve(__dirname, '../..');
+
+function element() {
+    const classes = new Set();
+    return {
+        style: {}, dataset: {}, innerHTML: '', textContent: '',
+        classList: {
+            add: name => classes.add(name), remove: name => classes.delete(name),
+            contains: name => classes.has(name),
+            toggle(name, on) { if (on) classes.add(name); else classes.delete(name); }
+        },
+        addEventListener() {}, removeEventListener() {},
+        querySelectorAll: () => [], querySelector: () => null,
+        setAttribute() {}, getAttribute: () => null,
+    };
+}
+
+function browser(ids = [], hash = '') {
+    const elements = Object.fromEntries(ids.map(id => [id, element()]));
+    const listeners = {};
+    const timers = new Map();
+    let nextTimer = 0;
+    let listenerCount = 0;
+    const context = {
+        document: {
+            getElementById: id => elements[id] || null,
+            querySelector: () => null,
+            querySelectorAll: selector => selector === '.main-content > .view'
+                ? Object.entries(elements).filter(([id]) => id.startsWith('view-')).map(([, el]) => el) : [],
+            addEventListener() { listenerCount++; },
+            documentElement: element(), body: element(), hidden: false,
+        },
+        location: {hash, pathname: '/docsight/', search: '?lang=en'},
+        history: {replaceState(_state, _title, url) { context.location.hash = ''; context.replacedUrl = url; }},
+        navigator: {onLine: true},
+        localStorage: {getItem: () => null, setItem() {}},
+        matchMedia: () => ({matches: false}),
+        addEventListener(name, fn) { listenerCount++; listeners[name] = fn; },
+        setTimeout(fn) { timers.set(++nextTimer, fn); return nextTimer; },
+        clearTimeout(id) { timers.delete(id); },
+        setInterval(fn) { timers.set(++nextTimer, fn); return nextTimer; },
+        clearInterval(id) { timers.delete(id); },
+        lucide: {createIcons() {}}, currentView: 'live', T: {},
+        DOCSightBrowserContracts: {parseDashboardBootstrapText: () => ({translations: {}})},
+        fetch() { throw new Error('Unexpected fetch'); },
+    };
+    context.window = context;
+    vm.createContext(context);
+    return {context, elements, listeners, timers, listenerCount: () => listenerCount};
+}
+
+function run(context, file) {
+    vm.runInContext(fs.readFileSync(path.join(root, file), 'utf8'), context, {filename: file});
+}
+
+for (const name of ['journal', 'bqm', 'speedtest']) {
+    test(`${name} loads on Settings and its hook is safe without dashboard globals`, () => {
+        const {context, timers} = browser();
+        run(context, `app/modules/${name}/static/main.js`);
+        const hook = `init${name[0].toUpperCase()}${name.slice(1)}View`;
+        assert.equal(typeof context[hook], 'function');
+        context[hook]();
+        context[hook]();
+        assert.equal(timers.size, 0);
+    });
+}
+
+for (const hash of ['#journal', '#bqm', '#speedtest', '#unknown?mode=timeline']) {
+    test(`unavailable initial ${hash} returns to live and clears the hash`, () => {
+        const {context, elements} = browser(['sidebar', 'sidebar-backdrop', 'theme-toggle-sidebar', 'view-dashboard'], hash);
+        context.initJournalView = context.initBqmView = context.initSpeedtestView = () => assert.fail('Unavailable module initialized');
+        run(context, 'app/static/js/dashboard.js');
+        run(context, 'app/static/js/dashboard-routing.js');
+        assert.equal(context.location.hash, '');
+        assert.equal(context.currentView, 'live');
+        assert.equal(elements['view-dashboard'].classList.contains('active'), true);
+    });
+}
+
+test('routing accepts optional hooks, repeated activation, deactivated views and browser back', () => {
+    const {context, elements, listeners} = browser(['sidebar', 'sidebar-backdrop', 'theme-toggle-sidebar', 'view-dashboard', 'view-speedtest']);
+    run(context, 'app/static/js/dashboard.js');
+    context.switchView('speedtest');
+    assert.equal(elements['view-speedtest'].classList.contains('active'), true);
+    let calls = 0;
+    context.initSpeedtestView = () => calls++;
+    context.switchView('speedtest');
+    context.switchView('speedtest');
+    assert.equal(calls, 2);
+    delete elements['view-speedtest'];
+    context.location.hash = '#speedtest';
+    listeners.hashchange();
+    assert.equal(context.currentView, 'live');
+    assert.equal(context.location.hash, '');
+    assert.equal(calls, 2);
+    assert.equal(elements['view-dashboard'].classList.contains('active'), true);
+});
+
+test('BQM repeated activation retains one timer and fixed listeners, leaving cancels it', () => {
+    const {context, timers, listenerCount} = browser(['view-bqm']);
+    context.todayStr = () => '2026-09-05';
+    run(context, 'app/modules/bqm/static/main.js');
+    context._bqmDatesLoaded = true;
+    context.renderBqmCalendar = () => {};
+    let loads = 0;
+    context.loadBqmLive = () => loads++;
+    context.currentView = 'bqm';
+    const before = listenerCount();
+    for (let i = 0; i < 5; i++) context.initBqmView();
+    assert.equal(timers.size, 1);
+    assert.equal(listenerCount(), before);
+    const [timerId, tick] = timers.entries().next().value;
+    timers.delete(timerId);
+    const beforeTick = loads;
+    tick();
+    assert.equal(loads, beforeTick + 1);
+    assert.equal(timers.size, 1);
+    context.stopBqmLiveRefresh();
+    assert.equal(timers.size, 0);
+});
+
+test('Journal and Speedtest activation does not rebind listeners or start timers', () => {
+    for (const name of ['journal', 'speedtest']) {
+        const {context, timers, listenerCount} = browser([`view-${name}`]);
+        run(context, `app/modules/${name}/static/main.js`);
+        let loads = 0;
+        context.loadJournal = context.loadSpeedtestHistory = () => loads++;
+        context.loadIncidents = () => {};
+        const before = listenerCount();
+        const hook = `init${name[0].toUpperCase()}${name.slice(1)}View`;
+        for (let i = 0; i < 5; i++) context[hook]();
+        assert.equal(loads, 5);
+        assert.equal(timers.size, 0);
+        assert.equal(listenerCount(), before);
+    }
+});
+
+test('Evidence retains unavailable status and hint while omitting impossible view actions', () => {
+    const {context, elements} = browser(['evidence-items', 'view-journal']);
+    run(context, 'app/modules/evidence/static/main.js');
+    const items = ['journal', 'bqm', 'speedtest'].map(key => ({
+        key, status: 'unavailable', hint_key: 'missing',
+        action: key === 'journal' ? {view: 'journal', action: 'add_note'} : {view: key}
+    }));
+    context._evidenceRenderItems(items);
+    const html = elements['evidence-items'].innerHTML;
+    assert.match(html, /data-evidence-view="journal"/);
+    assert.doesNotMatch(html, /data-evidence-view="(?:bqm|speedtest)"/);
+    assert.equal((html.match(/evidence-status-unavailable/g) || []).length, 3);
+    assert.equal((html.match(/Review this evidence source/g) || []).length, 3);
+    delete elements['view-journal'];
+    context._evidenceRenderItems(items);
+    const unavailableHtml = elements['evidence-items'].innerHTML;
+    assert.doesNotMatch(unavailableHtml, /data-evidence-view="journal"/);
+    assert.doesNotMatch(unavailableHtml, /data-evidence-action="add_note"/);
+});

--- a/tests/module_loader/test_atomic_registration.py
+++ b/tests/module_loader/test_atomic_registration.py
@@ -260,6 +260,7 @@ bp.add_url_rule("/api/modules/community.owned/status", "status", lambda: "ok")
         ("static", "missing-static/"),
         ("i18n", "missing-i18n/"),
         ("tab", "templates/missing.html"),
+        ("dialogs", "templates/missing.html"),
         ("collector", "missing.py:MissingCollector"),
         ("publisher", "missing.py:MissingPublisher"),
     ],
@@ -287,6 +288,41 @@ def test_implicit_static_directory_remains_optional(tmp_path):
 
     assert module.error is None
     assert module.has_css is False and module.has_js is False
+
+
+@pytest.mark.parametrize("reference", ["templates/dialogs.html", "templates/missing.html", "../outside.html", "/outside.html", "templates/escape.html"])
+def test_dialogs_resolve_or_reject_complete_plan(tmp_path, reference):
+    module = _write_module(
+        tmp_path, "dialogs", _manifest("community.dialogs", {
+            "dialogs": reference, "static": "static/", "i18n": "i18n/",
+            "routes": "routes.py",
+        }, config={"community_dialogs_setting": "value"}),
+        'from flask import Blueprint\nbp = Blueprint("dialogs_bp", __name__)\nbp.add_url_rule("/dialogs-ok", "ok", lambda: "ok")\n',
+    )
+    (module / "templates").mkdir()
+    (module / "templates/dialogs.html").write_text('<dialog id="contributed-dialog"></dialog>')
+    outside = tmp_path / "outside.html"
+    outside.write_text("outside")
+    (module / "templates/escape.html").symlink_to(outside)
+    (module / "static").mkdir()
+    (module / "static/main.js").write_text("/* dialogs */")
+    (module / "i18n").mkdir()
+    (module / "i18n/en.json").write_text('{"label": "Dialogs"}')
+    app = Flask(__name__)
+    before = _snapshot(app)
+    loader = ModuleLoader(app, search_paths=[str(tmp_path)])
+    info = loader.load_all()[0]
+    if reference == "templates/dialogs.html":
+        assert info.error is None
+        assert info.template_paths == {"dialogs": "dialogs.html"}
+        with app.app_context():
+            assert 'id="contributed-dialog"' in app.jinja_env.get_template(info.template_paths["dialogs"]).render()
+        assert app.test_client().get("/dialogs-ok").status_code == 200
+    else:
+        assert info.error
+        assert info.template_paths == {} and not info.has_js
+        assert _snapshot(app) == before
+        assert loader.registration_plan == type(loader.registration_plan)()
 
 
 def test_contribution_failure_diagnostics_are_redacted(tmp_path, caplog):

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -354,6 +354,8 @@ def _enabled_bqm_loader():
         type="integration",
         contributes={},
         path="",
+        template_paths={"tab": "bqm_tab.html", "dialogs": "bqm_dialogs.html"},
+        has_js=True,
     )
 
     class Loader:
@@ -684,7 +686,7 @@ class TestBqmUiRender:
         assert "bulk import" in html.lower()
 
     def test_bqm_setup_modal_points_to_csv_yesterday_and_bulk_import(self, bqm_client):
-        with open("app/templates/index.html", "r", encoding="utf-8") as f:
+        with open("app/modules/bqm/templates/bqm_dialogs.html", "r", encoding="utf-8") as f:
             html = f.read()
         assert "CSV Yesterday share URL" in html
         assert "CSV Live is for spot checks only" in html
@@ -694,9 +696,9 @@ class TestBqmUiRender:
         assert "A public or shareable BQM monitor URL" not in html
 
     def test_bqm_calendar_buttons_are_accessible(self):
-        with open("app/templates/index.html", "r", encoding="utf-8") as f:
+        with open("app/modules/bqm/templates/bqm_tab.html", "r", encoding="utf-8") as f:
             html = f.read()
-        with open("app/static/js/bqm.js", "r", encoding="utf-8") as f:
+        with open("app/modules/bqm/static/main.js", "r", encoding="utf-8") as f:
             js = f.read()
         assert 'aria-label="{{ t.bqm_import_title }}"' in html
         assert 'aria-label="{{ t.get(\'bqm_csv_import\', \'Import CSV\') }}"' in html
@@ -736,8 +738,8 @@ class TestBqmChartConfig:
         assert "u.series[seriesIdx].show === false" in plugin_body
 
     def test_toggle_logic_in_bqm_js(self):
-        """bqm.js must contain toggle handler wiring."""
-        with open("app/static/js/bqm.js", "r", encoding="utf-8") as f:
+        """BQM main.js must contain toggle handler wiring."""
+        with open("app/modules/bqm/static/main.js", "r", encoding="utf-8") as f:
             js = f.read()
         assert "bqm-toggle-uplot" in js
         assert "bqm-toggle-png" in js
@@ -745,15 +747,15 @@ class TestBqmChartConfig:
 
     def test_live_badge_labels_cached_png_without_claiming_live(self):
         """Cached fallback status must not be labelled as live freshness."""
-        with open("app/static/js/bqm.js", "r", encoding="utf-8") as f:
+        with open("app/modules/bqm/static/main.js", "r", encoding="utf-8") as f:
             js = f.read()
         assert "T.bqm_cached_png" in js
         assert "T.bqm_cached_png_loaded" in js
         assert "source === 'live' ? 'inline' : 'none'" not in js
 
     def test_no_slideshow_in_bqm_js(self):
-        """bqm.js must not contain any slideshow references."""
-        with open("app/static/js/bqm.js", "r", encoding="utf-8") as f:
+        """BQM main.js must not contain any slideshow references."""
+        with open("app/modules/bqm/static/main.js", "r", encoding="utf-8") as f:
             js = f.read()
         assert "slideshow" not in js.lower()
         assert "bqm-play" not in js

--- a/tests/test_browser_url_contract.py
+++ b/tests/test_browser_url_contract.py
@@ -18,7 +18,7 @@ EXPECTED_CONTRACT_CALLS = {
     "app/static/js/dashboard.js": 1,
     "app/static/js/service-worker-registration.js": 3,
     "app/static/js/setup.js": 8,
-    "app/static/js/bqm.js": 9,
+    "app/modules/bqm/static/main.js": 9,
     "app/static/js/channels.js": 7,
     "app/static/js/correlation.js": 5,
     "app/static/js/demo-banner.js": 3,
@@ -26,12 +26,12 @@ EXPECTED_CONTRACT_CALLS = {
     "app/static/js/glossary.js": 1,
     "app/static/js/hero-chart.js": 1,
     "app/static/js/integrations.js": 5,
-    "app/static/js/journal.js": 22,
+    "app/modules/journal/static/main.js": 22,
     "app/static/js/notices.js": 1,
     "app/static/js/segment-utilization.js": 2,
     "app/static/js/settings.js": 25,
     "app/static/js/sparklines.js": 1,
-    "app/static/js/speedtest.js": 6,
+    "app/modules/speedtest/static/main.js": 6,
     "app/static/js/trends.js": 2,
     "app/static/js/utils.js": 3,
     "app/modules/comparison/static/main.js": 1,
@@ -320,7 +320,7 @@ def test_demo_redirect_fails_closed_on_unexpected_api_destination(response_next)
 REPRESENTATIVE_SITES = [
     (
         "direct fetch",
-        ROOT / "app/static/js/bqm.js",
+        ROOT / "app/modules/bqm/static/main.js",
         "fetch(docsightUrl('/api/bqm/data/dates'))",
     ),
     (

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -187,7 +187,7 @@ def test_full_e2e_paths_concurrency_and_summary_contract():
         step for step in workflow["jobs"]["full-e2e"]["steps"]
         if step["name"].startswith("Verify complete successful")
     )["run"]
-    assert "--expected-total 549" in summarize
+    assert "--expected-total 551" in summarize
 
     preserve = next(
         step for step in workflow["jobs"]["full-e2e"]["steps"]

--- a/tests/test_dashboard_module_ownership.py
+++ b/tests/test_dashboard_module_ownership.py
@@ -1,0 +1,101 @@
+"""Enabled modules own their complete dashboard surface."""
+
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+import pytest
+
+from app.runtime import get_runtime
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULES = {
+    "journal": ("entry-modal", "incident-container-modal", "import-modal"),
+    "bqm": ("bqm-import-modal", "bqm-setup-modal"),
+    "speedtest": ("speedtest-setup-modal",),
+}
+
+
+@pytest.fixture
+def dashboard(make_config, make_app, builtin_module_loader_factory):
+    def build(disabled="", configured=True):
+        manager = make_config({
+            "modem_type": "fritzbox", "modem_password": "test",
+            "disabled_modules": disabled,
+            "bqm_url": "https://www.thinkbroadband.com/broadband/monitoring/quality/share/abc.csv" if configured else "",
+            "speedtest_tracker_url": "http://localhost:8999" if configured else "",
+            "speedtest_tracker_token": "test" if configured else "",
+        })
+        app = make_app(config_manager=manager,
+                       module_loader_factory=builtin_module_loader_factory(manager))
+        assert not [m.error for m in get_runtime(app).module_loader.get_modules() if m.error]
+        return app.test_client()
+    return build
+
+
+@pytest.mark.parametrize("prefix", ["", "/docsight"])
+@pytest.mark.parametrize("name", MODULES)
+def test_disabled_module_delivers_no_ui_or_script(dashboard, name, prefix):
+    client = dashboard(disabled=f"docsight.{name}")
+    env = {"SCRIPT_NAME": prefix}
+    for page in ("/", "/settings"):
+        response = client.get(page, environ_overrides=env)
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert soup.select_one(f"#view-{name}") is None
+        assert soup.select_one(f'.nav-item[data-view="{name}"]') is None
+        assert soup.select_one(f'.nav-item[onclick="open{name.title()}SetupModal()"]') is None
+        for dialog in MODULES[name]:
+            assert soup.select_one(f"#{dialog}") is None
+        assert not soup.select(f'script[src*="/modules/docsight.{name}/static/main.js"]')
+        assert not soup.select(f'script[src*="/static/js/{name}.js"]')
+    assert client.get(f"/modules/docsight.{name}/static/main.js", environ_overrides=env).status_code == 404
+
+
+@pytest.mark.parametrize("prefix", ["", "/docsight"])
+def test_configured_modules_render_once_with_versioned_scripts(dashboard, prefix):
+    client = dashboard()
+    for page in ("/", "/settings"):
+        response = client.get(page, environ_overrides={"SCRIPT_NAME": prefix})
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        scripts = [tag["src"] for tag in soup.select("script[src]")]
+        for name, dialogs in MODULES.items():
+            urls = [url for url in scripts if f"/modules/docsight.{name}/static/main.js" in url]
+            assert len(urls) == 1
+            assert urls[0].startswith(prefix + "/modules/") and "?v=" in urls[0]
+            assert client.get(urls[0].removeprefix(prefix)).status_code == 200
+            assert not (ROOT / f"app/static/js/{name}.js").exists()
+            assert client.get(f"/static/js/{name}.js").status_code == 404
+            if page == "/":
+                assert len(soup.select(f".main-content > #view-{name}")) == 1
+                for dialog in dialogs:
+                    elements = soup.select(f"#{dialog}")
+                    assert len(elements) == 1
+                    assert elements[0].find_parent(class_="view") is None
+        if page == "/":
+            positions = lambda path: next(i for i, url in enumerate(scripts) if path in url)
+            assert positions("js/dashboard.js") < positions("docsight.bqm/static/js/bqm-chart.js") < positions("docsight.bqm/static/main.js") < positions("js/dashboard-routing.js")
+            assert soup.select_one("#view-bqm #bqm-csv-import-section") is not None
+            assert soup.select_one("#view-correlation") is not None
+
+
+@pytest.mark.parametrize("prefix", ["", "/docsight"])
+def test_unconfigured_modules_keep_setup_without_empty_views(dashboard, prefix):
+    response = dashboard(configured=False).get(
+        "/", environ_overrides={"SCRIPT_NAME": prefix}
+    )
+    soup = BeautifulSoup(response.data, "html.parser")
+    for name, hook in (("bqm", "Bqm"), ("speedtest", "Speedtest")):
+        assert soup.select_one(f"#view-{name}") is None
+        assert soup.select_one(f"#{name}-setup-modal") is not None
+        assert soup.select_one(f'.nav-item[onclick="open{hook}SetupModal()"]') is not None
+        script = soup.select_one(
+            f'script[src*="/modules/docsight.{name}/static/main.js?v="]'
+        )
+        assert script is not None
+        assert script["src"].startswith(prefix + "/modules/")
+
+
+def test_module_asset_cache_generation():
+    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v89';")

--- a/tests/test_e2e_shards.py
+++ b/tests/test_e2e_shards.py
@@ -84,19 +84,19 @@ def _write_result(
     )
 
 
-def test_repository_manifest_covers_every_e2e_file_once_and_549_cases():
+def test_repository_manifest_covers_every_e2e_file_once_and_551_cases():
     manifest = load_manifest(MANIFEST)
     validated = validate_manifest(manifest, E2E_DIR)
 
-    assert manifest["expected_total"] == EXPECTED_TOTAL == 549
+    assert manifest["expected_total"] == EXPECTED_TOTAL == 551
     assert manifest["baseline_cpu_seconds"] > 0
     assert [shard["collected_cases"] for shard in manifest["shards"]] == [
-        80,
+        82,
         140,
         161,
         168,
     ]
-    assert len(validated) == 28
+    assert len(validated) == 29
 
 
 @pytest.mark.parametrize("defect", ["missing", "duplicate", "stale"])
@@ -258,7 +258,7 @@ def test_workflow_runs_safe_non_retrying_shards_and_an_always_gate():
     assert "E2E_JOB_STARTED_EPOCH" in workflow
     assert "python scripts/e2e_shards.py run" in workflow
     assert "python scripts/e2e_shards.py summarize" in workflow
-    assert "--expected-total 549" in workflow
+    assert "--expected-total 551" in workflow
     assert "--receipt" in workflow
     assert "run-receipt.json" in workflow
     assert "if: always()" in workflow

--- a/tests/test_manifest_contract.py
+++ b/tests/test_manifest_contract.py
@@ -28,6 +28,12 @@ def _valid_manifest() -> dict:
     }
 
 
+def test_dialogs_are_a_template_contribution():
+    manifest = _valid_manifest()
+    manifest["contributes"] = {"dialogs": "templates/dialogs.html"}
+    assert validate_manifest_contract(manifest) == []
+
+
 def test_contract_cli_validates_manifests_without_loading_application(tmp_path):
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(_valid_manifest()), encoding="utf-8")

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -509,6 +509,8 @@ def test_snapshot_storage_uses_single_storage_base() -> None:
 
 def test_shared_modals_use_native_dialog_contract() -> None:
     index = (TEMPLATES / "index.html").read_text(encoding="utf-8")
+    for name in ("journal", "bqm", "speedtest"):
+        index += (MODULES / name / "templates" / f"{name}_dialogs.html").read_text(encoding="utf-8")
     backup_settings = (
         MODULES / "backup" / "templates" / "backup_settings.html"
     ).read_text(encoding="utf-8")
@@ -544,8 +546,8 @@ def test_shared_modals_use_native_dialog_contract() -> None:
 
 def test_modal_consumers_have_no_absent_api_fallbacks() -> None:
     consumers = [
-        STATIC / "js" / "bqm.js",
-        STATIC / "js" / "journal.js",
+        MODULES / "bqm" / "static" / "main.js",
+        MODULES / "journal" / "static" / "main.js",
         STATIC / "js" / "utils.js",
         STATIC / "js" / "demo-banner.js",
         MODULES / "smokeping" / "static" / "main.js",


### PR DESCRIPTION
## Description

Moves the Journal, BQM, and Speedtest dashboard surfaces into their built-in module directories. Enabled modules now provide their own tab content, dialogs, and JavaScript through the manifest contribution contract; disabled modules no longer emit those assets.

Tracks https://github.com/itsDNNS/docsight-maintainer-backlog/issues/111

## User-Facing Impact

- Enabled Journal, BQM, and Speedtest views keep their existing navigation, setup dialogs, API behavior, timers, URL-prefix support, and direct hash links.
- Invalid or disabled view hashes safely return to the live dashboard.
- Evidence actions are only shown when their destination or supported action exists.
- The service-worker cache version is updated for the moved module assets.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Checklist

- [x] I have read the Contributing Guidelines
- [x] I have opened an issue before starting work on this PR
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] All tests pass
- [x] I have added tests for new functionality
- [x] I have tested both success and failure paths
- [x] I have updated the contributor documentation
- [x] No new user-facing strings require translation
- [x] I have documented the UI and module-contract impact
- [x] I have verified the changed views on desktop and mobile

## Testing

**Test Environment:**
- Deployment: local Linux test runtime
- Browser: Playwright Chromium, desktop and 390 px mobile viewport
- URL layouts: root and `/docsight` prefix

**Verification Commands:**
```bash
python -m pytest -q --ignore=tests/e2e
npm test
python scripts/e2e_shards.py validate
python app/manifest_contract.py --builtin app/modules
python scripts/i18n_check.py --validate
actionlint .github/workflows/full-e2e.yml
for shard in 1 2 3 4; do
  TZ=UTC python scripts/e2e_shards.py run --shard "$shard" -- -q --tb=short
done
```

**Results:**
```text
4114 passed, 2 skipped
27 JavaScript tests passed
4 E2E shards cover 29 files and 551 cases
551 E2E cases passed (82 + 140 + 161 + 168)
14 built-in manifests valid
92 language files synchronized
```

## Additional Notes

The contributor guide now documents module-owned dashboard tabs and dialogs. No user workflow, API contract, or configuration format changes are introduced.
