### PR TITLE
fix: harden journal DOM rendering

### DIFF
--- a/app/modules/journal/static/main.js
+++ b/app/modules/journal/static/main.js
@@ -391,27 +391,51 @@ function closeEntryModal() {
 }
 
 function renderAttachments(attachments, container, incidentId) {
-    container.innerHTML = '';
+    container.textContent = '';
     attachments.forEach(function(att) {
         var item = document.createElement('div');
         item.className = 'attachment-item';
         var isImage = att.mime_type && att.mime_type.indexOf('image/') === 0;
-        var thumbHtml = '';
+        var attachmentUrl = docsightUrl('/api/attachments/' + att.id);
+        var thumb;
         if (isImage) {
-            thumbHtml = '<img class="attachment-thumb" src="' + docsightUrl('/api/attachments/' + att.id) + '" alt="">';
-        } else if (att.mime_type === 'application/pdf') {
-            thumbHtml = '<div class="attachment-icon">&#128196;</div>';
+            thumb = document.createElement('img');
+            thumb.className = 'attachment-thumb';
+            thumb.src = attachmentUrl;
+            thumb.alt = '';
         } else {
-            thumbHtml = '<div class="attachment-icon">&#128462;</div>';
+            thumb = document.createElement('div');
+            thumb.className = 'attachment-icon';
+            thumb.textContent = att.mime_type === 'application/pdf' ? '\uD83D\uDCC4' : '\uD83D\uDDCE';
         }
-        item.innerHTML = thumbHtml +
-            '<div class="attachment-info">' +
-                '<span class="attachment-name">' + escapeHtml(att.filename) + '</span>' +
-                '<div class="attachment-actions">' +
-                    '<a href="' + docsightUrl('/api/attachments/' + att.id) + '" download title="Download">&#11015;</a>' +
-                    '<button onclick="deleteAttachment(' + att.id + ', ' + incidentId + ')" title="Delete">&#128465;</button>' +
-                '</div>' +
-            '</div>';
+        item.appendChild(thumb);
+
+        var info = document.createElement('div');
+        info.className = 'attachment-info';
+        var name = document.createElement('span');
+        name.className = 'attachment-name';
+        name.textContent = att.filename;
+        info.appendChild(name);
+
+        var actions = document.createElement('div');
+        actions.className = 'attachment-actions';
+        var download = document.createElement('a');
+        download.href = attachmentUrl;
+        download.download = '';
+        download.title = 'Download';
+        download.textContent = '\u2B07';
+        actions.appendChild(download);
+
+        var deleteBtn = document.createElement('button');
+        deleteBtn.type = 'button';
+        deleteBtn.title = 'Delete';
+        deleteBtn.textContent = '\uD83D\uDDD1';
+        deleteBtn.addEventListener('click', function() {
+            deleteAttachment(att.id, incidentId);
+        });
+        actions.appendChild(deleteBtn);
+        info.appendChild(actions);
+        item.appendChild(info);
         container.appendChild(item);
     });
 }
@@ -1005,9 +1029,13 @@ window.closeIncidentTimeline = function() {
     loadJournal();
 };
 
+function renderIncidentPdfButton(btn) {
+    btn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
+    btn.appendChild(document.createTextNode(' ' + (T.incident_download_pdf || 'Download PDF Report')));
+}
+
 window.downloadIncidentPdf = function(incidentId, incidentName) {
     var btn = document.querySelector('.incident-timeline-pdf-btn');
-    var origHtml = btn ? btn.innerHTML : '';
     var params = new URLSearchParams();
     var langInput = document.getElementById('report-lang');
     var nameInput = document.getElementById('report-name');
@@ -1034,7 +1062,7 @@ window.downloadIncidentPdf = function(incidentId, incidentName) {
             showToast(T.network_error || 'Error generating report', 'error');
         })
         .finally(function() {
-            if (btn) { btn.disabled = false; btn.innerHTML = origHtml; }
+            if (btn) { btn.disabled = false; renderIncidentPdfButton(btn); }
         });
 };
 
@@ -1088,11 +1116,15 @@ function renderIncidentTimeline(data) {
     if (inc.description) {
         hHtml += '<div class="incident-timeline-desc">' + escapeHtml(inc.description) + '</div>';
     }
-    hHtml += '<button class="incident-timeline-pdf-btn" onclick="downloadIncidentPdf(' + inc.id + ', \'' + escapeHtml(inc.name).replace(/'/g, "\\'") + '\')">';
-    hHtml += '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg> ';
-    hHtml += (T.incident_download_pdf || 'Download PDF Report');
-    hHtml += '</button>';
     header.innerHTML = hHtml;
+    var pdfBtn = document.createElement('button');
+    pdfBtn.type = 'button';
+    pdfBtn.className = 'incident-timeline-pdf-btn';
+    renderIncidentPdfButton(pdfBtn);
+    pdfBtn.addEventListener('click', function() {
+        downloadIncidentPdf(inc.id, inc.name);
+    });
+    header.appendChild(pdfBtn);
 
     // -- 2. Journal Entries as Cards --
     var entriesDiv = document.getElementById('incident-timeline-entries');

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v89';
+var CACHE_VERSION = 'v90';
 var REGISTRATION_SCOPE = new URL(self.registration.scope);
 
 if (REGISTRATION_SCOPE.origin !== self.location.origin || REGISTRATION_SCOPE.pathname.slice(-1) !== '/') {

--- a/tests/js/journal-security.test.js
+++ b/tests/js/journal-security.test.js
@@ -1,0 +1,294 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(
+    path.resolve(__dirname, '../../app/modules/journal/static/main.js'),
+    'utf8'
+);
+
+function functionBody(name, nextName) {
+    const start = source.indexOf(`function ${name}(`);
+    const end = source.indexOf(`function ${nextName}(`, start + 1);
+    assert.notEqual(start, -1, `${name} must exist`);
+    assert.notEqual(end, -1, `${nextName} must follow ${name}`);
+    return source.slice(start, end);
+}
+
+test('Journal attachments do not interpolate data into executable HTML', () => {
+    const attachments = functionBody('renderAttachments', 'saveEntry');
+
+    assert.doesNotMatch(attachments, /item\.innerHTML\s*=/);
+    assert.doesNotMatch(attachments, /\.(?:innerHTML|outerHTML)\s*=|insertAdjacentHTML|\bonclick\b/);
+});
+
+test('Journal PDF actions do not interpolate incident names into inline handlers', () => {
+    const timeline = functionBody('renderIncidentTimeline', '_renderTimelineChart');
+
+    assert.doesNotMatch(timeline, /onclick=["']downloadIncidentPdf/);
+});
+
+const hostile = String.raw`'"\\'"\\');globalThis.injected = true;//<img src=x onerror="globalThis.injected=true">&quot;`.repeat(3);
+
+// This DOM records HTML sinks without parsing them. Unexpected HTML construction
+// fails immediately; listener dispatch never evaluates strings. URL properties
+// record the assigned value (browser URL normalization is outside this test).
+function journalHarness() {
+    const nodes = new Map();
+    const created = [];
+    const htmlWrites = [];
+    class Element {
+        constructor(tagName) {
+            this.tagName = tagName;
+            this.children = [];
+            this.className = '';
+            this.style = {};
+            this.listeners = new Map();
+            this.disabled = false;
+            this.clickCount = 0;
+            this._text = '';
+        }
+        set textContent(value) {
+            this._text = String(value);
+            this.children = [];
+        }
+        get textContent() {
+            return this._text + this.children.map(child => child.textContent).join('');
+        }
+        set innerHTML(value) {
+            assert.doesNotMatch(value, /<[^>]*\son\w+\s*=/i, 'HTML must not contain inline handlers');
+            assert.ok(
+                value === '' || this.allowHeaderHTML || this.allowChartHTML ||
+                (this.className === 'incident-timeline-pdf-btn' && value.startsWith('<svg ')),
+                'Attachment data must not reach an HTML sink'
+            );
+            htmlWrites.push({node: this, value});
+            this._text = '';
+            this.children = [];
+        }
+        get innerHTML() {
+            assert.fail('Do not read DOM-produced HTML for later restoration');
+        }
+        appendChild(child) {
+            this.children.push(child);
+            return child;
+        }
+        addEventListener(type, listener) {
+            assert.equal(typeof listener, 'function');
+            this.listeners.set(type, [...(this.listeners.get(type) || []), listener]);
+        }
+        click() {
+            if (this.disabled) return;
+            this.clickCount++;
+            for (const listener of this.listeners.get('click') || []) {
+                listener.call(this, {type: 'click', target: this});
+            }
+        }
+        querySelector(selector) {
+            for (const child of this.children) {
+                if (selector === '.' + child.className) return child;
+                const match = child.querySelector?.(selector);
+                if (match) return match;
+            }
+            return null;
+        }
+    }
+    const document = {
+        createElement(tagName) {
+            const node = new Element(tagName);
+            created.push(node);
+            return node;
+        },
+        createTextNode(value) { return {textContent: String(value)}; },
+        getElementById(id) { return nodes.get(id) || null; },
+        querySelector(selector) {
+            for (const node of nodes.values()) {
+                const match = node.querySelector(selector);
+                if (match) return match;
+            }
+            return null;
+        },
+        addEventListener() {}
+    };
+    const context = vm.createContext({
+        document,
+        T: {},
+        URLSearchParams,
+        // Keep hostile values intact to test the rendering boundary even when
+        // upstream URL validation would reject them in the application.
+        docsightUrl: value => '/docsight' + value,
+        escapeHtml: value => String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+        fetch: () => assert.fail('Unexpected fetch'),
+        showToast: () => assert.fail('Unexpected toast')
+    });
+    context.window = context;
+    vm.runInContext(source, context, {filename: 'journal/main.js'});
+    for (const id of ['header', 'entries', 'chart-card', 'signals', 'bnetz']) {
+        nodes.set('incident-timeline-' + id, document.createElement('div'));
+    }
+    nodes.get('incident-timeline-header').allowHeaderHTML = true;
+    const chart = document.createElement('div');
+    chart.className = 'incident-timeline-chart-wrap';
+    chart.allowChartHTML = true;
+    nodes.get('incident-timeline-chart-card').appendChild(chart);
+    return {context, document, nodes, created, htmlWrites};
+}
+
+test('attachment DOM preserves hostile names, URL properties, icons and original delete arguments', () => {
+    const {context, document, htmlWrites, created} = journalHarness();
+    const container = document.createElement('div');
+    container.appendChild(document.createElement('stale'));
+    const incidentId = 'incident-' + hostile;
+    const attachments = ['image/png', 'application/pdf', 'text/plain', null].map((mime_type, index) => ({
+        id: index === 3 ? 123 : 'attachment-' + index + hostile,
+        filename: 'file-' + index + hostile,
+        mime_type
+    }));
+    const deleted = [];
+    context.deleteAttachment = (...args) => deleted.push(args);
+    context.renderAttachments(attachments, container, incidentId);
+
+    assert.equal(container.children.length, attachments.length);
+    attachments.forEach((att, index) => {
+        const item = container.children[index];
+        assert.equal(item.className, 'attachment-item');
+        const [thumb, info] = item.children;
+        if (index === 0) {
+            assert.equal(thumb.tagName, 'img');
+            assert.equal(thumb.className, 'attachment-thumb');
+            assert.equal(thumb.src, '/docsight/api/attachments/' + att.id);
+            assert.equal(thumb.alt, '');
+        } else {
+            assert.equal(thumb.className, 'attachment-icon');
+            assert.equal(thumb.textContent, index === 1 ? '\u{1F4C4}' : '\u{1F5CE}');
+        }
+        assert.equal(info.className, 'attachment-info');
+        const [name, actions] = info.children;
+        assert.equal(name.className, 'attachment-name');
+        assert.equal(name.textContent, att.filename);
+        assert.equal(name.children.length, 0);
+        assert.equal(actions.className, 'attachment-actions');
+        const [download, remove] = actions.children;
+        assert.equal(download.tagName, 'a');
+        assert.equal(download.href, '/docsight/api/attachments/' + att.id);
+        assert.equal(download.download, '');
+        assert.equal(download.title, 'Download');
+        assert.equal(download.textContent, '\u2B07');
+        assert.equal(remove.tagName, 'button');
+        assert.equal(remove.type, 'button');
+        assert.equal(remove.title, 'Delete');
+        assert.equal(remove.textContent, '\u{1F5D1}');
+        assert.equal(remove.listeners.get('click').length, 1);
+    });
+    assert.deepEqual(deleted, []);
+    // Reverse order catches listeners accidentally sharing the last attachment.
+    for (const item of [...container.children].reverse()) item.children[1].children[1].children[1].click();
+    assert.deepEqual(deleted, [...attachments].reverse().map(att => [att.id, incidentId]));
+    assert.equal(htmlWrites.length, 0);
+    assert.ok(created.every(node => node.onclick === undefined));
+    assert.equal(context.injected, undefined);
+    context.renderAttachments([], container, incidentId);
+    assert.equal(container.children.length, 0);
+});
+
+test('PDF buttons pass raw hostile and numeric incident values through click listeners', () => {
+    const {context, document, nodes, htmlWrites} = journalHarness();
+    const downloads = [];
+    context.downloadIncidentPdf = (...args) => downloads.push(args);
+    context.T.incident_download_pdf = 'PDF label ' + hostile;
+    for (const id of ['incident-' + hostile, 42]) {
+        const inc = {id, name: 'incident name ' + hostile, status: 'open'};
+        context.renderIncidentTimeline({incident: inc});
+        const header = nodes.get('incident-timeline-header');
+        assert.equal(header.children.length, 1, 'Rerender must replace the previous PDF button');
+        const button = document.querySelector('.incident-timeline-pdf-btn');
+        assert.ok(button, 'PDF action must be a DOM-created button');
+        assert.equal(button.tagName, 'button');
+        assert.equal(button.type, 'button');
+        assert.equal(button.onclick, undefined);
+        assert.equal(button.textContent, ' ' + context.T.incident_download_pdf);
+        assert.equal(button.listeners.get('click').length, 1);
+        button.click();
+        assert.deepEqual(downloads.at(-1), [inc.id, inc.name]);
+    }
+    for (const {node, value} of htmlWrites) {
+        if (node === nodes.get('incident-timeline-header')) {
+            assert.ok(value.includes(context.escapeHtml('incident name ' + hostile)));
+            assert.ok(!value.includes('incident-' + hostile));
+            assert.doesNotMatch(value, /<button|downloadIncidentPdf/);
+        } else {
+            assert.ok(!value.includes(hostile));
+        }
+    }
+    assert.equal(downloads.length, 2);
+    assert.equal(context.injected, undefined);
+});
+
+for (const outcome of ['success', 'http-error', 'network-error']) {
+    test(`PDF download restores static SVG and text safely after ${outcome}`, async () => {
+        const {context, document, nodes, created, htmlWrites} = journalHarness();
+        // Exercise download completion independently of timeline construction.
+        const button = document.createElement('button');
+        button.className = 'incident-timeline-pdf-btn';
+        button.textContent = 'Untrusted DOM content ' + hostile;
+        nodes.get('incident-timeline-header').appendChild(button);
+        context.T.incident_download_pdf = outcome === 'success' ? 'Translated ' + hostile : '';
+        const clicks = [];
+        button.addEventListener('click', () => clicks.push('clicked'));
+        const queries = {lang: 'de', name: hostile, number: 'customer-42', address: 'Somewhere & here'};
+        for (const [key, value] of Object.entries(queries)) nodes.set('report-' + key, {value});
+        const requests = [];
+        let finishFetch;
+        context.fetch = url => {
+            requests.push(url);
+            return new Promise((resolve, reject) => {
+                finishFetch = () => outcome === 'network-error'
+                    ? reject(new Error('offline'))
+                    : resolve({ok: outcome === 'success', blob: async () => 'pdf-blob'});
+            });
+        };
+        const blobs = [], revoked = [], toasts = [];
+        context.URL = {
+            createObjectURL: blob => { blobs.push(blob); return 'blob:report'; },
+            revokeObjectURL: url => revoked.push(url)
+        };
+        context.showToast = (...args) => toasts.push(args);
+        const incidentId = 'incident-' + hostile;
+        const incidentName = 'name-' + hostile;
+        context.downloadIncidentPdf(incidentId, incidentName);
+        assert.equal(button.disabled, true);
+        assert.equal(button.textContent, '\u23F3');
+        assert.deepEqual(requests, ['/docsight/api/incidents/' + incidentId + '/report?' + new URLSearchParams(queries)]);
+        finishFetch();
+        await new Promise(resolve => setImmediate(resolve));
+
+        assert.equal(button.disabled, false);
+        assert.equal(button.textContent, ' ' + (context.T.incident_download_pdf || 'Download PDF Report'));
+        assert.equal(htmlWrites.length, 1);
+        assert.equal(htmlWrites[0].node, button);
+        assert.match(htmlWrites[0].value, /^<svg .*width="16" height="16"/);
+        assert.match(htmlWrites[0].value, /<path .*<polyline .*<line .*<\/svg>$/);
+        assert.ok(!htmlWrites[0].value.includes(hostile));
+        button.click();
+        assert.deepEqual(clicks, ['clicked'], 'Restoring content must preserve the listener');
+        const anchors = created.filter(node => node.tagName === 'a');
+        if (outcome === 'success') {
+            assert.equal(anchors.length, 1);
+            assert.equal(anchors[0].href, 'blob:report');
+            assert.equal(anchors[0].clickCount, 1);
+            assert.equal(anchors[0].download, 'DOCSight_Beschwerde_' + incidentName.replace(/[^a-zA-Z0-9]/g, '_') + '_' + new Date().toISOString().slice(0, 10) + '.pdf');
+            assert.deepEqual(blobs, ['pdf-blob']);
+            assert.deepEqual(revoked, ['blob:report']);
+            assert.deepEqual(toasts, []);
+        } else {
+            assert.equal(anchors.length, 0);
+            assert.deepEqual(revoked, []);
+            assert.deepEqual(toasts, [['Error generating report', 'error']]);
+        }
+        assert.equal(context.injected, undefined);
+    });
+}

--- a/tests/test_browser_url_contract.py
+++ b/tests/test_browser_url_contract.py
@@ -26,7 +26,7 @@ EXPECTED_CONTRACT_CALLS = {
     "app/static/js/glossary.js": 1,
     "app/static/js/hero-chart.js": 1,
     "app/static/js/integrations.js": 5,
-    "app/modules/journal/static/main.js": 22,
+    "app/modules/journal/static/main.js": 21,
     "app/static/js/notices.js": 1,
     "app/static/js/segment-utilization.js": 2,
     "app/static/js/settings.js": 25,
@@ -382,7 +382,7 @@ def test_inventoried_files_keep_the_reviewed_contract_sites():
     }
 
     assert actual == EXPECTED_CONTRACT_CALLS
-    assert sum(actual.values()) == 135  # reviewed browser URL contract sites
+    assert sum(actual.values()) == 134  # reviewed browser URL contract sites
 
 
 def test_inventoried_actual_literal_forms_have_no_unwrapped_url_sink():

--- a/tests/test_dashboard_module_ownership.py
+++ b/tests/test_dashboard_module_ownership.py
@@ -98,4 +98,4 @@ def test_unconfigured_modules_keep_setup_without_empty_views(dashboard, prefix):
 
 
 def test_module_asset_cache_generation():
-    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v89';")
+    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v90';")


### PR DESCRIPTION
## Summary

- Builds Journal attachment rows with DOM nodes, text properties, and event listeners instead of interpolated HTML.
- Builds the incident PDF action separately from timeline markup while preserving exact IDs, names, report completion, and error handling.
- Bumps the PWA cache generation so existing installations fetch the corrected Journal script.

This is a focused security follow-up to #826 and resolves the two open Journal DOM-XSS findings created when the script moved into its module-owned path.

## Security behavior

- Attachment filenames remain text, not markup.
- Attachment and incident identifiers remain listener arguments, not inline JavaScript.
- Prefix-aware attachment URLs continue to use the shared URL contract.
- No finding is dismissed or suppressed.

## Validation

- [x] 7 hostile-payload Journal security tests
- [x] JavaScript suite: 34 tests
- [x] Python suite: 4114 passed, 2 skipped
- [x] Static and browser URL contracts: 112 tests
- [x] Module/PWA contracts: 36 tests
- [x] Module browser journeys: 2 tests
- [x] PWA browser gate: 5 tests
- [x] Whitespace and JavaScript syntax checks

## Scope

No API, data-model, UI-layout, translation, or documentation changes.
