### PR TITLE
Separate web authentication responsibilities

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -50,7 +50,7 @@ jobs:
               - 'app/templates/**'
               - 'app/static/**'
               - 'app/modules/**'
-              - 'app/web.py'
+              - 'app/web*.py'
               - 'app/blueprints/**'
               - 'app/tz.py'
               - 'app/i18n/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
               - 'app/templates/**'
               - 'app/static/**'
               - 'app/modules/**'
-              - 'app/web.py'
+              - 'app/web*.py'
               - 'app/blueprints/**'
               - 'app/tz.py'
               - 'app/i18n/**'

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,8 +53,8 @@ Each application owns a typed `DocsightRuntime` at
 `app.extensions["docsight"]`. It contains the configuration manager, storage,
 authentication state, rate limiter, update checker, module loader, collector
 references, derived-storage cache, and lock-protected dashboard state. Route
-and module code reaches the current application through the accessors in
-`app.web`; it must not retain app-specific values in module globals.
+and module code uses `app.web` runtime accessors; auth policy and factory bootstrap
+use `app.web_auth`, which accesses runtime directly and never imports `app.web`.
 
 Collector threads receive the same runtime explicitly through the existing
 `web=` duck-type parameter. The runtime implements `update_state()`,
@@ -860,7 +860,7 @@ CREATE TABLE de_tkg_claim_drafts (
 
 **Framework:** Flask  
 **Port:** 8765 (configurable)  
-**Auth:** Optional password protection (bcrypt hashing) + API token authentication (Bearer tokens)
+**Auth:** `app.web_auth` owns optional password protection (scrypt/pbkdf2), login CSRF/rate limits, persisted session policy, and Bearer authentication; `app.web` orchestrates login/logout routes.
 
 ### API Endpoints
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ app/
   module_contributions.py - Module filesystem/import/JSON contribution preflight
   main.py            - Entrypoint, ThreadPoolExecutor polling loop
   runtime.py         - Typed per-application runtime state and locks
-  web.py             - Core routes, filters, auth, and runtime accessors
+  web.py             - Core routes, filters, and runtime accessors
   analyzer.py        - DOCSIS channel health analysis
   threshold_profiles.py - Built-in analyzer threshold profiles
   event_detector.py  - Signal anomaly detection (thread-safe)
@@ -200,10 +200,10 @@ initialization hook (for example `window.initExampleView`) and wire it into the
 existing dashboard routing convention. Guard absent view elements and ensure
 repeated activation does not accumulate listeners, timers, or fetch loops.
 
-Server-side module code should import the established accessors it needs from
-`app.web`, such as `get_config_manager()`, `get_storage()`, `get_state()`, or
-`get_module_loader()`. These accessors resolve the active application's typed
-runtime. Do not import or create a module-level Flask application, and do not
+Community modules must keep using the stable, supported `app.web` imports:
+`require_auth`, `get_config_manager`, `get_storage`, `get_state`, and `get_module_loader`.
+Built-in modules use `app.web_auth` for authentication policy. Runtime accessors
+resolve the active application's runtime. Do not import or create a module-level Flask app or
 cache app-derived storage or mutable request/runtime state in module globals.
 Collectors receive their runtime-facing `web` object explicitly and must keep
 working without a Flask application context.

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -11,7 +11,7 @@ from typing import Any
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from . import web
+from . import web, web_auth
 from .base_path import configure_base_path
 from .module_loader import ModuleLoader
 from .registration import (
@@ -119,7 +119,7 @@ def create_app(
     app.config.update(
         SESSION_COOKIE_HTTPONLY=True,
         SESSION_COOKIE_SAMESITE="Lax",
-        PERMANENT_SESSION_LIFETIME=timedelta(days=web._session_lifetime_days(env)),
+        PERMANENT_SESSION_LIFETIME=timedelta(days=web_auth._session_lifetime_days(env)),
         SESSION_REFRESH_EACH_REQUEST=True,
         TESTING=testing,
     )
@@ -133,10 +133,10 @@ def create_app(
         on_config_changed=on_config_changed,
         auth_state=auth_state,
         login_rate_limiter=LoginRateLimiter(
-            max_attempts=web._LOGIN_MAX_ATTEMPTS,
-            window=web._LOGIN_WINDOW,
-            lockout_base=web._LOGIN_LOCKOUT_BASE,
-            max_tracked_ips=web._LOGIN_MAX_TRACKED_IPS,
+            max_attempts=web_auth._LOGIN_MAX_ATTEMPTS,
+            window=web_auth._LOGIN_WINDOW,
+            lockout_base=web_auth._LOGIN_LOCKOUT_BASE,
+            max_tracked_ips=web_auth._LOGIN_MAX_TRACKED_IPS,
         ),
         update_checker=UpdateChecker(
             app_version=web.APP_VERSION,
@@ -145,7 +145,7 @@ def create_app(
         ),
     )
     attach_runtime(app, runtime)
-    web.bootstrap_auth_state(app, runtime)
+    web_auth.bootstrap_auth_state(app, runtime)
     register_plan(app, complete_plan)
     web.install_core_template_hooks(app)
     runtime.module_loader = loader

--- a/app/blueprints/analysis_bp.py
+++ b/app/blueprints/analysis_bp.py
@@ -9,10 +9,10 @@ from app.analyzer import get_thresholds
 from app.time_ranges import parse_time_range_hours
 from app.tz import utc_now, utc_cutoff
 from app.web import (
-    require_auth,
     get_storage, get_config_manager, get_state,
     _localize_timestamps,
 )
+from app.web_auth import require_auth
 from app.gaming_index import compute_gaming_index
 
 log = logging.getLogger("docsis.web")

--- a/app/blueprints/config_bp.py
+++ b/app/blueprints/config_bp.py
@@ -8,10 +8,12 @@ from zoneinfo import ZoneInfo
 from flask import Blueprint, request, jsonify
 
 from app.web import (
-    require_auth, _require_session_auth, _admin_password_matches,
-    _invalidate_admin_sessions, _secret_values_match,
     get_config_manager, get_storage, get_on_config_changed,
-    _get_client_ip, _localize_timestamps,
+    _localize_timestamps,
+)
+from app.web_auth import (
+    require_auth, _require_session_auth, _admin_password_matches,
+    _invalidate_admin_sessions, _secret_values_match, _get_client_ip,
 )
 from app.config import (
     PASSWORD_MASK,

--- a/app/blueprints/data_bp.py
+++ b/app/blueprints/data_bp.py
@@ -8,10 +8,10 @@ from flask import Blueprint, request, jsonify
 
 from app.time_ranges import parse_time_range_hours
 from app.web import (
-    require_auth,
     get_storage, get_config_manager, get_state,
     _localize_timestamps,
 )
+from app.web_auth import require_auth
 
 log = logging.getLogger("docsis.web")
 

--- a/app/blueprints/events_bp.py
+++ b/app/blueprints/events_bp.py
@@ -9,10 +9,10 @@ from datetime import datetime, timezone
 from flask import Blueprint, request, jsonify, Response
 
 from app.web import (
-    require_auth,
     get_storage,
     _localize_timestamps,
 )
+from app.web_auth import require_auth
 
 log = logging.getLogger("docsis.web")
 

--- a/app/blueprints/modules_bp.py
+++ b/app/blueprints/modules_bp.py
@@ -18,7 +18,8 @@ from app.module_loader import (
 from app.module_paths import get_modules_dir
 from app.path_safety import safe_child_path
 from app.theme_registry import download_theme, fetch_registry as fetch_theme_registry
-from app.web import get_config_manager, get_module_loader, require_auth
+from app.web import get_config_manager, get_module_loader
+from app.web_auth import require_auth
 
 log = logging.getLogger("docsis.modules")
 

--- a/app/blueprints/notices_bp.py
+++ b/app/blueprints/notices_bp.py
@@ -9,7 +9,8 @@ from app.maintainer_notices import (
     get_active_notices,
     is_valid_notice_id,
 )
-from app.web import get_config_manager, require_auth
+from app.web import get_config_manager
+from app.web_auth import require_auth
 
 notices_bp = Blueprint("notices_bp", __name__)
 

--- a/app/blueprints/polling_bp.py
+++ b/app/blueprints/polling_bp.py
@@ -6,11 +6,11 @@ import time
 from flask import Blueprint, request, jsonify
 
 from app.web import (
-    require_auth,
     get_config_manager, get_storage, get_modem_collector, get_collectors,
     get_last_manual_poll, set_last_manual_poll,
     _get_lang,
 )
+from app.web_auth import require_auth
 from app.config import PASSWORD_MASK, parse_config_bool
 from app.i18n import get_translations
 

--- a/app/blueprints/segment_bp.py
+++ b/app/blueprints/segment_bp.py
@@ -7,7 +7,8 @@ from flask import Blueprint, jsonify, request
 
 from app.i18n import get_translations
 from app.storage.segment_utilization import SegmentUtilizationStorage
-from app.web import get_config_manager, get_storage, require_auth
+from app.web import get_config_manager, get_storage
+from app.web_auth import require_auth
 from app.runtime import current_runtime
 
 log = logging.getLogger("docsis.web.segment")

--- a/app/blueprints/smart_capture_bp.py
+++ b/app/blueprints/smart_capture_bp.py
@@ -2,7 +2,8 @@
 
 from flask import Blueprint, jsonify, request
 
-from ..web import require_auth, get_storage
+from ..web import get_storage
+from ..web_auth import require_auth
 
 smart_capture_bp = Blueprint("smart_capture", __name__)
 

--- a/app/modules/backup/routes.py
+++ b/app/modules/backup/routes.py
@@ -11,10 +11,9 @@ from datetime import datetime
 from flask import Blueprint, request, jsonify, redirect, send_file, url_for
 
 from app.web import (
-    require_auth, _auth_required,
     get_config_manager, get_on_config_changed,
-    _get_client_ip,
 )
+from app.web_auth import require_auth, _auth_required, _get_client_ip
 from app.runtime import current_runtime
 
 from werkzeug.utils import secure_filename

--- a/app/modules/bnetz/routes.py
+++ b/app/modules/bnetz/routes.py
@@ -5,7 +5,8 @@ from io import BytesIO
 
 from flask import Blueprint, request, jsonify, send_file
 
-from app.web import require_auth, get_storage, _get_client_ip, _get_lang
+from app.web import get_storage, _get_lang
+from app.web_auth import require_auth, _get_client_ip
 from app.runtime import current_runtime
 from app.storage import MAX_ATTACHMENT_SIZE
 from app.i18n import get_translations

--- a/app/modules/bqm/routes.py
+++ b/app/modules/bqm/routes.py
@@ -7,9 +7,9 @@ from urllib.parse import urlparse
 from flask import Blueprint, request, jsonify, make_response
 
 from app.web import (
-    require_auth,
-    get_storage, get_config_manager, _valid_date, _get_client_ip, _get_tz_name,
+    get_storage, get_config_manager, _valid_date, _get_tz_name,
 )
+from app.web_auth import require_auth, _get_client_ip
 from app.runtime import current_runtime
 from app.tz import local_today, utc_now
 

--- a/app/modules/comparison/routes.py
+++ b/app/modules/comparison/routes.py
@@ -9,7 +9,8 @@ from app.aggregation import (
     report_bounds,
 )
 from app.analyzer import threshold_snapshot
-from app.web import get_storage, require_auth
+from app.web import get_storage
+from app.web_auth import require_auth
 
 bp = Blueprint("comparison_module", __name__)
 

--- a/app/modules/connection_monitor/routes.py
+++ b/app/modules/connection_monitor/routes.py
@@ -13,7 +13,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from flask import Blueprint, jsonify, request, Response
 
 from app.tz import local_date_to_utc_range, local_today, to_local_display, _parse_utc
-from app.web import get_config_manager, require_auth, _get_tz_name
+from app.web import get_config_manager, _get_tz_name
+from app.web_auth import require_auth
 from app.runtime import current_runtime
 
 from .probe import ProbeEngine

--- a/app/modules/de_tkg_compensation/routes.py
+++ b/app/modules/de_tkg_compensation/routes.py
@@ -11,7 +11,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from flask import Blueprint, jsonify, request, send_file
 
 from app.tz import get_tz_name, local_to_utc, local_today
-from app.web import get_config_manager, get_module_loader, get_storage, require_auth
+from app.web import get_config_manager, get_module_loader, get_storage
+from app.web_auth import require_auth
 
 from .candidates import (
     CONNECTION_CANDIDATE_LOOKBACK_DAYS,

--- a/app/modules/evidence/routes.py
+++ b/app/modules/evidence/routes.py
@@ -21,7 +21,8 @@ from app.analyzer import threshold_snapshot
 from app.modules.journal.storage import JournalStorage
 from app.storage.sqlite import open_read
 from app.tz import get_tz_name, local_date_to_utc_range, local_to_utc, local_today
-from app.web import get_config_manager, get_storage, require_auth
+from app.web import get_config_manager, get_storage
+from app.web_auth import require_auth
 
 from .checklist import build_checklist, summarize_checklist
 

--- a/app/modules/journal/routes.py
+++ b/app/modules/journal/routes.py
@@ -12,10 +12,10 @@ from flask import Blueprint, request, jsonify, send_file, make_response
 
 from app.tz import local_date_to_utc_range
 from app.web import (
-    require_auth,
     get_config_manager, get_state, get_storage,
-    _valid_date, _localize_timestamps, _get_client_ip, _get_lang, _get_tz_name,
+    _valid_date, _localize_timestamps, _get_lang, _get_tz_name,
 )
+from app.web_auth import require_auth, _get_client_ip
 from app.storage import ALLOWED_MIME_TYPES, MAX_ATTACHMENT_SIZE, MAX_ATTACHMENTS_PER_ENTRY
 
 from .import_parser import parse_file

--- a/app/modules/modulation/routes.py
+++ b/app/modules/modulation/routes.py
@@ -6,7 +6,8 @@ from datetime import datetime, timedelta, timezone
 from flask import Blueprint, request, jsonify
 
 from app.tz import to_local, utc_now, utc_cutoff
-from app.web import require_auth, get_storage, get_config_manager, get_state
+from app.web import get_storage, get_config_manager, get_state
+from app.web_auth import require_auth
 
 from .engine import (
     compute_capacity_history,

--- a/app/modules/reports/routes.py
+++ b/app/modules/reports/routes.py
@@ -12,8 +12,8 @@ from app.web import (
     get_config_manager,
     get_state,
     get_storage,
-    require_auth,
 )
+from app.web_auth import require_auth
 
 from .report import generate_complaint_text, generate_report
 

--- a/app/modules/smokeping/routes.py
+++ b/app/modules/smokeping/routes.py
@@ -7,9 +7,9 @@ import requests as _requests
 from flask import Blueprint, jsonify, make_response
 
 from app.web import (
-    require_auth,
     get_config_manager,
 )
+from app.web_auth import require_auth
 
 log = logging.getLogger("docsis.web")
 

--- a/app/modules/speedtest/routes.py
+++ b/app/modules/speedtest/routes.py
@@ -7,7 +7,8 @@ import requests
 from flask import Blueprint, request, jsonify
 
 from app.config import parse_config_bool
-from app.web import require_auth, get_config_manager, get_state, get_storage, clear_speedtest_latest
+from app.web import get_config_manager, get_state, get_storage, clear_speedtest_latest
+from app.web_auth import require_auth
 from app.runtime import current_runtime
 from app.i18n import get_translations
 from app.storage.sqlite import open_read

--- a/app/modules/weather/routes.py
+++ b/app/modules/weather/routes.py
@@ -4,7 +4,8 @@ import logging
 
 from flask import Blueprint, request, jsonify
 
-from app.web import require_auth, get_config_manager, get_state, get_storage
+from app.web import get_config_manager, get_state, get_storage
+from app.web_auth import require_auth
 from app.runtime import current_runtime
 from .storage import WeatherStorage
 

--- a/app/web.py
+++ b/app/web.py
@@ -1,22 +1,18 @@
 """Flask web UI for DOCSight – DOCSIS channel monitoring."""
 
-import functools
 import json
 import logging
 import math
 import os
 import re
-import secrets
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from urllib.parse import urlencode
 
-from cryptography.hazmat.primitives import hashes, hmac
 from flask import current_app, render_template, request, jsonify, redirect, session, send_from_directory, url_for
 from markupsafe import Markup
-from werkzeug.security import check_password_hash
 from zoneinfo import available_timezones
 
 from .config import DEFAULTS, MODULE_SECRET_KEYS, PASSWORD_MASK, POLL_MIN, POLL_MAX
@@ -37,6 +33,7 @@ from .module_loader import module_static_url
 from .runtime import current_runtime, _version_newer as _runtime_version_newer
 from .tz import guess_iana_timezone as _guess_iana_timezone, get_tz_name as _get_public_tz_name, to_local as _to_local
 from .version import get_app_version
+from .web_auth import require_auth, _get_admin_password, _authenticate_login, _get_login_csrf_token, _sync_auth_state
 
 _IANA_REGIONS = {"Africa", "America", "Antarctica", "Arctic", "Asia",
                  "Atlantic", "Australia", "Europe", "Indian", "Pacific"}
@@ -55,7 +52,6 @@ def _server_tz_info():
     return name, offset_min
 
 log = logging.getLogger("docsis.web")
-audit_log = logging.getLogger("docsis.audit")
 
 DESKTOP_PREVIEW_NOTICE_ID = "docsight-desktop-preview-v0"
 DESKTOP_PREVIEW_DOC_URL = "https://github.com/itsDNNS/docsight/blob/main/docs/windows-desktop-preview.md"
@@ -142,63 +138,6 @@ def _build_theme_collections(theme_modules):
         })
 
     return collections
-
-_LOGIN_MAX_ATTEMPTS = 5
-_LOGIN_WINDOW = 900  # 15 min
-_LOGIN_LOCKOUT_BASE = 30  # seconds, doubles each excess attempt
-_LOGIN_MAX_TRACKED_IPS = 2048
-_LOGIN_CSRF_SESSION_KEY = "login_csrf_token"
-_AUTH_MARKER_SESSION_KEY = "auth_marker"
-_AUTH_MARKER_CONTEXT = b"docsight-admin-session-v1\0"
-_AUTH_STATE_CONTEXT = b"docsight-admin-auth-state-v1\0"
-_AUTH_STATE_FILENAME = ".auth_state"
-_SESSION_LIFETIME_DEFAULT_DAYS = 30
-_SESSION_LIFETIME_MIN_DAYS = 1
-_SESSION_LIFETIME_MAX_DAYS = 365
-
-
-def _get_client_ip():
-    """Get client IP from request.remote_addr.
-
-    When REVERSE_PROXY is configured, Werkzeug's ProxyFix middleware
-    rewrites remote_addr from trusted X-Forwarded-For headers before
-    the request reaches Flask.  Without ProxyFix the raw TCP peer
-    address is used, which prevents X-Forwarded-For spoofing.
-    """
-    return request.remote_addr or "unknown"
-
-
-def _prune_login_attempts(now=None):
-    """Drop expired and oldest login-attempt buckets to keep memory bounded."""
-    current_runtime().login_rate_limiter.prune(now)
-
-
-def _check_login_rate_limit(ip):
-    """Return seconds until retry allowed, or 0 if not limited."""
-    return current_runtime().login_rate_limiter.retry_after(ip)
-
-
-def _record_failed_login(ip):
-    """Record a failed login attempt."""
-    current_runtime().login_rate_limiter.record_failure(ip)
-
-
-def _get_login_csrf_token():
-    """Return the session-bound token used by the login form."""
-    token = session.get(_LOGIN_CSRF_SESSION_KEY)
-    if not token:
-        token = secrets.token_urlsafe(32)
-        session[_LOGIN_CSRF_SESSION_KEY] = token
-    return token
-
-
-def _valid_login_csrf_token(candidate):
-    """Validate the submitted login CSRF token against the session token."""
-    token = session.get(_LOGIN_CSRF_SESSION_KEY)
-    return bool(
-        token and candidate
-        and secrets.compare_digest(token.encode("utf-8"), candidate.encode("utf-8"))
-    )
 
 APP_VERSION = get_app_version()
 
@@ -461,249 +400,27 @@ def set_last_manual_poll(value):
     current_runtime().set_last_manual_poll(value)
 
 
-def _rotate_session_key():
-    """Persist and activate a new signing key, invalidating all old cookies."""
-    key = current_runtime().auth_state.rotate_session_key()
-    # In-memory activation assumes today's single-process waitress deployment;
-    # a future multi-worker server must coordinate shared signing-key rotation.
-    current_app.secret_key = key
-
-
-def _session_lifetime_days(environ: Mapping[str, str] | None = None):
-    """Return the safe, bounded operator-configured session lifetime."""
-    env = os.environ if environ is None else environ
-    configured = env.get("SESSION_LIFETIME_DAYS", "").strip()
-    if not configured:
-        return _SESSION_LIFETIME_DEFAULT_DAYS
-    try:
-        days = int(configured)
-    except (TypeError, ValueError):
-        log.warning(
-            "Invalid SESSION_LIFETIME_DAYS; using %d days",
-            _SESSION_LIFETIME_DEFAULT_DAYS,
-        )
-        return _SESSION_LIFETIME_DEFAULT_DAYS
-    return max(_SESSION_LIFETIME_MIN_DAYS, min(_SESSION_LIFETIME_MAX_DAYS, days))
-
-def _keyed_sha256_hexdigest(key: bytes, message: bytes) -> str:
-    """Return the HMAC-SHA256 of message as lowercase hexadecimal."""
-    mac = hmac.HMAC(key, hashes.SHA256())
-    mac.update(message)
-    return mac.finalize().hex()
-
-
-def _secret_values_match(left, right):
-    """Compare secret representations without timing-sensitive equality."""
-    return secrets.compare_digest(
-        str(left or "").encode(), str(right or "").encode()
-    )
-
-
-def _admin_password_matches(effective_password, candidate):
-    """Safely check whether candidate represents the current admin password."""
-    effective_password = str(effective_password or "")
-    candidate = str(candidate or "")
-    if effective_password.startswith(("scrypt:", "pbkdf2:")):
-        try:
-            return check_password_hash(effective_password, candidate)
-        except (TypeError, ValueError):
-            return False
-    return _secret_values_match(effective_password, candidate)
-
-
-def _auth_state_fingerprint(password_representation=None):
-    """Return a keyed fingerprint of the effective admin-password state."""
-    _config_manager = get_config_manager()
-    if password_representation is None:
-        password_representation = (
-            _config_manager.get("admin_password", "") if _config_manager else ""
-        )
-    key = current_app.secret_key.encode() if isinstance(current_app.secret_key, str) else current_app.secret_key
-    value = _AUTH_STATE_CONTEXT + str(password_representation or "").encode("utf-8")
-    return _keyed_sha256_hexdigest(key, value)
-
-
-def _read_auth_state():
-    return current_runtime().auth_state.read_fingerprint()
-
-
-def _write_auth_state():
-    fingerprint = _auth_state_fingerprint()
-    current_runtime().auth_state.write_fingerprint(fingerprint)
-
-
-def _init_auth_state():
-    """Create auth state or invalidate cookies after an offline state change."""
-    stored = _read_auth_state()
-    current = _auth_state_fingerprint()
-    if stored is None:
-        _write_auth_state()
-    elif not _secret_values_match(stored, current):
-        _rotate_session_key()
-        _write_auth_state()
-
-
-def bootstrap_auth_state(app, runtime):
-    """Initialize durable authentication state for a newly created app."""
-    if app.extensions.get("docsight") is not runtime:
-        raise RuntimeError("DOCSight runtime is not attached to this application")
-    with app.app_context():
-        _init_auth_state()
-
-
-def _sync_auth_state():
-    """Observe runtime auth changes and durably invalidate existing cookies."""
-    _config_manager = get_config_manager()
-    if not _config_manager:
-        return
-    stored = _read_auth_state()
-    current = _auth_state_fingerprint()
-    if stored is not None and _secret_values_match(stored, current):
-        return
-    _rotate_session_key()
-    _write_auth_state()
-
-
-def _admin_session_marker(password_representation=None):
-    """Create a keyed, non-reversible marker for the effective password state."""
-    _config_manager = get_config_manager()
-    if password_representation is None:
-        if not _config_manager:
-            return ""
-        password_representation = _config_manager.get("admin_password", "")
-    if not password_representation:
-        return ""
-    key = current_app.secret_key.encode() if isinstance(current_app.secret_key, str) else current_app.secret_key
-    value = _AUTH_MARKER_CONTEXT + str(password_representation).encode("utf-8")
-    return _keyed_sha256_hexdigest(key, value)
-
-
-def _authenticated_session_is_valid():
-    """Return True only for a password-bound authenticated browser session."""
-    if not session.get("authenticated"):
-        return False
-    actual = session.get(_AUTH_MARKER_SESSION_KEY, "")
-    expected = _admin_session_marker()
-    if actual and expected and _secret_values_match(actual, expected):
-        return True
-    session.clear()
-    return False
-
-
-def _invalidate_admin_sessions():
-    """Globally invalidate signed cookies and clear the current request session."""
-    _rotate_session_key()
-    _write_auth_state()
-    # The request cookie was loaded with the prior key. Clearing after rotation
-    # makes Flask write the logged-out session using the new key on this response.
-    session.clear()
-
-
-def _auth_required():
-    """Check if auth is enabled and user is not logged in.
-
-    Also checks for valid Bearer token in Authorization header.
-    Returns True if authentication is required but not provided.
-    """
-    _config_manager = get_config_manager()
-    _storage = get_storage()
-    if not _config_manager:
-        return False
-    _sync_auth_state()
-    admin_pw = _config_manager.get("admin_password", "")
-    if not admin_pw:
-        return False
-    if _authenticated_session_is_valid():
-        return False
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer ") and _storage:
-        token = auth_header[7:]
-        token_info = _storage.validate_api_token(token)
-        if token_info:
-            request._api_token = token_info
-            return False
-    return True
-
-
-def require_auth(f):
-    """Decorator: redirect to /login or return 401 JSON for API paths."""
-    @functools.wraps(f)
-    def decorated(*args, **kwargs):
-        if _auth_required():
-            if request.path.startswith("/api/"):
-                return jsonify({"error": "Authentication required"}), 401
-            return redirect(url_for("login"))
-        return f(*args, **kwargs)
-    return decorated
-
-
-def _require_session_auth(f):
-    """Decorator: only allow session-based login, no API tokens."""
-    @functools.wraps(f)
-    def decorated(*args, **kwargs):
-        _config_manager = get_config_manager()
-        _sync_auth_state()
-        if not _config_manager or not _config_manager.get("admin_password", ""):
-            return f(*args, **kwargs)
-        if not _authenticated_session_is_valid():
-            # Token auth is not sufficient for this endpoint
-            if getattr(request, "_api_token", None) or request.headers.get("Authorization", "").startswith("Bearer "):
-                return jsonify({"error": "Session authentication required"}), 403
-            if request.path.startswith("/api/"):
-                return jsonify({"error": "Authentication required"}), 401
-            return redirect(url_for("login"))
-        return f(*args, **kwargs)
-    return decorated
-
-
 def login():
     _config_manager = get_config_manager()
     _sync_auth_state()
-    if not _config_manager or not _config_manager.get("admin_password", ""):
+    if not _get_admin_password():
         return redirect(url_for("index"))
     lang = _get_lang()
     t = get_translations(lang)
     theme = _config_manager.get_theme() if _config_manager else "dark"
     error = None
+    status = 200
     csrf_token = _get_login_csrf_token()
     if request.method == "POST":
-        ip = _get_client_ip()
-        if not _valid_login_csrf_token(request.form.get("csrf_token", "")):
-            _record_failed_login(ip)
-            audit_log.warning("Login rejected: invalid csrf token for ip=%s", ip)
-            error = t.get("login_failed", "Invalid password")
-            return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token), 400
-        wait = _check_login_rate_limit(ip)
-        if wait > 0:
-            audit_log.warning("Login rate-limited: ip=%s (retry in %ds)", ip, int(wait))
-            error = t.get("login_rate_limited", "Too many attempts. Try again later.")
-            return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token)
-        pw = request.form.get("password", "")
-        stored = _config_manager.get("admin_password", "")
-        if stored.startswith(("scrypt:", "pbkdf2:")):
-            success = check_password_hash(stored, pw)
-        else:
-            success = _secret_values_match(pw, stored)
-            if success and not os.environ.get("ADMIN_PASSWORD"):
-                # Auto-upgrade plaintext password to hash
-                _config_manager.save({"admin_password": pw})
-                stored = _config_manager.get("admin_password", "")
-                # This is the same credential in a safer representation, so
-                # preserve the signing key while rebinding durable auth state.
-                _write_auth_state()
-                audit_log.info("Auto-upgraded plaintext password to hash for ip=%s", ip)
-        if success:
-            current_runtime().login_rate_limiter.reset(ip)
-            session.permanent = True
-            session["authenticated"] = True
-            session[_AUTH_MARKER_SESSION_KEY] = _admin_session_marker(stored)
-            session.pop(_LOGIN_CSRF_SESSION_KEY, None)
-            audit_log.info("Login successful: ip=%s", ip)
+        error_key, status = _authenticate_login()
+        if error_key is None:
             return redirect(url_for("index"))
-        _record_failed_login(ip)
-        audit_log.warning("Login failed: ip=%s", ip)
-        error = t.get("login_failed", "Invalid password")
-    return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token)
+        fallback = (
+            "Too many attempts. Try again later."
+            if error_key == "login_rate_limited" else "Invalid password"
+        )
+        error = t.get(error_key, fallback)
+    return render_template("login.html", t=t, lang=lang, theme=theme, error=error, csrf_token=csrf_token), status
 
 
 def logout():
@@ -724,7 +441,7 @@ def inject_auth():
     """Make auth_enabled and module info available in all templates."""
     _config_manager = get_config_manager()
     _module_loader = get_module_loader()
-    auth_enabled = bool(_config_manager and _config_manager.get("admin_password", ""))
+    auth_enabled = bool(_get_admin_password())
     modules = _module_loader.get_enabled_modules() if _module_loader else []
 
     # Resolve active theme module's CSS variables

--- a/app/web_auth.py
+++ b/app/web_auth.py
@@ -1,0 +1,270 @@
+"""Web authentication policy and sessions for the current application's runtime."""
+
+import functools
+import logging
+import os
+import secrets
+from collections.abc import Mapping
+
+from cryptography.hazmat.primitives import hashes, hmac
+from flask import current_app, jsonify, redirect, request, session, url_for
+from werkzeug.security import check_password_hash
+
+from .runtime import current_runtime
+
+log = logging.getLogger("docsis.web")
+audit_log = logging.getLogger("docsis.audit")
+
+_LOGIN_MAX_ATTEMPTS = 5
+_LOGIN_WINDOW = 900  # 15 min
+_LOGIN_LOCKOUT_BASE = 30  # seconds, doubles each excess attempt
+_LOGIN_MAX_TRACKED_IPS = 2048
+_LOGIN_CSRF_SESSION_KEY = "login_csrf_token"
+_AUTH_MARKER_SESSION_KEY = "auth_marker"
+_AUTH_MARKER_CONTEXT = b"docsight-admin-session-v1\0"
+_AUTH_STATE_CONTEXT = b"docsight-admin-auth-state-v1\0"
+_SESSION_LIFETIME_DEFAULT_DAYS = 30
+_SESSION_LIFETIME_MIN_DAYS = 1
+_SESSION_LIFETIME_MAX_DAYS = 365
+
+
+def _get_client_ip():
+    """Get client IP from request.remote_addr.
+
+    When REVERSE_PROXY is configured, Werkzeug's ProxyFix middleware
+    rewrites remote_addr from trusted X-Forwarded-For headers before
+    the request reaches Flask.  Without ProxyFix the raw TCP peer
+    address is used, which prevents X-Forwarded-For spoofing.
+    """
+    return request.remote_addr or "unknown"
+
+
+def _get_login_csrf_token():
+    """Return the session-bound token used by the login form."""
+    token = session.get(_LOGIN_CSRF_SESSION_KEY)
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session[_LOGIN_CSRF_SESSION_KEY] = token
+    return token
+
+
+def _valid_login_csrf_token(candidate):
+    """Validate the submitted login CSRF token against the session token."""
+    token = session.get(_LOGIN_CSRF_SESSION_KEY)
+    return bool(
+        token and candidate
+        and secrets.compare_digest(token.encode("utf-8"), candidate.encode("utf-8"))
+    )
+
+def _rotate_session_key():
+    """Persist and activate a new signing key, invalidating all old cookies."""
+    key = current_runtime().auth_state.rotate_session_key()
+    # In-memory activation assumes today's single-process waitress deployment;
+    # a future multi-worker server must coordinate shared signing-key rotation.
+    current_app.secret_key = key
+
+
+def _session_lifetime_days(environ: Mapping[str, str] | None = None):
+    """Return the safe, bounded operator-configured session lifetime."""
+    env = os.environ if environ is None else environ
+    configured = env.get("SESSION_LIFETIME_DAYS", "").strip()
+    if not configured:
+        return _SESSION_LIFETIME_DEFAULT_DAYS
+    try:
+        days = int(configured)
+    except (TypeError, ValueError):
+        log.warning(
+            "Invalid SESSION_LIFETIME_DAYS; using %d days",
+            _SESSION_LIFETIME_DEFAULT_DAYS,
+        )
+        return _SESSION_LIFETIME_DEFAULT_DAYS
+    return max(_SESSION_LIFETIME_MIN_DAYS, min(_SESSION_LIFETIME_MAX_DAYS, days))
+
+def _keyed_sha256_hexdigest(key: bytes, message: bytes) -> str:
+    """Return the HMAC-SHA256 of message as lowercase hexadecimal."""
+    mac = hmac.HMAC(key, hashes.SHA256())
+    mac.update(message)
+    return mac.finalize().hex()
+
+
+def _secret_values_match(left, right):
+    """Compare secret representations without timing-sensitive equality."""
+    return secrets.compare_digest(
+        str(left or "").encode(), str(right or "").encode()
+    )
+
+
+def _admin_password_matches(effective_password, candidate):
+    """Safely check whether candidate represents the current admin password."""
+    effective_password = str(effective_password or "")
+    candidate = str(candidate or "")
+    if effective_password.startswith(("scrypt:", "pbkdf2:")):
+        try:
+            return check_password_hash(effective_password, candidate)
+        except (TypeError, ValueError):
+            return False
+    return _secret_values_match(effective_password, candidate)
+
+
+def _get_admin_password():
+    """Return the current application's effective admin-password representation."""
+    _config_manager = current_runtime().config_manager
+    return _config_manager.get("admin_password", "") if _config_manager else ""
+
+
+def _auth_state_fingerprint(password_representation=None):
+    """Return a keyed fingerprint of the effective admin-password state."""
+    if password_representation is None:
+        password_representation = _get_admin_password()
+    key = current_app.secret_key.encode() if isinstance(current_app.secret_key, str) else current_app.secret_key
+    value = _AUTH_STATE_CONTEXT + str(password_representation or "").encode("utf-8")
+    return _keyed_sha256_hexdigest(key, value)
+
+
+def _write_auth_state():
+    fingerprint = _auth_state_fingerprint()
+    current_runtime().auth_state.write_fingerprint(fingerprint)
+
+
+def _init_auth_state():
+    """Create auth state or invalidate cookies after an offline state change."""
+    stored = current_runtime().auth_state.read_fingerprint()
+    current = _auth_state_fingerprint()
+    if stored is None:
+        _write_auth_state()
+    elif not _secret_values_match(stored, current):
+        _rotate_session_key()
+        _write_auth_state()
+
+
+def bootstrap_auth_state(app, runtime):
+    """Initialize durable authentication state for a newly created app."""
+    if app.extensions.get("docsight") is not runtime:
+        raise RuntimeError("DOCSight runtime is not attached to this application")
+    with app.app_context():
+        _init_auth_state()
+
+
+def _sync_auth_state():
+    """Observe runtime auth changes and durably invalidate existing cookies."""
+    if not current_runtime().config_manager:
+        return
+    stored = current_runtime().auth_state.read_fingerprint()
+    current = _auth_state_fingerprint()
+    if stored is not None and _secret_values_match(stored, current):
+        return
+    _rotate_session_key()
+    _write_auth_state()
+
+
+def _admin_session_marker(password_representation=None):
+    """Create a keyed, non-reversible marker for the effective password state."""
+    if password_representation is None:
+        password_representation = _get_admin_password()
+    if not password_representation:
+        return ""
+    key = current_app.secret_key.encode() if isinstance(current_app.secret_key, str) else current_app.secret_key
+    value = _AUTH_MARKER_CONTEXT + str(password_representation).encode("utf-8")
+    return _keyed_sha256_hexdigest(key, value)
+
+
+def _authenticated_session_is_valid():
+    """Return True only for a password-bound authenticated browser session."""
+    if not session.get("authenticated"):
+        return False
+    actual = session.get(_AUTH_MARKER_SESSION_KEY, "")
+    expected = _admin_session_marker()
+    if actual and expected and _secret_values_match(actual, expected):
+        return True
+    session.clear()
+    return False
+
+
+def _invalidate_admin_sessions():
+    """Globally invalidate signed cookies and clear the current request session."""
+    _rotate_session_key()
+    _write_auth_state()
+    # The request cookie was loaded with the prior key. Clearing after rotation
+    # makes Flask write the logged-out session using the new key on this response.
+    session.clear()
+
+
+def _auth_required(*, session_only=False):
+    """Check if auth is enabled and user is not logged in.
+
+    Also checks for valid Bearer token in Authorization header.
+    Returns True if authentication is required but not provided.
+    """
+    _storage = current_runtime().storage
+    _sync_auth_state()
+    if not _get_admin_password():
+        return False
+    if _authenticated_session_is_valid():
+        return False
+    auth_header = request.headers.get("Authorization", "")
+    if not session_only and auth_header.startswith("Bearer ") and _storage:
+        token = auth_header[7:]
+        token_info = _storage.validate_api_token(token)
+        if token_info:
+            request._api_token = token_info
+            return False
+    return True
+
+
+def require_auth(f, *, session_only=False):
+    """Decorator: redirect to /login or return 401 JSON for API paths."""
+    @functools.wraps(f)
+    def decorated(*args, **kwargs):
+        if _auth_required(session_only=session_only):
+            if session_only and (getattr(request, "_api_token", None) or request.headers.get("Authorization", "").startswith("Bearer ")):
+                return jsonify({"error": "Session authentication required"}), 403
+            if request.path.startswith("/api/"):
+                return jsonify({"error": "Authentication required"}), 401
+            return redirect(url_for("login"))
+        return f(*args, **kwargs)
+    return decorated
+
+
+def _require_session_auth(f):
+    """Decorator: only allow session-based login, no API tokens."""
+    return require_auth(f, session_only=True)
+
+
+def _authenticate_login():
+    """Validate a login submission and establish its password-bound session."""
+    _config_manager = current_runtime().config_manager
+    ip = _get_client_ip()
+    limiter = current_runtime().login_rate_limiter
+    if not _valid_login_csrf_token(request.form.get("csrf_token", "")):
+        limiter.record_failure(ip)
+        audit_log.warning("Login rejected: invalid csrf token for ip=%s", ip)
+        return "login_failed", 400
+    wait = limiter.retry_after(ip)
+    if wait > 0:
+        audit_log.warning("Login rate-limited: ip=%s (retry in %ds)", ip, int(wait))
+        return "login_rate_limited", 200
+    pw = request.form.get("password", "")
+    stored = _config_manager.get("admin_password", "")
+    if stored.startswith(("scrypt:", "pbkdf2:")):
+        success = check_password_hash(stored, pw)
+    else:
+        success = _secret_values_match(pw, stored)
+        if success and not os.environ.get("ADMIN_PASSWORD"):
+            # Auto-upgrade plaintext password to hash
+            _config_manager.save({"admin_password": pw})
+            stored = _config_manager.get("admin_password", "")
+            # This is the same credential in a safer representation, so
+            # preserve the signing key while rebinding durable auth state.
+            _write_auth_state()
+            audit_log.info("Auto-upgraded plaintext password to hash for ip=%s", ip)
+    if success:
+        limiter.reset(ip)
+        session.permanent = True
+        session["authenticated"] = True
+        session[_AUTH_MARKER_SESSION_KEY] = _admin_session_marker(stored)
+        session.pop(_LOGIN_CSRF_SESSION_KEY, None)
+        audit_log.info("Login successful: ip=%s", ip)
+        return None, 302
+    limiter.record_failure(ip)
+    audit_log.warning("Login failed: ip=%s", ip)
+    return "login_failed", 200

--- a/tests/architecture/test_app_globals_guard.py
+++ b/tests/architecture/test_app_globals_guard.py
@@ -3,12 +3,12 @@
 import ast
 from pathlib import Path
 
-import app.web as web
+from app import web, web_auth
 
 
 ROOT = Path(__file__).resolve().parents[2]
 GUARDED_FILES = (
-    ROOT / "app" / "web.py",
+    *(ROOT / "app").glob("web*.py"),
     ROOT / "app" / "app_factory.py",
     ROOT / "app" / "registration.py",
     ROOT / "app" / "runtime.py",
@@ -51,8 +51,6 @@ def test_guard_scope_excludes_documented_process_registries():
 def test_guarded_modules_have_no_global_or_nonlocal_statements():
     violations = []
     for path in GUARDED_FILES:
-        if not path.exists():
-            continue
         for node in ast.walk(_tree(path)):
             if isinstance(node, (ast.Global, ast.Nonlocal)):
                 violations.append(f"{path.relative_to(ROOT)}:{node.lineno}")
@@ -75,8 +73,6 @@ def test_factory_is_the_only_flask_constructor():
 def test_guarded_modules_have_no_lowercase_state_bindings():
     violations = []
     for path in GUARDED_FILES:
-        if not path.exists():
-            continue
         for node in _tree(path).body:
             if not isinstance(node, (ast.Assign, ast.AnnAssign)):
                 continue
@@ -92,4 +88,5 @@ def test_guarded_modules_have_no_lowercase_state_bindings():
 
 
 def test_web_has_no_legacy_application_or_initializer_exports():
-    assert FORBIDDEN_WEB_EXPORTS.isdisjoint(vars(web))
+    assert FORBIDDEN_WEB_EXPORTS.isdisjoint(vars(web).keys() | vars(web_auth).keys())
+    assert web.require_auth is web_auth.require_auth

--- a/tests/architecture/test_registration_contract.py
+++ b/tests/architecture/test_registration_contract.py
@@ -165,6 +165,8 @@ def test_productive_flask_registration_has_one_owner():
     [
         ("app/registration.py", "app.module_loader"),
         ("app/module_registry.py", "app.registration"),
+        ("app/web_auth.py", "app.web"),
+        ("app/web_auth.py", "app.app_factory"),
     ],
 )
 def test_registration_dependencies_have_no_reverse_imports(relative_path, forbidden):

--- a/tests/modules/connection_monitor/test_routes.py
+++ b/tests/modules/connection_monitor/test_routes.py
@@ -45,7 +45,7 @@ def _auth_session(c, marker_source=None):
     with c.session_transaction() as sess:
         sess["authenticated"] = True
         if marker_source:
-            from app.web import _admin_session_marker
+            from app.web_auth import _admin_session_marker
             sess["auth_marker"] = _admin_session_marker(marker_source)
 
 
@@ -724,7 +724,7 @@ class TestAuthProtection:
         mock_cfg.data_dir = os.path.dirname(storage.db_path)
         get_runtime(flask_app).config_manager = mock_cfg
         with flask_app.app_context():
-            from app.web import _init_auth_state
+            from app.web_auth import _init_auth_state
             _init_auth_state()
             yield flask_app.test_client(), storage
 

--- a/tests/modules/connection_monitor/test_traceroute_routes.py
+++ b/tests/modules/connection_monitor/test_traceroute_routes.py
@@ -96,7 +96,7 @@ class TestManualTraceroute:
         mock_cfg.data_dir = os.path.dirname(storage.db_path)
         get_runtime(flask_app).config_manager = mock_cfg
         with flask_app.app_context():
-            from app.web import _init_auth_state
+            from app.web_auth import _init_auth_state
             _init_auth_state()
             c = flask_app.test_client()
             resp = c.post(f"/api/connection-monitor/traceroute/{tid}")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,11 +9,11 @@ from email.utils import parsedate_to_datetime
 
 import pytest
 from werkzeug.security import generate_password_hash
-from app.web import (
+from app.web import update_state
+from app.web_auth import (
     _AUTH_STATE_CONTEXT,
     _LOGIN_MAX_TRACKED_IPS,
     _keyed_sha256_hexdigest,
-    update_state,
 )
 from app.config import ConfigManager
 from app.storage import SnapshotStorage

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -253,7 +253,7 @@ class TestBackupDownloadRoute:
         test_app.config.update(TESTING=True, SECRET_KEY="test-secret")
         test_app.register_blueprint(routes.bp)
         monkeypatch.setattr(routes, "get_config_manager", lambda: config_mgr)
-        monkeypatch.setattr("app.web._auth_required", lambda: False)
+        monkeypatch.setattr("app.web_auth._auth_required", lambda **kwargs: False)
         return test_app
 
     def test_download_is_file_backed_and_cleans_up_on_close(

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -22,7 +22,7 @@ E2E_BROWSER_PATHS = [
     "app/templates/**",
     "app/static/**",
     "app/modules/**",
-    "app/web.py",
+    "app/web*.py",
     "app/blueprints/**",
     "app/tz.py",
     "app/i18n/**",

--- a/tests/test_evidence_api.py
+++ b/tests/test_evidence_api.py
@@ -1,7 +1,7 @@
 import builtins
 from unittest.mock import Mock, patch
 
-import app.web as web
+from app import web_auth
 from app.runtime import current_runtime
 
 
@@ -94,7 +94,7 @@ class TestEvidenceChecklistApi:
         config.data_dir = str(tmp_path)
         current_runtime().config_manager = config
         current_runtime().storage = None
-        web._init_auth_state()
+        web_auth._init_auth_state()
         app.config["TESTING"] = True
 
         with app.test_client() as client:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -12,6 +12,7 @@ from app.theme_registry import _is_trusted_url, download_theme
 from app.collectors import _ModuleConfigProxy
 from app.config import ConfigManager, SECRET_KEYS, HASH_KEYS
 from app.runtime import current_runtime
+from tests.test_auth import _login_csrf
 
 
 # ── Reverse proxy / X-Forwarded-For ──
@@ -33,14 +34,15 @@ class TestClientIPWithoutProxy:
 
         # Simulate 6 failed logins with different spoofed IPs
         for i in range(6):
-            client.post(
+            response = client.post(
                 "/login",
-                data={"password": "wrong"},
+                data={"password": "wrong", "csrf_token": _login_csrf(client)},
                 headers={"X-Forwarded-For": f"10.0.0.{i}"},
             )
 
         # Without proxy trust, all requests come from same remote_addr,
         # so rate limiter should kick in.
+        assert b"Too many attempts. Please try again later." in response.data
         attempts_keys = list(current_runtime().login_rate_limiter.snapshot())
         assert len(attempts_keys) == 1, (
             f"Expected 1 IP in rate limiter, got {len(attempts_keys)}: {attempts_keys}"
@@ -352,7 +354,6 @@ class TestSafeManifestRef:
 @pytest.fixture
 def client():
     """Flask test client with minimal config for auth testing."""
-    from app import web
     from app.config import ConfigManager
     import tempfile
 


### PR DESCRIPTION
## Changes
- Give login, session, token and authentication policy one owner, separate from route and template handling.
- Update built-in routes and application startup to use that owner while preserving supported community imports.
- Keep existing URLs, session-only restrictions, cookies, password handling and rate limits unchanged.
- Update contributor documentation and browser-test path coverage.

## Validation
- Python suite: 4,118 passed, 2 skipped.
- JavaScript suite: 47 passed.
- Complete browser suite: 554 passed across all four test shards.
- Route, filter, blueprint and cookie contracts match the previous implementation.
- Desktop and mobile login, Dashboard and Settings verified under a path prefix.
- Localization and workflow validation passed.
