### PR TITLE
refactor: clarify web runtime and helper ownership

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -52,7 +52,7 @@ jobs:
               - 'app/modules/**'
               - 'app/{web*,signal_health_view}.py'
               - 'app/blueprints/**'
-              - 'app/tz.py'
+              - 'app/{tz,theme_registry,runtime,version}.py'
               - 'app/i18n/**'
               - 'app/app_factory.py'
               - 'app/base_path.py'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
               - 'app/modules/**'
               - 'app/{web*,signal_health_view}.py'
               - 'app/blueprints/**'
-              - 'app/tz.py'
+              - 'app/{tz,theme_registry,runtime,version}.py'
               - 'app/i18n/**'
               - 'app/app_factory.py'
               - 'app/base_path.py'

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,18 +49,18 @@ discovery, `app.module_config_registry` owns configuration-schema preflight,
 and `app.module_loader` orchestrates ownership and rejection policy behind its
 compatible public facade.
 
-Each application owns a typed `DocsightRuntime` at
-`app.extensions["docsight"]`. It contains the configuration manager, storage,
-authentication state, rate limiter, update checker, module loader, collector
-references, derived-storage cache, and lock-protected dashboard state. Route
-and module code uses `app.web` runtime accessors; auth policy and factory bootstrap
-use `app.web_auth`, which accesses runtime directly and never imports `app.web`.
-
-Collector threads receive the same runtime explicitly through the existing
-`web=` duck-type parameter. The runtime implements `update_state()`,
-`clear_speedtest_latest()`, `get_state()`, `get_module_loader()`, and the
-read-only `_state` snapshot expected by existing collectors, without requiring
-a Flask request or application context.
+Internal routes/modules use `app.runtime.current_runtime()` to access the `DocsightRuntime` at `app.extensions["docsight"]`, which owns per-application configuration, storage, auth state, rate limiter, update checker, module loader, collectors, derived storage, and lock-protected state.
+`get_state()` retains its lock-protected snapshot. Collectors receive that runtime through existing `web=` parameters;
+its collector-thread duck contract provides `update_state()`, `clear_speedtest_latest()`, `get_state()`, `get_module_loader()`, and the read-only `_state` snapshot without requiring a Flask request or application context.
+`app.web_locale` owns request/setup language; `app.tz` owns pure date validation
+and timestamp localization with explicit timezone input. `app.theme_registry`
+owns curated collections and active-theme resolution; `app.version` owns version lookup.
+`app.web` retains HTTP/Jinja/setup/settings/glossary/desktop adapters and community
+compatibility: `get_storage`, `get_config_manager`, `get_collectors`, `get_modem_collector`,
+`get_module_loader`, `get_on_config_changed`, `get_state`, `get_last_manual_poll`,
+`set_last_manual_poll`, `update_state`, `clear_speedtest_latest`, `reset_modem_state`,
+`APP_VERSION`, and `require_auth`. Existing community imports remain supported.
+Auth policy/bootstrap use `app.web_auth`; lower-level owners never import `app.web`.
 
 Module schema registries in `app.config`, analyzer threshold selection,
 translation catalogs, driver/theme registries, and dynamic Python imports are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Collector Registry → Base Collector (Fail-Safe) → Analyzer/Storage → Web U
 - New modem types must implement the `ModemDriver` base class (`app/drivers/base.py`)
 - Collectors run in **parallel threads** via `ThreadPoolExecutor`. Protect shared state with locks.
 - Use the collector pattern for automatic fail-safe and health monitoring
-- Construct applications only with `app.app_factory.create_app()`. Importing `app.web` must remain free of application construction and app-specific globals.
+- Construct apps with `app.app_factory.create_app()`; internal consumers use `current_runtime()` and the language/time/theme/version owners in [ARCHITECTURE.md](ARCHITECTURE.md). Community `app.web` accessors, mutations, `APP_VERSION`, and `require_auth` remain supported; importing it creates no app or app-specific globals.
 
 See [`ARCHITECTURE.md`](ARCHITECTURE.md) for detailed technical documentation and data flow diagrams.
 

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -14,6 +14,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from . import web, web_auth
 from .base_path import configure_base_path
 from .module_loader import ModuleLoader
+from .version import get_app_version
 from .registration import (
     RegistrationPlan,
     build_core_plan,
@@ -139,9 +140,8 @@ def create_app(
             max_tracked_ips=web_auth._LOGIN_MAX_TRACKED_IPS,
         ),
         update_checker=UpdateChecker(
-            app_version=web.APP_VERSION,
+            app_version=get_app_version(),
             is_enabled=enabled_check if callable(enabled_check) else lambda: False,
-            ttl=web._UPDATE_CACHE_TTL,
         ),
     )
     attach_runtime(app, runtime)

--- a/app/blueprints/analysis_bp.py
+++ b/app/blueprints/analysis_bp.py
@@ -1,5 +1,7 @@
 """Analysis routes: connection, channels, device, thresholds, gaming, channel history, correlation."""
 
+from app.runtime import current_runtime
+from app.tz import localize_timestamps, get_tz_name
 import logging
 from datetime import datetime
 
@@ -8,10 +10,6 @@ from flask import Blueprint, request, jsonify
 from app.analyzer import get_thresholds
 from app.time_ranges import parse_time_range_hours
 from app.tz import utc_now, utc_cutoff
-from app.web import (
-    get_storage, get_config_manager, get_state,
-    _localize_timestamps,
-)
 from app.web_auth import require_auth
 from app.gaming_index import compute_gaming_index
 
@@ -42,9 +40,9 @@ def api_connection():
     isp_name comes from user config. The remaining fields are populated
     by the modem driver and may be absent if the modem has not been polled yet.
     """
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     isp_name = _config_manager.get("isp_name", "") if _config_manager else ""
-    conn_info = get_state().get("connection_info") or {}
+    conn_info = current_runtime().get_state().get("connection_info") or {}
     return jsonify({
         "isp_name": isp_name or None,
         "connection_type": conn_info.get("connection_type"),
@@ -57,8 +55,8 @@ def api_connection():
 @require_auth
 def api_channels():
     """Return current DS and US channels with overall health summary."""
-    _storage = get_storage()
-    state = get_state()
+    _storage = current_runtime().storage
+    state = current_runtime().get_state()
     analysis = state.get("analysis")
     summary = analysis["summary"] if analysis else None
     if not _storage:
@@ -72,7 +70,7 @@ def api_channels():
 @require_auth
 def api_device():
     """Return modem device information."""
-    state = get_state()
+    state = current_runtime().get_state()
     return jsonify(state.get("device_info") or {})
 
 
@@ -97,9 +95,9 @@ def api_gaming_score():
       genres       - suitability verdict (ok/warn/bad) per game genre
       raw          - raw measured values that fed into the calculation
     """
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     enabled = _config_manager.is_gaming_quality_enabled() if _config_manager else False
-    state = get_state()
+    state = current_runtime().get_state()
     analysis = state.get("analysis")
     speedtest_latest = state.get("speedtest_latest")
     result = compute_gaming_index(analysis, speedtest_latest)
@@ -149,7 +147,7 @@ def api_channel_history():
     ?selector=X selects an exact channel identity; legacy ?channel_id=N remains
     supported for IDs that uniquely identify a channel. ?days=N also remains
     supported as a legacy time window."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify([])
     selector = request.args.get("selector")
@@ -166,7 +164,7 @@ def api_channel_history():
     data = _storage.get_channel_history(
         channel_id, direction, selector=selector, **window_args
     )
-    _localize_timestamps(data)
+    localize_timestamps(data, get_tz_name(current_runtime().config_manager))
     return jsonify(data)
 
 
@@ -176,7 +174,7 @@ def api_channel_compare():
     """Return per-channel time series for multiple channels.
     ?selectors=X,Y selects exact channel identities; legacy ?channels=1,2,3
     remains supported for unique IDs. ?days=N also remains supported."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({})
     channels_param = request.args.get("channels", "")
@@ -219,7 +217,7 @@ def api_correlation():
       hours: int (default 24, max 2160 / 90d)
       sources: comma-separated list of modem,speedtest,events,bnetz,capture,segment (default all)
     """
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify([])
     hours = request.args.get("hours", 24, type=int)

--- a/app/blueprints/config_bp.py
+++ b/app/blueprints/config_bp.py
@@ -1,5 +1,7 @@
 """Configuration and API token management routes."""
 
+from app.runtime import current_runtime
+from app.tz import localize_timestamps, get_tz_name
 import logging
 import os
 from urllib.parse import urlparse
@@ -7,10 +9,6 @@ from zoneinfo import ZoneInfo
 
 from flask import Blueprint, request, jsonify
 
-from app.web import (
-    get_config_manager, get_storage, get_on_config_changed,
-    _localize_timestamps,
-)
 from app.web_auth import (
     require_auth, _require_session_auth, _admin_password_matches,
     _invalidate_admin_sessions, _secret_values_match, _get_client_ip,
@@ -54,7 +52,7 @@ def run_bqm_initial_fetch(config_manager=None, storage=None):
 @_require_session_auth
 def api_config():
     """Save configuration."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager:
         return jsonify({"success": False, "error": "Config not initialized"}), 500
     try:
@@ -98,12 +96,12 @@ def api_config():
         if admin_password_changed:
             _invalidate_admin_sessions()
         audit_log.info("Config changed: ip=%s", _get_client_ip())
-        _on_config_changed = get_on_config_changed()
+        _on_config_changed = current_runtime().on_config_changed
         if _on_config_changed:
             _on_config_changed()
         response = {"success": True}
         if should_fetch_bqm:
-            response["bqm_initial_fetch"] = run_bqm_initial_fetch(_config_manager, get_storage())
+            response["bqm_initial_fetch"] = run_bqm_initial_fetch(_config_manager, current_runtime().storage)
         return jsonify(response)
     except ValueError as e:
         return jsonify({"success": False, "error": str(e)}), 400
@@ -118,11 +116,11 @@ def api_config():
 @require_auth
 def api_tokens_list():
     """List all API tokens (without hashes)."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"error": "Storage not available"}), 500
     tokens = _storage.get_api_tokens()
-    _localize_timestamps(tokens)
+    localize_timestamps(tokens, get_tz_name(current_runtime().config_manager))
     return jsonify({"tokens": tokens})
 
 
@@ -130,7 +128,7 @@ def api_tokens_list():
 @_require_session_auth
 def api_tokens_create():
     """Create a new API token. Session-only (no token auth)."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"error": "Storage not available"}), 500
     data = request.get_json()
@@ -146,7 +144,7 @@ def api_tokens_create():
 @_require_session_auth
 def api_tokens_revoke(token_id):
     """Revoke an API token. Session-only (no token auth)."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"error": "Storage not available"}), 500
     revoked = _storage.revoke_api_token(token_id)
@@ -166,7 +164,7 @@ def api_demo_start():
             "demo_mode": False,
             "status": "invalid_request",
         }), 415
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager:
         return jsonify({
             "success": False,
@@ -186,7 +184,7 @@ def api_demo_start():
             "status": "live_configured",
         }), 409
 
-    _on_config_changed = get_on_config_changed()
+    _on_config_changed = current_runtime().on_config_changed
     activated = False
     try:
         _config_manager.save({"demo_mode": True})
@@ -219,8 +217,8 @@ def api_demo_start():
 @require_auth
 def api_demo_migrate():
     """Switch from demo to live mode. Removes demo data, keeps user data."""
-    _config_manager = get_config_manager()
-    _storage = get_storage()
+    _config_manager = current_runtime().config_manager
+    _storage = current_runtime().storage
     if not _config_manager or not _config_manager.is_demo_mode():
         return jsonify({"success": False, "error": "Not in demo mode"}), 400
     if _config_manager.is_demo_mode_forced():
@@ -250,7 +248,7 @@ def api_demo_migrate():
         _config_manager.save({"demo_mode": False})
         _storage.max_days = _config_manager.get("history_days", 7)
         audit_log.info("Demo migration: ip=%s purged=%d rows", _get_client_ip(), purged)
-        _on_config_changed = get_on_config_changed()
+        _on_config_changed = current_runtime().on_config_changed
         if _on_config_changed:
             _on_config_changed()
         return jsonify({

--- a/app/blueprints/data_bp.py
+++ b/app/blueprints/data_bp.py
@@ -1,4 +1,6 @@
 """Data retrieval routes: trends, export, snapshots."""
+from app.runtime import current_runtime
+from app.tz import localize_timestamps, get_tz_name
 import logging
 import os
 from collections import defaultdict
@@ -7,10 +9,6 @@ from datetime import datetime, timedelta, timezone
 from flask import Blueprint, request, jsonify
 
 from app.time_ranges import parse_time_range_hours
-from app.web import (
-    get_storage, get_config_manager, get_state,
-    _localize_timestamps,
-)
 from app.web_auth import require_auth
 
 log = logging.getLogger("docsis.web")
@@ -63,7 +61,7 @@ def _append_connection_monitor_trends(data: list[dict], hours: int) -> None:
     a lightweight latency series here without coupling the card to a second
     request path.
     """
-    cfg = get_config_manager()
+    cfg = current_runtime().config_manager
     data_dir = getattr(cfg, "data_dir", None)
     if not data_dir:
         return
@@ -146,7 +144,7 @@ def api_trends():
     The date query parameter anchors only legacy day/week/month requests;
     normalized ranges are rolling windows ending at the current snapshot time.
     """
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify([])
     range_type = (request.args.get("range", "1d") or "1d").strip().lower()
@@ -176,7 +174,7 @@ def api_trends():
         _append_speedtest_trends(data, _storage.db_path, hours)
         _append_connection_monitor_trends(data, hours)
         data.sort(key=lambda row: row.get("timestamp") or "")
-    _localize_timestamps(data)
+    localize_timestamps(data, get_tz_name(current_runtime().config_manager))
     return jsonify(data)
 
 
@@ -184,9 +182,9 @@ def api_trends():
 @require_auth
 def api_export():
     """Generate a structured markdown report for LLM analysis."""
-    _storage = get_storage()
-    _config_manager = get_config_manager()
-    state = get_state()
+    _storage = current_runtime().storage
+    _config_manager = current_runtime().config_manager
+    state = current_runtime().get_state()
     analysis = state.get("analysis")
     if not analysis:
         return jsonify({"error": "No data available"}), 404
@@ -414,7 +412,7 @@ def api_export():
 @require_auth
 def api_snapshots():
     """Return list of available snapshot timestamps."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if _storage:
         return jsonify(_storage.get_snapshot_list())
     return jsonify([])
@@ -424,7 +422,7 @@ def api_snapshots():
 @require_auth
 def api_snapshot(timestamp):
     """Return full analysis for a specific snapshot."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"error": "No storage"}), 500
     snap = _storage.get_snapshot(timestamp)

--- a/app/blueprints/events_bp.py
+++ b/app/blueprints/events_bp.py
@@ -1,5 +1,7 @@
 """Event log routes."""
 
+from app.runtime import current_runtime
+from app.tz import localize_timestamps, get_tz_name
 import csv
 import io
 import json
@@ -8,10 +10,6 @@ from datetime import datetime, timezone
 
 from flask import Blueprint, request, jsonify, Response
 
-from app.web import (
-    get_storage,
-    _localize_timestamps,
-)
 from app.web_auth import require_auth
 
 log = logging.getLogger("docsis.web")
@@ -87,7 +85,7 @@ def _events_csv_response(events, truncated=False):
 @require_auth
 def api_events_list():
     """Return list of events with optional filters."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"events": [], "unacknowledged_count": 0})
     limit = request.args.get("limit", 200, type=int)
@@ -108,7 +106,7 @@ def api_events_list():
         event_prefix=filters["event_prefix"],
         severity=filters["severity"]
     )
-    _localize_timestamps(events)
+    localize_timestamps(events, get_tz_name(current_runtime().config_manager))
     return jsonify({"events": events, "unacknowledged_count": unack})
 
 
@@ -116,7 +114,7 @@ def api_events_list():
 @require_auth
 def api_events_export_csv():
     """Export all events matching the current event-log filters as CSV."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return _events_csv_response([])
     try:
@@ -140,7 +138,7 @@ def api_events_export_csv():
 @require_auth
 def api_events_count():
     """Return unacknowledged event count (for badge)."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"count": 0})
     event_prefix = request.args.get("event_prefix") or None
@@ -159,7 +157,7 @@ def api_events_count():
 @require_auth
 def api_event_acknowledge(event_id):
     """Acknowledge a single event."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"error": "Storage not initialized"}), 500
     if not _storage.acknowledge_event(event_id):
@@ -171,7 +169,7 @@ def api_event_acknowledge(event_id):
 @require_auth
 def api_events_acknowledge_all():
     """Acknowledge all unacknowledged events."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"error": "Storage not initialized"}), 500
     count = _storage.acknowledge_all_events()

--- a/app/blueprints/metrics_bp.py
+++ b/app/blueprints/metrics_bp.py
@@ -1,8 +1,8 @@
 """Flask blueprint for the Prometheus /metrics endpoint."""
 
+from app.runtime import current_runtime
 from flask import Blueprint, Response, request
 
-from app.web import get_state, get_modem_collector, get_config_manager, get_storage
 from app.prometheus import format_metrics
 
 metrics_bp = Blueprint("metrics_bp", __name__)
@@ -10,13 +10,13 @@ metrics_bp = Blueprint("metrics_bp", __name__)
 
 def _metrics_token_required() -> bool:
     """Return whether /metrics should require a Bearer API token."""
-    config = get_config_manager()
+    config = current_runtime().config_manager
     return bool(config and config.get("metrics_require_token", False))
 
 
 def _has_valid_bearer_token() -> bool:
     """Validate the request's Bearer token through DOCSight token storage."""
-    storage = get_storage()
+    storage = current_runtime().storage
     auth_header = request.headers.get("Authorization", "")
     if not storage or not auth_header.startswith("Bearer "):
         return False
@@ -38,12 +38,12 @@ def metrics():
     if _metrics_token_required() and not _has_valid_bearer_token():
         return Response("Authentication required\n", status=401, content_type="text/plain; charset=utf-8")
 
-    state = get_state()
+    state = current_runtime().get_state()
     analysis = state.get("analysis")
     device_info = state.get("device_info")
     connection_info = state.get("connection_info")
 
-    collector = get_modem_collector()
+    collector = current_runtime().modem_collector
     if collector is not None:
         last_poll_timestamp = collector.get_status().get("last_poll", 0.0)
     else:

--- a/app/blueprints/modules_bp.py
+++ b/app/blueprints/modules_bp.py
@@ -1,5 +1,6 @@
 """Module management API endpoints."""
 
+from app.runtime import current_runtime
 import json
 import logging
 import os
@@ -18,7 +19,6 @@ from app.module_loader import (
 from app.module_paths import get_modules_dir
 from app.path_safety import safe_child_path
 from app.theme_registry import download_theme, fetch_registry as fetch_theme_registry
-from app.web import get_config_manager, get_module_loader
 from app.web_auth import require_auth
 
 log = logging.getLogger("docsis.modules")
@@ -56,7 +56,7 @@ def _serialize_module(mod):
 @require_auth
 def api_modules_list():
     """List all discovered modules with metadata and status."""
-    loader = get_module_loader()
+    loader = current_runtime().module_loader
     if not loader:
         return jsonify([])
     modules = loader.get_modules()
@@ -67,7 +67,7 @@ def api_modules_list():
 @require_auth
 def api_module_enable(module_id):
     """Enable a disabled module (persisted, requires restart)."""
-    loader = get_module_loader()
+    loader = current_runtime().module_loader
     if not loader:
         return jsonify({"success": False, "error": "Module system not initialized"}), 500
 
@@ -75,7 +75,7 @@ def api_module_enable(module_id):
     if not module:
         return jsonify({"success": False, "error": f"Module '{module_id}' not found"}), 404
 
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     if not config_mgr:
         return jsonify({"success": False, "error": "Config not initialized"}), 500
 
@@ -110,7 +110,7 @@ def api_module_enable(module_id):
 @require_auth
 def api_module_disable(module_id):
     """Disable a module (persisted, requires restart)."""
-    loader = get_module_loader()
+    loader = current_runtime().module_loader
     if not loader:
         return jsonify({"success": False, "error": "Module system not initialized"}), 500
 
@@ -118,7 +118,7 @@ def api_module_disable(module_id):
     if not module:
         return jsonify({"success": False, "error": f"Module '{module_id}' not found"}), 404
 
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     if not config_mgr:
         return jsonify({"success": False, "error": "Config not initialized"}), 500
 
@@ -163,11 +163,11 @@ def api_module_disable(module_id):
 @require_auth
 def api_modules_batch():
     """Apply multiple non-theme module enable/disable states in one save."""
-    loader = get_module_loader()
+    loader = current_runtime().module_loader
     if not loader:
         return jsonify({"success": False, "error": "Module system not initialized"}), 500
 
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     if not config_mgr:
         return jsonify({"success": False, "error": "Config not initialized"}), 500
 
@@ -217,7 +217,7 @@ def api_modules_batch():
 @require_auth
 def api_themes_list():
     """List all theme modules with their CSS variable data."""
-    loader = get_module_loader()
+    loader = current_runtime().module_loader
     if not loader:
         return jsonify([])
     themes = loader.get_theme_modules()
@@ -233,7 +233,7 @@ def api_themes_list():
 @require_auth
 def api_themes_registry():
     """Fetch available themes from the remote registry."""
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     if not config_mgr:
         return jsonify([])
 
@@ -244,7 +244,7 @@ def api_themes_registry():
 
     themes = fetch_theme_registry(registry_url)
 
-    loader = get_module_loader()
+    loader = current_runtime().module_loader
     installed_ids = set()
     if loader:
         installed_ids = {m.id for m in loader.get_theme_modules()}
@@ -306,7 +306,7 @@ def _scan_installed_community_ids():
 @require_auth
 def api_modules_registry():
     """Fetch available community modules from the registry."""
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     if not config_mgr:
         return jsonify([])
 
@@ -353,7 +353,7 @@ def api_modules_install():
         return jsonify({"success": False, "error": "Module already installed"}), 409
 
     # Reject if ID conflicts with existing modules
-    loader = get_module_loader()
+    loader = current_runtime().module_loader
     if loader:
         existing_ids = {m.id for m in loader.get_modules()}
         if mod_id in existing_ids:
@@ -410,7 +410,7 @@ def api_modules_install():
         return jsonify({"success": False, "error": "Module validation failed"}), 500
 
     # Persist as disabled-by-default
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     if config_mgr:
         disabled_raw = config_mgr.get("disabled_modules", "")
         disabled_set = {s.strip() for s in disabled_raw.split(",") if s.strip()}
@@ -445,7 +445,7 @@ def api_modules_uninstall():
         return jsonify({"success": False, "error": "Invalid module path"}), 400
 
     # Only allow uninstalling non-builtin modules
-    loader = get_module_loader()
+    loader = current_runtime().module_loader
     if loader:
         mod = next((m for m in loader.get_modules() if m.id == mod_id), None)
         if mod and mod.builtin:
@@ -454,7 +454,7 @@ def api_modules_uninstall():
     _remove_downloaded_module(modules_dir, target_dir)
 
     # Remove from disabled_modules if present
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     if config_mgr:
         disabled_raw = config_mgr.get("disabled_modules", "")
         disabled_set = {s.strip() for s in disabled_raw.split(",") if s.strip()}

--- a/app/blueprints/notices_bp.py
+++ b/app/blueprints/notices_bp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from app.runtime import current_runtime
 from flask import Blueprint, jsonify, request
 
 from app.maintainer_notices import (
@@ -9,7 +10,6 @@ from app.maintainer_notices import (
     get_active_notices,
     is_valid_notice_id,
 )
-from app.web import get_config_manager
 from app.web_auth import require_auth
 
 notices_bp = Blueprint("notices_bp", __name__)
@@ -28,7 +28,7 @@ def api_notices_list():
     if location not in (None, "dashboard", "settings"):
         return jsonify({"success": False, "error": "Invalid notice location"}), 400
 
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     notices = get_active_notices(
         dismissed_ids=_dismissed_ids(config_mgr),
         location=location,
@@ -43,7 +43,7 @@ def api_notice_dismiss(notice_id):
     if not is_valid_notice_id(notice_id):
         return jsonify({"success": False, "error": "Invalid notice id"}), 400
 
-    config_mgr = get_config_manager()
+    config_mgr = current_runtime().config_manager
     if not config_mgr:
         return jsonify({"success": False, "error": "Config not initialized"}), 500
 

--- a/app/blueprints/polling_bp.py
+++ b/app/blueprints/polling_bp.py
@@ -1,15 +1,12 @@
 """Polling and connectivity test routes."""
 
+from app.runtime import current_runtime
+from app.web_locale import get_lang
 import logging
 import time
 
 from flask import Blueprint, request, jsonify
 
-from app.web import (
-    get_config_manager, get_storage, get_modem_collector, get_collectors,
-    get_last_manual_poll, set_last_manual_poll,
-    _get_lang,
-)
 from app.web_auth import require_auth
 from app.config import PASSWORD_MASK, parse_config_bool
 from app.i18n import get_translations
@@ -42,7 +39,7 @@ def _pwa_push_configured(config_mgr):
 @require_auth
 def api_test_modem():
     """Test modem connection."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     try:
         data = request.get_json()
         # Resolve masked passwords to real values
@@ -71,7 +68,7 @@ def api_test_modem():
 @require_auth
 def api_test_mqtt():
     """Test MQTT broker connection."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     try:
         data = request.get_json()
         # Resolve masked passwords to real values
@@ -96,11 +93,11 @@ def api_test_mqtt():
 @require_auth
 def api_notifications_test():
     """Send a test notification to all configured channels."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager or not _config_manager.is_notify_configured():
         return jsonify({"success": False, "error": "Notifications not configured"}), 400
     from app.notifier import NotificationDispatcher
-    dispatcher = NotificationDispatcher(_config_manager, storage=get_storage())
+    dispatcher = NotificationDispatcher(_config_manager, storage=current_runtime().storage)
     result = dispatcher.test()
     return jsonify(result)
 
@@ -109,8 +106,8 @@ def api_notifications_test():
 @require_auth
 def api_pwa_push_status():
     """Return browser Push API readiness without exposing private VAPID material."""
-    _config_manager = get_config_manager()
-    storage = get_storage()
+    _config_manager = current_runtime().config_manager
+    storage = current_runtime().storage
     configured = _pwa_push_configured(_config_manager)
     public_key = ""
     if _config_manager and _config_manager.get("notify_pwa_push_enabled"):
@@ -128,7 +125,7 @@ def api_pwa_push_status():
 @require_auth
 def api_pwa_push_subscribe():
     """Persist the current browser's Push API subscription."""
-    storage = get_storage()
+    storage = current_runtime().storage
     if not storage:
         return jsonify({"success": False, "error": "Storage unavailable"}), 503
     data = request.get_json(silent=True) or {}
@@ -149,7 +146,7 @@ def api_pwa_push_subscribe():
 @require_auth
 def api_pwa_push_unsubscribe():
     """Remove the current browser's Push API subscription by endpoint."""
-    storage = get_storage()
+    storage = current_runtime().storage
     if not storage:
         return jsonify({"success": False, "error": "Storage unavailable"}), 503
     data = request.get_json(silent=True) or {}
@@ -164,7 +161,7 @@ def api_pwa_push_unsubscribe():
 @require_auth
 def api_test_speedtest():
     """Test Speedtest Tracker connection."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     try:
         data = request.get_json(silent=True) or {}
         submitted_url = data.get("speedtest_tracker_url", "")
@@ -213,14 +210,14 @@ def api_poll():
     consistent behavior and fail-safe application.
     Uses _collect_lock to prevent collision with parallel auto-poll.
     """
-    _modem_collector = get_modem_collector()
+    _modem_collector = current_runtime().modem_collector
 
     if not _modem_collector:
         return jsonify({"success": False, "error": "Collector not initialized"}), 500
 
     now = time.time()
-    if now - get_last_manual_poll() < 10:
-        lang = _get_lang()
+    if now - current_runtime().get_last_manual_poll() < 10:
+        lang = get_lang()
         t = get_translations(lang)
         return jsonify({"success": False, "error": t.get("refresh_rate_limit", "Rate limited")}), 429
 
@@ -233,7 +230,7 @@ def api_poll():
         if not result.success:
             return jsonify({"success": False, "error": result.error}), 500
 
-        set_last_manual_poll(time.time())
+        current_runtime().set_last_manual_poll(time.time())
 
         # Return the analysis data from the collector result
         # (ModemCollector already updated web state and saved snapshot)
@@ -254,7 +251,7 @@ def api_collectors_status():
     Provides monitoring info: failure counts, penalties, next poll times.
     Useful for debugging collector issues and fail-safe behavior.
     """
-    _collectors = get_collectors()
+    _collectors = current_runtime().collectors
     if not _collectors:
         return jsonify([])
 

--- a/app/blueprints/segment_bp.py
+++ b/app/blueprints/segment_bp.py
@@ -7,7 +7,6 @@ from flask import Blueprint, jsonify, request
 
 from app.i18n import get_translations
 from app.storage.segment_utilization import SegmentUtilizationStorage
-from app.web import get_config_manager, get_storage
 from app.web_auth import require_auth
 from app.runtime import current_runtime
 
@@ -21,7 +20,7 @@ def _get_lang():
 
 def _get_storage():
     """Lazy-init segment storage using core DB path."""
-    storage = get_storage()
+    storage = current_runtime().storage
     if not storage:
         return None
     return current_runtime().derived_storage.get(
@@ -43,7 +42,7 @@ def _normalize_range_key(raw, default):
 @require_auth
 def api_segment_utilization():
     """Return stored segment utilization data for the tab view."""
-    config = get_config_manager()
+    config = current_runtime().config_manager
     t = get_translations(_get_lang())
     if not config:
         return jsonify({"error": t.get("seg_unavailable", "Configuration unavailable.")}), 503
@@ -92,7 +91,7 @@ def _clamp_int(value, default, lo, hi):
 @require_auth
 def api_segment_utilization_events():
     """Return detected segment saturation events for the requested range."""
-    config = get_config_manager()
+    config = current_runtime().config_manager
     t = get_translations(_get_lang())
     if not config:
         return jsonify({"error": t.get("seg_unavailable", "Configuration unavailable.")}), 503
@@ -135,7 +134,7 @@ def api_segment_utilization_range():
     This matches ``/api/weather/range`` so the correlation view degrades
     gracefully when optional data sources are absent.
     """
-    config = get_config_manager()
+    config = current_runtime().config_manager
     if not config or config.get("modem_type") != "fritzbox" or not config.is_segment_utilization_enabled():
         return jsonify([])
     storage = _get_storage()

--- a/app/blueprints/smart_capture_bp.py
+++ b/app/blueprints/smart_capture_bp.py
@@ -2,7 +2,7 @@
 
 from flask import Blueprint, jsonify, request
 
-from ..web import get_storage
+from ..runtime import current_runtime
 from ..web_auth import require_auth
 
 smart_capture_bp = Blueprint("smart_capture", __name__)
@@ -12,7 +12,7 @@ smart_capture_bp = Blueprint("smart_capture", __name__)
 @require_auth
 def api_smart_capture_executions():
     """Return Smart Capture execution history."""
-    _storage = get_storage()
+    _storage = current_runtime().storage
     if not _storage:
         return jsonify({"executions": []})
     limit = request.args.get("limit", 50, type=int)

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from . import analyzer, web
+from . import analyzer
 from .app_factory import create_app, default_module_loader_factory
 from .base_path import validate_base_path_configuration
 from .config import ConfigManager

--- a/app/modules/backup/routes.py
+++ b/app/modules/backup/routes.py
@@ -10,9 +10,6 @@ from datetime import datetime
 
 from flask import Blueprint, request, jsonify, redirect, send_file, url_for
 
-from app.web import (
-    get_config_manager, get_on_config_changed,
-)
 from app.web_auth import require_auth, _auth_required, _get_client_ip
 from app.runtime import current_runtime
 
@@ -65,7 +62,7 @@ def _int_config(config_mgr, key, default):
 @require_auth
 def api_backup_download():
     """Create a backup and stream it as download."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager:
         return jsonify({"error": "Not initialized"}), 500
     temp_dir = None
@@ -113,7 +110,7 @@ def api_backup_download():
 @require_auth
 def api_backup_scheduled():
     """Create a backup in the configured backup path."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager:
         return jsonify({"error": "Not initialized"}), 500
     backup_path = _config_manager.get("backup_path", "/backup")
@@ -132,7 +129,7 @@ def api_backup_scheduled():
 @require_auth
 def api_backup_list():
     """List backups in the configured backup path."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager:
         return jsonify([])
     backup_path = _config_manager.get("backup_path", "/backup")
@@ -143,7 +140,7 @@ def api_backup_list():
 @require_auth
 def api_backup_delete(filename):
     """Delete a backup file."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager:
         return jsonify({"error": "Not initialized"}), 500
     backup_path = _config_manager.get("backup_path", "/backup")
@@ -169,7 +166,7 @@ def api_restore_validate():
     No auth required during initial setup (not configured yet).
     Auth required if already configured.
     """
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if _config_manager and _config_manager.is_configured() and _auth_required():
         return redirect(url_for("login"))
     if not (_config_manager and _config_manager.is_configured()):
@@ -199,7 +196,7 @@ def api_restore():
     No auth required during initial setup (not configured yet).
     Auth required if already configured.
     """
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if _config_manager is None:
         return jsonify({"error": "Not initialized"}), 500
     if _config_manager.is_configured() and _auth_required():
@@ -225,7 +222,7 @@ def api_restore():
         )
         # Reload config so the app recognizes the restored state
         _config_manager._load()
-        _on_config_changed = get_on_config_changed()
+        _on_config_changed = current_runtime().on_config_changed
         if _on_config_changed:
             _on_config_changed()
         return jsonify({

--- a/app/modules/bnetz/routes.py
+++ b/app/modules/bnetz/routes.py
@@ -1,11 +1,11 @@
 """BNetzA module routes."""
 
+from app.web_locale import get_lang
 import logging
 from io import BytesIO
 
 from flask import Blueprint, request, jsonify, send_file
 
-from app.web import get_storage, _get_lang
 from app.web_auth import require_auth, _get_client_ip
 from app.runtime import current_runtime
 from app.storage import MAX_ATTACHMENT_SIZE
@@ -20,7 +20,7 @@ log = logging.getLogger("docsis.web.bnetz")
 bp = Blueprint("bnetz_module", __name__)
 
 def _get_bnetz_storage():
-    core_storage = get_storage()
+    core_storage = current_runtime().storage
     if not core_storage:
         return None
     return current_runtime().derived_storage.get(
@@ -52,7 +52,7 @@ def api_bnetz_upload():
     if len(file_bytes) > MAX_ATTACHMENT_SIZE:
         return jsonify({"error": "File too large (max 10 MB)"}), 400
 
-    lang = _get_lang()
+    lang = get_lang()
     t = get_translations(lang)
 
     if is_csv:

--- a/app/modules/bqm/auth.py
+++ b/app/modules/bqm/auth.py
@@ -1,11 +1,11 @@
 """ThinkBroadband BQM CSV download via public share URLs."""
 
+from app.version import get_app_version
 import logging
 import re
 
 import requests
 
-from app.web import APP_VERSION
 
 log = logging.getLogger("docsis.bqm.auth")
 
@@ -63,7 +63,7 @@ def fetch_share_csv(share_id: str, variant: str = "y") -> str:
         response = requests.get(
             url,
             headers={
-                "User-Agent": f"DOCSight/{APP_VERSION} (+https://github.com/itsDNNS/docsight)",
+                "User-Agent": f"DOCSight/{get_app_version()} (+https://github.com/itsDNNS/docsight)",
                 "Accept": "text/csv,text/plain;q=0.9,*/*;q=0.8",
             },
             timeout=30,

--- a/app/modules/bqm/routes.py
+++ b/app/modules/bqm/routes.py
@@ -1,14 +1,12 @@
 """BQM module routes."""
 
+from app.tz import valid_date, get_tz_name
 import logging
 from datetime import datetime
 from urllib.parse import urlparse
 
 from flask import Blueprint, request, jsonify, make_response
 
-from app.web import (
-    get_storage, get_config_manager, _valid_date, _get_tz_name,
-)
 from app.web_auth import require_auth, _get_client_ip
 from app.runtime import current_runtime
 from app.tz import local_today, utc_now
@@ -27,7 +25,7 @@ _TBB_SHARE_PATH = "/broadband/monitoring/quality/share/"
 _TBB_HOSTS = {"thinkbroadband.com", "www.thinkbroadband.com"}
 
 def _get_bqm_storage():
-    core_storage = get_storage()
+    core_storage = current_runtime().storage
     if not core_storage:
         return None
     return current_runtime().derived_storage.get(
@@ -61,8 +59,8 @@ def _is_thinkbroadband_share_url(url):
 
 def run_bqm_initial_fetch(config_manager=None, storage=None):
     """Fetch and store BQM data immediately after setup or manual request."""
-    config_manager = config_manager or get_config_manager()
-    core_storage = storage or get_storage()
+    config_manager = config_manager or current_runtime().config_manager
+    core_storage = storage or current_runtime().storage
     if not config_manager or not core_storage:
         return {"success": False, "error": "BQM storage is not ready"}
 
@@ -74,7 +72,7 @@ def run_bqm_initial_fetch(config_manager=None, storage=None):
         return {"success": False, "error": "Use a ThinkBroadband CSV Yesterday share URL for fetch now"}
 
     bs = BqmStorage(core_storage.db_path)
-    collection_date = local_today(_get_tz_name())
+    collection_date = local_today(get_tz_name(current_runtime().config_manager))
 
     if is_csv_url(bqm_url):
         share_id = extract_share_id(bqm_url)
@@ -154,7 +152,7 @@ def api_bqm_dates():
 def api_bqm_data(date):
     """Return column-oriented BQM CSV data for a single day."""
     bs = _get_bqm_storage()
-    if not _valid_date(date):
+    if not valid_date(date):
         return jsonify({"error": "Invalid date format"}), 400
     if not bs:
         return jsonify({"error": "No storage"}), 404
@@ -173,7 +171,7 @@ def api_bqm_data_range():
     bs = _get_bqm_storage()
     start = request.args.get("start", "")
     end = request.args.get("end", "")
-    if not _valid_date(start) or not _valid_date(end):
+    if not valid_date(start) or not valid_date(end):
         return jsonify({"error": "Invalid date format"}), 400
     start_dt = datetime.strptime(start, "%Y-%m-%d").date()
     end_dt = datetime.strptime(end, "%Y-%m-%d").date()
@@ -212,7 +210,7 @@ def api_bqm_data_dates():
 def api_bqm_image(date):
     """Return BQM graph PNG for a given date."""
     bs = _get_bqm_storage()
-    if not _valid_date(date):
+    if not valid_date(date):
         return jsonify({"error": "Invalid date format"}), 400
     if not bs:
         return jsonify({"error": "No storage"}), 404
@@ -229,7 +227,7 @@ def api_bqm_image(date):
 @require_auth
 def api_bqm_live():
     """Fetch live BQM graph PNG from ThinkBroadband, fallback to today's cached."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     bs = _get_bqm_storage()
     bqm_url = _config_manager.get("bqm_url") if _config_manager else None
     image = None
@@ -245,7 +243,7 @@ def api_bqm_live():
             ts = utc_now()
 
     if not image and bs:
-        today = local_today(_get_tz_name())
+        today = local_today(get_tz_name(current_runtime().config_manager))
         image = bs.get_bqm_graph(today)
         if image:
             source = "cached"
@@ -315,7 +313,7 @@ def api_bqm_import():
     for f, date in zip(files, dates):
         fname = f.filename or "unknown"
 
-        if not _valid_date(date):
+        if not valid_date(date):
             errors.append({"filename": fname, "error": "Invalid date"})
             continue
 
@@ -429,7 +427,7 @@ def api_bqm_delete():
     start = data.get("start")
     end = data.get("end")
     if start and end:
-        if not _valid_date(start) or not _valid_date(end):
+        if not valid_date(start) or not valid_date(end):
             return jsonify({"error": "Invalid date format"}), 400
         deleted = bs.delete_bqm_graphs_range(start, end)
         audit_log.info("BQM images deleted range: ip=%s start=%s end=%s count=%d", _get_client_ip(), start, end, deleted)
@@ -437,7 +435,7 @@ def api_bqm_delete():
 
     date = data.get("date")
     if date:
-        if not _valid_date(date):
+        if not valid_date(date):
             return jsonify({"error": "Invalid date format"}), 400
         deleted = 1 if bs.delete_bqm_graph(date) else 0
         audit_log.info("BQM image deleted: ip=%s date=%s", _get_client_ip(), date)

--- a/app/modules/bqm/thinkbroadband.py
+++ b/app/modules/bqm/thinkbroadband.py
@@ -1,9 +1,9 @@
 """Fetch ThinkBroadband BQM quality graphs."""
 
+from app.version import get_app_version
 import logging
 import urllib.request
 
-from app.web import APP_VERSION
 
 log = logging.getLogger("docsis.thinkbroadband")
 
@@ -13,7 +13,7 @@ def fetch_graph(url, timeout=30):
     if not url:
         return None
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": f"DOCSight/{APP_VERSION} (+https://github.com/itsDNNS/docsight)"})
+        req = urllib.request.Request(url, headers={"User-Agent": f"DOCSight/{get_app_version()} (+https://github.com/itsDNNS/docsight)"})
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = resp.read()
         if len(data) < 100:

--- a/app/modules/comparison/routes.py
+++ b/app/modules/comparison/routes.py
@@ -1,5 +1,6 @@
 """Before/After Comparison module routes."""
 
+from app.runtime import current_runtime
 from flask import Blueprint, jsonify, request
 
 from app.aggregation import (
@@ -9,14 +10,13 @@ from app.aggregation import (
     report_bounds,
 )
 from app.analyzer import threshold_snapshot
-from app.web import get_storage
 from app.web_auth import require_auth
 
 bp = Blueprint("comparison_module", __name__)
 
 
 def _get_storage():
-    return get_storage()
+    return current_runtime().storage
 
 
 def _comparison_view(aggregate):

--- a/app/modules/connection_monitor/routes.py
+++ b/app/modules/connection_monitor/routes.py
@@ -1,5 +1,6 @@
 """API routes for Connection Monitor."""
 
+from app.tz import get_tz_name
 import csv
 import io
 import logging
@@ -13,7 +14,6 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from flask import Blueprint, jsonify, request, Response
 
 from app.tz import local_date_to_utc_range, local_today, to_local_display, _parse_utc
-from app.web import get_config_manager, _get_tz_name
 from app.web_auth import require_auth
 from app.runtime import current_runtime
 
@@ -36,7 +36,7 @@ def _no_cache_api(response):
 
 def _get_cm_storage():
     """Get ConnectionMonitorStorage. Uses DATA_DIR like collector."""
-    config_manager = get_config_manager()
+    config_manager = current_runtime().config_manager
     data_dir = config_manager.data_dir if config_manager else os.environ.get("DATA_DIR", "/data")
     db_path = os.path.join(data_dir, "connection_monitor.db")
     return current_runtime().derived_storage.get(
@@ -46,7 +46,7 @@ def _get_cm_storage():
 
 def _get_probe_engine():
     """Get ProbeEngine for capability info using configured method."""
-    cfg = get_config_manager()
+    cfg = current_runtime().config_manager
     method = cfg.get("connection_monitor_probe_method", "auto") if cfg else "auto"
     return ProbeEngine(method=method)
 
@@ -128,7 +128,7 @@ _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _get_tz():
-    return _get_tz_name()
+    return get_tz_name(current_runtime().config_manager)
 
 
 def _date_to_epoch_range(date_str, tz_name):
@@ -453,7 +453,7 @@ def api_get_range_stats():
 @bp.route("/api/connection-monitor/summary")
 @require_auth
 def api_get_summary():
-    cfg = get_config_manager()
+    cfg = current_runtime().config_manager
     if cfg is not None and not cfg.get("connection_monitor_enabled", False):
         return jsonify({})
 
@@ -478,7 +478,7 @@ def api_get_outages(target_id):
     storage = _get_cm_storage()
     start = request.args.get("start", type=float)
     end = request.args.get("end", type=float)
-    cfg = get_config_manager()
+    cfg = current_runtime().config_manager
     default_threshold = int(cfg.get("connection_monitor_outage_threshold", 5)) if cfg else 5
     threshold = request.args.get("threshold", default_threshold, type=int)
     outages = storage.get_outages(target_id, threshold=threshold, start=start, end=end)

--- a/app/modules/de_tkg_compensation/routes.py
+++ b/app/modules/de_tkg_compensation/routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from app.runtime import current_runtime
 import os
 from datetime import date, datetime, timezone
 from io import BytesIO
@@ -11,7 +12,6 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from flask import Blueprint, jsonify, request, send_file
 
 from app.tz import get_tz_name, local_to_utc, local_today
-from app.web import get_config_manager, get_module_loader, get_storage
 from app.web_auth import require_auth
 
 from .candidates import (
@@ -118,7 +118,7 @@ def _validation_error_response(exc: RuleValidationError, status: int = 400):
 
 
 def _storage() -> ClaimStorage | None:
-    core = get_storage()
+    core = current_runtime().storage
     return ClaimStorage(core.db_path) if core else None
 
 
@@ -128,7 +128,7 @@ def _connection_db_path() -> str:
 
 def _capabilities() -> dict[str, bool]:
     return get_capabilities(
-        get_config_manager(), get_module_loader(), connection_db_path=_connection_db_path()
+        current_runtime().config_manager, current_runtime().module_loader, connection_db_path=_connection_db_path()
     )
 
 
@@ -317,7 +317,7 @@ def _calculate_claim(claim: dict):
             "eligibility_claim_basis_required",
             "Confirm a complete outage or at least one missed appointment",
         )
-    tz_name = get_tz_name(get_config_manager())
+    tz_name = get_tz_name(current_runtime().config_manager)
     ruleset = resolve_ruleset(claim.get("rules_version"))
     if has_outage:
         if any(
@@ -370,7 +370,7 @@ def _calculate_claim(claim: dict):
 
 
 def _customer_defaults(capabilities: dict[str, bool]) -> dict[str, str]:
-    config = get_config_manager()
+    config = current_runtime().config_manager
     if not capabilities["reports"] or capabilities["demo_mode"] or not config:
         return {}
     return {
@@ -428,11 +428,11 @@ def _calculation_response(claim: dict, breakdown, appointments) -> dict:
 def api_candidates():
     capabilities = _capabilities()
     candidates = []
-    tz_name = get_tz_name(get_config_manager())
+    tz_name = get_tz_name(current_runtime().config_manager)
     today_value = local_today(tz_name)
     if capabilities["connection_monitor_source"]:
         candidates.extend(load_connection_monitor_candidates(_connection_db_path(), tz_name))
-    core = get_storage()
+    core = current_runtime().storage
     if capabilities["journal"] and core:
         candidates.extend(
             load_incident_candidates(
@@ -475,7 +475,7 @@ def api_claims_create():
     if not storage:
         return _error("technical_storage_unavailable", "Storage unavailable", 500)
     try:
-        tz_name = get_tz_name(get_config_manager())
+        tz_name = get_tz_name(current_runtime().config_manager)
         payload = _normalise_claim_payload(request.get_json(silent=True), tz_name)
     except RuleValidationError as exc:
         return _validation_error_response(exc)
@@ -485,7 +485,7 @@ def api_claims_create():
             "Generate the letter from calculated claim facts before editing it",
             409,
         )
-    config = get_config_manager()
+    config = current_runtime().config_manager
     claim = storage.create(
         payload, is_demo=bool(config and config.is_demo_mode())
     )
@@ -507,7 +507,7 @@ def api_claim_update(claim_id):
     if not storage:
         return _error("technical_storage_unavailable", "Storage unavailable", 500)
     try:
-        tz_name = get_tz_name(get_config_manager())
+        tz_name = get_tz_name(current_runtime().config_manager)
         payload = _normalise_claim_payload(request.get_json(silent=True), tz_name)
     except RuleValidationError as exc:
         return _validation_error_response(exc)

--- a/app/modules/evidence/routes.py
+++ b/app/modules/evidence/routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from app.runtime import current_runtime
 import logging
 import os
 import sqlite3
@@ -21,7 +22,6 @@ from app.analyzer import threshold_snapshot
 from app.modules.journal.storage import JournalStorage
 from app.storage.sqlite import open_read
 from app.tz import get_tz_name, local_date_to_utc_range, local_to_utc, local_today
-from app.web import get_config_manager, get_storage
 from app.web_auth import require_auth
 
 from .checklist import build_checklist, summarize_checklist
@@ -34,7 +34,7 @@ _INCIDENT_ID_ERROR = "incident_id must be a positive integer"
 
 
 def _get_journal_storage():
-    core = get_storage()
+    core = current_runtime().storage
     if not core:
         return None
     return JournalStorage(core.db_path)
@@ -42,7 +42,7 @@ def _get_journal_storage():
 
 def _get_tz_name() -> str:
     """Return the configured timezone without depending on app.web privates."""
-    return get_tz_name(get_config_manager())
+    return get_tz_name(current_runtime().config_manager)
 
 
 def _utc_datetime(value: str) -> datetime:
@@ -275,7 +275,7 @@ def api_evidence_checklist():
     if incident_id is None and not has_range:
         return jsonify({"error": "incident_id or from/to required"}), 400
 
-    core = get_storage()
+    core = current_runtime().storage
     if not core:
         return jsonify({"error": "storage not available"}), 503
 
@@ -313,7 +313,7 @@ def api_evidence_checklist():
     )
     bqm_rows = _get_bqm_rows(core.db_path, window["from"], window["to"])
     connection_latency_rows = _get_connection_latency_rows(window["from"], window["to"])
-    config_manager = get_config_manager()
+    config_manager = current_runtime().config_manager
     capabilities = _capabilities(config_manager)
     items = build_checklist(
         window,

--- a/app/modules/journal/routes.py
+++ b/app/modules/journal/routes.py
@@ -1,5 +1,8 @@
 """Journal and incident management routes."""
 
+from app.runtime import current_runtime
+from app.tz import valid_date, localize_timestamps, get_tz_name
+from app.web_locale import get_lang
 import csv
 import json
 import logging
@@ -11,10 +14,6 @@ from io import BytesIO
 from flask import Blueprint, request, jsonify, send_file, make_response
 
 from app.tz import local_date_to_utc_range
-from app.web import (
-    get_config_manager, get_state, get_storage,
-    _valid_date, _localize_timestamps, _get_lang, _get_tz_name,
-)
 from app.web_auth import require_auth, _get_client_ip
 from app.storage import ALLOWED_MIME_TYPES, MAX_ATTACHMENT_SIZE, MAX_ATTACHMENTS_PER_ENTRY
 
@@ -33,7 +32,7 @@ _VALID_INCIDENT_STATUSES = {"open", "resolved", "escalated"}
 
 def _get_journal_storage():
     """Get JournalStorage for journal-specific queries."""
-    core = get_storage()
+    core = current_runtime().storage
     if not core:
         return None
     return JournalStorage(core.db_path)
@@ -59,7 +58,7 @@ def api_journal_list():
         except (ValueError, TypeError):
             pass
     entries = _storage.get_entries(limit=limit, offset=offset, search=search, incident_id=incident_id)
-    _localize_timestamps(entries)
+    localize_timestamps(entries, get_tz_name(current_runtime().config_manager))
     return jsonify(entries)
 
 
@@ -163,7 +162,7 @@ def api_journal_create():
     date = (data.get("date") or "").strip()
     title = (data.get("title") or "").strip()
     description = (data.get("description") or "").strip()
-    if not _valid_date(date):
+    if not valid_date(date):
         return jsonify({"error": "Invalid date format (YYYY-MM-DD)"}), 400
     if not title:
         return jsonify({"error": "Title is required"}), 400
@@ -209,7 +208,7 @@ def api_journal_update(entry_id):
     date = (data.get("date") or "").strip()
     title = (data.get("title") or "").strip()
     description = (data.get("description") or "").strip()
-    if not _valid_date(date):
+    if not valid_date(date):
         return jsonify({"error": "Invalid date format (YYYY-MM-DD)"}), 400
     if not title:
         return jsonify({"error": "Title is required"}), 400
@@ -374,7 +373,7 @@ def api_journal_import_confirm():
         title = (row.get("title") or "").strip()
         description = (row.get("description") or "").strip()
 
-        if not _valid_date(date):
+        if not valid_date(date):
             continue
         if not title:
             continue
@@ -460,7 +459,7 @@ def api_incidents_list():
     if status and status not in _VALID_INCIDENT_STATUSES:
         status = None
     incidents = _storage.get_incidents(status=status)
-    _localize_timestamps(incidents)
+    localize_timestamps(incidents, get_tz_name(current_runtime().config_manager))
     return jsonify(incidents)
 
 
@@ -487,9 +486,9 @@ def api_incidents_create():
         return jsonify({"error": "Invalid status (open, resolved, escalated)"}), 400
     start_date = (data.get("start_date") or "").strip() or None
     end_date = (data.get("end_date") or "").strip() or None
-    if start_date and not _valid_date(start_date):
+    if start_date and not valid_date(start_date):
         return jsonify({"error": "Invalid start_date format (YYYY-MM-DD)"}), 400
-    if end_date and not _valid_date(end_date):
+    if end_date and not valid_date(end_date):
         return jsonify({"error": "Invalid end_date format (YYYY-MM-DD)"}), 400
     icon = (data.get("icon") or "").strip() or None
     incident_id = _storage.save_incident(name, description, status, start_date, end_date, icon)
@@ -533,9 +532,9 @@ def api_incident_update(incident_id):
         return jsonify({"error": "Invalid status (open, resolved, escalated)"}), 400
     start_date = (data.get("start_date") or "").strip() or None
     end_date = (data.get("end_date") or "").strip() or None
-    if start_date and not _valid_date(start_date):
+    if start_date and not valid_date(start_date):
         return jsonify({"error": "Invalid start_date format (YYYY-MM-DD)"}), 400
-    if end_date and not _valid_date(end_date):
+    if end_date and not valid_date(end_date):
         return jsonify({"error": "Invalid end_date format (YYYY-MM-DD)"}), 400
     icon = (data.get("icon") or "").strip() or None
     if not _storage.update_incident(incident_id, name, description, status, start_date, end_date, icon):
@@ -573,11 +572,11 @@ def api_incident_timeline(incident_id):
     timeline = []
     bnetz = []
     if incident.get("start_date"):
-        tz = _get_tz_name()
+        tz = get_tz_name(current_runtime().config_manager)
         start_ts, _ = local_date_to_utc_range(incident["start_date"], tz)
         end_date = incident.get("end_date") or datetime.now().strftime("%Y-%m-%d")
         _, end_ts = local_date_to_utc_range(end_date, tz)
-        _core = get_storage()
+        _core = current_runtime().storage
         if _core:
             timeline = _core.get_correlation_timeline(start_ts, end_ts)
         try:
@@ -587,10 +586,10 @@ def api_incident_timeline(incident_id):
         except (ImportError, Exception):
             bnetz = []
 
-    _localize_timestamps(timeline)
-    _localize_timestamps(entries)
-    _localize_timestamps(incident)
-    _localize_timestamps(bnetz)
+    localize_timestamps(timeline, get_tz_name(current_runtime().config_manager))
+    localize_timestamps(entries, get_tz_name(current_runtime().config_manager))
+    localize_timestamps(incident, get_tz_name(current_runtime().config_manager))
+    localize_timestamps(bnetz, get_tz_name(current_runtime().config_manager))
     return jsonify({
         "incident": incident,
         "entries": entries,
@@ -606,7 +605,7 @@ def api_incident_report(incident_id):
     from app.modules.reports.report import generate_incident_report
 
     _storage = _get_journal_storage()
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
 
     if not _storage:
         return jsonify({"error": "Storage not initialized"}), 500
@@ -627,11 +626,11 @@ def api_incident_report(incident_id):
     speedtests = []
     bnetz = []
     if incident.get("start_date"):
-        _tz = _get_tz_name()
+        _tz = get_tz_name(current_runtime().config_manager)
         start_ts, _ = local_date_to_utc_range(incident["start_date"], _tz)
         end_date = incident.get("end_date") or datetime.now().strftime("%Y-%m-%d")
         _, end_ts = local_date_to_utc_range(end_date, _tz)
-        _core = get_storage()
+        _core = current_runtime().storage
         snapshots = _core.get_range_data(start_ts, end_ts) if _core else []
         try:
             from app.modules.speedtest.storage import SpeedtestStorage
@@ -653,8 +652,8 @@ def api_incident_report(incident_id):
             "modem_type": _config_manager.get("modem_type", ""),
         }
 
-    conn_info = get_state().get("connection_info") or {}
-    lang = _get_lang()
+    conn_info = current_runtime().get_state().get("connection_info") or {}
+    lang = get_lang()
     customer_name = request.args.get("name", "")
     customer_number = request.args.get("number", "")
     customer_address = request.args.get("address", "")

--- a/app/modules/modulation/routes.py
+++ b/app/modules/modulation/routes.py
@@ -1,12 +1,12 @@
 """Modulation performance API routes (v2)."""
 
+from app.runtime import current_runtime
 import logging
 from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, request, jsonify
 
 from app.tz import to_local, utc_now, utc_cutoff
-from app.web import get_storage, get_config_manager, get_state
 from app.web_auth import require_auth
 
 from .engine import (
@@ -23,7 +23,7 @@ bp = Blueprint("modulation_bp", __name__)
 
 def _get_tz():
     """Get the configured timezone name."""
-    cm = get_config_manager()
+    cm = current_runtime().config_manager
     if cm:
         return cm.get("timezone", "")
     return ""
@@ -42,13 +42,13 @@ def _positive_number(value):
 
 def _get_capacity_tariffs():
     """Return configured or detected tariff values for capacity comparison."""
-    cm = get_config_manager()
+    cm = current_runtime().config_manager
     booked_download = _positive_number(cm.get("booked_download")) if cm else None
     booked_upload = _positive_number(cm.get("booked_upload")) if cm else None
     if booked_download and booked_upload:
         return booked_download, booked_upload
 
-    state = get_state()
+    state = current_runtime().get_state()
     conn_info = state.get("connection_info") if isinstance(state, dict) else {}
     conn_info = conn_info or {}
     detected_download = _positive_number(conn_info.get("max_downstream_kbps"))
@@ -65,7 +65,7 @@ def _get_capacity_tariffs():
 @require_auth
 def api_modulation_distribution():
     """Return per-protocol-group distribution, health index, and trend per day."""
-    storage = get_storage()
+    storage = current_runtime().storage
     if not storage:
         return jsonify({"error": "No storage available"}), 503
 
@@ -96,7 +96,7 @@ def api_modulation_distribution():
 @require_auth
 def api_modulation_intraday():
     """Return per-channel modulation timeline for a single day."""
-    storage = get_storage()
+    storage = current_runtime().storage
     if not storage:
         return jsonify({"error": "No storage available"}), 503
 
@@ -139,7 +139,7 @@ def api_modulation_intraday():
 @require_auth
 def api_modulation_trend():
     """Return per-day trend data (health index + low-QAM %) for the trend chart."""
-    storage = get_storage()
+    storage = current_runtime().storage
     if not storage:
         return jsonify({"error": "No storage available"}), 503
 

--- a/app/modules/reports/routes.py
+++ b/app/modules/reports/routes.py
@@ -1,5 +1,7 @@
 """Report generation routes."""
 
+from app.runtime import current_runtime
+from app.web_locale import get_lang
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -7,12 +9,6 @@ from flask import Blueprint, jsonify, make_response, request
 
 from app.aggregation import select_preferred_bnetz
 from app.tz import utc_cutoff, utc_now
-from app.web import (
-    _get_lang,
-    get_config_manager,
-    get_state,
-    get_storage,
-)
 from app.web_auth import require_auth
 
 from .report import generate_complaint_text, generate_report
@@ -128,8 +124,8 @@ def _get_comparison_data(storage):
 @require_auth
 def api_report():
     """Generate a PDF incident report."""
-    _storage = get_storage()
-    _config_manager = get_config_manager()
+    _storage = current_runtime().storage
+    _config_manager = current_runtime().config_manager
     window, error = _get_report_window()
     if error:
         return error
@@ -146,8 +142,8 @@ def api_report():
             "modem_type": _config_manager.get("modem_type", ""),
         }
 
-    conn_info = (get_state().get("connection_info") or {})
-    lang = request.args.get("lang", _get_lang())
+    conn_info = (current_runtime().get_state().get("connection_info") or {})
+    lang = request.args.get("lang", get_lang())
     comparison_data = _get_comparison_data(_storage)
     customer_name = request.args.get("name", "")
     customer_number = request.args.get("number", "")
@@ -177,8 +173,8 @@ def api_report():
 @require_auth
 def api_complaint():
     """Generate ISP complaint letter as text."""
-    _storage = get_storage()
-    _config_manager = get_config_manager()
+    _storage = current_runtime().storage
+    _config_manager = current_runtime().config_manager
     window, error = _get_report_window()
     if error:
         return error
@@ -195,7 +191,7 @@ def api_complaint():
             "modem_type": _config_manager.get("modem_type", ""),
         }
 
-    lang = request.args.get("lang", _get_lang())
+    lang = request.args.get("lang", get_lang())
     customer_name = request.args.get("name", "")
     customer_number = request.args.get("number", "")
     customer_address = request.args.get("address", "")

--- a/app/modules/smokeping/routes.py
+++ b/app/modules/smokeping/routes.py
@@ -1,14 +1,12 @@
 """Smokeping module routes."""
 
+from app.runtime import current_runtime
 import logging
 
 import requests as _requests
 
 from flask import Blueprint, jsonify, make_response
 
-from app.web import (
-    get_config_manager,
-)
 from app.web_auth import require_auth
 
 log = logging.getLogger("docsis.web")
@@ -30,7 +28,7 @@ SMOKEPING_TIMESPANS = {
 @require_auth
 def api_smokeping_targets():
     """Return list of configured Smokeping targets."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager or not _config_manager.is_smokeping_configured():
         return jsonify([])
     raw = _config_manager.get("smokeping_targets", "")
@@ -42,7 +40,7 @@ def api_smokeping_targets():
 @require_auth
 def api_smokeping_graph(target, timespan):
     """Proxy a Smokeping graph PNG."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager or not _config_manager.is_smokeping_configured():
         return jsonify({"error": "Smokeping not configured"}), 404
 

--- a/app/modules/speedtest/routes.py
+++ b/app/modules/speedtest/routes.py
@@ -7,7 +7,6 @@ import requests
 from flask import Blueprint, request, jsonify
 
 from app.config import parse_config_bool
-from app.web import get_config_manager, get_state, get_storage, clear_speedtest_latest
 from app.web_auth import require_auth
 from app.runtime import current_runtime
 from app.i18n import get_translations
@@ -24,7 +23,7 @@ _TRIGGER_COOLDOWN = 60  # seconds
 
 
 def _get_speedtest_storage():
-    core_storage = get_storage()
+    core_storage = current_runtime().storage
     if not core_storage:
         return None
     return current_runtime().derived_storage.get(
@@ -46,11 +45,11 @@ def _classify_speed(actual, booked):
 
 def _enrich_speedtest(result):
     """Add speed_health, download_class, upload_class to a speedtest result."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     booked_dl = _config_manager.get("booked_download", 0) if _config_manager else 0
     booked_ul = _config_manager.get("booked_upload", 0) if _config_manager else 0
     if not booked_dl or not booked_ul:
-        conn_info = get_state().get("connection_info") or {}
+        conn_info = current_runtime().get_state().get("connection_info") or {}
         if not booked_dl:
             booked_dl = conn_info.get("max_downstream_kbps", 0) // 1000 if conn_info.get("max_downstream_kbps") else 0
         if not booked_ul:
@@ -93,7 +92,7 @@ def _get_lang():
 @require_auth
 def api_speedtest():
     """Return speedtest results from local cache, with delta fetch from STT."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     ss = _get_speedtest_storage()
     if not _config_manager or not _config_manager.is_speedtest_configured():
         return jsonify([])
@@ -126,7 +125,7 @@ def api_speedtest():
                     # Remote is reachable but empty — server was wiped
                     log.info("Remote has no results but cache has %d, clearing", cached_count)
                     ss.clear_cache()
-                    clear_speedtest_latest()
+                    current_runtime().clear_speedtest_latest()
                     cached_count = 0
                 elif remote_latest and remote_latest[0].get("id", 0) < last_id:
                     log.info(
@@ -177,7 +176,7 @@ def api_speedtest_detail(result_id):
 def api_speedtest_signal(result_id):
     """Return the closest DOCSIS snapshot signal data for a speedtest result."""
     ss = _get_speedtest_storage()
-    core_storage = get_storage()
+    core_storage = current_runtime().storage
     if not ss:
         return jsonify({"error": "Storage not initialized"}), 500
     result = ss.get_speedtest_by_id(result_id)
@@ -228,7 +227,7 @@ def api_speedtest_signal(result_id):
 @require_auth
 def api_speedtest_run():
     """Trigger a speedtest run via the Speedtest Tracker API."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager or not _config_manager.is_speedtest_configured():
         return jsonify({"success": False, "error": "Speedtest Tracker not configured"}), 400
 
@@ -279,6 +278,6 @@ def api_speedtest_clear_cache():
     if not ss:
         return jsonify({"success": False, "error": "Storage not initialized"}), 500
     count = ss.clear_cache()
-    clear_speedtest_latest()
+    current_runtime().clear_speedtest_latest()
     log.info("Speedtest cache cleared via API (%d results removed)", count)
     return jsonify({"success": True, "cleared": count})

--- a/app/modules/weather/routes.py
+++ b/app/modules/weather/routes.py
@@ -4,7 +4,6 @@ import logging
 
 from flask import Blueprint, request, jsonify
 
-from app.web import get_config_manager, get_state, get_storage
 from app.web_auth import require_auth
 from app.runtime import current_runtime
 from .storage import WeatherStorage
@@ -14,7 +13,7 @@ log = logging.getLogger("docsis.web.weather")
 bp = Blueprint("weather_module", __name__)
 
 def _get_weather_storage():
-    core_storage = get_storage()
+    core_storage = current_runtime().storage
     if not core_storage:
         return None
     return current_runtime().derived_storage.get(
@@ -26,7 +25,7 @@ def _get_weather_storage():
 @require_auth
 def api_weather():
     """Return weather (temperature) history, newest first."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager or not _config_manager.is_weather_configured():
         return jsonify([])
     ws = _get_weather_storage()
@@ -40,7 +39,7 @@ def api_weather():
 @require_auth
 def api_weather_current():
     """Return latest weather reading from state."""
-    state = get_state()
+    state = current_runtime().get_state()
     weather = state.get("weather_latest")
     if not weather:
         return jsonify({"error": "No weather data yet"}), 404
@@ -51,7 +50,7 @@ def api_weather_current():
 @require_auth
 def api_weather_range():
     """Return weather data within a timestamp range (for correlation)."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager or not _config_manager.is_weather_configured():
         return jsonify([])
     ws = _get_weather_storage()

--- a/app/theme_registry.py
+++ b/app/theme_registry.py
@@ -883,3 +883,93 @@ def download_theme(download_url: str, target_dir: str, timeout: int = 30) -> boo
         return False
 
     return True
+
+
+_THEME_COLLECTIONS = [
+    {
+        "key": "signature",
+        "title_key": "theme_collection_signature",
+        "title_fallback": "Signature Themes",
+        "description_key": "theme_collection_signature_desc",
+        "description_fallback": "DOCSight's built-in identity themes",
+        "ids": (
+            "docsight.theme_classic",
+            "docsight.theme_tribu",
+            "docsight.theme_ocean",
+        ),
+    },
+    {
+        "key": "community",
+        "title_key": "theme_collection_community",
+        "title_fallback": "Community Favorites",
+        "description_key": "theme_collection_community_desc",
+        "description_fallback": "Popular palettes inspired by widely loved developer themes",
+        "ids": (
+            "docsight.theme_one_dark",
+            "docsight.theme_dracula",
+            "docsight.theme_catppuccin_mocha",
+            "docsight.theme_tokyo_night",
+            "docsight.theme_nord",
+            "docsight.theme_synthwave",
+            "docsight.theme_gruvbox",
+        ),
+    },
+    {
+        "key": "playful",
+        "title_key": "theme_collection_playful",
+        "title_fallback": "Easter Eggs",
+        "description_key": "theme_collection_playful_desc",
+        "description_fallback": "Delight-first themes for fun installs and screenshots",
+        "ids": (
+            "docsight.theme_matrix",
+            "docsight.theme_amber_terminal",
+            "docsight.theme_gameboy",
+            "docsight.theme_doom",
+        ),
+    },
+]
+
+_THEME_COLLECTION_INDEX = {
+    theme_id: (collection["key"], position)
+    for collection in _THEME_COLLECTIONS
+    for position, theme_id in enumerate(collection["ids"])
+}
+
+
+def build_theme_collections(theme_modules):
+    """Group theme modules into curated gallery collections."""
+    grouped = {collection["key"]: [] for collection in _THEME_COLLECTIONS}
+
+    for mod in theme_modules:
+        collection_key = _THEME_COLLECTION_INDEX.get(mod.id, ("community", 999))[0]
+        grouped.setdefault(collection_key, []).append(mod)
+
+    collections = []
+    for collection in _THEME_COLLECTIONS:
+        modules = grouped.get(collection["key"], [])
+        if not modules:
+            continue
+        modules.sort(
+            key=lambda mod: (
+                _THEME_COLLECTION_INDEX.get(mod.id, (collection["key"], 999))[1],
+                mod.name.lower(),
+            )
+        )
+        collections.append({
+            **collection,
+            "modules": modules,
+        })
+
+    return collections
+
+
+def resolve_active_theme(active_id, theme_modules):
+    """Return active theme data and ID, falling back to Classic then first usable."""
+    fallback = None
+    for mod in theme_modules:
+        if mod.enabled and not mod.error and mod.theme_data:
+            if mod.id == active_id:
+                return mod.theme_data, mod.id
+            if fallback is None or mod.id == "docsight.theme_classic":
+                fallback = mod
+    return (fallback.theme_data, fallback.id) if fallback else (None, "")

--- a/app/tz.py
+++ b/app/tz.py
@@ -5,6 +5,7 @@ Conversion to local time happens only at the display boundary (web/charts/report
 """
 
 import os
+import re
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -178,3 +179,33 @@ def _parse_utc(ts):
         ts_clean = ts_clean.split(".")[0]
     naive = datetime.strptime(ts_clean, _LOCAL_FMT)
     return naive.replace(tzinfo=timezone.utc)
+
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def valid_date(date_str):
+    """Validate date string format AND actual calendar validity."""
+    if not date_str or not _DATE_RE.match(date_str):
+        return False
+    try:
+        datetime.strptime(date_str, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False
+
+
+def localize_timestamps(data, tz_name, keys=("timestamp", "created_at", "updated_at", "last_used_at")):
+    """Convert UTC timestamps to local time in-place for API responses.
+
+    Works on dicts and lists of dicts. Modifies data in-place and returns it.
+    """
+    if not tz_name:
+        return data
+    items = data if isinstance(data, list) else [data]
+    for item in items:
+        if isinstance(item, dict):
+            for k in keys:
+                if k in item and item[k] and isinstance(item[k], str) and item[k].endswith("Z"):
+                    item[k] = to_local(item[k], tz_name)
+    return data

--- a/app/web.py
+++ b/app/web.py
@@ -14,7 +14,7 @@ from flask import current_app, render_template, request, jsonify, redirect, sess
 from markupsafe import Markup
 from zoneinfo import available_timezones
 
-from .config import DEFAULTS, MODULE_SECRET_KEYS, PASSWORD_MASK, POLL_MIN, POLL_MAX
+from .config import MODULE_SECRET_KEYS, PASSWORD_MASK, POLL_MIN, POLL_MAX
 from .analyzer import get_thresholds
 from .base_path import normalize_base_path
 from . import signal_health_view
@@ -29,8 +29,10 @@ from .glossary import (
 from .i18n import get_translations, LANGUAGES, LANG_FLAGS
 from .maintainer_notices import coerce_dismissed_notice_ids, get_active_notices
 from .module_loader import module_static_url
-from .runtime import current_runtime, _version_newer as _runtime_version_newer
-from .tz import guess_iana_timezone as _guess_iana_timezone, get_tz_name as _get_public_tz_name, to_local as _to_local
+from .runtime import current_runtime
+from .tz import guess_iana_timezone as _guess_iana_timezone, get_tz_name, to_local as _to_local
+from .theme_registry import build_theme_collections, resolve_active_theme
+from .web_locale import get_lang, get_setup_lang
 from .version import get_app_version
 from .web_auth import require_auth, _get_admin_password, _authenticate_login, _get_login_csrf_token, _sync_auth_state
 
@@ -61,111 +63,8 @@ def is_desktop_preview_mode() -> bool:
     return os.environ.get(DESKTOP_MODE_ENV) == "1"
 
 
-_THEME_COLLECTIONS = [
-    {
-        "key": "signature",
-        "title_key": "theme_collection_signature",
-        "title_fallback": "Signature Themes",
-        "description_key": "theme_collection_signature_desc",
-        "description_fallback": "DOCSight's built-in identity themes",
-        "ids": (
-            "docsight.theme_classic",
-            "docsight.theme_tribu",
-            "docsight.theme_ocean",
-        ),
-    },
-    {
-        "key": "community",
-        "title_key": "theme_collection_community",
-        "title_fallback": "Community Favorites",
-        "description_key": "theme_collection_community_desc",
-        "description_fallback": "Popular palettes inspired by widely loved developer themes",
-        "ids": (
-            "docsight.theme_one_dark",
-            "docsight.theme_dracula",
-            "docsight.theme_catppuccin_mocha",
-            "docsight.theme_tokyo_night",
-            "docsight.theme_nord",
-            "docsight.theme_synthwave",
-            "docsight.theme_gruvbox",
-        ),
-    },
-    {
-        "key": "playful",
-        "title_key": "theme_collection_playful",
-        "title_fallback": "Easter Eggs",
-        "description_key": "theme_collection_playful_desc",
-        "description_fallback": "Delight-first themes for fun installs and screenshots",
-        "ids": (
-            "docsight.theme_matrix",
-            "docsight.theme_amber_terminal",
-            "docsight.theme_gameboy",
-            "docsight.theme_doom",
-        ),
-    },
-]
-
-_THEME_COLLECTION_INDEX = {
-    theme_id: (collection["key"], position)
-    for collection in _THEME_COLLECTIONS
-    for position, theme_id in enumerate(collection["ids"])
-}
-
-
-def _build_theme_collections(theme_modules):
-    """Group theme modules into curated gallery collections."""
-    grouped = {collection["key"]: [] for collection in _THEME_COLLECTIONS}
-
-    for mod in theme_modules:
-        collection_key = _THEME_COLLECTION_INDEX.get(mod.id, ("community", 999))[0]
-        grouped.setdefault(collection_key, []).append(mod)
-
-    collections = []
-    for collection in _THEME_COLLECTIONS:
-        modules = grouped.get(collection["key"], [])
-        if not modules:
-            continue
-        modules.sort(
-            key=lambda mod: (
-                _THEME_COLLECTION_INDEX.get(mod.id, (collection["key"], 999))[1],
-                mod.name.lower(),
-            )
-        )
-        collections.append({
-            **collection,
-            "modules": modules,
-        })
-
-    return collections
-
 APP_VERSION = get_app_version()
 
-_UPDATE_CACHE_TTL = 3600  # 1 hour
-
-def _check_for_update():
-    """Return cached update info. Triggers background check if stale."""
-    return current_runtime().update_checker.latest()
-
-def _version_newer(latest, current):
-    """Compare date-based version strings (e.g. '2026-02-16.1' > '2026-02-13.8').
-
-    Splits on '.' to compare the date part lexicographically and the
-    trailing build number numerically so that '.10' > '.9'.
-    """
-    return _runtime_version_newer(latest, current)
-
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-
-
-def _valid_date(date_str):
-    """Validate date string format AND actual calendar validity."""
-    if not date_str or not _DATE_RE.match(date_str):
-        return False
-    try:
-        datetime.strptime(date_str, "%Y-%m-%d")
-        return True
-    except ValueError:
-        return False
 _STRIP_TAGS_RE = re.compile(r"<(?!/?(?:b|a|strong|em|br)\b)[^>]+>", re.IGNORECASE)
 _CLOSE_TAG_RE = re.compile(r"</(a|b|strong|em|br)\s[^>]*>", re.IGNORECASE)
 _OPEN_TAG_RE = re.compile(r"<(a|b|strong|em|br)([\s/][^>]*)?>", re.IGNORECASE)
@@ -269,80 +168,13 @@ def format_uptime(seconds):
     return f"{minutes}m"
 
 
-def _get_lang():
-    """Get language from query param or config."""
-    _config_manager = get_config_manager()
-    lang = request.args.get("lang")
-    if lang and lang in LANGUAGES:
-        return lang
-    if _config_manager:
-        return _config_manager.get("language", "en")
-    return "en"
-
-
-def _get_setup_lang():
-    """Resolve and persist the language for the unconfigured setup route."""
-    _config_manager = get_config_manager()
-    lang = request.args.get("lang")
-    if lang in LANGUAGES:
-        if _config_manager:
-            _config_manager.save({"language": lang})
-        return lang
-
-    if _config_manager and _config_manager.has_stored_value("language"):
-        return _config_manager.get("language", DEFAULTS["language"])
-
-    inferred = DEFAULTS["language"]
-    for requested, quality in request.accept_languages:
-        if quality <= 0:
-            continue
-        normalized = requested.lower().replace("_", "-")
-        if normalized in LANGUAGES:
-            inferred = normalized
-            break
-        base = normalized.split("-", 1)[0]
-        if base in LANGUAGES:
-            inferred = base
-            break
-
-    if _config_manager:
-        _config_manager.save({"language": inferred})
-    return inferred
-
-
-def _get_tz_name():
-    """Get configured IANA timezone name."""
-    return _get_public_tz_name(get_config_manager())
-
-
-def _localize_timestamps(data, keys=("timestamp", "created_at", "updated_at", "last_used_at")):
-    """Convert UTC timestamps to local time in-place for API responses.
-
-    Works on dicts and lists of dicts. Modifies data in-place and returns it.
-    """
-    tz = _get_tz_name()
-    if not tz:
-        return data
-    if isinstance(data, dict):
-        for k in keys:
-            if k in data and data[k] and isinstance(data[k], str) and data[k].endswith("Z"):
-                data[k] = _to_local(data[k], tz)
-    elif isinstance(data, list):
-        for item in data:
-            if isinstance(item, dict):
-                for k in keys:
-                    if k in item and item[k] and isinstance(item[k], str) and item[k].endswith("Z"):
-                        item[k] = _to_local(item[k], tz)
-    return data
-
-
 # ── Jinja2 Filters for timestamp display ──
 
 def _jinja_localtime(value):
     """Jinja2 filter: convert UTC timestamp to local display time."""
     if not value or not isinstance(value, str):
         return value
-    tz = _get_tz_name()
+    tz = get_tz_name(current_runtime().config_manager)
     return _to_local(value, tz) if tz else value.rstrip("Z")
 
 
@@ -378,7 +210,7 @@ def get_module_loader():
 
 def _get_dismissed_notice_ids():
     """Return locally persisted maintainer notice dismissals."""
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if not _config_manager:
         return []
     return coerce_dismissed_notice_ids(_config_manager.get("dismissed_notice_ids", []))
@@ -400,11 +232,11 @@ def set_last_manual_poll(value):
 
 
 def login():
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     _sync_auth_state()
     if not _get_admin_password():
         return redirect(url_for("index"))
-    lang = _get_lang()
+    lang = get_lang()
     t = get_translations(lang)
     theme = _config_manager.get_theme() if _config_manager else "dark"
     error = None
@@ -438,48 +270,29 @@ def inject_browser_url_bootstrap():
 
 def inject_auth():
     """Make auth_enabled and module info available in all templates."""
-    _config_manager = get_config_manager()
-    _module_loader = get_module_loader()
+    _config_manager = current_runtime().config_manager
+    _module_loader = current_runtime().module_loader
     auth_enabled = bool(_get_admin_password())
     modules = _module_loader.get_enabled_modules() if _module_loader else []
 
-    # Resolve active theme module's CSS variables
-    active_theme_data = None
-    active_theme_id = ""
-    if _module_loader and _config_manager:
-        active_id = _config_manager.get("active_theme", "")
-        theme_modules = _module_loader.get_theme_modules()
-        active_mod = None
-        classic_mod = None
-        first_with_data = None
-        for m in theme_modules:
-            if m.enabled and not m.error and m.theme_data:
-                if first_with_data is None:
-                    first_with_data = m
-                if m.id == "docsight.theme_classic":
-                    classic_mod = m
-                if m.id == active_id:
-                    active_mod = m
-                    break
-        if active_mod is None:
-            active_mod = classic_mod or first_with_data
-        if active_mod:
-            active_theme_data = active_mod.theme_data
-            active_theme_id = active_mod.id
+    active_theme_data, active_theme_id = (
+        resolve_active_theme(_config_manager.get("active_theme", ""), _module_loader.get_theme_modules())
+        if _module_loader and _config_manager else (None, "")
+    )
 
     # All themes with loaded data (enabled + disabled) for settings gallery
     all_theme_modules = [
         m for m in (_module_loader.get_theme_modules() if _module_loader else [])
         if m.theme_data
     ]
-    theme_collections = _build_theme_collections(all_theme_modules)
+    theme_collections = build_theme_collections(all_theme_modules)
 
     desktop_mode = is_desktop_preview_mode()
     return {
         "auth_enabled": auth_enabled,
         "module_static_url": module_static_url,
         "version": APP_VERSION,
-        "update_available": _check_for_update(),
+        "update_available": current_runtime().update_checker.latest(),
         "modules": modules,
         "all_theme_modules": all_theme_modules,
         "theme_collections": theme_collections,
@@ -563,7 +376,7 @@ def _build_glossary_context(lang, t, selected_term_id=None):
 @require_auth
 def glossary_page():
     """Compatibility endpoint for existing glossary deep links."""
-    lang = _get_lang()
+    lang = get_lang()
     terms = {term["id"] for term in get_glossary_terms(lang)}
     hash_params = {}
     term_id = request.args.get("term", "")
@@ -577,14 +390,14 @@ def glossary_page():
 
 @require_auth
 def index():
-    _config_manager = get_config_manager()
-    _storage = get_storage()
+    _config_manager = current_runtime().config_manager
+    _storage = current_runtime().storage
     demo_mode = _config_manager.is_demo_mode() if _config_manager else False
     if _config_manager and not demo_mode and not _config_manager.is_configured():
         return redirect(url_for("setup"))
 
     theme = _config_manager.get_theme() if _config_manager else "dark"
-    lang = _get_lang()
+    lang = get_lang()
     t = get_translations(lang)
 
     isp_name = _config_manager.get("isp_name", "") if _config_manager else ""
@@ -609,7 +422,7 @@ def index():
     segment_utilization_enabled = _config_manager.is_segment_utilization_enabled() if _config_manager else False
     is_fritzbox = (_config_manager.get("modem_type") == "fritzbox") if _config_manager else False
     bnetz_enabled = _config_manager.is_bnetz_enabled() if _config_manager else True
-    state = get_state()
+    state = current_runtime().get_state()
     speedtest_latest = state.get("speedtest_latest")
     booked_download = _config_manager.get("booked_download", 0) if _config_manager else 0
     booked_upload = _config_manager.get("booked_upload", 0) if _config_manager else 0
@@ -675,7 +488,7 @@ def index():
 
 def health():
     """Simple health check endpoint."""
-    state = get_state()
+    state = current_runtime().get_state()
     if state["analysis"]:
         return {"status": "ok", "docsis_health": state["analysis"]["summary"]["health"], "version": APP_VERSION}
     return {"status": "ok", "docsis_health": "waiting", "version": APP_VERSION}
@@ -692,11 +505,11 @@ def desktop_runtime():
 
 
 def setup():
-    _config_manager = get_config_manager()
+    _config_manager = current_runtime().config_manager
     if _config_manager and (_config_manager.is_configured() or _config_manager.is_demo_mode()):
         return redirect(url_for("index"))
     config = _config_manager.get_all(mask_secrets=True) if _config_manager else {}
-    lang = _get_setup_lang()
+    lang = get_setup_lang()
     t = get_translations(lang)
     tz_name, tz_offset = _server_tz_info()
     from .drivers import driver_registry
@@ -709,11 +522,11 @@ def setup():
 
 @require_auth
 def settings():
-    _config_manager = get_config_manager()
-    _module_loader = get_module_loader()
+    _config_manager = current_runtime().config_manager
+    _module_loader = current_runtime().module_loader
     config = _config_manager.get_all(mask_secrets=True) if _config_manager else {}
     theme = _config_manager.get_theme() if _config_manager else "dark"
-    lang = _get_lang()
+    lang = get_lang()
     t = get_translations(lang)
     tz_name, tz_offset = _server_tz_info()
     from .drivers import driver_registry

--- a/app/web_locale.py
+++ b/app/web_locale.py
@@ -1,0 +1,48 @@
+"""Request and setup language selection for HTTP adapters."""
+
+from flask import request
+
+from .config import DEFAULTS
+from .i18n import LANGUAGES
+from .runtime import current_runtime
+
+
+def get_lang():
+    """Get language from query param or config."""
+    _config_manager = current_runtime().config_manager
+    lang = request.args.get("lang")
+    if lang and lang in LANGUAGES:
+        return lang
+    if _config_manager:
+        return _config_manager.get("language", "en")
+    return "en"
+
+
+def get_setup_lang():
+    """Resolve and persist the language for the unconfigured setup route."""
+    _config_manager = current_runtime().config_manager
+    lang = request.args.get("lang")
+    if lang in LANGUAGES:
+        if _config_manager:
+            _config_manager.save({"language": lang})
+        return lang
+
+    if _config_manager and _config_manager.has_stored_value("language"):
+        return _config_manager.get("language", DEFAULTS["language"])
+
+    inferred = DEFAULTS["language"]
+    for requested, quality in request.accept_languages:
+        if quality <= 0:
+            continue
+        normalized = requested.lower().replace("_", "-")
+        if normalized in LANGUAGES:
+            inferred = normalized
+            break
+        base = normalized.split("-", 1)[0]
+        if base in LANGUAGES:
+            inferred = base
+            break
+
+    if _config_manager:
+        _config_manager.save({"language": inferred})
+    return inferred

--- a/tests/architecture/test_app_globals_guard.py
+++ b/tests/architecture/test_app_globals_guard.py
@@ -4,6 +4,7 @@ import ast
 from pathlib import Path
 
 from app import web, web_auth
+from app.runtime import current_runtime
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -33,6 +34,8 @@ FORBIDDEN_WEB_EXPORTS = {
     "init_modules", "setup_module_templates",
     "_build_metric_ranges", "_build_home_snr_display_context", "_build_home_modulation_context",
     "_build_capacity_context", "_snr_channel_family", "_power_metric_health", "_snr_metric_health",
+    "_get_lang", "_get_setup_lang", "_get_tz_name", "_localize_timestamps", "_valid_date",
+    "_build_theme_collections", "_check_for_update", "_version_newer", "_UPDATE_CACHE_TTL",
 }
 
 
@@ -63,6 +66,17 @@ def test_factory_is_the_only_flask_constructor():
     calls = []
     for path in (ROOT / "app").rglob("*.py"):
         for node in ast.walk(_tree(path)):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                module = getattr(node, "module", "") or ""
+                imports = {a.name for a in node.names} if isinstance(node, ast.Import) else {module}
+                if isinstance(node, ast.ImportFrom) and module in {"", "app"}:
+                    imports.update("app." + a.name for a in node.names)
+                if path.relative_to(ROOT).as_posix() not in {"app/app_factory.py", "app/registration.py"}:
+                    assert "app.web" not in imports and "web" not in imports, path
+                if path.name in {"tz.py", "theme_registry.py", "version.py"}:
+                    assert imports.isdisjoint({"flask", "app.runtime", "runtime", "app.app_factory"}), path
+            if path.name == "tz.py" and isinstance(node, ast.Name):
+                assert node.id not in {"current_app", "request", "current_runtime", "get_runtime"}
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Flask":
                 calls.append(path.relative_to(ROOT).as_posix())
     assert sorted(calls) == [
@@ -89,6 +103,24 @@ def test_guarded_modules_have_no_lowercase_state_bindings():
     assert violations == []
 
 
-def test_web_has_no_legacy_application_or_initializer_exports():
+def test_web_has_no_legacy_application_or_initializer_exports(app, monkeypatch):
     assert FORBIDDEN_WEB_EXPORTS.isdisjoint(vars(web).keys() | vars(web_auth).keys())
     assert web.require_auth is web_auth.require_auth
+    with app.app_context():
+        runtime = current_runtime()
+        for name in ("storage", "config_manager", "modem_collector", "collectors", "module_loader", "on_config_changed"):
+            marker = object()
+            monkeypatch.setattr(runtime, name, marker)
+            assert getattr(web, "get_" + name)() is marker
+        web.set_last_manual_poll(12.5)
+        assert web.get_last_manual_poll() == runtime.get_last_manual_poll() == 12.5
+        web.update_state(analysis={"health": "good"}, speedtest_latest={"value": 1})
+        snapshot = web.get_state()
+        assert snapshot == runtime.get_state() and snapshot is not runtime.get_state()
+        snapshot["error"] = "external"
+        assert runtime.get_state()["error"] is None
+        web.reset_modem_state()
+        assert runtime.get_state()["analysis"] is None
+        assert runtime.get_state()["speedtest_latest"] == {"value": 1}
+        web.clear_speedtest_latest()
+        assert runtime.get_state()["speedtest_latest"] is None

--- a/tests/collectors/test_discovery_orchestrator.py
+++ b/tests/collectors/test_discovery_orchestrator.py
@@ -198,6 +198,11 @@ class TestDiscoverCollectors:
         mock_load.assert_called_once_with("fritzbox", "http://fritz.box", "admin", "pass")
 
 
+@pytest.fixture
+def mock_runtime():
+    return MagicMock()
+
+
 class TestPollingLoopOrchestrator:
     def _make_storage(self):
         import tempfile, os
@@ -234,9 +239,8 @@ class TestPollingLoopOrchestrator:
         return mgr
 
     @patch("app.main.discover_collectors")
-    @patch("app.main.web")
     def test_long_running_collector_is_tracked_until_result(
-        self, mock_web, mock_discover, caplog, monkeypatch
+        self, mock_discover, mock_runtime, caplog, monkeypatch
     ):
         """A collector crossing the old observation window is not resubmitted."""
         from app import main
@@ -304,9 +308,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = advance_tick
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        polling_loop(config_mgr, storage, stop, mock_web)
+        polling_loop(config_mgr, storage, stop, mock_runtime)
 
         assert collector.collect_calls == 1
         assert collector.success_calls == 1
@@ -321,9 +325,8 @@ class TestPollingLoopOrchestrator:
     @patch("app.drivers.driver_registry.load_driver")
     @patch("app.collectors.modem.ModemCollector")
     @patch("app.main.discover_collectors")
-    @patch("app.main.web")
     def test_hot_swap_waits_for_in_flight_collector_with_same_name(
-        self, mock_web, mock_discover, mock_modem_cls, mock_load, monkeypatch
+        self, mock_discover, mock_modem_cls, mock_load, mock_runtime, monkeypatch
     ):
         """A replacement modem waits for the prior modem future to finish."""
         from app import main
@@ -411,16 +414,15 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = advance_tick
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        main.polling_loop(config_mgr, storage, stop, mock_web)
+        main.polling_loop(config_mgr, storage, stop, mock_runtime)
 
         assert old_collector.success_calls == 1
         assert replacement_collector.success_calls == 1
 
     @patch("app.drivers.driver_registry.load_driver")
-    @patch("app.main.web")
-    def test_orchestrator_calls_enabled_collectors(self, mock_web, mock_load):
+    def test_orchestrator_calls_enabled_collectors(self, mock_load, mock_runtime):
         """Orchestrator should call collect() for enabled collectors."""
         import threading
         from app.main import polling_loop
@@ -450,16 +452,15 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = stop_after_one_tick
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        polling_loop(config_mgr, storage, stop, mock_web)
+        polling_loop(config_mgr, storage, stop, mock_runtime)
 
         mock_driver.login.assert_called()
         mock_driver.get_docsis_data.assert_called()
 
     @patch("app.drivers.driver_registry.load_driver")
-    @patch("app.main.web")
-    def test_orchestrator_skips_disabled_collectors(self, mock_web, mock_load):
+    def test_orchestrator_skips_disabled_collectors(self, mock_load, mock_runtime):
         """Speedtest/BQM collectors should be skipped when not configured."""
         import threading
         from app.main import polling_loop
@@ -486,9 +487,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = stop_after_one_tick
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        polling_loop(config_mgr, storage, stop, mock_web)
+        polling_loop(config_mgr, storage, stop, mock_runtime)
 
         # Core storage should not have speedtest/bqm methods called
         # (those are now handled by module-internal storage)
@@ -496,8 +497,7 @@ class TestPollingLoopOrchestrator:
         storage.save_bqm_graph.assert_not_called()
 
     @patch("app.drivers.driver_registry.load_driver")
-    @patch("app.main.web")
-    def test_orchestrator_handles_collector_exception(self, mock_web, mock_load):
+    def test_orchestrator_handles_collector_exception(self, mock_load, mock_runtime):
         """Orchestrator should catch exceptions and continue running."""
         import threading
         from app.main import polling_loop
@@ -522,15 +522,14 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = stop_after_one_tick
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        polling_loop(config_mgr, storage, stop, mock_web)
+        polling_loop(config_mgr, storage, stop, mock_runtime)
 
-        mock_web.update_state.assert_any_call(error=mock_driver.login.side_effect)
+        mock_runtime.update_state.assert_any_call(error=mock_driver.login.side_effect)
 
     @patch("app.drivers.driver_registry.load_driver")
-    @patch("app.main.web")
-    def test_orchestrator_stops_on_event(self, mock_web, mock_load):
+    def test_orchestrator_stops_on_event(self, mock_load, mock_runtime):
         """Orchestrator should exit when stop_event is set."""
         import threading
         from app.main import polling_loop
@@ -542,14 +541,13 @@ class TestPollingLoopOrchestrator:
         stop = threading.Event()
         stop.set()  # Pre-set: should exit immediately
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        polling_loop(config_mgr, storage, stop, mock_web)
+        polling_loop(config_mgr, storage, stop, mock_runtime)
         # If we get here without hanging, the test passes
 
     @patch("app.drivers.driver_registry.load_driver")
-    @patch("app.main.web")
-    def test_driver_hot_swap_on_modem_type_change(self, mock_web, mock_load):
+    def test_driver_hot_swap_on_modem_type_change(self, mock_load, mock_runtime):
         """Polling loop should hot-swap the modem driver when modem_type changes."""
         import threading
         from app.main import polling_loop
@@ -587,9 +585,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = change_modem_after_first_tick
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        polling_loop(config_mgr, storage, stop, mock_web)
+        polling_loop(config_mgr, storage, stop, mock_runtime)
 
         # load_driver should have been called at least twice:
         # once for initial setup, once for hot-swap
@@ -598,12 +596,11 @@ class TestPollingLoopOrchestrator:
         second_call = mock_load.call_args_list[1]
         assert second_call[0][0] == "tc4400"
         # Web state should have been reset for the swap
-        mock_web.reset_modem_state.assert_called()
-        assert mock_web.modem_collector.name == "modem"
+        mock_runtime.reset_modem_state.assert_called()
+        assert mock_runtime.modem_collector.name == "modem"
 
     @patch("app.drivers.driver_registry.load_driver")
-    @patch("app.main.web")
-    def test_driver_hot_swap_on_url_change(self, mock_web, mock_load):
+    def test_driver_hot_swap_on_url_change(self, mock_load, mock_runtime):
         """Hot-swap should trigger when modem URL changes, not just type."""
         import threading
         from app.main import polling_loop
@@ -640,9 +637,9 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = change_url_after_first_tick
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        polling_loop(config_mgr, storage, stop, mock_web)
+        polling_loop(config_mgr, storage, stop, mock_runtime)
 
         # load_driver called twice: initial + hot-swap for URL change
         assert mock_load.call_count >= 2
@@ -650,8 +647,7 @@ class TestPollingLoopOrchestrator:
         assert second_call[0][1] == "http://192.168.100.1"
 
     @patch("app.drivers.driver_registry.load_driver")
-    @patch("app.main.web")
-    def test_no_hot_swap_when_config_unchanged(self, mock_web, mock_load):
+    def test_no_hot_swap_when_config_unchanged(self, mock_load, mock_runtime):
         """No hot-swap should occur when modem config hasn't changed."""
         import threading
         from app.main import polling_loop
@@ -678,11 +674,11 @@ class TestPollingLoopOrchestrator:
 
         stop.wait = stop_after_ticks
 
-        mock_web.derived_storage.value.return_value = 0
+        mock_runtime.derived_storage.value.return_value = 0
 
-        polling_loop(config_mgr, storage, stop, mock_web)
+        polling_loop(config_mgr, storage, stop, mock_runtime)
 
         # load_driver should only be called once (initial setup)
         assert mock_load.call_count == 1
         # reset_modem_state should NOT have been called (no swap)
-        mock_web.reset_modem_state.assert_not_called()
+        mock_runtime.reset_modem_state.assert_not_called()

--- a/tests/e2e/test_pwa_gate.py
+++ b/tests/e2e/test_pwa_gate.py
@@ -1,10 +1,10 @@
 """PWA installability and offline behavior gate."""
 
+from app.version import get_app_version
 from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError, expect
 
-from app.web import APP_VERSION
 
 
 def _open_authenticated_pwa(page, servers):
@@ -129,7 +129,7 @@ def test_static_js_and_css_requests_include_app_version(page, live_server):
                     && url.searchParams.get('v') !== expectedVersion;
             })
         """,
-        APP_VERSION,
+        get_app_version(),
     )
 
     assert offenders == []

--- a/tests/modules/connection_monitor/test_routes.py
+++ b/tests/modules/connection_monitor/test_routes.py
@@ -571,7 +571,7 @@ class TestSummaryAPI:
         mock_cfg.get.side_effect = lambda key, default=None: (
             False if key == "connection_monitor_enabled" else default
         )
-        with patch("app.modules.connection_monitor.routes.get_config_manager", return_value=mock_cfg):
+        with patch.object(get_runtime(c.application), "config_manager", mock_cfg):
             resp = c.get("/api/connection-monitor/summary")
 
         assert resp.status_code == 200

--- a/tests/modules/test_fritzbox_cable_routes.py
+++ b/tests/modules/test_fritzbox_cable_routes.py
@@ -22,13 +22,13 @@ def client(app):
 
 class TestSegmentDataEndpoint:
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
-    def test_returns_stored_data(self, mock_get_storage, mock_get_config, client):
+    def test_returns_stored_data(self, mock_get_storage, mock_runtime, client):
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "fritzbox"
         mock_cfg.is_demo_mode.return_value = False
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
 
         mock_storage = MagicMock()
         mock_storage.get_range.return_value = [
@@ -53,13 +53,13 @@ class TestSegmentDataEndpoint:
 
 class TestSegmentEventsEndpoint:
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
-    def test_returns_events_payload(self, mock_get_storage, mock_get_config, client):
+    def test_returns_events_payload(self, mock_get_storage, mock_runtime, client):
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "fritzbox"
         mock_cfg.is_segment_utilization_enabled.return_value = True
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
 
         mock_storage = MagicMock()
         mock_storage.get_events.return_value = [
@@ -89,13 +89,13 @@ class TestSegmentEventsEndpoint:
         assert data.get("min_minutes") == 3
 
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
-    def test_clamps_invalid_threshold_and_min_minutes(self, mock_get_storage, mock_get_config, client):
+    def test_clamps_invalid_threshold_and_min_minutes(self, mock_get_storage, mock_runtime, client):
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "fritzbox"
         mock_cfg.is_segment_utilization_enabled.return_value = True
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
 
         mock_storage = MagicMock()
         mock_storage.get_events.return_value = []
@@ -115,25 +115,25 @@ class TestSegmentEventsEndpoint:
         assert data["min_minutes"] == 1440
 
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
-    def test_rejects_when_driver_unsupported(self, mock_get_storage, mock_get_config, client):
+    def test_rejects_when_driver_unsupported(self, mock_get_storage, mock_runtime, client):
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "arris"
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
         mock_get_storage.return_value = MagicMock()
 
         resp = client.get("/api/fritzbox/segment-utilization/events")
         assert resp.status_code == 400
 
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
-    def test_passes_range_to_storage(self, mock_get_storage, mock_get_config, client):
+    def test_passes_range_to_storage(self, mock_get_storage, mock_runtime, client):
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "fritzbox"
         mock_cfg.is_segment_utilization_enabled.return_value = True
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
 
         mock_storage = MagicMock()
         mock_storage.get_events.return_value = []
@@ -147,15 +147,15 @@ class TestSegmentEventsEndpoint:
         assert kwargs.get("min_minutes") == 5
 
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
-    def test_invalid_range_is_normalized_in_echo(self, mock_get_storage, mock_get_config, client):
+    def test_invalid_range_is_normalized_in_echo(self, mock_get_storage, mock_runtime, client):
         """An unrecognized range string must not be echoed verbatim —
         the response reports the default the server actually used."""
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "fritzbox"
         mock_cfg.is_segment_utilization_enabled.return_value = True
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
 
         mock_storage = MagicMock()
         mock_storage.get_events.return_value = []
@@ -169,13 +169,13 @@ class TestSegmentEventsEndpoint:
 
 class TestSegmentDataEndpointRange:
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
-    def test_invalid_range_normalizes_to_default(self, mock_get_storage, mock_get_config, client):
+    def test_invalid_range_normalizes_to_default(self, mock_get_storage, mock_runtime, client):
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "fritzbox"
         mock_cfg.is_segment_utilization_enabled.return_value = True
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
 
         mock_storage = MagicMock()
         mock_storage.get_range.return_value = []
@@ -191,13 +191,13 @@ class TestSegmentDataEndpointRange:
 
 class TestSegmentRangeEndpoint:
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
-    def test_range_endpoint_for_correlation(self, mock_get_storage, mock_get_config, client):
+    def test_range_endpoint_for_correlation(self, mock_get_storage, mock_runtime, client):
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "fritzbox"
         mock_cfg.is_segment_utilization_enabled.return_value = True
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
 
         mock_storage = MagicMock()
         mock_storage.get_range.return_value = [
@@ -212,10 +212,10 @@ class TestSegmentRangeEndpoint:
         assert data[0]["ds_total"] == pytest.approx(6.2)
 
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
     def test_range_endpoint_returns_empty_when_driver_unsupported(
-        self, mock_get_storage, mock_get_config, client,
+        self, mock_get_storage, mock_runtime, client,
     ):
         """The correlation graph fetches this range endpoint opportunistically.
         When the modem driver isn't fritzbox, the endpoint must return an
@@ -223,7 +223,7 @@ class TestSegmentRangeEndpoint:
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "arris"
         mock_cfg.is_segment_utilization_enabled.return_value = True
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
         mock_get_storage.return_value = MagicMock()
 
         resp = client.get(
@@ -234,15 +234,15 @@ class TestSegmentRangeEndpoint:
         assert resp.get_json() == []
 
     @patch("app.blueprints.segment_bp.require_auth", lambda f: f)
-    @patch("app.blueprints.segment_bp.get_config_manager")
+    @patch("app.blueprints.segment_bp.current_runtime")
     @patch("app.blueprints.segment_bp._get_storage")
     def test_range_endpoint_returns_empty_when_feature_disabled(
-        self, mock_get_storage, mock_get_config, client,
+        self, mock_get_storage, mock_runtime, client,
     ):
         mock_cfg = MagicMock()
         mock_cfg.get.return_value = "fritzbox"
         mock_cfg.is_segment_utilization_enabled.return_value = False
-        mock_get_config.return_value = mock_cfg
+        mock_runtime.return_value.config_manager = mock_cfg
         mock_get_storage.return_value = MagicMock()
 
         resp = client.get(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,6 @@ from email.utils import parsedate_to_datetime
 
 import pytest
 from werkzeug.security import generate_password_hash
-from app.web import update_state
 from app.web_auth import (
     _AUTH_STATE_CONTEXT,
     _LOGIN_MAX_TRACKED_IPS,
@@ -101,7 +100,7 @@ def noauth_client(noauth_config):
 
 class TestAuthDisabled:
     def test_index_accessible(self, noauth_client):
-        update_state(analysis={"summary": {"ds_total": 1, "us_total": 1, "ds_power_min": 0, "ds_power_max": 0, "ds_power_avg": 0, "us_power_min": 0, "us_power_max": 0, "us_power_avg": 0, "ds_snr_min": 0, "ds_snr_avg": 0, "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0, "health": "good", "health_issues": []}, "ds_channels": [], "us_channels": []})
+        current_runtime().update_state(analysis={"summary": {"ds_total": 1, "us_total": 1, "ds_power_min": 0, "ds_power_max": 0, "ds_power_avg": 0, "us_power_min": 0, "us_power_max": 0, "us_power_avg": 0, "ds_snr_min": 0, "ds_snr_avg": 0, "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0, "health": "good", "health_issues": []}, "ds_channels": [], "us_channels": []})
         resp = noauth_client.get("/")
         assert resp.status_code == 200
 
@@ -126,7 +125,7 @@ class TestAuthEnabled:
         assert "/login" in resp.headers["Location"]
 
     def test_health_always_accessible(self, auth_client):
-        update_state(analysis={"summary": {"ds_total": 1, "us_total": 1, "ds_power_min": 0, "ds_power_max": 0, "ds_power_avg": 0, "us_power_min": 0, "us_power_max": 0, "us_power_avg": 0, "ds_snr_min": 0, "ds_snr_avg": 0, "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0, "health": "good", "health_issues": []}, "ds_channels": [], "us_channels": []})
+        current_runtime().update_state(analysis={"summary": {"ds_total": 1, "us_total": 1, "ds_power_min": 0, "ds_power_max": 0, "ds_power_avg": 0, "us_power_min": 0, "us_power_max": 0, "us_power_avg": 0, "ds_snr_min": 0, "ds_snr_avg": 0, "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0, "health": "good", "health_issues": []}, "ds_channels": [], "us_channels": []})
         resp = auth_client.get("/health")
         assert resp.status_code == 200
 
@@ -180,7 +179,7 @@ class TestAuthEnabled:
 
     def test_session_persists(self, auth_client):
         auth_client.post("/login", data={"password": "secret123", "csrf_token": _login_csrf(auth_client)})
-        update_state(analysis={"summary": {"ds_total": 1, "us_total": 1, "ds_power_min": 0, "ds_power_max": 0, "ds_power_avg": 0, "us_power_min": 0, "us_power_max": 0, "us_power_avg": 0, "ds_snr_min": 0, "ds_snr_avg": 0, "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0, "health": "good", "health_issues": []}, "ds_channels": [], "us_channels": []})
+        current_runtime().update_state(analysis={"summary": {"ds_total": 1, "us_total": 1, "ds_power_min": 0, "ds_power_max": 0, "ds_power_avg": 0, "us_power_min": 0, "us_power_max": 0, "us_power_avg": 0, "ds_snr_min": 0, "ds_snr_avg": 0, "ds_correctable_errors": 0, "ds_uncorrectable_errors": 0, "health": "good", "health_issues": []}, "ds_channels": [], "us_channels": []})
         resp = auth_client.get("/")
         assert resp.status_code == 200
 
@@ -605,7 +604,7 @@ class TestApiTokenAuth:
 
     def test_health_stays_public(self, auth_client_with_storage):
         """/health remains accessible without any auth."""
-        update_state(analysis={
+        current_runtime().update_state(analysis={
             "summary": {"ds_total": 1, "us_total": 1, "ds_power_min": 0,
                         "ds_power_max": 0, "ds_power_avg": 0, "us_power_min": 0,
                         "us_power_max": 0, "us_power_avg": 0, "ds_snr_min": 0,

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -243,16 +243,15 @@ class TestCreateBackup:
 class TestBackupDownloadRoute:
     @staticmethod
     def _app(data_dir, monkeypatch):
-        from flask import Flask
+        from app.app_factory import create_app
         from app.modules.backup import routes
 
         config_mgr = MagicMock()
         config_mgr.data_dir = data_dir
 
-        test_app = Flask(__name__)
+        test_app = create_app(config_manager=config_mgr, environ={}, testing=True)
         test_app.config.update(TESTING=True, SECRET_KEY="test-secret")
         test_app.register_blueprint(routes.bp)
-        monkeypatch.setattr(routes, "get_config_manager", lambda: config_mgr)
         monkeypatch.setattr("app.web_auth._auth_required", lambda **kwargs: False)
         return test_app
 

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -6,7 +6,6 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-import app.web as web
 from app.modules.bqm.collector import BQMCollector
 from app.modules.bqm.thinkbroadband import fetch_graph
 from app.modules.bqm.storage import BqmStorage
@@ -400,7 +399,7 @@ def bqm_client(tmp_path, bqm_api_storage):
     mgr.save({"modem_password": "test", "modem_type": "fritzbox", "bqm_url": "https://example.com/graph.png"})
     current_runtime().config_manager = mgr
     current_runtime().storage = s
-    previous_module_loader = web.get_module_loader()
+    previous_module_loader = current_runtime().module_loader
     current_runtime().module_loader = _enabled_bqm_loader()
     _reset_bqm_module_storage()
     app.config["TESTING"] = True
@@ -640,7 +639,7 @@ class TestBqmUiRender:
 
     def test_index_omits_chart_script_when_bqm_module_is_disabled(self, bqm_client):
         client, _ = bqm_client
-        enabled_loader = web.get_module_loader()
+        enabled_loader = current_runtime().module_loader
         try:
             current_runtime().module_loader = None
             resp = client.get("/")

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -24,7 +24,7 @@ E2E_BROWSER_PATHS = [
     "app/modules/**",
     "app/{web*,signal_health_view}.py",
     "app/blueprints/**",
-    "app/tz.py",
+    "app/{tz,theme_registry,runtime,version}.py",
     "app/i18n/**",
     "app/app_factory.py",
     "app/base_path.py",

--- a/tests/test_comparison_module.py
+++ b/tests/test_comparison_module.py
@@ -402,7 +402,7 @@ class TestModuleDiscovery:
 
     def teardown_method(self):
         from app.i18n import _TRANSLATIONS
-        from app import web
+
 
         _TRANSLATIONS.clear()
         _TRANSLATIONS.update(self._orig_translations)

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 from app.storage import SnapshotStorage
 from app.modules.speedtest.storage import SpeedtestStorage
 from app.tz import utc_now, utc_cutoff
-from app.web import update_state
 from app.config import ConfigManager
 from app.runtime import current_runtime
 

--- a/tests/test_device_info_display.py
+++ b/tests/test_device_info_display.py
@@ -3,7 +3,7 @@
 import json
 import pytest
 
-from app.web import update_state, format_uptime
+from app.web import format_uptime
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.runtime import current_runtime
@@ -42,7 +42,7 @@ def client(config_mgr, storage):
     current_runtime().storage = storage
     app.config["TESTING"] = True
     # Seed analysis so the dashboard renders the hero card
-    update_state(analysis=_SAMPLE_ANALYSIS)
+    current_runtime().update_state(analysis=_SAMPLE_ANALYSIS)
     with app.test_client() as c:
         yield c
 
@@ -89,7 +89,7 @@ class TestFormatUptime:
 class TestDeviceInfoAPI:
     def test_device_endpoint_returns_full_info(self, client):
         """Device endpoint returns all fields from driver."""
-        update_state(device_info={
+        current_runtime().update_state(device_info={
             "manufacturer": "Compal",
             "model": "CH7465LG",
             "sw_version": "1.2.3",
@@ -104,7 +104,7 @@ class TestDeviceInfoAPI:
 
     def test_device_endpoint_partial_info(self, client):
         """Device endpoint returns partial info when driver doesn't provide all fields."""
-        update_state(device_info={
+        current_runtime().update_state(device_info={
             "manufacturer": "Arris",
             "model": "CM8200A",
             "sw_version": "",
@@ -134,21 +134,21 @@ class TestDeviceInfoDashboard:
 
     def test_model_badge_rendered(self, client):
         """Model badge appears when device_info has model."""
-        update_state(device_info={"model": "CH7465LG", "manufacturer": "Compal"})
+        current_runtime().update_state(device_info={"model": "CH7465LG", "manufacturer": "Compal"})
         html = self._render_index(client)
         assert "CH7465LG" in html
         assert 'data-lucide="router"' in html
 
     def test_firmware_badge_rendered(self, client):
         """Firmware badge appears when sw_version is non-empty."""
-        update_state(device_info={"model": "TC4400", "sw_version": "2.1.0beta3"})
+        current_runtime().update_state(device_info={"model": "TC4400", "sw_version": "2.1.0beta3"})
         html = self._render_index(client)
         assert "2.1.0beta3" in html
         assert 'data-lucide="package"' in html
 
     def test_uptime_badge_rendered(self, client):
         """Uptime badge appears when uptime_seconds is present."""
-        update_state(device_info={"model": "CH7465LG", "uptime_seconds": 259200})
+        current_runtime().update_state(device_info={"model": "CH7465LG", "uptime_seconds": 259200})
         html = self._render_index(client)
         assert "3d 0h 0m" in html
 
@@ -160,14 +160,14 @@ class TestDeviceInfoDashboard:
 
     def test_no_firmware_badge_when_empty(self, client):
         """No firmware badge when sw_version is empty string."""
-        update_state(device_info={"model": "Hitron CODA-56", "sw_version": ""})
+        current_runtime().update_state(device_info={"model": "Hitron CODA-56", "sw_version": ""})
         html = self._render_index(client)
         assert "Hitron CODA-56" in html
         assert 'data-lucide="package"' not in html
 
     def test_no_uptime_badge_when_missing(self, client):
         """No uptime badge when uptime_seconds is not in device_info."""
-        update_state(device_info={"model": "CM8200A"})
+        current_runtime().update_state(device_info={"model": "CM8200A"})
         html = self._render_index(client)
         assert "CM8200A" in html
         # Extract hero-meta section and verify no clock badge
@@ -178,6 +178,6 @@ class TestDeviceInfoDashboard:
 
     def test_zero_uptime_rendered(self, client):
         """Uptime badge shows '0m' when uptime_seconds is 0 (falsy but valid)."""
-        update_state(device_info={"model": "DemoRouter", "uptime_seconds": 0})
+        current_runtime().update_state(device_info={"model": "DemoRouter", "uptime_seconds": 0})
         html = self._render_index(client)
         assert "0m" in html

--- a/tests/test_evidence_api.py
+++ b/tests/test_evidence_api.py
@@ -47,8 +47,8 @@ class TestEvidenceChecklistApi:
         with app.test_request_context(
             "/api/evidence/checklist?from=2026-06-10T18:00:00Z&to=2026-06-10T23:00:00Z"
         ):
-            with patch.object(routes, "get_storage", return_value=core), \
-                 patch.object(routes, "get_config_manager", return_value=config), \
+            with patch.object(routes.current_runtime(), "storage", core), \
+                 patch.object(routes.current_runtime(), "config_manager", config), \
                  patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
                  patch.object(routes, "_get_bqm_rows", return_value=[]), \
                  patch.object(routes, "_get_connection_latency_rows", return_value=[]):
@@ -123,8 +123,8 @@ class TestEvidenceChecklistApi:
         config.is_demo_mode.return_value = False
 
         with app.test_request_context("/api/evidence/checklist?incident_id=7"):
-            with patch.object(routes, "get_storage", return_value=core), \
-                 patch.object(routes, "get_config_manager", return_value=config), \
+            with patch.object(routes.current_runtime(), "storage", core), \
+                 patch.object(routes.current_runtime(), "config_manager", config), \
                  patch.object(routes, "_get_journal_storage", return_value=journal), \
                  patch.object(routes, "_get_bqm_rows", return_value=[]), \
                  patch.object(routes, "_get_connection_latency_rows", return_value=[]), \
@@ -153,8 +153,8 @@ class TestEvidenceChecklistApi:
         config.is_demo_mode.return_value = False
 
         with app.test_request_context("/api/evidence/checklist?from=2026-06-10T18:00:00Z&to=2026-06-10T23:00:00Z"):
-            with patch.object(routes, "get_storage", return_value=core), \
-                 patch.object(routes, "get_config_manager", return_value=config), \
+            with patch.object(routes.current_runtime(), "storage", core), \
+                 patch.object(routes.current_runtime(), "config_manager", config), \
                  patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
                  patch.object(routes, "_get_bqm_rows", return_value=[]), \
                  patch.object(routes, "_get_connection_latency_rows", return_value=[]):
@@ -178,8 +178,8 @@ class TestEvidenceChecklistApi:
         config.is_demo_mode.return_value = False
 
         with app.test_request_context("/api/evidence/checklist?from=2026-06-10T18:00:00Z&to=2026-06-10T23:00:00Z"):
-            with patch.object(routes, "get_storage", return_value=core), \
-                 patch.object(routes, "get_config_manager", return_value=config), \
+            with patch.object(routes.current_runtime(), "storage", core), \
+                 patch.object(routes.current_runtime(), "config_manager", config), \
                  patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
                  patch.object(routes, "_get_bqm_rows", return_value=[]), \
                  patch.object(routes, "_get_connection_latency_rows", return_value=[
@@ -229,8 +229,8 @@ class TestEvidenceChecklistApi:
         config.is_demo_mode.return_value = False
 
         with app.test_request_context("/api/evidence/checklist?from=2026-06-10T19:00:00&to=2026-06-10T23:00:00"):
-            with patch.object(routes, "get_storage", return_value=core), \
-                 patch.object(routes, "get_config_manager", return_value=config), \
+            with patch.object(routes.current_runtime(), "storage", core), \
+                 patch.object(routes.current_runtime(), "config_manager", config), \
                  patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
                  patch.object(routes, "_get_bqm_rows", return_value=[]), \
                  patch.object(routes, "_get_connection_latency_rows", return_value=[]), \
@@ -253,8 +253,8 @@ class TestEvidenceChecklistApi:
         config.is_demo_mode.return_value = False
 
         with app.test_request_context("/api/evidence/checklist?from=2026-06-10T19:00:00%2B02:00&to=2026-06-10T23:00:00%2B02:00"):
-            with patch.object(routes, "get_storage", return_value=core), \
-                 patch.object(routes, "get_config_manager", return_value=config), \
+            with patch.object(routes.current_runtime(), "storage", core), \
+                 patch.object(routes.current_runtime(), "config_manager", config), \
                  patch.object(routes, "_get_journal_entries_for_window", return_value=[]), \
                  patch.object(routes, "_get_bqm_rows", return_value=[]), \
                  patch.object(routes, "_get_connection_latency_rows", return_value=[]), \
@@ -395,8 +395,8 @@ class TestEvidenceChecklistApi:
         config.is_demo_mode.return_value = False
 
         with app.test_request_context("/api/evidence/checklist?from=not-a-date&to=2026-06-10T23:00:00Z"):
-            with patch.object(routes, "get_storage", return_value=core), \
-                 patch.object(routes, "get_config_manager", return_value=config), \
+            with patch.object(routes.current_runtime(), "storage", core), \
+                 patch.object(routes.current_runtime(), "config_manager", config), \
                  patch.object(routes, "_get_tz_name", return_value="Europe/Berlin"):
                 response, status = getattr(routes.api_evidence_checklist, "__wrapped__")()
 
@@ -411,7 +411,7 @@ class TestEvidenceChecklistApi:
         journal.get_incident.return_value = {"id": 7, "name": "Bad evening"}
 
         with app.test_request_context("/api/evidence/checklist?incident_id=7"):
-            with patch.object(routes, "get_storage", return_value=core), \
+            with patch.object(routes.current_runtime(), "storage", core), \
                  patch.object(routes, "_get_journal_storage", return_value=journal):
                 response, status = getattr(routes.api_evidence_checklist, "__wrapped__")()
 

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,7 +1,6 @@
 """Integration tests for the GET /metrics HTTP endpoint."""
 
 import pytest
-from app.web import update_state
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.runtime import current_runtime
@@ -73,7 +72,7 @@ def protected_metrics_client(protected_metrics_config, tmp_path):
 @pytest.fixture
 def metrics_client_with_data(metrics_client):
     """Flask test client with realistic modem analysis state populated."""
-    update_state(
+    current_runtime().update_state(
         analysis={
             "summary": {
                 "ds_total": 2,
@@ -136,7 +135,7 @@ class TestMetricsEndpoint:
 
     def test_no_data_returns_health_unknown(self, metrics_client):
         """Without analysis data, response contains health_status 3 (unknown)."""
-        update_state()  # reset to no analysis
+        current_runtime().update_state()  # reset to no analysis
         resp = metrics_client.get("/metrics")
         assert resp.status_code == 200
         body = resp.data.decode("utf-8")

--- a/tests/test_modulation_api.py
+++ b/tests/test_modulation_api.py
@@ -1,5 +1,6 @@
 """Tests for modulation performance API routes (v2)."""
 
+from app.runtime import current_runtime
 import json
 from datetime import datetime, timedelta, timezone
 
@@ -187,10 +188,9 @@ class TestDistributionEndpoint:
 
     def test_capacity_history_uses_detected_connection_speed_when_booked_tariff_empty(self, client_with_storage):
         client, storage = client_with_storage
-        from app.web import reset_modem_state, update_state
 
         with client.application.app_context():
-            update_state(connection_info={"max_downstream_kbps": 50000, "max_upstream_kbps": 25000})
+            current_runtime().update_state(connection_info={"max_downstream_kbps": 50000, "max_upstream_kbps": 25000})
         day = _ts_days_ago(1)[:10]
         _store_snapshot(
             storage,
@@ -213,7 +213,7 @@ class TestDistributionEndpoint:
             assert us["status"] == "below_some_samples"
         finally:
             with client.application.app_context():
-                reset_modem_state()
+                current_runtime().reset_modem_state()
 
 
     def test_aggregate_low_qam_pct_weighted_across_protocol_sample_counts(self, client_with_storage):

--- a/tests/test_module_install_api.py
+++ b/tests/test_module_install_api.py
@@ -50,9 +50,9 @@ def test_download_cleanup_is_confined_to_module_root(tmp_path):
 
 class TestModulesRegistry:
     def test_registry_returns_list(self, client):
-        with patch("app.blueprints.modules_bp.get_config_manager") as mock_cfg:
-            mock_cfg.return_value = MagicMock()
-            mock_cfg.return_value.get = MagicMock(return_value="https://raw.githubusercontent.com/itsDNNS/docsight-modules/main/registry.json")
+        with patch("app.blueprints.modules_bp.current_runtime") as mock_cfg:
+            mock_cfg.return_value.config_manager = MagicMock()
+            mock_cfg.return_value.config_manager.get = MagicMock(return_value="https://raw.githubusercontent.com/itsDNNS/docsight-modules/main/registry.json")
             resp = client.get("/api/modules/registry")
             assert resp.status_code == 200
             data = json.loads(resp.data)
@@ -74,10 +74,10 @@ class TestModulesInstall:
         assert data["success"] is False
 
     def test_rejects_duplicate_builtin(self, client):
-        with patch("app.blueprints.modules_bp.get_module_loader") as mock_loader:
+        with patch("app.blueprints.modules_bp.current_runtime") as mock_loader:
             mock_mod = MagicMock()
             mock_mod.id = "docsight.speedtest"
-            mock_loader.return_value.get_modules.return_value = [mock_mod]
+            mock_loader.return_value.module_loader.get_modules.return_value = [mock_mod]
             resp = client.post("/api/modules/install",
                                data=json.dumps({"id": "docsight.speedtest", "download_url": "https://api.github.com/test"}),
                                content_type="application/json")
@@ -284,12 +284,12 @@ class TestModulesUninstall:
 
     def test_rejects_builtin_uninstall(self, client):
         with patch("app.blueprints.modules_bp._scan_installed_community_ids") as mock_scan, \
-             patch("app.blueprints.modules_bp.get_module_loader") as mock_loader:
+             patch("app.blueprints.modules_bp.current_runtime") as mock_loader:
             mock_scan.return_value = {"docsight.speedtest": "docsight_speedtest"}
             mock_mod = MagicMock()
             mock_mod.id = "docsight.speedtest"
             mock_mod.builtin = True
-            mock_loader.return_value.get_modules.return_value = [mock_mod]
+            mock_loader.return_value.module_loader.get_modules.return_value = [mock_mod]
             resp = client.post("/api/modules/uninstall",
                                data=json.dumps({"id": "docsight.speedtest"}),
                                content_type="application/json")

--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -66,7 +66,7 @@ class TestModuleIntegration:
                 del sys.modules[key]
 
         # Clean up global module loader to avoid polluting other tests
-        from app import web
+
         self._runtime.module_loader = None
 
     def test_full_load_cycle(self, tmp_path):
@@ -244,7 +244,6 @@ class TestModuleManagementAPI:
             if key not in self._orig_sys_modules:
                 del sys.modules[key]
 
-        from app import web
         self._runtime.module_loader = getattr(self, '_orig_module_loader', None)
         self._runtime.config_manager = getattr(self, '_orig_config_manager', None)
 
@@ -259,7 +258,6 @@ class TestModuleManagementAPI:
         loader = ModuleLoader(app, search_paths=[FIXTURE_DIR])
         loader.load_all()
 
-        from app import web
         self._orig_module_loader = self._runtime.module_loader
         self._orig_config_manager = self._runtime.config_manager
         self._runtime.module_loader = loader

--- a/tests/test_pwa_web_push.py
+++ b/tests/test_pwa_web_push.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 from app.config import ConfigManager, PASSWORD_MASK
 from app.notifier import NotificationDispatcher, WebPushChannel
 from app.storage import SnapshotStorage
-from app import web
+
 from app.runtime import current_runtime
 
 

--- a/tests/test_report_customer_defaults.py
+++ b/tests/test_report_customer_defaults.py
@@ -12,7 +12,7 @@ from jinja2 import ChoiceLoader, FileSystemLoader
 
 from app import config as config_module
 from app import module_loader as module_loader_module
-from app import web
+
 from app.config import ConfigManager
 from app.runtime import current_runtime
 from app.module_loader import (
@@ -330,7 +330,7 @@ def test_demo_settings_and_index_hide_saved_private_values(
         "demo_mode": True,
     })
     current_runtime().config_manager = config_mgr
-    web.update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     settings_html = client.get("/settings?lang=en").get_data(as_text=True)
     index_html = client.get("/?lang=en").get_data(as_text=True)
@@ -354,7 +354,7 @@ def test_index_prefills_saved_customer_defaults_with_autoescaping(
     }
     config_mgr.save(values.copy())
     current_runtime().config_manager = config_mgr
-    web.update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     response = client.get("/?lang=en")
 
@@ -377,7 +377,7 @@ def test_index_prefills_saved_customer_defaults_with_autoescaping(
 
 def test_index_report_fields_have_empty_server_defaults(client, config_mgr, sample_analysis):
     current_runtime().config_manager = config_mgr
-    web.update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     soup = BeautifulSoup(client.get("/?lang=en").get_data(as_text=True), "html.parser")
 
@@ -440,10 +440,8 @@ def test_direct_report_routes_do_not_fall_back_to_saved_customer_values():
     report_storage.get_range_data.return_value = []
 
     with app.test_request_context("/api/report"):
-        with patch.object(report_routes, "get_storage", return_value=report_storage), patch.object(
-            report_routes, "get_config_manager", return_value=config_manager
-        ), patch.object(
-            report_routes, "get_state", return_value={"analysis": analysis, "connection_info": {}}
+        with patch.object(report_routes.current_runtime(), "storage", report_storage), patch.object(report_routes.current_runtime(), "config_manager", config_manager
+        ), patch.object(report_routes.current_runtime(), "get_state", return_value={"analysis": analysis, "connection_info": {}}
         ), patch.object(report_routes, "generate_report", return_value=b"%PDF") as generate_report:
             getattr(report_routes.api_report, "__wrapped__")()
     assert generate_report.call_args.kwargs["customer_name"] == ""
@@ -451,9 +449,8 @@ def test_direct_report_routes_do_not_fall_back_to_saved_customer_values():
     assert generate_report.call_args.kwargs["customer_address"] == ""
 
     with app.test_request_context("/api/complaint"):
-        with patch.object(report_routes, "get_storage", return_value=report_storage), patch.object(
-            report_routes, "get_config_manager", return_value=config_manager
-        ), patch.object(report_routes, "get_state", return_value={"analysis": analysis}), patch.object(
+        with patch.object(report_routes.current_runtime(), "storage", report_storage), patch.object(report_routes.current_runtime(), "config_manager", config_manager
+        ), patch.object(report_routes.current_runtime(), "get_state", return_value={"analysis": analysis}), patch.object(
             report_routes, "generate_complaint_text", return_value="letter"
         ) as generate_complaint:
             getattr(report_routes.api_complaint, "__wrapped__")()
@@ -469,9 +466,8 @@ def test_direct_report_routes_do_not_fall_back_to_saved_customer_values():
     }
     incident_storage.get_entries.return_value = []
     with app.test_request_context("/api/incidents/7/report"):
-        with patch.object(journal_routes, "_get_journal_storage", return_value=incident_storage), patch.object(
-            journal_routes, "get_config_manager", return_value=config_manager
-        ), patch.object(journal_routes, "get_state", return_value={"connection_info": {}}), patch(
+        with patch.object(journal_routes, "_get_journal_storage", return_value=incident_storage), patch.object(journal_routes.current_runtime(), "config_manager", config_manager
+        ), patch.object(journal_routes.current_runtime(), "get_state", return_value={"connection_info": {}}), patch(
             "app.modules.reports.report.generate_incident_report", return_value=b"%PDF"
         ) as generate_incident:
             getattr(journal_routes.api_incident_report, "__wrapped__")(7)

--- a/tests/test_security_audit_fixes.py
+++ b/tests/test_security_audit_fixes.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.module_download import fetch_registry, is_trusted_url
+from app.runtime import get_runtime
 
 
 # ── Finding 1: SSRF via registry URL ──
@@ -92,7 +93,7 @@ class TestRestoreRateLimit:
             test_app.register_blueprint(backup_bp)
 
             # Patch the getters that backup routes use
-            with patch("app.modules.backup.routes.get_config_manager", return_value=cfg), \
+            with patch.object(get_runtime(test_app), "config_manager", cfg), \
                  patch("app.modules.backup.routes._auth_required", return_value=False), \
                  patch("app.modules.backup.routes._get_client_ip", return_value="127.0.0.1"):
                 with test_app.test_client() as c:
@@ -137,7 +138,6 @@ class TestRestoreRateLimit:
         before touching the filesystem — no fallback to a hardcoded data dir."""
         from app.app_factory import create_app
         from app.config import ConfigManager
-        from app.runtime import get_runtime
         from app.modules.backup import routes as br
         from app.modules.backup.routes import bp as backup_bp
 
@@ -145,7 +145,7 @@ class TestRestoreRateLimit:
             config_manager=ConfigManager(tempfile.mkdtemp()), environ={}, testing=True
         )
 
-        with patch("app.modules.backup.routes.get_config_manager", return_value=None), \
+        with patch.object(get_runtime(test_app), "config_manager", None), \
              patch("app.modules.backup.routes._auth_required", return_value=False), \
              patch("app.modules.backup.routes._get_client_ip", return_value="127.0.0.1"), \
              patch("app.modules.backup.routes.restore_backup") as mock_restore:
@@ -175,7 +175,7 @@ class TestRestoreRateLimit:
             cfg.save({"admin_password": "testpass", "modem_type": "demo"})
             test_app = create_app(config_manager=cfg, environ={}, testing=True)
 
-            with patch("app.modules.backup.routes.get_config_manager", return_value=cfg), \
+            with patch.object(get_runtime(test_app), "config_manager", cfg), \
                  patch("app.modules.backup.routes._auth_required", return_value=False), \
                  patch("app.modules.backup.routes._get_client_ip", return_value="127.0.0.1"):
                 from app.modules.backup.routes import bp as backup_bp

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -371,9 +371,8 @@ class TestSpeedtestAPI:
 
     @patch("app.modules.speedtest.client.requests.Session.get")
     def test_api_test_speedtest_passes_insecure_tls_flag(self, mock_get, speedtest_client):
-        from app.web import get_config_manager
 
-        get_config_manager().save({"speedtest_tracker_url": "https://speedtest.local:8443"})
+        current_runtime().config_manager.save({"speedtest_tracker_url": "https://speedtest.local:8443"})
 
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"data": [SAMPLE_RESULT]}
@@ -433,7 +432,7 @@ class TestSpeedtestAPI:
                 }
 
         monkeypatch.setattr(speedtest_routes, "_get_speedtest_storage", lambda: SpeedtestStorage())
-        monkeypatch.setattr(speedtest_routes, "get_storage", lambda: CoreStorage())
+        monkeypatch.setattr(speedtest_routes.current_runtime(), "storage", CoreStorage())
 
         resp = speedtest_client.get("/api/speedtest/1/signal")
 
@@ -464,7 +463,7 @@ class TestSpeedtestAPI:
                 }
 
         monkeypatch.setattr(speedtest_routes, "_get_speedtest_storage", lambda: SpeedtestStorage())
-        monkeypatch.setattr(speedtest_routes, "get_storage", lambda: CoreStorage())
+        monkeypatch.setattr(speedtest_routes.current_runtime(), "storage", CoreStorage())
 
         resp = speedtest_client.get("/api/speedtest/1/signal")
 
@@ -515,9 +514,8 @@ class TestSpeedtestRun:
         mock_resp = MagicMock()
         mock_resp.status_code = 201
         mock_post.return_value = mock_resp
-        from app.web import get_config_manager
 
-        get_config_manager().save({"speedtest_tls_insecure": True})
+        current_runtime().config_manager.save({"speedtest_tls_insecure": True})
 
         resp = speedtest_client.post("/api/speedtest/run")
 

--- a/tests/test_trends_api.py
+++ b/tests/test_trends_api.py
@@ -12,7 +12,6 @@ from app.modules.connection_monitor.storage import ConnectionMonitorStorage
 from app.modules.speedtest.storage import SpeedtestStorage
 from app.storage import SnapshotStorage
 from app.runtime import current_runtime
-from app.web import get_config_manager
 
 
 def _utc_ts(delta: timedelta) -> str:
@@ -154,7 +153,7 @@ class TestTrendsRangeEndpoint:
         flask_client, storage = client
         _insert_snapshot(storage, _analysis(2.0), _utc_ts(timedelta(minutes=20)))
 
-        manager = get_config_manager()
+        manager = current_runtime().config_manager
         assert manager is not None
         cm_storage = ConnectionMonitorStorage(str(Path(manager.data_dir) / "connection_monitor.db"))
         target_id = cm_storage.create_target("Gateway", "192.0.2.1", enabled=True)

--- a/tests/test_update_checks.py
+++ b/tests/test_update_checks.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock
 
 from app.config import ConfigManager
-from app import web
 from app.runtime import UpdateChecker, current_runtime
 
 
@@ -30,7 +29,7 @@ def test_update_check_disabled_by_default_does_not_start_fetch_thread(tmp_path, 
         spawn=lambda target: _ThreadProbe(target, daemon=True).start(),
     )
 
-    assert web._check_for_update() is None
+    assert current_runtime().update_checker.latest() is None
 
     assert _ThreadProbe.calls == []
     assert current_runtime().update_checker.snapshot()["checking"] is False
@@ -47,7 +46,7 @@ def test_update_check_enabled_starts_background_fetch_thread(tmp_path, monkeypat
         spawn=lambda target: _ThreadProbe(target, daemon=True).start(),
     )
 
-    assert web._check_for_update() is None
+    assert current_runtime().update_checker.latest() is None
 
     assert len(_ThreadProbe.calls) == 1
     assert _ThreadProbe.calls[0].daemon is True

--- a/tests/test_version_newer.py
+++ b/tests/test_version_newer.py
@@ -1,8 +1,8 @@
 """Tests for _version_newer date-based version comparison."""
 
+from app.runtime import _version_newer
 import pytest
 
-from app.web import _version_newer
 
 
 class TestVersionNewer:

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -13,7 +13,6 @@ from app.modules.weather.client import OpenMeteoClient
 from app.modules.weather.collector import WeatherCollector
 from app.modules.weather.storage import WeatherStorage
 from app.config import ConfigManager
-from app.web import update_state
 from app.runtime import current_runtime
 
 
@@ -352,7 +351,7 @@ class TestWeatherAPI:
 
     def test_api_weather_current_with_state(self, weather_client):
         client, _ = weather_client
-        update_state(weather_latest={"timestamp": "2026-02-27 12:00:00Z", "temperature": 7.5})
+        current_runtime().update_state(weather_latest={"timestamp": "2026-02-27 12:00:00Z", "temperature": 7.5})
         resp = client.get("/api/weather/current")
         assert resp.status_code == 200
         data = resp.get_json()

--- a/tests/test_web_theme.py
+++ b/tests/test_web_theme.py
@@ -8,7 +8,7 @@ from app.runtime import current_runtime
 class TestThemeContext:
     """Test active theme module is available in template context."""
 
-    def test_active_theme_in_context(self):
+    def test_active_theme_in_context(self, monkeypatch):
         """Context processor includes active_theme_data when theme module is active."""
         from app import web
 
@@ -34,21 +34,15 @@ class TestThemeContext:
                     return "test.theme"
                 return default
 
-        old_loader = current_runtime().module_loader
-        old_config = current_runtime().config_manager
-        try:
-            current_runtime().module_loader = FakeLoader()
-            current_runtime().config_manager = FakeConfig()
+        monkeypatch.setattr(current_runtime(), "module_loader", FakeLoader())
+        monkeypatch.setattr(current_runtime(), "config_manager", FakeConfig())
 
-            with app.test_request_context("/"):
-                ctx = web.inject_auth()
-                assert "active_theme_data" in ctx
-                assert ctx["active_theme_data"]["dark"]["--bg"] == "#111"
-        finally:
-            current_runtime().module_loader = old_loader
-            current_runtime().config_manager = old_config
+        with app.test_request_context("/"):
+            ctx = web.inject_auth()
+            assert "active_theme_data" in ctx
+            assert ctx["active_theme_data"]["dark"]["--bg"] == "#111"
 
-    def test_no_theme_returns_none(self):
+    def test_no_theme_returns_none(self, monkeypatch):
         """Context processor returns None when no theme modules exist."""
         from app import web
 
@@ -62,21 +56,15 @@ class TestThemeContext:
             def get(self, key, default=""):
                 return default
 
-        old_loader = current_runtime().module_loader
-        old_config = current_runtime().config_manager
-        try:
-            current_runtime().module_loader = FakeLoader()
-            current_runtime().config_manager = FakeConfig()
+        monkeypatch.setattr(current_runtime(), "module_loader", FakeLoader())
+        monkeypatch.setattr(current_runtime(), "config_manager", FakeConfig())
 
-            with app.test_request_context("/"):
-                ctx = web.inject_auth()
-                assert "active_theme_data" in ctx
-                assert ctx["active_theme_data"] is None
-        finally:
-            current_runtime().module_loader = old_loader
-            current_runtime().config_manager = old_config
+        with app.test_request_context("/"):
+            ctx = web.inject_auth()
+            assert "active_theme_data" in ctx
+            assert ctx["active_theme_data"] is None
 
-    def test_fallback_prefers_classic_over_alphabetical(self):
+    def test_fallback_prefers_classic_over_alphabetical(self, monkeypatch):
         """When no active_theme is configured, Classic is chosen over alphabetically first."""
         from app import web
 
@@ -103,21 +91,15 @@ class TestThemeContext:
             def get(self, key, default=""):
                 return default  # no active_theme set
 
-        old_loader = current_runtime().module_loader
-        old_config = current_runtime().config_manager
-        try:
-            current_runtime().module_loader = FakeLoader()
-            current_runtime().config_manager = FakeConfig()
+        monkeypatch.setattr(current_runtime(), "module_loader", FakeLoader())
+        monkeypatch.setattr(current_runtime(), "config_manager", FakeConfig())
 
-            with app.test_request_context("/"):
-                ctx = web.inject_auth()
-                assert ctx["active_theme_id"] == "docsight.theme_classic"
-                assert ctx["active_theme_data"]["dark"]["--bg"] == "#111"
-        finally:
-            current_runtime().module_loader = old_loader
-            current_runtime().config_manager = old_config
+        with app.test_request_context("/"):
+            ctx = web.inject_auth()
+            assert ctx["active_theme_id"] == "docsight.theme_classic"
+            assert ctx["active_theme_data"]["dark"]["--bg"] == "#111"
 
-    def test_theme_collections_are_grouped_for_gallery(self):
+    def test_theme_collections_are_grouped_for_gallery(self, monkeypatch):
         """Theme gallery collections group signature, community, and playful themes."""
         from app import web
 
@@ -152,22 +134,16 @@ class TestThemeContext:
                     return "docsight.theme_classic"
                 return default
 
-        old_loader = current_runtime().module_loader
-        old_config = current_runtime().config_manager
-        try:
-            current_runtime().module_loader = FakeLoader()
-            current_runtime().config_manager = FakeConfig()
+        monkeypatch.setattr(current_runtime(), "module_loader", FakeLoader())
+        monkeypatch.setattr(current_runtime(), "config_manager", FakeConfig())
 
-            with app.test_request_context("/settings"):
-                ctx = web.inject_auth()
-                assert [c["key"] for c in ctx["theme_collections"]] == [
-                    "signature",
-                    "community",
-                    "playful",
-                ]
-                assert [m.id for m in ctx["theme_collections"][1]["modules"]] == [
-                    "docsight.theme_tokyo_night",
-                ]
-        finally:
-            current_runtime().module_loader = old_loader
-            current_runtime().config_manager = old_config
+        with app.test_request_context("/settings"):
+            ctx = web.inject_auth()
+            assert [c["key"] for c in ctx["theme_collections"]] == [
+                "signature",
+                "community",
+                "playful",
+            ]
+            assert [m.id for m in ctx["theme_collections"][1]["modules"]] == [
+                "docsight.theme_tokyo_night",
+            ]

--- a/tests/web/test_connection_and_gaming_api.py
+++ b/tests/web/test_connection_and_gaming_api.py
@@ -1,8 +1,8 @@
 """Tests for connection and gaming score endpoints."""
 
+from app.runtime import current_runtime
 import pytest
 
-from app.web import update_state
 
 class TestConnectionEndpoint:
     def test_no_connection_info(self, client):
@@ -14,7 +14,7 @@ class TestConnectionEndpoint:
         assert data["max_upstream_kbps"] is None
 
     def test_with_connection_info(self, client):
-        update_state(connection_info={
+        current_runtime().update_state(connection_info={
             "connection_type": "DOCSIS 3.1",
             "max_downstream_kbps": 250000,
             "max_upstream_kbps": 40000,
@@ -45,7 +45,7 @@ class TestGamingScoreEndpoint:
         assert set(data["genres"].keys()) == {"fps", "moba", "mmo", "strategy"}
 
     def test_with_analysis_no_speedtest(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         resp = client.get("/api/gaming-score")
         assert resp.status_code == 200
         data = resp.get_json()
@@ -59,7 +59,7 @@ class TestGamingScoreEndpoint:
         assert "ping_ms" not in data["raw"]
 
     def test_with_analysis_and_speedtest(self, client, sample_analysis):
-        update_state(
+        current_runtime().update_state(
             analysis=sample_analysis,
             speedtest_latest={"ping_ms": 15, "jitter_ms": 3, "packet_loss_pct": 0},
         )
@@ -80,7 +80,7 @@ class TestGamingScoreEndpoint:
         # Simulate a poor connection: zero SNR headroom, no speedtest
         sample_analysis["summary"]["health"] = "poor"
         sample_analysis["summary"]["ds_snr_min"] = 25.0
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         data = client.get("/api/gaming-score").get_json()
         # Without speedtest data the score may still be partial, but genres key must exist
         assert all(v in ("ok", "warn", "bad") for v in data["genres"].values())
@@ -89,6 +89,6 @@ class TestGamingScoreEndpoint:
         config_mgr.save({"gaming_quality_enabled": True})
         app = make_app(config_manager=config_mgr)
         with app.app_context(), app.test_client() as c:
-            update_state(analysis=sample_analysis)
+            current_runtime().update_state(analysis=sample_analysis)
             data = c.get("/api/gaming-score").get_json()
         assert data["enabled"] is True

--- a/tests/web/test_device_channel_threshold_api.py
+++ b/tests/web/test_device_channel_threshold_api.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from app.web import update_state
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.modules.speedtest.storage import SpeedtestStorage
@@ -10,7 +9,7 @@ from app.runtime import current_runtime
 
 class TestChannelsAPI:
     def test_channels_includes_summary(self, client, sample_analysis, tmp_path):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         db_path = str(tmp_path / "channels_test.db")
         storage = SnapshotStorage(db_path, max_days=7)
         storage.save_snapshot(sample_analysis)
@@ -39,7 +38,7 @@ class TestChannelsAPI:
 
 class TestDeviceAPI:
     def test_device_returns_info(self, client):
-        update_state(device_info={
+        current_runtime().update_state(device_info={
             "model": "FRITZ!Box 6690 Cable",
             "manufacturer": "AVM",
             "sw_version": "7.57",

--- a/tests/web/test_glossary_route.py
+++ b/tests/web/test_glossary_route.py
@@ -1,13 +1,13 @@
 """Tests for glossary app-shell routing."""
 
+from app.runtime import current_runtime
 import re
 
 from app.glossary import get_glossary_terms
-from app.web import update_state
 
 
 def test_glossary_route_redirects_to_in_app_glossary(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/glossary?lang=en&term=sc_qam&level=basic")
 
@@ -16,7 +16,7 @@ def test_glossary_route_redirects_to_in_app_glossary(client, sample_analysis):
 
 
 def test_glossary_route_drops_invalid_deep_link_values(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/glossary?lang=en&term=https://evil.example/&level=invalid")
 
@@ -25,7 +25,7 @@ def test_glossary_route_drops_invalid_deep_link_values(client, sample_analysis):
 
 
 def test_index_renders_glossary_inside_app_shell(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/?lang=en&term=docsis")
 
@@ -42,7 +42,7 @@ def test_index_renders_glossary_inside_app_shell(client, sample_analysis):
 
 
 def test_index_glossary_renders_simple_summary_and_explanation(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/?lang=en&term=sc_qam")
 
@@ -64,7 +64,7 @@ def test_index_glossary_renders_simple_summary_and_explanation(client, sample_an
 
 
 def test_index_glossary_renders_shared_medium_media(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/?lang=en&term=shared_medium")
 
@@ -80,7 +80,7 @@ def test_index_glossary_renders_shared_medium_media(client, sample_analysis):
 
 
 def test_index_glossary_renders_localized_media_metadata(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/?lang=de&term=shared_medium")
 
@@ -92,7 +92,7 @@ def test_index_glossary_renders_localized_media_metadata(client, sample_analysis
 
 
 def test_index_glossary_renders_tkg_rights_with_collapsed_german_law_appendix(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/?lang=en&term=tkg_rights_de")
 
@@ -122,7 +122,7 @@ def test_index_glossary_renders_tkg_rights_with_collapsed_german_law_appendix(cl
 
 
 def test_index_glossary_keeps_tkg_law_german_in_localized_article(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/?lang=fr&term=tkg_rights_de")
 
@@ -134,7 +134,7 @@ def test_index_glossary_keeps_tkg_law_german_in_localized_article(client, sample
 
 
 def test_index_glossary_exposes_wiki_source_search_metadata(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/?lang=en&term=docsis")
 
@@ -152,7 +152,7 @@ def test_index_glossary_exposes_wiki_source_search_metadata(client, sample_analy
 
 
 def test_index_glossary_lists_terms_alphabetically(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     resp = client.get("/?lang=en&term=docsis")
 
@@ -182,7 +182,7 @@ def test_contextual_glossary_links_target_existing_terms(client, sample_analysis
             },
         ],
     }
-    update_state(analysis=docsis31_analysis)
+    current_runtime().update_state(analysis=docsis31_analysis)
     valid_terms = {term["id"] for term in get_glossary_terms("en")}
 
     resp = client.get("/?lang=en")

--- a/tests/web/test_health_export.py
+++ b/tests/web/test_health_export.py
@@ -1,12 +1,11 @@
 """Tests for health, export, and state reset endpoints."""
 
 import json
-from app.web import update_state, reset_modem_state, get_state
 from app.runtime import current_runtime
 
 class TestHealthEndpoint:
     def test_health_waiting(self, client):
-        update_state(analysis=None)
+        current_runtime().update_state(analysis=None)
         # Reset state
         current_runtime().reset_modem_state()
         resp = client.get("/health")
@@ -14,7 +13,7 @@ class TestHealthEndpoint:
         assert resp.get_json()["docsis_health"] == "waiting"
 
     def test_health_ok(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         resp = client.get("/health")
         assert resp.status_code == 200
         data = json.loads(resp.data)
@@ -22,15 +21,15 @@ class TestHealthEndpoint:
         assert data["docsis_health"] == "good"
 
     def test_reset_modem_state_clears_stale_dashboard_data(self, client, sample_analysis):
-        update_state(
+        current_runtime().update_state(
             analysis=sample_analysis,
             device_info={"model": "Generic Router"},
             connection_info={"connection_type": "generic"},
             speedtest_latest={"download_mbps": 230.5},
         )
 
-        reset_modem_state()
-        state = get_state()
+        current_runtime().reset_modem_state()
+        state = current_runtime().get_state()
 
         assert state["analysis"] is None
         assert state["device_info"] is None
@@ -47,7 +46,7 @@ class TestExportEndpoint:
         assert resp.status_code == 404
 
     def test_export_returns_markdown(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         resp = client.get("/api/export")
         assert resp.status_code == 200
         data = json.loads(resp.data)
@@ -61,7 +60,7 @@ class TestExportEndpoint:
             "ds_correctable_errors": None,
             "ds_uncorrectable_errors": None,
         })
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/api/export")
 

--- a/tests/web/test_index.py
+++ b/tests/web/test_index.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 
 from app.analyzer import analyze, get_thresholds
-from app.web import update_state
 from app.signal_health_view import (
     build_home_snr_display_context,
     build_metric_ranges,
@@ -281,18 +280,18 @@ class TestIndexRoute:
             assert "/setup" in resp.headers["Location"]
 
     def test_index_renders(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         resp = client.get("/")
         assert resp.status_code == 200
         assert b"DOCSight" in resp.data
 
     def test_index_with_lang(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         resp = client.get("/?lang=de")
         assert resp.status_code == 200
 
     def test_dashboard_exposes_docsis_basics_help_in_english_and_german(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
         assert resp.status_code == 200
@@ -333,7 +332,7 @@ class TestIndexRoute:
                 "health_detail": "",
             },
         ]
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -360,7 +359,7 @@ class TestIndexRoute:
                 "upstream": {"calculated": 1, "total": 1, "unsupported": 0},
             },
         })
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -403,7 +402,7 @@ class TestIndexRoute:
 
     def test_speed_kpi_card_links_to_speedtest_view_and_uses_rabbit_icon(self, client, config_mgr, sample_analysis):
         _configure_speedtest(config_mgr)
-        update_state(analysis=sample_analysis, speedtest_latest=_latest_speedtest())
+        current_runtime().update_state(analysis=sample_analysis, speedtest_latest=_latest_speedtest())
 
         resp = client.get("/?lang=en")
 
@@ -420,7 +419,7 @@ class TestIndexRoute:
 
     def test_no_docsis_speed_kpi_card_links_to_speedtest_view_and_uses_rabbit_icon(self, client, config_mgr, no_docsis_analysis):
         _configure_speedtest(config_mgr)
-        update_state(analysis=no_docsis_analysis, speedtest_latest=_latest_speedtest())
+        current_runtime().update_state(analysis=no_docsis_analysis, speedtest_latest=_latest_speedtest())
 
         resp = client.get("/?lang=en")
 
@@ -441,7 +440,7 @@ class TestIndexRoute:
         sample_analysis["summary"]["ds_uncorrectable_errors"] = 0
         sample_analysis["ds_channels"][0]["correctable_errors"] = None
         sample_analysis["ds_channels"][0]["uncorrectable_errors"] = None
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/")
 
@@ -453,7 +452,7 @@ class TestIndexRoute:
         sample_analysis["summary"]["errors_supported"] = False
         sample_analysis["summary"]["ds_correctable_errors"] = None
         sample_analysis["summary"]["ds_uncorrectable_errors"] = None
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/")
 
@@ -474,7 +473,7 @@ class TestIndexRoute:
             "unsupported_channels": 0,
             "families": {},
         }
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/")
 
@@ -506,7 +505,7 @@ class TestIndexRoute:
                 "families": {},
             },
         })
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/")
 
@@ -554,7 +553,7 @@ class TestIndexRoute:
                 "health_detail": "power critical; snr critical",
             }
         ]
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -581,7 +580,7 @@ class TestIndexRoute:
             _snr_render_channel(1, '602 MHz', 3.0, 35.0, '256QAM', '3.1'),
             _snr_render_channel(2, '610 MHz', 3.1, 37.0, '256QAM', '3.1'),
         ]
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -602,7 +601,7 @@ class TestIndexRoute:
         sample_analysis["ds_channels"] = [
             _snr_render_channel(33, '774 MHz', 1.0, 41.0, 'OFDM', '3.1'),
         ]
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -623,7 +622,7 @@ class TestIndexRoute:
             _snr_render_channel(1, '602 MHz', 3.0, 36.0, '256QAM', '3.1'),
             _snr_render_channel(33, '774 MHz', 1.0, 41.0, 'OFDM', '3.1'),
         ]
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -643,7 +642,7 @@ class TestIndexRoute:
         sample_analysis["ds_channels"] = [
             _snr_render_channel(33, '774 MHz', 1.0, 42.0, '4096QAM', '3.1'),
         ]
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -662,7 +661,7 @@ class TestIndexRoute:
         sample_analysis["ds_channels"] = [
             _snr_render_channel(1, '602 MHz', 1.0, 39.0, '', ''),
         ]
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -674,7 +673,7 @@ class TestIndexRoute:
     def test_home_renders_downstream_signal_family_cards_without_mixed_average(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
         sample_analysis["summary"].update({"ds_snr_avg": 38.5})
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -704,7 +703,7 @@ class TestIndexRoute:
 
     def test_home_signal_family_cards_follow_ds_us_order(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -724,7 +723,7 @@ class TestIndexRoute:
     def test_home_signal_family_cards_explain_average_context_without_title_spam(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
         sample_analysis["summary"]["signal_families"]["downstream"]["families"]["sc_qam"]["count"] = 2
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -747,7 +746,7 @@ class TestIndexRoute:
         ofdma["power"].update({"available": True, "avg": 49.5, "min": 49.5, "max": 49.5, "health": "warning"})
         ofdma["modulation"].update({"value": "32QAM", "distinct": ["32QAM"], "health": "critical"})
         sample_analysis["summary"]["us_ofdma_power_avg"] = 49.5
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -783,7 +782,7 @@ class TestIndexRoute:
         })
         ofdm["mer"].update({"avg": 27.0, "min": 25.0, "max": 29.0, "health": "warning"})
         sample_analysis["summary"]["ds_ofdm_mer_avg"] = 27.0
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -848,7 +847,7 @@ class TestIndexRoute:
         assert injected_ranges["ds_ofdm_mer"]["bands"] != metric_ranges["ds_ofdm_mer"]["bands"]
 
     def test_legacy_metric_card_keeps_generic_status_label(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -887,7 +886,7 @@ class TestIndexRoute:
             "health": "critical",
         })
         sample_analysis["summary"]["us_scqam_power_avg"] = 41.9
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -925,7 +924,7 @@ class TestIndexRoute:
             "health": "critical",
         })
         sample_analysis["summary"]["us_ofdma_power_avg"] = 49.5
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -952,7 +951,7 @@ class TestIndexRoute:
             "values": [{"value": "64QAM", "health": "good"}],
             "health": "good",
         })
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -969,7 +968,7 @@ class TestIndexRoute:
         ofdm = sample_analysis["summary"]["signal_families"]["downstream"]["families"]["ofdm"]
         ofdm["health"] = "warning"
         ofdm["health_cause"] = "mer"
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -982,7 +981,7 @@ class TestIndexRoute:
 
     def test_home_signal_family_cards_show_metric_health_bars(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1006,7 +1005,7 @@ class TestIndexRoute:
         family_metric = sample_analysis["summary"]["signal_families"]["downstream"]["families"]["sc_qam"]["snr"]
         family_metric.pop("min")
         family_metric.pop("max")
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1019,7 +1018,7 @@ class TestIndexRoute:
 
     def test_home_renders_upstream_signal_family_cards_separately(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1036,7 +1035,7 @@ class TestIndexRoute:
 
     def test_home_family_cards_expose_family_sparkline_keys(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1051,7 +1050,7 @@ class TestIndexRoute:
 
     def test_home_family_cards_use_direction_icons_and_spark_colors(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1073,7 +1072,7 @@ class TestIndexRoute:
 
     def test_home_removes_modulation_context_when_family_cards_include_ranges(self, client, sample_analysis):
         _add_mixed_signal_families(sample_analysis)
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1082,7 +1081,7 @@ class TestIndexRoute:
         assert 'class="hero-modulation-context"' not in html
 
     def test_home_surfaces_normal_modulation_context(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1106,7 +1105,7 @@ class TestIndexRoute:
             "health": "warning",
             "health_detail": "modulation marginal",
         })
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1139,7 +1138,7 @@ class TestIndexRoute:
             "health": "critical" if issue == "ds_modulation_critical" else "warning",
             "health_detail": detail,
         })
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=de")
 
@@ -1159,7 +1158,7 @@ class TestIndexRoute:
             "health": "critical",
             "health_detail": "modulation critical",
         })
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1175,7 +1174,7 @@ class TestIndexRoute:
             channel["health"] = "good"
             channel["health_detail"] = ""
         sample_analysis["summary"].update({"health": "good", "health_issues": []})
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
 
         resp = client.get("/?lang=en")
 
@@ -1207,7 +1206,7 @@ class TestIndexRoute:
             "measurements_download": [],
             "measurements_upload": [],
         })
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         with app.test_client() as c:
             resp = c.get("/")
         assert resp.status_code == 200
@@ -1229,7 +1228,7 @@ class TestIndexRoute:
             "ds_channels": [],
             "us_channels": [],
         }
-        update_state(analysis=analysis)
+        current_runtime().update_state(analysis=analysis)
         resp = client.get("/")
         assert resp.status_code == 200
         assert b"no-docsis-placeholder" in resp.data
@@ -1265,7 +1264,7 @@ class TestIndexRoute:
             "ds_channels": [],
             "us_channels": [],
         }
-        update_state(
+        current_runtime().update_state(
             analysis=analysis,
             speedtest_latest={
                 "download_mbps": 230.5,
@@ -1315,7 +1314,7 @@ class TestIndexRoute:
             "ds_channels": [],
             "us_channels": [],
         }
-        update_state(
+        current_runtime().update_state(
             analysis=analysis,
             speedtest_latest={
                 "download_mbps": 230.5,
@@ -1345,7 +1344,7 @@ class TestIndexSegmentUtilizationVisibility:
     def test_index_hides_segment_tab_when_disabled(self, client, config_mgr, sample_analysis):
         config_mgr.save({"segment_utilization_enabled": False})
         current_runtime().config_manager = config_mgr
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         resp = client.get("/?lang=en")
         assert resp.status_code == 200
         assert b'data-view="segment-utilization"' not in resp.data

--- a/tests/web/test_notices.py
+++ b/tests/web/test_notices.py
@@ -1,7 +1,7 @@
+from app.runtime import current_runtime
 import pytest
 
 from app import maintainer_notices
-from app.web import reset_modem_state
 
 
 @pytest.fixture
@@ -62,7 +62,7 @@ def test_notice_api_rejects_invalid_location_and_id(client, local_notices):
 
 
 def test_dashboard_renders_notice_until_dismissed(client, config_mgr, local_notices):
-    reset_modem_state()
+    current_runtime().reset_modem_state()
 
     response = client.get("/")
     assert response.status_code == 200

--- a/tests/web/test_path_prefix_urls.py
+++ b/tests/web/test_path_prefix_urls.py
@@ -12,9 +12,6 @@ import pytest
 import app.web as web
 from app.config import ConfigManager
 from app.module_loader import ModuleInfo
-from app.web import (
-    update_state,
-)
 from app.runtime import current_runtime
 
 
@@ -143,7 +140,7 @@ def _enabled_bqm_loader():
 def test_dashboard_and_settings_render_prefix_aware_navigation_and_assets(
     client, sample_analysis
 ):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     dashboard = client.get("/?lang=en", environ_overrides=PREFIX_ENV)
     settings = client.get("/settings?lang=en", environ_overrides=PREFIX_ENV)
@@ -292,7 +289,7 @@ def test_auth_setup_glossary_and_backup_redirects_preserve_script_name(tmp_path)
 def test_root_mount_keeps_existing_effective_server_generated_paths(
     client, sample_analysis
 ):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     response = client.get("/?lang=en")
 
@@ -311,7 +308,7 @@ def test_root_mount_keeps_existing_effective_server_generated_paths(
 def test_pwa_routes_and_manifest_identity_follow_effective_mount(
     client, sample_analysis, environ, mount_path
 ):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     dashboard = client.get("/", environ_overrides=environ)
     service_worker = client.get("/sw.js", environ_overrides=environ)
@@ -346,7 +343,7 @@ def test_pwa_routes_and_manifest_identity_follow_effective_mount(
 def test_browser_url_bootstrap_is_minimal_canonical_and_early(
     client, sample_analysis, tmp_path
 ):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
     dashboard_html = client.get(
         "/?lang=en", environ_overrides=PREFIX_ENV
     ).get_data(as_text=True)
@@ -373,7 +370,7 @@ def test_browser_url_bootstrap_is_minimal_canonical_and_early(
 
 
 def test_root_browser_url_bootstrap_preserves_root_deployment(client, sample_analysis):
-    update_state(analysis=sample_analysis)
+    current_runtime().update_state(analysis=sample_analysis)
 
     html = client.get("/?lang=en").get_data(as_text=True)
     bootstrap, _ = _browser_bootstrap(html)

--- a/tests/web/test_report_period.py
+++ b/tests/web/test_report_period.py
@@ -15,9 +15,9 @@ def _call_route(route, path, *, storage=None, state=None, generated="artifact"):
     generator_name = "generate_report" if route == "report" else "generate_complaint_text"
     generator_value = b"%PDF-test" if route == "report" else generated
     with app.test_request_context(path), \
-         patch.object(routes, "get_storage", return_value=storage), \
-         patch.object(routes, "get_config_manager", return_value=None), \
-         patch.object(routes, "get_state", return_value=state or {}), \
+         patch.object(routes.current_runtime(), "storage", storage), \
+         patch.object(routes.current_runtime(), "config_manager", None), \
+         patch.object(routes.current_runtime(), "get_state", return_value=state or {}), \
          patch.object(routes, generator_name, return_value=generator_value) as generator:
         result = getattr(getattr(routes, f"api_{route}"), "__wrapped__")()
     return result, storage, generator
@@ -43,9 +43,9 @@ def test_exact_complaint_window_succeeds_without_live_analysis():
 
     with app.test_request_context(
         "/api/complaint?from=2026-05-01T00:00:00Z&to=2026-05-03T00:00:00Z"
-    ), patch.object(routes, "get_storage", return_value=storage), \
-         patch.object(routes, "get_config_manager", return_value=None), \
-         patch.object(routes, "get_state", return_value={}), \
+    ), patch.object(routes.current_runtime(), "storage", storage), \
+         patch.object(routes.current_runtime(), "config_manager", None), \
+         patch.object(routes.current_runtime(), "get_state", return_value={}), \
          patch.object(routes, "generate_complaint_text", return_value="historical") as generate:
         response = getattr(routes.api_complaint, "__wrapped__")()
 
@@ -163,9 +163,9 @@ def test_rolling_window_default_explicit_and_clamp_remain_compatible(
     generator_name = "generate_report" if route == "report" else "generate_complaint_text"
     generator_value = b"%PDF-test" if route == "report" else "text"
     with app.test_request_context(f"/api/{route}{query}"), \
-         patch.object(routes, "get_storage", return_value=storage), \
-         patch.object(routes, "get_config_manager", return_value=None), \
-         patch.object(routes, "get_state", return_value={}), \
+         patch.object(routes.current_runtime(), "storage", storage), \
+         patch.object(routes.current_runtime(), "config_manager", None), \
+         patch.object(routes.current_runtime(), "get_state", return_value={}), \
          patch.object(routes, "utc_now", return_value="2026-08-13T12:00:00Z"), \
          patch.object(routes, "utc_cutoff", return_value="2026-08-06T12:00:00Z") as cutoff, \
          patch.object(routes, generator_name, return_value=generator_value):
@@ -217,9 +217,9 @@ def test_automatic_bnetz_lookup_uses_normalized_exact_window():
     with app.test_request_context(
         "/api/complaint?include_bnetz=true"
         "&from=2026-05-01T02:00:00%2B02:00&to=2026-05-03T02:00:00%2B02:00"
-    ), patch.object(routes, "get_storage", return_value=storage), \
-         patch.object(routes, "get_config_manager", return_value=None), \
-         patch.object(routes, "get_state", return_value={}), \
+    ), patch.object(routes.current_runtime(), "storage", storage), \
+         patch.object(routes.current_runtime(), "config_manager", None), \
+         patch.object(routes.current_runtime(), "get_state", return_value={}), \
          patch("app.modules.bnetz.storage.BnetzStorage", return_value=bnetz_storage), \
          patch.object(routes, "generate_complaint_text", return_value="text") as generate:
         response = getattr(routes.api_complaint, "__wrapped__")()
@@ -241,9 +241,9 @@ def test_explicit_bnetz_id_keeps_id_lookup_compatibility():
     with app.test_request_context(
         "/api/complaint?bnetz_id=9"
         "&from=2026-05-01T00:00:00Z&to=2026-05-02T00:00:00Z"
-    ), patch.object(routes, "get_storage", return_value=storage), \
-         patch.object(routes, "get_config_manager", return_value=None), \
-         patch.object(routes, "get_state", return_value={}), \
+    ), patch.object(routes.current_runtime(), "storage", storage), \
+         patch.object(routes.current_runtime(), "config_manager", None), \
+         patch.object(routes.current_runtime(), "get_state", return_value={}), \
          patch("app.modules.bnetz.storage.BnetzStorage", return_value=bnetz_storage), \
          patch.object(routes, "generate_complaint_text", return_value="text") as generate:
         response = getattr(routes.api_complaint, "__wrapped__")()

--- a/tests/web/test_reports.py
+++ b/tests/web/test_reports.py
@@ -319,9 +319,9 @@ class TestComplaintRoutes:
             "&number=KD-123456"
             "&address=Musterstra%C3%9Fe%201%0A12345%20Musterstadt"
         ):
-            with patch.object(routes, "get_storage", return_value=storage), \
-                 patch.object(routes, "get_config_manager", return_value=config_manager), \
-                 patch.object(routes, "get_state", return_value={"analysis": analysis, "connection_info": {}}), \
+            with patch.object(routes.current_runtime(), "storage", storage), \
+                 patch.object(routes.current_runtime(), "config_manager", config_manager), \
+                 patch.object(routes.current_runtime(), "get_state", return_value={"analysis": analysis, "connection_info": {}}), \
                  patch.object(routes, "generate_report", return_value=pdf_bytes) as generate_report:
                 response = getattr(routes.api_report, "__wrapped__")()
 
@@ -358,8 +358,8 @@ class TestComplaintRoutes:
             "&address=Musterstra%C3%9Fe%201%0A12345%20Musterstadt"
         ):
             with patch.object(routes, "_get_journal_storage", return_value=storage), \
-                 patch.object(routes, "get_config_manager", return_value=config_manager), \
-                 patch.object(routes, "get_state", return_value={"connection_info": {}}), \
+                 patch.object(routes.current_runtime(), "config_manager", config_manager), \
+                 patch.object(routes.current_runtime(), "get_state", return_value={"connection_info": {}}), \
                  patch("app.modules.reports.report.generate_incident_report", return_value=pdf_bytes) as generate_incident_report:
                 response = getattr(routes.api_incident_report, "__wrapped__")(7)
 

--- a/tests/web/test_security.py
+++ b/tests/web/test_security.py
@@ -1,16 +1,16 @@
 """Tests for security-related web behavior."""
 
+from app.runtime import current_runtime
 import os
 from datetime import timedelta
 
 import pytest
 
-from app.web import update_state
 from app.config import ConfigManager
 
 class TestSecurityHeaders:
     def test_headers_present(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         resp = client.get("/")
         assert resp.headers["X-Content-Type-Options"] == "nosniff"
         assert resp.headers["X-Frame-Options"] == "DENY"
@@ -24,7 +24,7 @@ class TestSecurityHeaders:
 
 class TestTimestampValidation:
     def test_valid_timestamp_accepted(self, client, sample_analysis):
-        update_state(analysis=sample_analysis)
+        current_runtime().update_state(analysis=sample_analysis)
         # No storage, so snapshot lookup returns None and falls through to live view
         resp = client.get("/?t=2026-01-01T06:00:00")
         assert resp.status_code == 200


### PR DESCRIPTION
## Changes
- Use the request runtime directly in built-in routes and modules while retaining the public `app.web` accessors for community compatibility.
- Give request-language selection, pure date/time handling and theme selection explicit owners.
- Remove obsolete private wrappers and document the separate collector-thread contract.
- Preserve authentication, configuration, API responses, URLs and presentation.

## Validation
- Python suite: 4,124 passed, 2 skipped.
- JavaScript suite: 47 passed.
- Complete browser suite: 554 passed.
- Desktop and mobile checks under a URL prefix, including language selection and theme activation.
- Before/after checks for runtime accessors, language, dates, timezones, themes, routes and API responses.
- Architecture, workflow, localization and production undefined-name checks.
