### PR TITLE
fix: preserve existing theme installation targets

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -232,6 +232,10 @@ Maintainers use this checklist when reviewing changes that touch integration or 
 - **Token, credential, and private config metadata storage** — Fernet-at-rest storage for modem, webhook, Apprise sidecar, and PWA Web Push VAPID private-key secrets plus report customer defaults, hash-only persistence for the admin password and API tokens, and config redaction.
 - **MQTT/Home Assistant integration payloads** — outbound notifier payload shaping, severity mapping, length limits, and log redaction for webhook URLs.
 - **Module/plugin manifest loading** — manifest validation and the install/list API surface.
+  Theme installs return HTTP 409 for existing destination files, directories, or
+  symlinks before downloading. Installation paths must resolve strictly below
+  `MODULES_DIR`, rejecting aliases to the root or outside it. Installers must pass
+  new targets to the downloader because failed downloads can remove that tree.
 - **Docker/self-hosted runtime defaults** — bundled image defaults, secret bootstrap, and end-to-end auth on a fresh deployment.
 - **Rate limiting or abuse resistance** — login backoff and capture guardrails.
 - **Test fixtures and documentation examples** — fixtures and public docs should avoid reusable-looking secrets so that example values cannot be mistaken for credentials.

--- a/app/blueprints/modules_bp.py
+++ b/app/blueprints/modules_bp.py
@@ -266,9 +266,14 @@ def api_themes_install():
         return jsonify({"success": False, "error": "Invalid theme ID"}), 400
 
     modules_dir = get_modules_dir()
+    dir_name = theme_id.replace(".", "_")
+
+    # Check the entry before resolving symlinks, including dangling/root aliases.
+    if os.path.lexists(os.path.join(modules_dir, dir_name)):
+        return jsonify({"success": False, "error": "Theme already installed"}), 409
 
     try:
-        theme_dir = safe_child_path(modules_dir, theme_id.replace(".", "_"))
+        theme_dir = safe_child_path(modules_dir, dir_name)
     except ValueError:
         return jsonify({"success": False, "error": "Invalid theme ID"}), 400
 

--- a/app/blueprints/modules_bp.py
+++ b/app/blueprints/modules_bp.py
@@ -268,8 +268,13 @@ def api_themes_install():
     modules_dir = get_modules_dir()
     dir_name = theme_id.replace(".", "_")
 
-    # Check the entry before resolving symlinks, including dangling/root aliases.
-    if os.path.lexists(os.path.join(modules_dir, dir_name)):
+    # Guard the unresolved entry before checking even dangling/root symlinks.
+    entry_path = os.path.normcase(os.path.abspath(os.path.join(modules_dir, dir_name)))
+    entry_root = os.path.normcase(os.path.abspath(modules_dir))
+    if entry_path == entry_root or not entry_path.startswith(entry_root.rstrip(os.sep) + os.sep):
+        return jsonify({"success": False, "error": "Invalid theme ID"}), 400
+
+    if os.path.lexists(entry_path):
         return jsonify({"success": False, "error": "Theme already installed"}), 409
 
     try:

--- a/app/path_safety.py
+++ b/app/path_safety.py
@@ -13,8 +13,8 @@ def safe_child_path(base_dir: str, child_name: str) -> str:
     """Resolve *child_name* inside *base_dir* safely.
 
     Validates *child_name* against ``ID_PATTERN`` (lowercase alphanum,
-    dots, underscores) and ensures the resolved path is actually inside
-    *base_dir* via ``os.path.commonpath``.
+    dots, underscores) and ensures the resolved path is a strict descendant
+    of *base_dir*, using a normalized, separator-aware prefix check.
 
     Returns the resolved absolute path on success.
     Raises ``ValueError`` for any invalid or escaping name.
@@ -26,7 +26,9 @@ def safe_child_path(base_dir: str, child_name: str) -> str:
     real_base = os.path.realpath(base_dir)
     real_candidate = os.path.realpath(candidate)
 
-    if os.path.commonpath([real_base, real_candidate]) != real_base:
+    if os.path.normcase(real_candidate) == os.path.normcase(real_base) or not os.path.normcase(real_candidate).startswith(
+        os.path.normcase(real_base).rstrip(os.sep) + os.sep
+    ):
         raise ValueError(f"Path escapes base directory: {child_name!r}")
 
     return real_candidate

--- a/app/static/js/settings/themes.js
+++ b/app/static/js/settings/themes.js
@@ -208,7 +208,12 @@ function installTheme(themeId, downloadUrl) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: themeId, download_url: downloadUrl }),
     })
-        .then(function(r) { return r.json(); })
+        .then(function(r) {
+            return r.json().then(function(data) {
+                if (r.status === 409) data.error = T.theme_install_failed || 'Install failed';
+                return data;
+            });
+        })
         .then(function(data) {
             if (data.success) {
                 showToast(T.theme_installed || 'Theme installed — restart required', true);

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v91';
+var CACHE_VERSION = 'v92';
 var REGISTRATION_SCOPE = new URL(self.registration.scope);
 
 if (REGISTRATION_SCOPE.origin !== self.location.origin || REGISTRATION_SCOPE.pathname.slice(-1) !== '/') {

--- a/tests/js/settings-form.test.js
+++ b/tests/js/settings-form.test.js
@@ -234,3 +234,65 @@ test('all settings owners initialize together and expose only the legacy handler
     }
     assert.equal(f.dirty(), false);
 });
+
+test('theme installation localizes conflicts and preserves success and other failures', async t => {
+    const T = JSON.parse(fs.readFileSync('app/i18n/de.json', 'utf8'));
+    const theme = {id: 'community.example', name: 'Example', version: '1.0.0',
+        download_url: 'https://api.github.com/repos/example/themes/contents/theme'};
+    for (const scenario of [
+        {name: '409 conflict', status: 409, data: {success: false, error: 'Theme already installed'}, expected: T.theme_install_failed},
+        {name: '409 without message', status: 409, data: {success: false}, expected: T.theme_install_failed},
+        {name: '400 retains API message', status: 400, data: {success: false, error: 'Theme already installed'}, expected: 'Theme already installed'},
+        {name: '500 retains API message', status: 500, data: {success: false, error: 'Download failed'}, expected: 'Download failed'},
+        {name: '500 without message', status: 500, data: {success: false}, expected: T.theme_install_failed},
+        {name: 'successful install', status: 200, data: {success: true, restart_required: true}, expected: T.theme_installed, success: true},
+        {name: 'network failure', failure: new Error('offline'), expected: T.error_prefix + ': offline'},
+        {name: 'invalid response JSON', status: 500, jsonFailure: new Error('invalid JSON'), expected: T.error_prefix + ': invalid JSON'},
+    ]) {
+        await t.test(scenario.name, async () => {
+            const requests = [], toasts = [], buttons = [];
+            const element = () => ({appendChild() {}, addEventListener(event, fn) {
+                assert.equal(event, 'click');
+                this.click = fn;
+            }});
+            const gallery = element();
+            const context = vm.createContext({DOCSightSettings: {}, T,
+                document: {
+                    getElementById: id => id === 'registry-gallery' ? gallery : null,
+                    createElement(tag) {
+                        const node = element();
+                        if (tag === 'button') buttons.push(node);
+                        return node;
+                    }
+                },
+                docsightUrl: path => '/prefix' + path, lucide: {createIcons() {}},
+                async fetch(url, options) {
+                    requests.push({url, options});
+                    if (url === '/prefix/api/themes/registry') return {json: async () => [theme]};
+                    assert.equal(url, '/prefix/api/themes/install');
+                    if (scenario.failure) throw scenario.failure;
+                    return {status: scenario.status, json: async () => {
+                        if (scenario.jsonFailure) throw scenario.jsonFailure;
+                        return {...scenario.data};
+                    }};
+                }
+            });
+            vm.runInContext(fs.readFileSync('app/static/js/settings/themes.js', 'utf8'), context);
+            const owner = context.DOCSightSettings.themes({showToast: (...args) => toasts.push(args)});
+            owner.refreshRegistry();
+            await tick();
+            assert.equal(buttons.length, 1);
+            buttons[0].click();
+            await tick();
+            assert.equal(requests[1].options.method, 'POST');
+            assert.equal(requests[1].options.headers['Content-Type'], 'application/json');
+            assert.deepEqual(JSON.parse(requests[1].options.body), {id: theme.id, download_url: theme.download_url});
+            assert.deepEqual(toasts, [[scenario.expected, !!scenario.success]]);
+            assert.deepEqual(requests.map(request => request.url), [
+                '/prefix/api/themes/registry', '/prefix/api/themes/install',
+                ...(scenario.success ? ['/prefix/api/themes/registry'] : [])
+            ]);
+            assert.equal(buttons.length, scenario.success ? 2 : 1);
+        });
+    }
+});

--- a/tests/test_dashboard_module_ownership.py
+++ b/tests/test_dashboard_module_ownership.py
@@ -109,4 +109,4 @@ def test_unconfigured_modules_keep_setup_without_empty_views(dashboard, prefix):
 
 
 def test_module_asset_cache_generation():
-    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v91';")
+    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v92';")

--- a/tests/test_module_install_api.py
+++ b/tests/test_module_install_api.py
@@ -1,9 +1,12 @@
 """Tests for community module install/uninstall API endpoints."""
 
 import json
+import ntpath
 import os
+import posixpath
 import shutil
 from io import BytesIO
+from types import SimpleNamespace
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -262,6 +265,37 @@ class TestModulesInstall:
 
 class TestThemesInstall:
     download_url = "https://api.github.com/repos/example/themes/contents/theme"
+
+    @pytest.mark.parametrize("path_module,base,expected", [
+        (posixpath, "/", "/root_alias"),
+        (posixpath, "//", "//root_alias"),
+        (posixpath, "/Modules/../Themes/", "/Themes/root_alias"),
+        (ntpath, "C:\\", "c:\\root_alias"),
+        (ntpath, "C:/Modules/../Themes/", "c:\\themes\\root_alias"),
+        (ntpath, "//SERVER/Share/", "\\\\server\\share\\root_alias"),
+        (ntpath, "//SERVER/Share/Modules/../Themes/", "\\\\server\\share\\themes\\root_alias"),
+    ])
+    def test_occupied_check_uses_absolute_unresolved_path(self, client, monkeypatch, path_module, base, expected):
+        from app.blueprints import modules_bp
+
+        occupied = MagicMock(return_value=True)
+        path_ops = SimpleNamespace(
+            join=path_module.join, abspath=path_module.abspath,
+            normcase=path_module.normcase, lexists=occupied,
+        )
+        # Keep foreign path operations local; resolving the entry is not allowed.
+        monkeypatch.setattr(modules_bp, "os", SimpleNamespace(path=path_ops, sep=path_module.sep))
+        monkeypatch.setattr(modules_bp, "get_modules_dir", lambda: base)
+        with patch.object(modules_bp, "safe_child_path") as resolve, \
+             patch.object(modules_bp, "download_theme") as download:
+            response = client.post("/api/themes/install", json={
+                "id": "root.alias", "download_url": self.download_url,
+            })
+        assert response.status_code == 409
+        assert response.get_json() == {"success": False, "error": "Theme already installed"}
+        occupied.assert_called_once_with(expected)
+        resolve.assert_not_called()
+        download.assert_not_called()
 
     @pytest.fixture
     def modules_dir(self, tmp_path, monkeypatch):

--- a/tests/test_module_install_api.py
+++ b/tests/test_module_install_api.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import shutil
+from io import BytesIO
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -9,6 +11,7 @@ from app.blueprints.modules_bp import _remove_downloaded_module
 from app.config import ConfigManager
 from app.storage import SnapshotStorage
 from app.runtime import current_runtime
+from app.theme_registry import download_theme
 
 
 @pytest.fixture
@@ -258,6 +261,119 @@ class TestModulesInstall:
 
 
 class TestThemesInstall:
+    download_url = "https://api.github.com/repos/example/themes/contents/theme"
+
+    @pytest.fixture
+    def modules_dir(self, tmp_path, monkeypatch):
+        modules_dir = tmp_path / "modules"
+        modules_dir.mkdir()
+        monkeypatch.setenv("MODULES_DIR", str(modules_dir))
+        return modules_dir
+
+    @pytest.mark.parametrize("download_result", ["empty", "failed"])
+    @pytest.mark.parametrize("target_kind", [
+        "directory", "file", "symlink", "dangling_symlink", "root_alias",
+        "outside_symlink", "sibling_symlink",
+    ])
+    def test_existing_target_is_untouched(self, client, modules_dir, tmp_path, target_kind, download_result):
+        target = modules_dir / "root_alias"
+        sentinel = modules_dir / "keep.txt"
+        sentinel.write_text("keep", encoding="utf-8")
+        link_target = None
+        if target_kind == "directory":
+            target.mkdir()
+            (target / "keep.txt").write_text("keep", encoding="utf-8")
+        elif target_kind == "file":
+            target.write_text("keep", encoding="utf-8")
+        else:
+            link_target = {
+                "symlink": modules_dir / "existing",
+                "dangling_symlink": modules_dir / "missing",
+                "root_alias": modules_dir,
+                "outside_symlink": tmp_path / "outside",
+                "sibling_symlink": tmp_path / "modules_sibling",
+            }[target_kind]
+            if target_kind != "dangling_symlink":
+                link_target.mkdir(exist_ok=True)
+                (link_target / "keep.txt").write_text("keep", encoding="utf-8")
+            target.symlink_to(link_target, target_is_directory=True)
+            original_link = os.readlink(target)
+
+        with patch("app.module_download.urllib.request.urlopen") as transport, \
+             patch("app.blueprints.modules_bp.download_theme", wraps=download_theme) as download, \
+             patch("shutil.rmtree") as remove:
+            transport.return_value = BytesIO(b"[]")
+            if download_result == "failed":
+                transport.side_effect = OSError("download interrupted")
+            response = client.post("/api/themes/install", json={
+                "id": "root.alias", "download_url": self.download_url,
+            })
+
+            assert response.status_code == 409, (response.get_json(), remove.call_args_list)
+            assert response.get_json() == {"success": False, "error": "Theme already installed"}
+            download.assert_not_called()
+            transport.assert_not_called()
+            remove.assert_not_called()
+
+        assert sentinel.read_text(encoding="utf-8") == "keep"
+        if link_target is not None:
+            assert target.is_symlink()
+            assert os.readlink(target) == original_link
+            assert target.resolve() == link_target.resolve()
+            if target_kind == "dangling_symlink":
+                assert not link_target.exists()
+            else:
+                assert (link_target / "keep.txt").read_text(encoding="utf-8") == "keep"
+        elif target_kind == "directory":
+            assert (target / "keep.txt").read_text(encoding="utf-8") == "keep"
+        else:
+            assert target.read_text(encoding="utf-8") == "keep"
+
+    @pytest.mark.parametrize("download_result", ["empty", "failed"])
+    def test_failed_fresh_install_cleans_only_new_target(self, client, modules_dir, download_result):
+        sentinel = modules_dir / "keep.txt"
+        sentinel.write_text("keep", encoding="utf-8")
+        with patch("app.module_download.urllib.request.urlopen") as transport, \
+             patch("shutil.rmtree", wraps=shutil.rmtree) as remove:
+            transport.return_value = BytesIO(b"[]")
+            if download_result == "failed":
+                transport.side_effect = OSError("download interrupted")
+            response = client.post("/api/themes/install", json={
+                "id": "fresh.theme", "download_url": self.download_url,
+            })
+
+            assert response.status_code == 500
+            assert response.get_json() == {"success": False, "error": "Download failed"}
+            transport.assert_called_once_with(self.download_url, timeout=30)
+            remove.assert_called_once_with(str(modules_dir.resolve() / "fresh_theme"), ignore_errors=True)
+        assert not (modules_dir / "fresh_theme").exists()
+        assert sentinel.read_text(encoding="utf-8") == "keep"
+
+    def test_fresh_install_downloads_theme(self, client, modules_dir):
+        files = {
+            "manifest.json": {"id": "fresh.theme", "name": "Fresh", "description": "Test theme",
+                              "version": "1.0.0", "author": "DOCSight", "minAppVersion": "2026.2",
+                              "type": "theme", "contributes": {"theme": "theme.json"}},
+            "theme.json": {"dark": {"--bg": "#111"}, "light": {"--bg": "#fff"}},
+        }
+        listing = [
+            {"type": "file", "name": name,
+             "download_url": f"https://raw.githubusercontent.com/example/themes/main/{name}"}
+            for name in files
+        ]
+        responses = [BytesIO(json.dumps(data).encode()) for data in [listing, *files.values()]]
+        with patch("app.module_download.urllib.request.urlopen", side_effect=responses) as transport, \
+             patch("shutil.rmtree") as remove:
+            response = client.post("/api/themes/install", json={
+                "id": "fresh.theme", "download_url": self.download_url,
+            })
+            assert response.status_code == 200
+            assert response.get_json() == {"success": True, "restart_required": True}
+            assert transport.call_count == 3
+            remove.assert_not_called()
+        for name, data in files.items():
+            assert json.loads((modules_dir / "fresh_theme" / name).read_text(encoding="utf-8")) == data
+
     def test_rejects_invalid_theme_id(self, client):
         """Theme ID with special chars or traversal patterns is rejected with 400."""
         for bad_id in ["../etc/passwd", "UPPER", "has spaces", "semi;colon"]:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,8 +1,11 @@
 """Tests for security hardening: proxy trust, theme SSRF, module isolation."""
 
 import json
+import ntpath
 import os
+import posixpath
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -232,6 +235,70 @@ class TestSafeChildPath:
 
         with pytest.raises(ValueError, match="Invalid ID"):
             safe_child_path(str(tmp_path), "a/b")
+
+    @pytest.mark.parametrize("child_name", [None, 12, "", "/absolute", r"a\b", r"C:\child"])
+    def test_rejects_invalid_ids(self, tmp_path, child_name):
+        from app.path_safety import safe_child_path
+
+        with pytest.raises(ValueError, match="Invalid ID"):
+            safe_child_path(str(tmp_path), child_name)
+
+    @pytest.mark.parametrize("destination", ["base", "outside", "modules_sibling"])
+    def test_rejects_symlink_to_base_or_outside(self, tmp_path, destination):
+        from app.path_safety import safe_child_path
+
+        base = tmp_path / "modules"
+        base.mkdir()
+        target = base if destination == "base" else tmp_path / destination
+        target.mkdir(exist_ok=True)
+        sentinel = target / "keep.txt"
+        sentinel.write_text("keep", encoding="utf-8")
+        alias = base / "root_alias"
+        alias.symlink_to(target, target_is_directory=True)
+
+        with patch("shutil.rmtree") as remove:
+            with pytest.raises(ValueError):
+                resolved = safe_child_path(str(base), alias.name)
+                # Intercept the sink so the vulnerable baseline cannot delete data.
+                import shutil
+                shutil.rmtree(resolved)
+            remove.assert_not_called()
+        assert sentinel.read_text(encoding="utf-8") == "keep"
+        assert alias.is_symlink()
+
+    @pytest.mark.parametrize("path_module,base,candidate,allowed", [
+        (posixpath, "/", "/child", True),
+        (posixpath, "/", "/", False),
+        (posixpath, "/modules/", "/modules/child", True),
+        (posixpath, "/modules", "/modules_sibling/child", False),
+        (ntpath, "C:\\", "C:\\child", True),
+        (ntpath, "C:\\", "c:\\", False),
+        (ntpath, "C:\\Modules\\", "c:\\modules\\child", True),
+        (ntpath, "C:\\Users\\Tester\\Modules", "C:\\Users\\Tester\\Modules\\MiXeD", True),
+        (ntpath, "C:\\Modules", "c:\\MODULES", False),
+        (ntpath, "C:\\Modules", "C:\\Modules_sibling\\child", False),
+        (ntpath, "C:\\Modules", "D:\\Modules\\child", False),
+        (ntpath, "//server/share/", "\\\\SERVER\\SHARE\\child", True),
+        (ntpath, "//server/share/", "\\\\SERVER\\SHARE\\", False),
+    ])
+    def test_resolved_path_boundaries(self, monkeypatch, path_module, base, candidate, allowed):
+        from app import path_safety
+
+        # Substitute only this module's path operations, never the host's os.path.
+        path_ops = SimpleNamespace(
+            join=path_module.join,
+            realpath=lambda path: path_module.normpath(base if path == base else candidate),
+            normcase=path_module.normcase,
+            commonpath=path_module.commonpath,
+        )
+        monkeypatch.setattr(path_safety, "os", SimpleNamespace(path=path_ops, sep=path_module.sep))
+        if allowed:
+            result = path_safety.safe_child_path(base, "child")
+            assert path_module.normcase(result) == path_module.normcase(path_module.normpath(candidate))
+            assert result == path_module.normpath(candidate)
+        else:
+            with pytest.raises(ValueError):
+                path_safety.safe_child_path(base, "child")
 
 
 class TestSafeChildFile:


### PR DESCRIPTION
## Summary

- Reject existing theme installation targets before downloading, including files and symlinks.
- Require installation paths to resolve strictly below the modules directory while preserving Windows path spelling.
- Show the existing translated failure message for installation conflicts and refresh cached settings code.
- Document the installation safety contract and add regression coverage for preserved data, fresh installs and failure cleanup.

## Validation

- Full Python and JavaScript suites passed locally.
- Desktop and mobile browser checks passed under a URL prefix, including German and French conflict messages and preservation of existing files.
- Full browser suite and cross-platform CI are required before merge.

Existing installations are no longer overwritten through the theme installation endpoint. New installations keep the same success response and restart requirement.
