### PR TITLE
fix: restore Vodafone TG downstream channels with numeric SNR

### DIFF
--- a/app/drivers/formats/vodafone.py
+++ b/app/drivers/formats/vodafone.py
@@ -212,7 +212,7 @@ def parse_vodafone_station_tg_embedded_json(html: str) -> ParseResult[DocsisData
         try:
             channel_type = row.get("ChannelType", "SC-QAM")
             frequency = parse_tg_frequency(row.get("Frequency", "0"))
-            snr = abs(parse_number(row.get("SNRLevel", "0")))
+            snr = abs(parse_vodafone_number(row.get("SNRLevel", "0")))
             modulation = normalize_modulation(row.get("Modulation", ""))
             ofdm = "OFDM" in channel_type.upper()
             if ofdm:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,6 +19,7 @@ from tests.e2e.support.lifecycle import (
     running_processes,
 )
 from tests.e2e.support.profiles import ServerProfile, ServerTarget
+from tests.e2e.support.vodafone import seed_vodafone_tg_data
 
 DEMO_PROFILE = ServerProfile("demo", configured=True, demo_mode=True)
 AUTH_PROFILE = ServerProfile("auth", configured=True, demo_mode=True)
@@ -60,6 +61,10 @@ FRITZBOX_PROFILE = ServerProfile(
     post_seed_callback=seed_fritzbox_segment_data,
 )
 AUTH_TEST_CREDENTIAL = "e2e-test-password"
+VODAFONE_TG_PROFILE = ServerProfile(
+    "vodafone-tg", configured=True, demo_mode=False,
+    modem_type="vodafone_station", seed_callback=seed_vodafone_tg_data,
+)
 
 
 @pytest.fixture(scope="session")
@@ -137,6 +142,15 @@ def live_server(tmp_path_factory):
     )
     with running_processes([spec]):
         yield target.base_url
+
+
+@pytest.fixture(scope="session")
+def vodafone_tg_server(tmp_path_factory):
+    target, spec = _new_target(
+        "vodafone-tg", tmp_path_factory.mktemp("docsight_e2e_tg"), VODAFONE_TG_PROFILE
+    )
+    with running_processes([spec]):
+        yield target
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/support/application.py
+++ b/tests/e2e/support/application.py
@@ -147,15 +147,18 @@ def serve_server(
     )
     runtime = get_runtime(application)
     if target.profile.configured:
-        collector = DemoCollector(
-            analyzer_fn=analyzer.analyze,
-            event_detector=EventDetector(),
-            storage=storage,
-            mqtt_pub=None,
-            web=runtime,
-            poll_interval=300,
-        )
-        collector.collect()
+        if target.profile.seed_callback is not None:
+            target.profile.seed_callback(runtime)
+        else:
+            collector = DemoCollector(
+                analyzer_fn=analyzer.analyze,
+                event_detector=EventDetector(),
+                storage=storage,
+                mqtt_pub=None,
+                web=runtime,
+                poll_interval=300,
+            )
+            collector.collect()
         if target.profile.post_seed_callback is not None:
             target.profile.post_seed_callback(db_path)
 

--- a/tests/e2e/support/profiles.py
+++ b/tests/e2e/support/profiles.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.runtime import DocsightRuntime
 
 _INHERITED_ENVIRONMENT = {
     "HOME",
@@ -34,6 +38,9 @@ class ServerProfile:
     production_startup: bool = False
     disabled_modules: str = ""
     post_seed_callback: Callable[[str], None] | None = field(
+        default=None, repr=False, compare=False
+    )
+    seed_callback: Callable[[DocsightRuntime], None] | None = field(
         default=None, repr=False, compare=False
     )
 

--- a/tests/e2e/support/vodafone.py
+++ b/tests/e2e/support/vodafone.py
@@ -1,0 +1,48 @@
+"""Replay synthetic TG HTTP responses through the real collection pipeline."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+def seed_vodafone_tg_data(runtime):
+    from requests import Response
+
+    from app.analyzer import analyze
+    from app.collectors.modem import ModemCollector
+    from app.drivers.vodafone_station import VodafoneStationDriver
+    from app.event_detector import EventDetector
+
+    html = (Path(__file__).parents[2] / "fixtures/vodafone_tg/status_docsis_data.html").read_text()
+    responses = {
+        "http://tg.test/php/status_docsis_data.php": html,
+        "http://tg.test/php/status_status_data.php": """
+            js_HWTypeVersion = 'TG6442VF';
+            js_FWVersion = 'synthetic';
+            js_ipv4addr = '';
+            js_ipv6addr = '';
+            js_UptimeSinceReboot = '0,3,25';
+        """,
+        "http://tg.test/?status_status": """
+            _ga.modemConnectionStatus = 'DOCSIS Online';
+            _ga.lastRebootReason = 'Power On';
+        """,
+    }
+
+    def get(url, **kwargs):
+        response = Response()
+        response.status_code = 200
+        response.encoding = "utf-8"
+        response._content = responses[url].encode("utf-8")
+        return response
+
+    driver = VodafoneStationDriver("http://tg.test", "admin", "synthetic")
+    # Start with an authenticated session; payload parsing remains real.
+    driver._variant = driver.VARIANT_TG
+    driver._tg_nonce = "test-session"
+    driver._session.cookies.set("credential", "synthetic")
+    collector = ModemCollector(
+        driver=driver, analyzer_fn=analyze, event_detector=EventDetector(),
+        storage=runtime.storage, mqtt_pub=None, web=runtime, poll_interval=300,
+    )
+    with patch.object(driver._session, "get", side_effect=get):
+        collector.collect()

--- a/tests/e2e/test_channels.py
+++ b/tests/e2e/test_channels.py
@@ -1,6 +1,8 @@
 """E2E tests for the channels view."""
 
-import pytest
+from pathlib import Path
+
+from playwright.sync_api import expect
 
 
 class TestChannelsView:
@@ -21,8 +23,36 @@ class TestChannelsView:
         nav.click()
         assert "active" in nav.get_attribute("class")
 
-    def test_channels_api_returns_data(self, live_server, page):
-        resp = page.request.get(f"{live_server}/api/channels")
+    def test_tg_channels_survive_collection_and_rendering(self, vodafone_tg_server, page):
+        from app.storage import SnapshotStorage
+
+        page.goto(vodafone_tg_server.base_url)
+        downstream = page.locator(".dashboard-channel-panel").filter(
+            has=page.locator(".channel-title", has_text="Downstream")
+        )
+        scqam = downstream.locator(".docsis-group").filter(
+            has=page.locator(".docsis-group-header", has_text="DOCSIS 3.0 SC-QAM")
+        )
+        expect(scqam).to_have_count(1)
+        scqam.locator(".docsis-group-header").click()
+        rows = scqam.locator("tbody tr")
+        expect(rows).to_have_count(2)
+        expect(rows.nth(0).locator("td").nth(0)).to_have_text("7")
+        expect(rows.nth(0).locator("td").nth(3)).to_have_text("40.0 dB")
+        expect(rows.nth(1).locator("td").nth(0)).to_have_text("8")
+        expect(rows.nth(1).locator("td").nth(3)).to_have_text("40.5 dB")
+
+        resp = page.request.get(f"{vodafone_tg_server.base_url}/api/channels")
         assert resp.status == 200
-        data = resp.json()
-        assert isinstance(data, dict)
+        channels = resp.json()
+        assert {ch["channel_id"] for ch in channels["ds_channels"]} == {7, 8, 193}
+        assert {ch["channel_id"] for ch in channels["us_channels"]} == {6, 41}
+
+        storage = SnapshotStorage(str(Path(vodafone_tg_server.data_dir) / "docsis_history.db"))
+        timestamp, = storage.get_snapshot_list()
+        raw = storage.get_snapshot_raw_data(timestamp)
+        for direction, version, ids in (
+            ("channelDs", "docsis30", [7, 8]), ("channelDs", "docsis31", [193]),
+            ("channelUs", "docsis30", [6]), ("channelUs", "docsis31", [41]),
+        ):
+            assert [ch["channelID"] for ch in raw[direction][version]] == ids

--- a/tests/fixtures/vodafone_tg/status_docsis_data.html
+++ b/tests/fixtures/vodafone_tg/status_docsis_data.html
@@ -1,0 +1,13 @@
+<!-- Synthetic regression fixture for #835, not a captured modem response.
+     SC-QAM SNR values are JSON numbers; OFDM SNR is a string. -->
+<script>
+json_dsData = [
+  {"ChannelID":7,"ChannelType":"SC-QAM","Frequency":591000000,"Modulation":"256QAM","PowerLevel":-1.2,"SNRLevel":40},
+  {"ChannelID":8,"ChannelType":"SC-QAM","Frequency":599000000,"Modulation":"256QAM","PowerLevel":"-1.5 dBmV/58.5 dBuV","SNRLevel":40.5},
+  {"ChannelID":193,"ChannelType":"OFDM","Frequency":"275600000~472950000","Modulation":"OFDM","PowerLevel":"3.2 dBmV","SNRLevel":"38 dB"}
+];
+json_usData = [
+  {"ChannelID":6,"ChannelType":"SC-QAM","Frequency":25900000,"Modulation":"64QAM","PowerLevel":35},
+  {"ChannelID":41,"ChannelType":"OFDMA","Frequency":42000000,"Modulation":"","PowerLevel":37.75}
+];
+</script>

--- a/tests/test_vodafone_station_tg.py
+++ b/tests/test_vodafone_station_tg.py
@@ -1,14 +1,57 @@
 import json
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
 import requests
 
+from app.drivers.formats.vodafone import parse_vodafone_station_tg_embedded_json
 from app.drivers.vodafone_station import (
     VodafoneStationDriver,
     _aes_ccm_decrypt_hex,
     _aes_ccm_encrypt_hex,
 )
 from app.drivers.utils import pbkdf2_sha256
+
+
+@pytest.mark.parametrize("channel_type,version", [("SC-QAM", "docsis30"), ("OFDM", "docsis31")])
+@pytest.mark.parametrize("snr,expected", [
+    (40, 40.0), (40.5, 40.5), (-40.5, 40.5),
+    ("40.5", 40.5), ("40.5 dB", 40.5), (0, None), (None, None),
+])
+def test_tg_downstream_accepts_numeric_and_string_snr(channel_type, version, snr, expected):
+    row = {
+        "ChannelID": 7, "ChannelType": channel_type, "Frequency": 591000000,
+        "Modulation": "256QAM", "PowerLevel": -1.2, "SNRLevel": snr,
+    }
+    parsed = parse_vodafone_station_tg_embedded_json(
+        f"json_dsData = {json.dumps([row])};"
+    )
+
+    assert parsed.diagnostics == ()
+    channels = parsed.value["channelDs"][version]
+    assert len(channels) == 1
+    assert channels[0]["channelID"] == 7
+    assert channels[0]["mer"] == expected
+    assert channels[0]["mse"] == (-expected if expected is not None else None)
+
+
+def test_tg_driver_preserves_all_lanes_with_mixed_snr_types():
+    html = (Path(__file__).parent / "fixtures/vodafone_tg/status_docsis_data.html").read_text()
+    driver = VodafoneStationDriver("http://dummy", "admin", "dummy")
+    driver._variant = driver.VARIANT_TG
+    driver._tg_nonce = "test-session"
+    response = MagicMock(status_code=200, text=html)
+
+    with patch.object(driver._session, "get", return_value=response) as get:
+        data = driver.get_docsis_data()
+
+    get.assert_called_once_with("http://dummy/php/status_docsis_data.php", timeout=10)
+    assert [ch["channelID"] for ch in data["channelDs"]["docsis30"]] == [7, 8]
+    assert [ch["mer"] for ch in data["channelDs"]["docsis30"]] == [40.0, 40.5]
+    assert [ch["channelID"] for ch in data["channelDs"]["docsis31"]] == [193]
+    assert [ch["channelID"] for ch in data["channelUs"]["docsis30"]] == [6]
+    assert [ch["channelID"] for ch in data["channelUs"]["docsis31"]] == [41]
 
 # ===== Embedded fixture HTML =====
 # Two pages are fetched per call:


### PR DESCRIPTION
## Description

Vodafone Station TG downstream channels disappear when the modem returns `SNRLevel` as a JSON number. The parser extraction in #792 replaced the driver's number-aware conversion with a string-only helper; its `AttributeError` is caught and the entire channel is discarded.

Use the existing Vodafone numeric converter so both JSON numbers and strings remain supported. Add regression coverage for SC-QAM and OFDM, including negative SNR, zero, and null values.

Fixes #835.

## User-Facing Impact

- Restore downstream channels and their SNR values in the dashboard, channel API, and newly stored snapshots when TG firmware returns numeric SNR values.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the Contributing Guidelines.
- [x] Existing issue #835 documents the problem.
- [x] My code follows the project's code style.
- [x] I have tested my changes locally.
- [x] The full Python, browser, and JavaScript suites pass (two expected Python skips).
- [x] I have added regression tests and checked both failing and passing behavior.
- [x] I have documented the user-facing impact.
- [x] Translation validation passes; this change adds no UI strings.

## Testing

The isolated server profiles introduced in #795 now support a custom collection seed. The TG profile replays synthetic HTTP responses through the real driver, modem collector, analyzer, storage, API, and dashboard. It starts with an authenticated session; authentication is outside this regression's scope.

Before the fix, seven focused regression cases fail and the browser test cannot find the DOCSIS 3.0 group. After the fix, the browser checks both recovered SC-QAM channel IDs and SNR values, and verifies that all four channel families survive in the API and stored raw snapshot.

- Complete non-E2E Python suite, Python 3.13 with GCC and Node 22: **4,211 passed, 2 skipped**.
- Complete Chromium suite across all four shards: **555 passed** (82 / 140 / 161 / 172). The canonical aggregator verified the exact case union, zero retries, and no process or listener leaks.
- Native JavaScript suite on Node 22: **66 passed**.
- Translation validation: **all 92 language files in sync**.
- `git diff --check` and shard manifest validation passed.

Commands:
```bash
python -m pytest -q tests/ --ignore=tests/e2e --tb=short
npm test
python scripts/i18n_check.py --validate
# For each shard 1 through 4:
TZ=UTC python scripts/e2e_shards.py run --shard N --junit ... --receipt ... -- -q --tb=short
python scripts/e2e_shards.py summarize --results-root ... --expected-total 555
```

The strengthened channel test replaces the previous API smoke check. The canonical browser manifest remains at 555 cases across four shards.

## Additional Notes

The fixture is explicitly synthetic, not a captured response from the reporter's modem. A real TG response would provide additional confirmation that the reported installation uses this numeric SNR representation.
