### PR TITLE
fix: highlight BQM timeframes and show multi-day dates

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -264,7 +264,7 @@ jobs:
           pattern: full-e2e-shard-*
           path: shard-artifacts
 
-      - name: Verify complete successful 566-case union
+      - name: Verify complete successful 570-case union
         if: env.E2E_REQUIRED == 'true'
         run: |
           if [ "$SHARD_JOB_RESULT" != "success" ]; then
@@ -273,7 +273,7 @@ jobs:
           fi
           python scripts/e2e_shards.py summarize \
             --results-root shard-artifacts \
-            --expected-total 566
+            --expected-total 570
 
       - name: Browser gate not required for this change
         if: env.E2E_REQUIRED != 'true'

--- a/app/modules/bqm/static/js/bqm-chart.js
+++ b/app/modules/bqm/static/js/bqm-chart.js
@@ -2,8 +2,8 @@
 var BQMChart = (function() {
     'use strict';
 
-    function formatTick(ts) {
-        return docsightFormatXAxisLabel(ts, 'bqm');
+    function formatTick(ts, dateAxis) {
+        return docsightFormatXAxisLabel(ts, dateAxis ? '30d' : 'bqm');
     }
 
     function toUnixSeries(timestamps) {
@@ -61,8 +61,11 @@ var BQMChart = (function() {
         var sentMax = sentPolls.length ? Math.max.apply(null, sentPolls) : 100;
         if (sentMax < 1) sentMax = 100;
         var xData = toUnixSeries(timestamps);
-        var labels = timestamps.map(function(ts) {
-            return formatTick(Math.floor(new Date(ts).getTime() / 1000));
+        // Use the selected view, not the payload span: ranges can contain only one day.
+        var dateAxis = opts.dateAxis === true;
+        var labels = xData.map(function(ts) {
+            var time = formatTick(ts, false);
+            return dateAxis ? formatTick(ts, true) + ' ' + time : time;
         });
 
         renderChart(el.id, labels, [
@@ -95,7 +98,7 @@ var BQMChart = (function() {
             },
         ], 'line', null, {
             xData: xData,
-            xValueCallback: formatTick,
+            xValueCallback: function(ts) { return formatTick(ts, dateAxis); },
             zoomable: true,
             yMin: 0,
             heightRatio: 0.48,

--- a/app/modules/bqm/static/main.js
+++ b/app/modules/bqm/static/main.js
@@ -38,13 +38,38 @@ function fetchBqmDates(cb) {
 
 function updateBqmQuickButtons() {
     var hasCsv = _bqmCsvDates.size > 0;
+    var today = typeof todayStr === 'function' ? todayStr() : null;
+    var selected = null;
+    if (today) {
+        var relativeDate = function(daysAgo) {
+            var d = new Date(today + 'T12:00:00');
+            d.setDate(d.getDate() - daysAgo);
+            return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+        };
+        if (_bqmRangeStart && _bqmRangeEnd && _bqmRangeStart !== _bqmRangeEnd) {
+            if (_bqmRangeEnd === today) {
+                if (_bqmRangeStart === relativeDate(6)) selected = '7d';
+                else if (_bqmRangeStart === relativeDate(29)) selected = '30d';
+            }
+        } else {
+            var date = _bqmRangeStart || bqmDate;
+            if (date === today) selected = 'today';
+            else if (date === relativeDate(1)) selected = 'yesterday';
+        }
+    }
     ['bqm-today-btn', 'bqm-yesterday-btn', 'bqm-7d-btn', 'bqm-30d-btn'].forEach(function(id) {
         var btn = document.getElementById(id);
-        if (btn) btn.style.display = hasCsv ? 'inline-flex' : 'none';
+        if (btn) {
+            btn.style.display = hasCsv ? 'inline-flex' : 'none';
+            var active = id === 'bqm-' + selected + '-btn';
+            btn.classList.toggle('active', active);
+            btn.setAttribute('aria-pressed', String(active));
+        }
     });
 }
 
 function renderBqmCalendar(year, month) {
+    updateBqmQuickButtons();
     var grid = document.getElementById('bqm-calendar-grid');
     var label = document.getElementById('bqm-month-label');
     if (!grid || !label) return;
@@ -163,7 +188,7 @@ function loadBqmChart(date) {
                 showBqmNoData(T.bqm_no_csv_data || 'No CSV data for this date.');
                 return;
             }
-            BQMChart.render('bqm-chart-container', data);
+            BQMChart.render('bqm-chart-container', data, { dateAxis: false });
             showBqmCard();
         })
         .catch(function() {
@@ -183,7 +208,7 @@ function loadBqmRangeChart(start, end) {
                 showBqmNoData(T.bqm_csv_dates_only || 'This range only has PNG fallback data.');
                 return;
             }
-            BQMChart.render('bqm-chart-container', data);
+            BQMChart.render('bqm-chart-container', data, { dateAxis: start !== end });
             showBqmCard();
         })
         .catch(function() {

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v93';
+var CACHE_VERSION = 'v94';
 var REGISTRATION_SCOPE = new URL(self.registration.scope);
 
 if (REGISTRATION_SCOPE.origin !== self.location.origin || REGISTRATION_SCOPE.pathname.slice(-1) !== '/') {

--- a/scripts/e2e_shards.py
+++ b/scripts/e2e_shards.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover - Windows can validate manifests only
 ROOT = Path(__file__).resolve().parents[1]
 E2E_DIR = ROOT / "tests" / "e2e"
 DEFAULT_MANIFEST = E2E_DIR / "shards.json"
-EXPECTED_TOTAL = 566
+EXPECTED_TOTAL = 570
 
 
 class ManifestError(ValueError):

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "expected_total": 566,
+  "expected_total": 570,
   "baseline_cpu_seconds": 1534.372,
   "shards": [
     {
       "id": 1,
-      "collected_cases": 82,
+      "collected_cases": 86,
       "files": [
         "test_connection_monitor.py",
         "test_event_log_redesign.py",

--- a/tests/e2e/test_module_views.py
+++ b/tests/e2e/test_module_views.py
@@ -129,3 +129,72 @@ def test_prefixed_module_hash_navigation_and_script_urls(page, prefixed_module_s
         expect(page).to_have_url(base + "/" + expected_hash)
         assert errors == []
     assert errors == []
+
+
+@pytest.mark.parametrize("theme,width", [("light", 1280), ("dark", 1280), ("light", 390), ("dark", 390)])
+def test_bqm_quick_selection_and_sparse_range_axes(page, live_server, theme, width):
+    """Real controls and uPlot callbacks retain the selected view with sparse CSV data."""
+    from datetime import datetime, timezone
+
+    page.clock.install(time=datetime(2026, 6, 15, 12, tzinfo=timezone.utc))
+    page.set_viewport_size({"width": width, "height": 844})
+    dates = ["2026-06-15", "2026-06-14", "2026-06-12"]
+    page.route("**/api/bqm/data/dates", lambda route: route.fulfill(json={
+        "csv_dates": dates, "png_dates": [],
+    }))
+    # Both multi-day selections deliberately contain only a single day's samples.
+    payload = {"points": 2, "data": {
+        "timestamps": ["2026-06-15T12:00:00", "2026-06-15T12:05:00"],
+        "latency_avg": [10, 11], "latency_min": [8, 9], "latency_max": [12, 13],
+        "lost_polls": [0, 1], "sent_polls": [100, 100],
+    }}
+    page.route("**/api/bqm/data/range?*", lambda route: route.fulfill(json=payload))
+    page.route("**/api/bqm/data/2026-*", lambda route: route.fulfill(json=payload))
+    page.goto(live_server + "/#bqm")
+    page.evaluate("theme => document.documentElement.setAttribute('data-theme', theme)", theme)
+    expect(page.locator("#bqm-today-btn")).to_have_attribute("aria-pressed", "true")
+    page.locator("#bqm-today-btn").click()
+    page.wait_for_function("() => !!charts['bqm-chart-container']")
+    page.wait_for_load_state("networkidle")
+
+    def selection(name):
+        for key in ("today", "yesterday", "7d", "30d"):
+            button = page.locator(f"#bqm-{key}-btn")
+            expect(button).to_have_attribute("aria-pressed", str(key == name).lower())
+            assert button.evaluate("el => el.classList.contains('active')") == (key == name)
+        if name:
+            active = page.locator(f"#bqm-{name}-btn")
+            inactive = page.locator(".bqm-quick:not(.active)").first
+            assert active.evaluate("el => getComputedStyle(el).backgroundColor") != inactive.evaluate(
+                "el => getComputedStyle(el).backgroundColor")
+
+    def click_chart(selector, modifiers=None):
+        page.evaluate("window.previousBqmChart = charts['bqm-chart-container']")
+        page.locator(selector).click(modifiers=modifiers or [])
+        page.wait_for_function("() => charts['bqm-chart-container'] !== window.previousBqmChart")
+
+    def axis(dates_mode):
+        values = page.evaluate("""() => {
+            const chart = charts['bqm-chart-container'];
+            return chart.axes[0].values(chart, chart.data[0]);
+        }""")
+        assert values == (["06-15", "06-15"] if dates_mode else ["12:00", "12:05"])
+        expect(page.locator("#bqm-chart-container .uplot canvas").first).to_be_visible()
+
+    selection("today")
+    for name in ("today", "yesterday", "7d", "30d"):
+        click_chart(f"#bqm-{name}-btn")
+        selection(name)
+        axis(name in ("7d", "30d"))
+    page.locator("#bqm-month-prev").click()
+    selection("30d")
+    page.locator("#bqm-month-next").click()
+    click_chart('.bqm-day[data-date="2026-06-12"]')
+    selection(None)
+    axis(False)
+    click_chart('.bqm-day[data-date="2026-06-14"]', ["Shift"])
+    selection(None)
+    axis(True)
+    click_chart("#bqm-yesterday-btn")
+    selection("yesterday")
+    axis(False)

--- a/tests/js/bqm.test.js
+++ b/tests/js/bqm.test.js
@@ -1,0 +1,76 @@
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const test = require('node:test');
+const run = (c, file) => vm.runInContext(fs.readFileSync(file, 'utf8'), c);
+function setup() {
+    const elements = {};
+    function element(id) {
+        const classes = new Set();
+        return elements[id] = {id, style: {}, attrs: {}, children: [],
+            classList: {toggle(n, on) { on ? classes.add(n) : classes.delete(n); }, add(n) { classes.add(n); }, contains(n) { return classes.has(n); }},
+            setAttribute(n, v) { this.attrs[n] = v; }, addEventListener(n, fn) { this[n] = fn; },
+            appendChild(el) { this.children.push(el); }};
+    }
+    for (const id of ['today', 'yesterday', '7d', '30d']) element('bqm-' + id + '-btn');
+    element('bqm-calendar-grid'); element('bqm-month-label');
+    const c = vm.createContext({document: {getElementById: id => elements[id], createElement: () => element('cell')},
+        T: {}, todayStr: () => '2026-01-02', pad: n => String(n).padStart(2, '0'),
+        formatDateDE: s => s, clearTimeout() {}, docsightUrl: s => s,
+        fetch: async () => ({json: async () => ({points: 1, data: {}})}),
+        BQMChart: {render(...args) { c.rendered = args; }}});
+    c.window = c;
+    run(c, 'app/modules/bqm/static/main.js');
+    c._bqmCsvDates = new Set(['2026-01-02', '2026-01-01', '2025-12-30']);
+    c._bqmAvailableDates = c._bqmCsvDates;
+    return {c, elements};
+}
+function selected(elements, expected) {
+    for (const name of ['today', 'yesterday', '7d', '30d']) {
+        const el = elements['bqm-' + name + '-btn'];
+        assert.equal(el.classList.contains('active'), name === expected, name);
+        assert.equal(el.attrs['aria-pressed'], String(name === expected), name);
+    }
+}
+test('quick selection follows dates, ranges, calendar transitions and month navigation', () => {
+    const {c, elements} = setup();
+    c.updateBqmQuickButtons(); selected(elements, 'today');
+    c.setBqmQuickRange(7); selected(elements, '7d');
+    c.bqmMonthNav(-1); selected(elements, '7d');
+    c.setBqmQuickRange(30); selected(elements, '30d');
+    c.selectBqmDate('2026-01-01'); selected(elements, 'yesterday');
+    c.selectBqmDate('2025-12-30'); selected(elements, null);
+    c.setBqmQuickRange(7);
+    const cell = elements['bqm-calendar-grid'].children.findLast(el => el.attrs['data-date'] === '2026-01-01');
+    cell.click({shiftKey: true}); selected(elements, null);
+    c.setBqmQuickRange(1); selected(elements, 'today');
+});
+test('loaders pass selected date mode even for sparse responses', async () => {
+    const {c} = setup();
+    for (const [start, end, dates] of [['2025-12-27', '2026-01-02', true], ['2025-12-04', '2026-01-02', true], ['2026-01-02', '2026-01-02', false]]) {
+        c.loadBqmRangeChart(start, end);
+        await new Promise(resolve => setImmediate(resolve));
+        assert.equal(c.rendered[2].dateAxis, dates);
+    }
+    c.loadBqmChart('2026-01-01');
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(c.rendered[2].dateAxis, false);
+});
+test('BQM axis uses dates for sparse ranges and retains time in tooltip labels', () => {
+    let rendered;
+    const c = vm.createContext({window: {}, document: {getElementById: id => ({id})}, T: {},
+        pad: n => String(n).padStart(2, '0'), bandPlugin() {}, zoomPlugin() {},
+        renderChart(...args) { rendered = args; }});
+    run(c, 'app/static/js/chart-engine.js');
+    c.renderChart = (...args) => { rendered = args; };
+    run(c, 'app/modules/bqm/static/js/bqm-chart.js');
+    const payload = {data: {timestamps: ['2026-01-02T12:34:00'], latency_avg: [10], latency_min: [8], latency_max: [12], lost_polls: [0]}};
+    for (const dates of [true, false]) {
+        c.BQMChart.render('chart', payload, {dateAxis: dates});
+        const opts = rendered[5];
+        assert.equal(opts.xValueCallback(opts.xData[0]), dates ? '01-02' : '12:34');
+        assert.equal(rendered[1][0], dates ? '01-02 12:34' : '12:34');
+        assert.match(opts.tooltipLabelCallback({dataIndex: 0, dataset: {label: 'Avg Latency'}}), /10.00 ms/);
+    }
+});

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -187,7 +187,7 @@ def test_full_e2e_paths_concurrency_and_summary_contract():
         step for step in workflow["jobs"]["full-e2e"]["steps"]
         if step["name"].startswith("Verify complete successful")
     )["run"]
-    assert "--expected-total 566" in summarize
+    assert "--expected-total 570" in summarize
 
     preserve = next(
         step for step in workflow["jobs"]["full-e2e"]["steps"]

--- a/tests/test_dashboard_module_ownership.py
+++ b/tests/test_dashboard_module_ownership.py
@@ -109,4 +109,4 @@ def test_unconfigured_modules_keep_setup_without_empty_views(dashboard, prefix):
 
 
 def test_module_asset_cache_generation():
-    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v93';")
+    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v94';")

--- a/tests/test_e2e_shards.py
+++ b/tests/test_e2e_shards.py
@@ -84,14 +84,14 @@ def _write_result(
     )
 
 
-def test_repository_manifest_covers_every_e2e_file_once_and_566_cases():
+def test_repository_manifest_covers_every_e2e_file_once_and_570_cases():
     manifest = load_manifest(MANIFEST)
     validated = validate_manifest(manifest, E2E_DIR)
 
-    assert manifest["expected_total"] == EXPECTED_TOTAL == 566
+    assert manifest["expected_total"] == EXPECTED_TOTAL == 570
     assert manifest["baseline_cpu_seconds"] > 0
     assert [shard["collected_cases"] for shard in manifest["shards"]] == [
-        82,
+        86,
         151,
         161,
         172,
@@ -258,7 +258,7 @@ def test_workflow_runs_safe_non_retrying_shards_and_an_always_gate():
     assert "E2E_JOB_STARTED_EPOCH" in workflow
     assert "python scripts/e2e_shards.py run" in workflow
     assert "python scripts/e2e_shards.py summarize" in workflow
-    assert "--expected-total 566" in workflow
+    assert "--expected-total 570" in workflow
     assert "--receipt" in workflow
     assert "run-receipt.json" in workflow
     assert "if: always()" in workflow


### PR DESCRIPTION
## Summary
- Highlight the selected BQM quick timeframe and keep it synchronized with calendar selection.
- Show dates on multi-day chart axes, including ranges containing only one day of CSV data. Keep times on single-day axes and retain date/time in multi-day tooltips.
- Refresh cached module assets.

## Verification
- New JavaScript regressions fail on the previous behavior and pass with the fix.
- JavaScript suite: 76 passed.
- BQM Python tests: 77 passed.
- Module browser tests: 6 passed, including light/dark desktop/mobile, sparse ranges and calendar transitions.
- Desktop and mobile screenshot checks passed with a real chart and deterministic test data.
- Full Python suite: 4212 passed, 3 skipped.
- Full browser suite: 570 passed locally and in CI.
- Linux/Windows tests, Windows build, mobile browser checks and CodeQL passed in CI.

No backend, stored-data, shared chart-formatting or setup changes. No user documentation changes needed for this correction.

Closes #838
