### PR TITLE
fix: normalize chart curves without persistent point markers

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -264,7 +264,7 @@ jobs:
           pattern: full-e2e-shard-*
           path: shard-artifacts
 
-      - name: Verify complete successful 570-case union
+      - name: Verify complete successful 581-case union
         if: env.E2E_REQUIRED == 'true'
         run: |
           if [ "$SHARD_JOB_RESULT" != "success" ]; then
@@ -273,7 +273,7 @@ jobs:
           fi
           python scripts/e2e_shards.py summarize \
             --results-root shard-artifacts \
-            --expected-total 570
+            --expected-total 581
 
       - name: Browser gate not required for this change
         if: env.E2E_REQUIRED != 'true'

--- a/app/modules/modulation/static/main.js
+++ b/app/modules/modulation/static/main.js
@@ -698,7 +698,7 @@ function renderGroupTrendChart(pg, idx) {
                 fill: 'rgba(34,197,94,0.1)',
                 width: 2,
                 scale: 'health',
-                points: { show: true, size: 6 }
+                points: { show: false }
             },
             {
                 label: T['docsight.modulation.low_qam_pct'] || 'Low-QAM %',
@@ -706,7 +706,7 @@ function renderGroupTrendChart(pg, idx) {
                 fill: 'rgba(239,68,68,0.1)',
                 width: 2,
                 scale: 'lowqam',
-                points: { show: true, size: 6 }
+                points: { show: false }
             }
         ],
         cursor: { show: true, x: true, y: false, points: { show: false } },
@@ -998,7 +998,7 @@ function renderChannelTimeline(canvasId, timeline) {
                 stroke: '#ffab40',
                 width: 2,
                 paths: uPlot.paths.stepped({ align: -1 }),
-                points: { show: true, size: 8, stroke: '#ffab40', fill: '#ffab40' }
+                points: { show: false }
             }
         ],
         cursor: { show: true, x: true, y: false, points: { show: false } },

--- a/app/static/js/chart-engine.js
+++ b/app/static/js/chart-engine.js
@@ -455,7 +455,7 @@ function renderChart(canvasId, labels, datasets, type, zones, opts) {
 
     allDatasets.forEach(function(ds) {
         var showPoints = ds.showPoints;
-        if (showPoints === undefined) showPoints = n <= 30 && !isBar;
+        if (showPoints === undefined) showPoints = false;
         var s = {
             label: ds.label,
             stroke: ds.color || 'rgba(168,85,247,0.9)',
@@ -773,7 +773,7 @@ function openChartZoom(canvasId) {
         var uSeries = [{ label: 'X', value: function(u, v) { return params.labels[v] || ''; } }];
         params.datasets.forEach(function(ds) {
             var zoomShowPoints = ds.showPoints;
-            if (zoomShowPoints === undefined) zoomShowPoints = n <= 30 && !isBar;
+            if (zoomShowPoints === undefined) zoomShowPoints = false;
             var s = {
                 label: ds.label,
                 stroke: ds.color || 'rgba(168,85,247,0.9)',
@@ -796,7 +796,7 @@ function openChartZoom(canvasId) {
                 width: 1.5,
                 dash: [5, 3],
                 scale: 'temp',
-                points: { show: n <= 30, size: 4 },
+                points: { show: false, size: 4 },
                 spanGaps: true
             };
             ts._docsightAxisID = 'y-temp';

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,4 +1,4 @@
-var CACHE_VERSION = 'v94';
+var CACHE_VERSION = 'v95';
 var REGISTRATION_SCOPE = new URL(self.registration.scope);
 
 if (REGISTRATION_SCOPE.origin !== self.location.origin || REGISTRATION_SCOPE.pathname.slice(-1) !== '/') {

--- a/scripts/e2e_shards.py
+++ b/scripts/e2e_shards.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover - Windows can validate manifests only
 ROOT = Path(__file__).resolve().parents[1]
 E2E_DIR = ROOT / "tests" / "e2e"
 DEFAULT_MANIFEST = E2E_DIR / "shards.json"
-EXPECTED_TOTAL = 570
+EXPECTED_TOTAL = 581
 
 
 class ManifestError(ValueError):

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "expected_total": 570,
+  "expected_total": 581,
   "baseline_cpu_seconds": 1534.372,
   "shards": [
     {
@@ -18,7 +18,7 @@
     },
     {
       "id": 2,
-      "collected_cases": 151,
+      "collected_cases": 158,
       "files": [
         "test_auth.py",
         "test_charts.py",
@@ -45,7 +45,7 @@
     },
     {
       "id": 4,
-      "collected_cases": 172,
+      "collected_cases": 176,
       "files": [
         "test_channels.py",
         "test_events.py",

--- a/tests/e2e/test_charts.py
+++ b/tests/e2e/test_charts.py
@@ -5,6 +5,7 @@ Tests cover: hero chart, trend charts, channel charts, compare charts,
 zoom modal, theme switching, responsive sizing, and crosshair sync.
 """
 
+import pytest
 from playwright.sync_api import expect
 
 # ── Helpers ──
@@ -1334,3 +1335,63 @@ class TestSignalLifecycle:
         expect(page.locator('#hero-trend-chart')).to_have_text(page.evaluate('T.network_error'))
         toggle_theme(page)
         expect(page.locator('#hero-trend-chart')).to_have_text(page.evaluate('T.network_error'))
+
+
+def _assert_curve_points_hidden(page, expression):
+    """Resolve uPlot's normalized points.show callback for each plotted series."""
+    points = page.evaluate(
+        """charts => charts.map(chart => chart.series.slice(1).map((series, i) =>
+            typeof series.points.show === 'function'
+                ? series.points.show(chart, i + 1) : series.points.show))""",
+        page.evaluate_handle(expression),
+    )
+    assert points and all(points), "Expected plotted data series"
+    assert all(value is False for series in points for value in series), points
+
+
+def _assert_curve_zoom_and_tooltip(page, chart_id):
+    page.locator(f'.chart-expand-btn[data-chart="{chart_id}"]').click()
+    wait_for_uplot(page, "chart-zoom-canvas")
+    _assert_curve_points_hidden(page, "[window.zoomChart]")
+    page.locator('#chart-zoom-canvas .u-over').hover()
+    expect(page.locator('#chart-zoom-canvas .uplot-tooltip')).to_be_visible()
+    page.keyboard.press("Escape")
+    expect(page.locator('#chart-zoom-overlay')).not_to_be_visible()
+
+
+@pytest.mark.parametrize("range_value", ["1h", "6h", "1d", "2d"])
+def test_signal_curves_without_points_keep_zoom_and_tooltip(demo_page, range_value):
+    demo_page.locator('.nav-item[data-view="trends"]').click()
+    wait_for_uplot(demo_page, "chart-ds-power")
+    tab = demo_page.locator(f'.trend-tab[data-range="{range_value}"]')
+    if "active" not in (tab.get_attribute("class") or ""):
+        previous = demo_page.locator('#chart-ds-power .uplot canvas').element_handle()
+        tab.click()
+        wait_for_uplot_replacement(demo_page, "chart-ds-power", previous)
+        previous.dispose()
+    _assert_curve_points_hidden(demo_page,
+        "['chart-ds-power', 'chart-ds-snr', 'chart-us-power'].map(id => window.charts[id])")
+    _assert_curve_zoom_and_tooltip(demo_page, "chart-ds-power")
+
+
+@pytest.mark.parametrize("preset", ["yesterday_today", "peak_offpeak", "custom"])
+def test_comparison_curves_without_points_keep_zoom_and_tooltip(demo_page, preset):
+    from tests.e2e.test_comparison import _comparison_payload, navigate_to_comparison
+
+    payload = _comparison_payload(True, 0)
+    # Sparse periods reproduce the marker default while allowing a visible curve.
+    for key in ("period_a", "period_b"):
+        row = payload[key]["timeseries"][0]
+        payload[key]["timeseries"].append(dict(row, timestamp=row["timestamp"].replace("06:00", "12:00")))
+    demo_page.route("**/api/comparison**", lambda route: route.fulfill(json=payload))
+    navigate_to_comparison(demo_page)
+    demo_page.locator('#comparison-preset').select_option(preset)
+    if preset == 'custom':
+        for suffix, value in [('from-a', '2026-03-01T00:00'), ('to-a', '2026-03-01T23:59'),
+                              ('from-b', '2026-03-08T00:00'), ('to-b', '2026-03-08T23:59')]:
+            demo_page.locator(f'#comparison-{suffix}').fill(value)
+    demo_page.locator('#comparison-run-btn').click()
+    wait_for_uplot(demo_page, "cmp-chart-ds-power")
+    _assert_curve_points_hidden(demo_page,
+        "['cmp-chart-ds-power', 'cmp-chart-ds-snr', 'cmp-chart-us-power'].map(id => window.charts[id])")
+    _assert_curve_zoom_and_tooltip(demo_page, "cmp-chart-ds-power")

--- a/tests/e2e/test_modulation.py
+++ b/tests/e2e/test_modulation.py
@@ -497,3 +497,27 @@ class TestNoConsoleErrors:
         page.wait_for_load_state("networkidle")
         page.wait_for_timeout(2000)
         assert len(errors) == 0, f"JS errors: {errors}"
+
+
+@pytest.mark.parametrize("direction", ["us", "ds"])
+@pytest.mark.parametrize("days", [7, 30])
+def test_modulation_curves_without_points_keep_tooltip_and_drilldown(demo_page, direction, days):
+    from tests.e2e.test_charts import _assert_curve_points_hidden
+
+    demo_page.locator('.nav-item[data-view="modulation"]').click()
+    demo_page.wait_for_function("() => window._modCharts.length >= 2", timeout=150_000)
+    if direction == "ds":
+        _switch_distribution(demo_page, '#modulation-direction-tabs [data-dir="ds"]',
+                             direction=direction, min_samples=7)
+    if days == 30:
+        _switch_distribution(demo_page, '#modulation-range-tabs [data-days="30"]',
+                             direction=direction, min_samples=30)
+    _assert_curve_points_hidden(demo_page, "window._modCharts")
+    demo_page.locator('[id^="mod-trend-chart-"] .u-over').first.hover()
+    expect(demo_page.locator('[id^="mod-trend-chart-"] .uplot-tooltip').first).to_be_visible()
+
+    with demo_page.expect_response(lambda response: "/api/modulation/intraday?" in response.url) as response:
+        demo_page.locator('#modulation-range-tabs [data-days="1"]').click()
+    expect(demo_page.locator('#mod-intraday-title')).to_contain_text(response.value.json()["date"])
+    expect(demo_page.locator('#modulation-intraday')).to_be_visible()
+    expect(demo_page.locator('#modulation-overview')).not_to_be_visible()

--- a/tests/js/chart-points.test.js
+++ b/tests/js/chart-points.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const test = require('node:test');
+
+function browser() {
+    const elements = new Map();
+    const element = () => ({tagName: 'DIV', style: {}, offsetWidth: 800,
+        offsetHeight: 400, closest: () => null});
+    function Chart(options, data) {
+        Object.assign(this, {options, data, destroy() {}});
+    }
+    Chart.paths = {bars: () => () => {}, stepped: () => () => {}};
+    const context = {
+        document: {getElementById(id) {
+            if (!elements.has(id)) elements.set(id, element());
+            return elements.get(id);
+        }, documentElement: {getAttribute: () => 'dark'}},
+        uPlot: Chart, T: {}, setTimeout: fn => fn(),
+        ResizeObserver: class {observe() {} disconnect() {}},
+        DOCSightModal: {open() {}, close() {}},
+    };
+    context.window = context;
+    vm.runInNewContext(fs.readFileSync('app/static/js/chart-engine.js', 'utf8'), context);
+    return context;
+}
+
+for (const count of [1, 30, 31, 100]) {
+    for (const type of ['line', 'bar']) {
+        for (const mode of ['normal', 'zoom']) {
+            test(`${mode} ${type}, ${count} samples: points are opt-in and bars always opt out`, () => {
+                const b = browser();
+                const data = Array.from({length: count}, (_, i) => i === 1 ? null : i);
+                const datasets = [undefined, false, true].map(showPoints => ({
+                    label: String(showPoints), data, showPoints,
+                }));
+                b.renderChart('chart', data.map(String), datasets, type, null, {tempData: data});
+                if (mode === 'zoom') b.openChartZoom('chart');
+                const chart = mode === 'zoom' ? b.zoomChart : b.charts.chart;
+                assert.deepEqual(Array.from(chart.options.series.slice(1), s => s.points.show),
+                    type === 'bar' ? [false, false, false] : [false, false, true, false]);
+                assert.equal(chart.data[1], data);
+                assert.equal(chart.options.series[1].spanGaps, false);
+                assert.equal(chart.options.cursor.points.show, false);
+                assert.ok(chart.options.plugins[0].hooks.setCursor);
+            });
+        }
+    }
+}

--- a/tests/js/modulation-contracts.test.js
+++ b/tests/js/modulation-contracts.test.js
@@ -47,7 +47,7 @@ function browser(lang = 'en', translations = {}) {
         this.destroy = () => { this.destroyed = true; };
         charts.push(this);
     }
-    Chart.paths = {bars: () => () => {}};
+    Chart.paths = {bars: () => () => {}, stepped: () => () => {}};
     const context = {
         document: {getElementById: id => ids.get(id), createElement: () => element(),
             querySelectorAll: selector => selector.includes('direction') ? directions : ranges},
@@ -58,7 +58,7 @@ function browser(lang = 'en', translations = {}) {
     };
     context.window = context;
     vm.runInNewContext(read('app/modules/modulation/static/main.js'), context);
-    return {ids, charts, requests, directions, ranges, init: () => context.initModulation(),
+    return {ids, charts, requests, directions, ranges, context, init: () => context.initModulation(),
         async reply(data, index = requests.length - 1) {
             requests[index].resolve({json: async () => data});
             await new Promise(resolve => setImmediate(resolve));
@@ -215,3 +215,30 @@ for (const lang of ['en', 'de']) {
         assert.equal(b.ids.get('modulation-capacity-panel').style.display, 'none');
     });
 }
+
+for (const direction of ['us', 'ds']) {
+    for (const count of [7, 30]) {
+        test(`${direction} ${count}d modulation curves have no persistent points`, async () => {
+            const b = browser();
+            b.init();
+            await b.reply(overview(direction, '3.0', count));
+            assert.equal(b.charts.length, 2);
+            for (const chart of b.charts) {
+                for (const series of chart.options.series.slice(1)) {
+                    assert.equal(series.points.show, false, series.label);
+                }
+            }
+        });
+    }
+}
+
+test('intraday stepped modulation curve has no persistent points', () => {
+    const b = browser();
+    b.context.renderChannelTimeline('modulation-intraday-content', [
+        {time: '12:00', modulation: '64QAM'}, {time: '12:05', modulation: '16QAM'},
+    ]);
+    const chart = b.charts[0];
+    assert.equal(chart.options.series[1].points.show, false);
+    assert.equal(typeof chart.options.series[1].paths, 'function');
+    assert.equal(chart.options.cursor.show, true);
+});

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -187,7 +187,7 @@ def test_full_e2e_paths_concurrency_and_summary_contract():
         step for step in workflow["jobs"]["full-e2e"]["steps"]
         if step["name"].startswith("Verify complete successful")
     )["run"]
-    assert "--expected-total 570" in summarize
+    assert "--expected-total 581" in summarize
 
     preserve = next(
         step for step in workflow["jobs"]["full-e2e"]["steps"]

--- a/tests/test_dashboard_module_ownership.py
+++ b/tests/test_dashboard_module_ownership.py
@@ -109,4 +109,4 @@ def test_unconfigured_modules_keep_setup_without_empty_views(dashboard, prefix):
 
 
 def test_module_asset_cache_generation():
-    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v94';")
+    assert (ROOT / "app/static/sw.js").read_text().startswith("var CACHE_VERSION = 'v95';")

--- a/tests/test_e2e_shards.py
+++ b/tests/test_e2e_shards.py
@@ -84,17 +84,17 @@ def _write_result(
     )
 
 
-def test_repository_manifest_covers_every_e2e_file_once_and_570_cases():
+def test_repository_manifest_covers_every_e2e_file_once_and_581_cases():
     manifest = load_manifest(MANIFEST)
     validated = validate_manifest(manifest, E2E_DIR)
 
-    assert manifest["expected_total"] == EXPECTED_TOTAL == 570
+    assert manifest["expected_total"] == EXPECTED_TOTAL == 581
     assert manifest["baseline_cpu_seconds"] > 0
     assert [shard["collected_cases"] for shard in manifest["shards"]] == [
         86,
-        151,
+        158,
         161,
-        172,
+        176,
     ]
     assert len(validated) == 29
 
@@ -258,7 +258,7 @@ def test_workflow_runs_safe_non_retrying_shards_and_an_always_gate():
     assert "E2E_JOB_STARTED_EPOCH" in workflow
     assert "python scripts/e2e_shards.py run" in workflow
     assert "python scripts/e2e_shards.py summarize" in workflow
-    assert "--expected-total 570" in workflow
+    assert "--expected-total 581" in workflow
     assert "--receipt" in workflow
     assert "run-receipt.json" in workflow
     assert "if: always()" in workflow


### PR DESCRIPTION
## Summary
- Use curve-only styling by default in Signal Trends and Before/After Comparison, including expanded charts and the temperature overlay.
- Remove persistent markers from modulation trend and channel timeline curves.
- Keep explicit dataset marker overrides, bar charts, tooltips, and zoom behavior intact.
- Refresh the service-worker cache so existing installations receive the updated assets.

## Verification
- 4,230 Python tests passed, 2 skipped.
- 97 JavaScript tests passed. The new regressions produce 9 failures against the original code.
- 120 Chromium tests passed for charts, comparisons, and modulation, including the 11 new regressions.
- Checked the changed charts in the browser.
- Verified all four E2E shard collections against the updated 581-case total.

No data or configuration migration. No documentation changes needed for this visual consistency fix.

Closes #839
