### PR TITLE
Simplify correlation around independent observations

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -264,7 +264,7 @@ jobs:
           pattern: full-e2e-shard-*
           path: shard-artifacts
 
-      - name: Verify complete successful 585-case union
+      - name: Verify complete successful 586-case union
         if: env.E2E_REQUIRED == 'true'
         run: |
           if [ "$SHARD_JOB_RESULT" != "success" ]; then
@@ -273,7 +273,7 @@ jobs:
           fi
           python scripts/e2e_shards.py summarize \
             --results-root shard-artifacts \
-            --expected-total 585
+            --expected-total 586
 
       - name: Browser gate not required for this change
         if: env.E2E_REQUIRED != 'true'

--- a/app/blueprints/analysis_bp.py
+++ b/app/blueprints/analysis_bp.py
@@ -3,7 +3,6 @@
 from app.runtime import current_runtime
 from app.tz import localize_timestamps, get_tz_name
 import logging
-from datetime import datetime
 
 from flask import Blueprint, request, jsonify
 
@@ -213,6 +212,10 @@ def api_channel_compare():
 @require_auth
 def api_correlation():
     """Return unified timeline with data from all sources for cross-source correlation.
+
+    Each entry describes its own source observation; nearby modem samples do not
+    establish signal health at the time of a speedtest.
+
     Query params:
       hours: int (default 24, max 2160 / 90d)
       sources: comma-separated list of modem,speedtest,events,bnetz,capture,segment (default all)
@@ -235,22 +238,5 @@ def api_correlation():
         sources = None
 
     timeline = _storage.get_correlation_timeline(start_ts, end_ts, sources)
-
-    # Enrich speedtest entries with closest modem health
-    modem_entries = [e for e in timeline if e["source"] == "modem"]
-    for entry in timeline:
-        if entry["source"] == "speedtest" and modem_entries:
-            closest = min(modem_entries, key=lambda m: abs(
-                datetime.fromisoformat(m["timestamp"]).timestamp() -
-                datetime.fromisoformat(entry["timestamp"]).timestamp()
-            ))
-            delta_min = abs(
-                datetime.fromisoformat(closest["timestamp"]).timestamp() -
-                datetime.fromisoformat(entry["timestamp"]).timestamp()
-            ) / 60
-            if delta_min <= 120:
-                entry["modem_health"] = closest.get("health")
-                entry["modem_ds_snr_min"] = closest.get("ds_snr_min")
-                entry["modem_ds_power_avg"] = closest.get("ds_power_avg")
 
     return jsonify(timeline)

--- a/app/i18n/bg.json
+++ b/app/i18n/bg.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Здраве на сигнала",
   "correlation_speed_vs_signal": "Скорост срещу сигнал",
   "correlation_all_sources": "Всички източници",
-  "correlation_modem_health_good": "Сигналът е здрав в най-бързото време",
-  "correlation_modem_health_poor": "Сигналът се влоши при тестово време",
   "correlation_chart_title": "Хронология на здравето на сигнала",
   "correlation_timeline": "Унифицирана хронология",
   "demo_mode": "ДЕМО",

--- a/app/i18n/cs.json
+++ b/app/i18n/cs.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Stav signálu",
   "correlation_speed_vs_signal": "Rychlost vs. signál",
   "correlation_all_sources": "Všechny zdroje",
-  "correlation_modem_health_good": "Signál zdravý v nejrychlejším čase",
-  "correlation_modem_health_poor": "Signál degradován v době testu rychlosti",
   "correlation_chart_title": "Časová osa zdraví signálu",
   "correlation_timeline": "Jednotná časová osa",
   "demo_mode": "DEMO",

--- a/app/i18n/da.json
+++ b/app/i18n/da.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signalsundhed",
   "correlation_speed_vs_signal": "Hastighed vs. signal",
   "correlation_all_sources": "Alle kilder",
-  "correlation_modem_health_good": "Signal sundt ved hastighedstest",
-  "correlation_modem_health_poor": "Signal forringet ved hastighedstest",
   "correlation_chart_title": "Tidslinje for signalsundhed",
   "correlation_timeline": "Samlet tidslinje",
   "demo_mode": "DEMO",

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signalzustand",
   "correlation_speed_vs_signal": "Speed vs. Signal",
   "correlation_all_sources": "Alle Quellen",
-  "correlation_modem_health_good": "Signal gesund zum Speedtest Zeitpunkt",
-  "correlation_modem_health_poor": "Signal beeinträchtigt zum Speedtest Zeitpunkt",
   "correlation_chart_title": "Signal-Gesundheitsverlauf",
   "correlation_timeline": "Zeitstrahl",
   "demo_mode": "Demo-Modus",

--- a/app/i18n/el.json
+++ b/app/i18n/el.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signal Health",
   "correlation_speed_vs_signal": "Ταχύτητα έναντι σήματος",
   "correlation_all_sources": "Όλες οι πηγές",
-  "correlation_modem_health_good": "Σήμα υγιές σε χρόνο δοκιμής ταχύτητας",
-  "correlation_modem_health_poor": "Το σήμα υποβαθμίστηκε στον χρόνο δοκιμής της ταχύτητας",
   "correlation_chart_title": "Χρονοδιάγραμμα Signal Health",
   "correlation_timeline": "Ενοποιημένο χρονοδιάγραμμα",
   "demo_mode": "DEMO",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signal Health",
   "correlation_speed_vs_signal": "Speed vs. Signal",
   "correlation_all_sources": "All Sources",
-  "correlation_modem_health_good": "Signal healthy at speedtest time",
-  "correlation_modem_health_poor": "Signal degraded at speedtest time",
   "correlation_chart_title": "Signal Health Timeline",
   "correlation_timeline": "Unified Timeline",
   "demo_mode": "DEMO",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -412,8 +412,6 @@
   "correlation_signal_health": "Salud de la senal",
   "correlation_speed_vs_signal": "Velocidad vs. Senal",
   "correlation_all_sources": "Todas las fuentes",
-  "correlation_modem_health_good": "Senal saludable al momento del speedtest",
-  "correlation_modem_health_poor": "Senal degradada al momento del speedtest",
   "correlation_chart_title": "Cronología de salud de señal",
   "correlation_timeline": "Línea de tiempo unificada",
   "demo_mode": "DEMO",

--- a/app/i18n/et.json
+++ b/app/i18n/et.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signaali tervis",
   "correlation_speed_vs_signal": "Kiirus vs signaal",
   "correlation_all_sources": "Kõik allikad",
-  "correlation_modem_health_good": "Anna kiiruskatse ajal terve signaal",
-  "correlation_modem_health_poor": "Signaal on kiirustesti ajal halvenenud",
   "correlation_chart_title": "Signaali tervise ajaskaala",
   "correlation_timeline": "Ühtne ajaskaala",
   "demo_mode": "DEMO",

--- a/app/i18n/fi.json
+++ b/app/i18n/fi.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signaalin kunto",
   "correlation_speed_vs_signal": "Nopeus vs. signaali",
   "correlation_all_sources": "Kaikki lähteet",
-  "correlation_modem_health_good": "Signaali terve nopeustestin aikaan",
-  "correlation_modem_health_poor": "Signaali heikkeni nopeustestin aikana",
   "correlation_chart_title": "Signaalin kunnon aikajana",
   "correlation_timeline": "Yhtenäinen aikajana",
   "demo_mode": "DEMO",

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -409,8 +409,6 @@
   "correlation_signal_health": "Sante du signal",
   "correlation_speed_vs_signal": "Vitesse vs. Signal",
   "correlation_all_sources": "Toutes les sources",
-  "correlation_modem_health_good": "Signal sain au moment du speedtest",
-  "correlation_modem_health_poor": "Signal degrade au moment du speedtest",
   "correlation_chart_title": "Chronologie de santé du signal",
   "correlation_timeline": "Chronologie unifiée",
   "demo_mode": "DÉMO",

--- a/app/i18n/ga.json
+++ b/app/i18n/ga.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Sláinte Comhartha",
   "correlation_speed_vs_signal": "Luas vs Comhartha",
   "correlation_all_sources": "Gach Foinse",
-  "correlation_modem_health_good": "Comhartha sláintiúil ag an am is tapúla",
-  "correlation_modem_health_poor": "Comhartha díghrádaithe ag an am is tapúla",
   "correlation_chart_title": "Amlíne Sláinte Comhartha",
   "correlation_timeline": "Amlíne Aontaithe",
   "demo_mode": "DEMO",

--- a/app/i18n/hr.json
+++ b/app/i18n/hr.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signal Health",
   "correlation_speed_vs_signal": "Brzina u odnosu na signal",
   "correlation_all_sources": "Svi izvori",
-  "correlation_modem_health_good": "Signal ispravan u najvećem vremenu",
-  "correlation_modem_health_poor": "Signal je oslabio u vremenu najveće brzine",
   "correlation_chart_title": "Vremenska traka stanja signala",
   "correlation_timeline": "Unified Timeline",
   "demo_mode": "DEMO",

--- a/app/i18n/hu.json
+++ b/app/i18n/hu.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Jelállapot",
   "correlation_speed_vs_signal": "Sebesség kontra jel",
   "correlation_all_sources": "Minden forrás",
-  "correlation_modem_health_good": "Adjon egészséges jelet a sebességteszt idején",
-  "correlation_modem_health_poor": "A jel leromlott a sebességteszt idején",
   "correlation_chart_title": "Jelállapot idővonala",
   "correlation_timeline": "Egységes idővonal",
   "demo_mode": "DEMO",

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Stato del segnale",
   "correlation_speed_vs_signal": "Velocità e segnale",
   "correlation_all_sources": "Tutte le fonti",
-  "correlation_modem_health_good": "Segnale sano al momento dello speedtest",
-  "correlation_modem_health_poor": "Segnale degradato durante il test di velocità",
   "correlation_chart_title": "Cronologia della salute del segnale",
   "correlation_timeline": "Cronologia unificata",
   "demo_mode": "DEMO",

--- a/app/i18n/lt.json
+++ b/app/i18n/lt.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signalo sveikata",
   "correlation_speed_vs_signal": "Greitis ir signalas",
   "correlation_all_sources": "Visi šaltiniai",
-  "correlation_modem_health_good": "Signalizuokite sveiką greitį",
-  "correlation_modem_health_poor": "Signalas pablogėjo greičio bandymo metu",
   "correlation_chart_title": "Signalo būklės laiko juosta",
   "correlation_timeline": "Vieninga laiko juosta",
   "demo_mode": "DEMO",

--- a/app/i18n/lv.json
+++ b/app/i18n/lv.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signāla veselība",
   "correlation_speed_vs_signal": "Ātrums pret signālu",
   "correlation_all_sources": "Visi avoti",
-  "correlation_modem_health_good": "Signāls ir veselīgs ātruma pārbaudes laikā",
-  "correlation_modem_health_poor": "Signāls ir pasliktināts ātruma pārbaudes laikā",
   "correlation_chart_title": "Signāla veselības laika skala",
   "correlation_timeline": "Vienota laika skala",
   "demo_mode": "DEMO",

--- a/app/i18n/nb.json
+++ b/app/i18n/nb.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signalhelse",
   "correlation_speed_vs_signal": "Hastighet vs. signal",
   "correlation_all_sources": "Alle kilder",
-  "correlation_modem_health_good": "Signal sunt ved hastighetstest",
-  "correlation_modem_health_poor": "Signalet ble forringet ved hastighetstest",
   "correlation_chart_title": "Tidslinje for signalhelse",
   "correlation_timeline": "Unified Timeline",
   "demo_mode": "DEMO",

--- a/app/i18n/nl.json
+++ b/app/i18n/nl.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signaalgezondheid",
   "correlation_speed_vs_signal": "Snelheid versus signaal",
   "correlation_all_sources": "Alle bronnen",
-  "correlation_modem_health_good": "Signaal gezond op snelheidstesttijd",
-  "correlation_modem_health_poor": "Signaal verslechterd tijdens de speedtesttijd",
   "correlation_chart_title": "Signaalgezondheidstijdlijn",
   "correlation_timeline": "Uniforme tijdlijn",
   "demo_mode": "DEMO",

--- a/app/i18n/pl.json
+++ b/app/i18n/pl.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Sygnał zdrowia",
   "correlation_speed_vs_signal": "Prędkość a sygnał",
   "correlation_all_sources": "Wszystkie źródła",
-  "correlation_modem_health_good": "Sygnał jest sprawny w czasie testu prędkości",
-  "correlation_modem_health_poor": "Sygnał uległ obniżeniu w czasie testu prędkości",
   "correlation_chart_title": "Oś czasu stanu sygnału",
   "correlation_timeline": "Ujednolicona oś czasu",
   "demo_mode": "DEMO",

--- a/app/i18n/pt.json
+++ b/app/i18n/pt.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Sinal de Saúde",
   "correlation_speed_vs_signal": "Velocidade vs. Sinal",
   "correlation_all_sources": "Todas as fontes",
-  "correlation_modem_health_good": "Sinal saudável no momento do teste de velocidade",
-  "correlation_modem_health_poor": "Sinal degradado no tempo de teste de velocidade",
   "correlation_chart_title": "Cronograma de integridade do sinal",
   "correlation_timeline": "Linha do tempo unificada",
   "demo_mode": "DEMONSTRAÇÃO",

--- a/app/i18n/ro.json
+++ b/app/i18n/ro.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Sănătatea semnalului",
   "correlation_speed_vs_signal": "Viteză vs. semnal",
   "correlation_all_sources": "Toate sursele",
-  "correlation_modem_health_good": "Semnal sănătos la cea mai mare viteză",
-  "correlation_modem_health_poor": "Semnal degradat la cea mai mare viteză",
   "correlation_chart_title": "Cronologie pentru sănătatea semnalului",
   "correlation_timeline": "Cronologie unificată",
   "demo_mode": "DEMO",

--- a/app/i18n/sk.json
+++ b/app/i18n/sk.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Zdravie signálu",
   "correlation_speed_vs_signal": "Rýchlosť vs. signál",
   "correlation_all_sources": "Všetky zdroje",
-  "correlation_modem_health_good": "Signál zdravý v najrýchlejšom čase",
-  "correlation_modem_health_poor": "Signál degradovaný pri teste rýchlosti",
   "correlation_chart_title": "Časová os zdravia signálu",
   "correlation_timeline": "Jednotná časová os",
   "demo_mode": "DEMO",

--- a/app/i18n/sl.json
+++ b/app/i18n/sl.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signal Health",
   "correlation_speed_vs_signal": "Hitrost proti signalu",
   "correlation_all_sources": "Vsi viri",
-  "correlation_modem_health_good": "Signal zdrav v najhitrejšem času",
-  "correlation_modem_health_poor": "Signal se je poslabšal v času hitrosti",
   "correlation_chart_title": "Časovnica stanja signala",
   "correlation_timeline": "Enotna časovnica",
   "demo_mode": "DEMO",

--- a/app/i18n/sv.json
+++ b/app/i18n/sv.json
@@ -417,8 +417,6 @@
   "correlation_signal_health": "Signalhälsa",
   "correlation_speed_vs_signal": "Hastighet vs. signal",
   "correlation_all_sources": "Alla källor",
-  "correlation_modem_health_good": "Signalen frisk vid hastighetstesttid",
-  "correlation_modem_health_poor": "Signalen försämrades vid hastighetstestningstid",
   "correlation_chart_title": "Signal Health Timeline",
   "correlation_timeline": "Unified Timeline",
   "demo_mode": "DEMO",

--- a/app/static/js/correlation.js
+++ b/app/static/js/correlation.js
@@ -2,7 +2,6 @@
 
 /* ═══ Correlation Analysis ═══ */
 var _correlationData = [];
-var _correlationChart = null;
 var _corrVisible = { snr: true, txPower: true, dsPower: true, download: true, upload: true, events: false, errors: true, poorSignal: false, temperature: true, segmentDs: true, segmentUs: false, reachability: true };
 var _corrWeatherData = [];
 var _corrSegmentData = [];
@@ -667,7 +666,8 @@ function renderCorrelationChart(data) {
         upload: _corrVisible.upload
     });
 
-    // Draw modem SNR line without an area fill to keep the chart uncluttered
+    // Connect observations directly; smoothed curves imply unmeasured trends.
+    // Keep SNR unfilled so other evidence remains visible.
     if (_corrVisible.snr && modem.length > 1) {
         ctx.beginPath();
         for (var i = 0; i < modem.length; i++) {
@@ -676,10 +676,7 @@ function renderCorrelationChart(data) {
             if (i === 0) {
                 ctx.moveTo(x, y);
             } else {
-                var x0 = xScale(new Date(modem[i - 1].timestamp).getTime());
-                var y0 = ySnr(modem[i - 1].ds_snr_min || snrMin);
-                var cpx = x0 + (x - x0) * 0.4;
-                ctx.bezierCurveTo(cpx, y0, x - (x - x0) * 0.4, y, x, y);
+                ctx.lineTo(x, y);
             }
         }
         ctx.strokeStyle = snrColor;
@@ -690,26 +687,19 @@ function renderCorrelationChart(data) {
     // Draw upstream TX power line
     if (_corrVisible.txPower && modem.length > 1 && txValues.length > 0) {
         ctx.beginPath();
+        var txStarted = false;
         for (var i = 0; i < modem.length; i++) {
             var txVal = modem[i].us_power_avg;
             if (!txVal) continue;
             var x = xScale(new Date(modem[i].timestamp).getTime());
             var y = yTx(txVal);
-            if (ctx._txStarted) {
-                var x0 = ctx._txLastX;
-                var y0 = ctx._txLastY;
-                var cpx = x0 + (x - x0) * 0.4;
-                ctx.bezierCurveTo(cpx, y0, x - (x - x0) * 0.4, y, x, y);
+            if (txStarted) {
+                ctx.lineTo(x, y);
             } else {
                 ctx.moveTo(x, y);
-                ctx._txStarted = true;
+                txStarted = true;
             }
-            ctx._txLastX = x;
-            ctx._txLastY = y;
         }
-        delete ctx._txStarted;
-        delete ctx._txLastX;
-        delete ctx._txLastY;
         ctx.strokeStyle = txColor;
         ctx.lineWidth = 2;
         ctx.setLineDash([6, 3]);
@@ -788,10 +778,7 @@ function renderCorrelationChart(data) {
             var y = yTemp(weather[i].temperature);
             if (!started) { ctx.moveTo(x, y); started = true; }
             else {
-                var x0 = xScale(new Date(weather[i - 1].timestamp).getTime());
-                var y0 = yTemp(weather[i - 1].temperature);
-                var cpx = x0 + (x - x0) * 0.4;
-                ctx.bezierCurveTo(cpx, y0, x - (x - x0) * 0.4, y, x, y);
+                ctx.lineTo(x, y);
             }
         }
         ctx.strokeStyle = tempColor;
@@ -1712,9 +1699,6 @@ function renderCorrelationTable(data) {
     var tbody = document.getElementById('correlation-tbody');
     while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
 
-    // Show newest first in table
-    var sorted = data.slice().reverse();
-
     var healthLabels = {
         good: T.health_good,
         tolerated: T.health_tolerated,
@@ -1751,7 +1735,8 @@ function renderCorrelationTable(data) {
         }
     }
 
-    var sorted = data.slice().reverse();
+    // Show newest first in table.
+    var sorted = chronological.slice().reverse();
     var maxRows = 200;
     var count = 0;
     for (var i = 0; i < sorted.length && count < maxRows; i++) {
@@ -1789,12 +1774,7 @@ function renderCorrelationTable(data) {
         } else if (src === 'speedtest') {
             src = '<span style="color:var(--good);">Speedtest</span>';
             msg = (e.download_mbps ? e.download_mbps.toFixed(1) + ' / ' + (e.upload_mbps || 0).toFixed(1) + ' Mbps' : '');
-            var mhBadge = '';
-            if (e.modem_health) {
-                mhBadge = ' <span class="st-health-badge health-' + e.modem_health + '" style="font-size:0.75em;">'
-                    + (healthLabels[e.modem_health] || e.modem_health) + '</span>';
-            }
-            details = (T.speedtest_ping || 'Ping') + ' ' + (e.ping_ms || '') + ' ms | Jitter ' + (e.jitter_ms || '') + ' ms' + mhBadge;
+            details = (T.speedtest_ping || 'Ping') + ' ' + (e.ping_ms || '') + ' ms | Jitter ' + (e.jitter_ms || '') + ' ms';
         } else if (src === 'capture') {
             var scStatus = e.status || '';
             var scColor = scStatus === 'completed' ? 'var(--good)'

--- a/scripts/e2e_shards.py
+++ b/scripts/e2e_shards.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover - Windows can validate manifests only
 ROOT = Path(__file__).resolve().parents[1]
 E2E_DIR = ROOT / "tests" / "e2e"
 DEFAULT_MANIFEST = E2E_DIR / "shards.json"
-EXPECTED_TOTAL = 585
+EXPECTED_TOTAL = 586
 
 
 class ManifestError(ValueError):

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "expected_total": 585,
+  "expected_total": 586,
   "baseline_cpu_seconds": 1534.372,
   "shards": [
     {
@@ -32,7 +32,7 @@
     },
     {
       "id": 3,
-      "collected_cases": 161,
+      "collected_cases": 162,
       "files": [
         "test_comparison.py",
         "test_correlation_ui.py",

--- a/tests/e2e/test_correlation_ui.py
+++ b/tests/e2e/test_correlation_ui.py
@@ -36,7 +36,6 @@ def _sample_correlation_data():
             "upload_mbps": 48.2,
             "ping_ms": 12.5,
             "jitter_ms": 1.7,
-            "modem_health": "good",
         },
         {
             "source": "event",
@@ -1004,6 +1003,50 @@ def test_correlation_renders_sparse_speedtests_as_unconnected_point_measurements
     assert max(speed_operation_indexes) < min(signal_indexes)
     assert max(speed_operation_indexes) < min(error_indexes)
     assert max(speed_operation_indexes) < min(event_indexes)
+
+
+def test_correlation_draws_unsmoothed_observations_and_keeps_health_on_modem_rows(demo_page):
+    page = demo_page
+    payload = _sample_correlation_data()
+    first = payload[0]
+    payload.append({**first, "timestamp": payload[2]["timestamp"], "ds_snr_min": 30.0, "us_power_avg": 48.0})
+    payload.append({**first, "timestamp": payload[3]["timestamp"], "ds_snr_min": 37.0, "us_power_avg": 43.0})
+    payload.sort(key=lambda entry: entry["timestamp"])
+    weather = [
+        {"timestamp": entry["timestamp"], "temperature": temperature}
+        for entry, temperature in zip(
+            (entry for entry in payload if entry["source"] == "modem"),
+            (10.0, 20.0, 12.0),
+        )
+    ]
+    _record_correlation_canvas_operations(page)
+    _route_correlation(page, payload)
+    page.route("**/api/weather/range?**", lambda route: route.fulfill(json=weather))
+    _open_correlation(page)
+
+    series = page.evaluate(
+        """() => {
+            const st = window._corrChartState;
+            return [
+                ['snr', st.modem, 'ds_snr_min', st.ySnr],
+                ['txPower', st.modem, 'us_power_avg', st.yTx],
+                ['temperature', st.weather, 'temperature', st.yTemp],
+            ].map(([metric, samples, field, scale]) => ({
+                expected: samples.map(sample => [st.xScale(new Date(sample.timestamp).getTime()), scale(sample[field])]),
+                paths: window.__corrCanvasOps.filter(op => op.kind === 'stroke' && op.strokeStyle === st.colors[metric]).map(op => op.path),
+            }));
+        }"""
+    )
+    for rendered in series:
+        assert len(rendered["paths"]) == 1
+        path = rendered["paths"][0]
+        assert [part["kind"] for part in path] == ["moveTo", "lineTo", "lineTo"]
+        for part, expected in zip(path, rendered["expected"]):
+            assert part["args"] == pytest.approx(expected)
+
+    expect(page.locator('#correlation-tbody tr[data-src="modem"] .st-health-badge')).to_have_count(1)
+    expect(page.locator('#correlation-tbody tr[data-src="speedtest"] .st-health-badge')).to_have_count(0)
+    expect(page.locator('#correlation-tbody tr[data-src="speedtest"]')).to_contain_text("280.4 / 48.2 Mbps")
 
 
 def test_correlation_single_speedtest_uses_stem_and_larger_head(demo_page):

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -187,7 +187,7 @@ def test_full_e2e_paths_concurrency_and_summary_contract():
         step for step in workflow["jobs"]["full-e2e"]["steps"]
         if step["name"].startswith("Verify complete successful")
     )["run"]
-    assert "--expected-total 585" in summarize
+    assert "--expected-total 586" in summarize
 
     preserve = next(
         step for step in workflow["jobs"]["full-e2e"]["steps"]

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -353,13 +353,18 @@ class TestCorrelationAPI:
         data = json.loads(resp.data)
         assert all(e["source"] == "event" for e in data)
 
-    def test_correlation_speedtest_enrichment(self, client_with_storage, storage, speedtest_storage, sample_analysis):
-        """Speedtest entries get enriched with modem_health."""
-        ts = utc_now()
+    @pytest.mark.parametrize("modem_age_minutes", [-90, 0, 90])
+    def test_correlation_speedtest_keeps_its_own_observations(
+        self, client_with_storage, storage, speedtest_storage, sample_analysis,
+        modem_age_minutes,
+    ):
+        """Selecting modem data must not attach its health to a speedtest."""
+        ts = utc_cutoff(hours=3)
+        modem_ts = utc_cutoff(hours=3, minutes=modem_age_minutes)
         with sqlite3.connect(storage.db_path) as conn:
             conn.execute(
                 "INSERT INTO snapshots (timestamp, summary_json, ds_channels_json, us_channels_json) VALUES (?,?,?,?)",
-                (ts, json.dumps(sample_analysis["summary"]),
+                (modem_ts, json.dumps(sample_analysis["summary"]),
                  json.dumps(sample_analysis["ds_channels"]),
                  json.dumps(sample_analysis["us_channels"])),
             )
@@ -370,11 +375,16 @@ class TestCorrelationAPI:
             "download_human": "480 Mbps", "upload_human": "48 Mbps",
             "ping_ms": 11.0, "jitter_ms": 1.5, "packet_loss_pct": 0.0,
         }])
-        resp = client_with_storage.get("/api/correlation?hours=1")
+        resp = client_with_storage.get("/api/correlation?hours=24")
         data = json.loads(resp.data)
         speedtest_entries = [e for e in data if e["source"] == "speedtest"]
         assert len(speedtest_entries) == 1
-        assert speedtest_entries[0].get("modem_health") == "good"
+        assert any(e["source"] == "modem" for e in data)
+        speedtest_only = client_with_storage.get(
+            "/api/correlation?hours=24&sources=speedtest"
+        ).get_json()
+        assert speedtest_entries == speedtest_only
+        assert not any(key.startswith("modem_") for key in speedtest_entries[0])
 
     def test_correlation_hours_clamped(self, client_with_storage):
         """Hours parameter is clamped to 1-2160 (90d)."""

--- a/tests/test_e2e_shards.py
+++ b/tests/test_e2e_shards.py
@@ -84,16 +84,16 @@ def _write_result(
     )
 
 
-def test_repository_manifest_covers_every_e2e_file_once_and_585_cases():
+def test_repository_manifest_covers_every_e2e_file_once_and_586_cases():
     manifest = load_manifest(MANIFEST)
     validated = validate_manifest(manifest, E2E_DIR)
 
-    assert manifest["expected_total"] == EXPECTED_TOTAL == 585
+    assert manifest["expected_total"] == EXPECTED_TOTAL == 586
     assert manifest["baseline_cpu_seconds"] > 0
     assert [shard["collected_cases"] for shard in manifest["shards"]] == [
         86,
         162,
-        161,
+        162,
         176,
     ]
     assert len(validated) == 29
@@ -258,7 +258,7 @@ def test_workflow_runs_safe_non_retrying_shards_and_an_always_gate():
     assert "E2E_JOB_STARTED_EPOCH" in workflow
     assert "python scripts/e2e_shards.py run" in workflow
     assert "python scripts/e2e_shards.py summarize" in workflow
-    assert "--expected-total 585" in workflow
+    assert "--expected-total 586" in workflow
     assert "--receipt" in workflow
     assert "run-receipt.json" in workflow
     assert "if: always()" in workflow


### PR DESCRIPTION
## Description

Correlation should show independent observations on a shared timeline. Previously, a speedtest could inherit a modem health badge from a reading up to two hours before or after the test. Remove that inferred association and keep modem health on its own timestamped observations.

Replace smoothed SNR, upstream power, and temperature curves with straight connections between recorded points. Remove unused chart state, duplicate table preparation, and obsolete health labels from all core locales.

## User-Facing Impact

- Speedtest rows show their measured results without an inferred modem health badge.
- Signal and temperature traces no longer imply a smoothed trend between samples.
- **API compatibility:** `/api/correlation` no longer adds `modem_health`, `modem_ds_snr_min`, or `modem_ds_power_avg` to speedtest entries. Consumers should use the separate modem observations and their timestamps.

## Type of Change

- [x] Breaking change (removes inferred API fields)

## Checklist

- [x] I have read the Contributing Guidelines
- [ ] I have opened an issue before starting work on this PR
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] All tests pass
- [x] I have added regression tests
- [x] I have documented UI and API impact
- [ ] I have attached screenshots/video for UI changes

## Testing

Environment: Windows, Python 3.13, Node 22, Playwright Chromium; browser tests use demo data.

- Correlation API/storage tests: **26 passed**.
- Correlation browser tests: **33 passed**, including recorded-point rendering and keeping modem health separate from speedtest rows.
- JavaScript suite under Node 22: **95 passed**.
- Translation validation: **all 92 catalogs in sync**.
- Portable Windows suite: **4,155 passed, 29 failed, 3 skipped, 27 deselected**. All 29 failures reproduced on unchanged base commit `f32b0843`; each fails with Windows error 1314 because this account cannot create symlinks.
- `git diff --check`: passed.

## Final CI verification

- Linux Python suite: **4,229 passed, 2 skipped**.
- Windows Python suite: **4,185 passed, 2 skipped, 27 deselected**.
- Full browser E2E: **586 passed** across all four shards. Updated the collection manifest and CI assertions for the added regression test.
- JavaScript suite: **95 passed**; all **92** translation catalogs synchronized.
- Windows Desktop Preview build, mobile browser checks, and CodeQL: passed.
- Desktop and mobile-width correlation views checked with isolated demo data, with no page errors or horizontal overflow.
