### PR TITLE
fix: make Sagemcom modem metrics reliable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ docs/**/*.md
 !docs/notifications-apprise.md
 !docs/windows-desktop-preview.md
 !docs/reverse-proxy.md
+!docs/sagemcom-monitoring.md
 docs/superpowers/
 
 # Internal development docs (belong in workspace, not repo)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=builder /build/out/docsight-icmp-helper /usr/local/bin/docsight-icmp
 COPY --from=builder /build/out/docsight-traceroute-helper /usr/local/bin/docsight-traceroute-helper
 
 # Keep elevated privileges scoped to the dedicated ICMP helper.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     gosu \
     libjpeg62-turbo \
     && chown root:root /usr/local/bin/docsight-icmp-helper \

--- a/app/analyzer.py
+++ b/app/analyzer.py
@@ -807,6 +807,8 @@ def _assess_ds_channel(
             elif power < pt["good_min"] or power > pt["good_max"]:
                 issues.append("power tolerated")
 
+    if ch.get("snr_valid") is False:
+        issues.append("snr warning (unavailable)")
     snr_val = None
     raw_mse = ch.get("mse")
     raw_mer = ch.get("mer")
@@ -938,6 +940,8 @@ def analyze(data: DocsisData) -> AnalysisResult:
         }
         if profile_modulation:
             channel["profile_modulation"] = profile_modulation
+        if "snr_valid" in ch:
+            channel["snr_valid"] = ch["snr_valid"]
         ds_channels.append(channel)
     for ch in ds31:
         raw_power = ch.get("powerLevel")
@@ -987,6 +991,8 @@ def analyze(data: DocsisData) -> AnalysisResult:
         }
         if profile_modulation:
             channel["profile_modulation"] = profile_modulation
+        if "snr_valid" in ch:
+            channel["snr_valid"] = ch["snr_valid"]
         ds_channels.append(channel)
 
     ds_channels.sort(key=lambda c: c["channel_id"])

--- a/app/blueprints/metrics_bp.py
+++ b/app/blueprints/metrics_bp.py
@@ -44,10 +44,9 @@ def metrics():
     connection_info = state.get("connection_info")
 
     collector = current_runtime().modem_collector
-    if collector is not None:
-        last_poll_timestamp = collector.get_status().get("last_poll", 0.0)
-    else:
-        last_poll_timestamp = 0.0
-
-    output = format_metrics(analysis, device_info, connection_info, last_poll_timestamp)
+    status = collector.get_status() if collector is not None else {}
+    output = format_metrics(
+        analysis, device_info, connection_info,
+        status.get("last_success", 0.0), status.get("poll_success", False),
+    )
     return Response(output, status=200, content_type="text/plain; version=0.0.4; charset=utf-8")

--- a/app/collectors/base.py
+++ b/app/collectors/base.py
@@ -36,6 +36,8 @@ class Collector:
     def __init__(self, poll_interval_seconds: int):
         self._poll_interval_seconds = poll_interval_seconds
         self._last_poll: float = 0.0
+        self._last_success: float = 0.0
+        self._poll_success = False
         self._consecutive_failures: int = 0
         self._last_failure_time: float = 0.0
         self._lock = threading.Lock()          # guards scheduling state
@@ -116,6 +118,8 @@ class Collector:
             self._consecutive_failures = 0
             self._last_failure_time = 0.0
             self._last_poll = time.time()
+            self._last_success = self._last_poll
+            self._poll_success = True
 
     def record_skip(self):
         """Advance poll timestamp without penalty or failure count.
@@ -133,6 +137,7 @@ class Collector:
     def record_failure(self):
         """Increment penalty counter and update last poll timestamp."""
         with self._lock:
+            self._poll_success = False
             self._consecutive_failures += 1
             self._last_failure_time = time.time()
             self._last_poll = time.time()
@@ -163,5 +168,7 @@ class Collector:
                 "poll_interval": self._poll_interval_seconds,
                 "effective_interval": eff,
                 "last_poll": self._last_poll,
+                "last_success": self._last_success,
+                "poll_success": self._poll_success,
                 "next_poll_in": int(time_until_next),
             }

--- a/app/drivers/formats/sagemcom.py
+++ b/app/drivers/formats/sagemcom.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from ...types import DocsisDataFritz, RawChannel
@@ -45,20 +46,30 @@ def parse_sagemcom_xmo_downstream(
             channel_id = row.get("ChannelID", 0)
             frequency = _sagemcom_frequency(row.get("Frequency", 0))
             power = row.get("PowerLevel", 0)
-            snr = row.get("SNR", 0)
+            raw_snr = row.get("SNR")
+            try:
+                snr = float(raw_snr) if not isinstance(raw_snr, bool) else None
+            except (TypeError, ValueError):
+                snr = None
+            quality = {}
+            if snr is None or not math.isfinite(snr) or snr <= 0:
+                quality = {"snr_valid": False}
+                if snr == 0:
+                    quality["snr_raw"] = 0.0
+                snr = None
             modulation = row.get("Modulation", "")
             corrected = row.get("CorrectableCodewords", 0)
             uncorrected = row.get("UncorrectableCodewords", 0)
             if _sagemcom_is_ofdm(modulation, row.get("BandWidth", 0)):
                 docsis31.append({
                     "channelID": channel_id, "type": "OFDM", "frequency": frequency,
-                    "powerLevel": power, "mer": snr, "mse": None,
+                    "powerLevel": power, "mer": snr, "mse": None, **quality,
                     "corrErrors": corrected, "nonCorrErrors": uncorrected,
                 })
             else:
                 docsis30.append({
                     "channelID": channel_id, "frequency": frequency, "powerLevel": power,
-                    "mer": snr, "mse": -snr if snr else None,
+                    "mer": snr, "mse": -snr if snr else None, **quality,
                     "modulation": _sagemcom_modulation(modulation),
                     "corrErrors": corrected, "nonCorrErrors": uncorrected,
                 })

--- a/app/drivers/sagemcom.py
+++ b/app/drivers/sagemcom.py
@@ -215,35 +215,36 @@ class SagemcomDriver(ModemDriver):
         return values
 
     def get_device_info(self) -> DeviceInfo:
+        info = {"manufacturer": "Sagemcom", "model": "", "sw_version": ""}
+        paths = {
+            "model": "Device/DeviceInfo/ModelName",
+            "sw_version": "Device/DeviceInfo/SoftwareVersion",
+            "uptime_seconds": "Device/DeviceInfo/UpTime",
+            "docsis_status": "Device/Docsis/CableModem/Status",
+        }
         try:
-            actions = [
-                {"id": 0, "method": "getValue",
-                 "xpath": "Device/DeviceInfo/ModelName"},
-                {"id": 1, "method": "getValue",
-                 "xpath": "Device/DeviceInfo/SoftwareVersion"},
-            ]
-            resp = self._api_call(actions)
-            reply_actions = resp.get("reply", {}).get("actions", [])
-
-            model = ""
-            sw_version = ""
-            for action in reply_actions:
-                for cb in action.get("callbacks", []):
-                    xpath = cb.get("xpath", "")
-                    value = cb.get("parameters", {}).get("value", "")
-                    if "ModelName" in xpath:
-                        model = value
-                    elif "SoftwareVersion" in xpath:
-                        sw_version = value
-
-            return {
-                "manufacturer": "Sagemcom",
-                "model": model,
-                "sw_version": sw_version,
-            }
+            actions = [{"id": index, "method": "getValue", "xpath": path}
+                       for index, path in enumerate(paths.values())]
+            values = self._response_values(self._api_call(actions))
+            for field in ("model", "sw_version"):
+                value = values.get(paths[field])
+                if isinstance(value, str):
+                    info[field] = value
+            uptime = values.get(paths["uptime_seconds"])
+            if isinstance(uptime, int) and not isinstance(uptime, bool) and uptime >= 0:
+                info["uptime_seconds"] = uptime
+            elif isinstance(uptime, str) and uptime.isascii() and uptime.isdecimal():
+                info["uptime_seconds"] = int(uptime)
+            status = values.get(paths["docsis_status"])
+            # These states are named by the FAST3896 DNA firmware's GUI constants.
+            states = {"OPERATIONAL": "online", "ONLINE": "online",
+                      "FORWARDING_DISABLED": "offline"}
+            if isinstance(status, str) and status.upper() in states:
+                info["docsis_status"] = states[status.upper()]
+            return info
         except Exception:
             self._logged_in = False
-            return {"manufacturer": "Sagemcom", "model": "", "sw_version": ""}
+            return info
 
     def get_connection_info(self) -> ConnectionInfo:
         return {}

--- a/app/drivers/sagemcom.py
+++ b/app/drivers/sagemcom.py
@@ -176,26 +176,43 @@ class SagemcomDriver(ModemDriver):
              "options": {"capability-flags": {"interface": True}}},
         ]
         resp = self._api_call(actions)
-        reply_actions = resp.get("reply", {}).get("actions", [])
-
-        ds_raw = []
-        us_raw = []
-        for action in reply_actions:
-            for cb in action.get("callbacks", []):
-                xpath = cb.get("xpath", "")
-                values = cb.get("parameters", {}).get("value", [])
-                if "Downstreams" in xpath:
-                    ds_raw = values
-                elif "Upstreams" in xpath:
-                    us_raw = values
-
+        paths = [action["xpath"] for action in actions]
+        values = self._response_values(resp, required=paths)
+        ds_raw, us_raw = (values[path] for path in paths)
+        if any(not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows)
+               for rows in (ds_raw, us_raw)):
+            raise RuntimeError("Sagemcom returned malformed channel data")
         ds30, ds31 = self._parse_downstream(ds_raw)
         us30, us31 = self._parse_upstream(us_raw)
+        if not (ds30 or ds31 or us30 or us31):
+            raise RuntimeError("Sagemcom returned no locked channels")
 
         return {
             "channelDs": {"docsis30": ds30, "docsis31": ds31},
             "channelUs": {"docsis30": us30, "docsis31": us31},
         }
+
+    @staticmethod
+    def _response_values(resp, *, required=()):
+        values = {}
+        try:
+            reply = resp["reply"]
+            if reply["error"]["description"] != "XMO_REQUEST_NO_ERR":
+                raise ValueError("request failed")
+            for action in reply["actions"]:
+                if action.get("error", {}).get("description") != "XMO_NO_ERR":
+                    continue
+                for callback in action.get("callbacks", []):
+                    if callback.get("result", {}).get("description") != "XMO_NO_ERR":
+                        continue
+                    parameters = callback.get("parameters", {})
+                    if "value" in parameters:
+                        values[callback["xpath"]] = parameters["value"]
+        except (KeyError, TypeError, AttributeError, ValueError) as exc:
+            raise RuntimeError("Sagemcom returned a malformed XMO response") from exc
+        if any(path not in values for path in required):
+            raise RuntimeError("Sagemcom response is missing required channel values")
+        return values
 
     def get_device_info(self) -> DeviceInfo:
         try:

--- a/app/prometheus.py
+++ b/app/prometheus.py
@@ -177,6 +177,12 @@ def format_metrics(
                 _metric_value(lines, "docsight_downstream_snr_db", ch["snr"],
                               _channel_labels(ch))
 
+        _metric_family_open(lines, "Whether downstream SNR is a usable measurement", "gauge",
+                            "docsight_downstream_snr_valid")
+        for ch in ds_channels:
+            valid = ch.get("snr_valid", ch.get("snr") is not None)
+            _metric_value(lines, "docsight_downstream_snr_valid", int(valid), _channel_labels(ch))
+
         _metric_family_open(
             lines,
             "Downstream channel correctable codeword errors (cumulative)",

--- a/app/prometheus.py
+++ b/app/prometheus.py
@@ -96,6 +96,7 @@ def format_metrics(
     device_info: DeviceInfo | None,
     connection_info: ConnectionInfo | None,
     last_poll_timestamp: float,
+    poll_success: bool = False,
 ) -> str:
     """Format DOCSight state as Prometheus text exposition format.
 
@@ -342,5 +343,8 @@ def format_metrics(
         "docsight_last_poll_timestamp_seconds",
         float(last_poll_timestamp),
     )
+
+    _metric(lines, "Whether the latest completed modem poll succeeded (0 before first success)", "gauge",
+           "docsight_modem_poll_success", int(poll_success))
 
     return "\n".join(lines) + "\n"

--- a/app/types.py
+++ b/app/types.py
@@ -27,6 +27,8 @@ class RawChannel(TypedDict, total=False):
     powerLevel: float | str | None
     modulation: str
     type: str
+    snr_valid: bool
+    snr_raw: float
     mse: float | str | None          # DS 3.0 signal-to-noise (negative dB)
     mer: float | str | None           # DS 3.1 MER
     corrErrors: int | None
@@ -73,6 +75,7 @@ class DownstreamChannel(TypedDict):
     frequency: str
     power: float | None
     modulation: str
+    snr_valid: NotRequired[bool]
     snr: float | None
     correctable_errors: int | None
     uncorrectable_errors: int | None

--- a/app/types.py
+++ b/app/types.py
@@ -366,6 +366,8 @@ class CollectorStatus(TypedDict):
     poll_interval: int
     effective_interval: float
     last_poll: float
+    last_success: float
+    poll_success: bool
     next_poll_in: int
 
 

--- a/docs/sagemcom-monitoring.md
+++ b/docs/sagemcom-monitoring.md
@@ -1,0 +1,34 @@
+# Sagemcom monitoring
+
+The Sagemcom XMO driver exposes modem uptime through
+`docsight_device_uptime_seconds` and recognized connection state through
+`docsight_docsis_online`. The FAST3896 DNA firmware reports uptime at
+`Device/DeviceInfo/UpTime` and connection state at
+`Device/Docsis/CableModem/Status`. `OPERATIONAL` and `ONLINE` map to 1;
+`FORWARDING_DISABLED` maps to 0. Other, missing or unsupported values do not
+produce an online-status sample. Unknown is not offline.
+
+Three separate signals describe availability:
+
+- Prometheus `up`: the exporter can be scraped.
+- `docsight_modem_poll_success`: the most recent completed modem poll succeeded.
+  It starts at 0, changes on success/failure, and is unchanged by a skipped poll.
+- `docsight_docsis_online`: the modem's reported DOCSIS connection state.
+
+`docsight_last_poll_timestamp_seconds` is the time of the last successful modem
+poll (0 before the first success), independent of retry scheduling. A failed or
+skipped poll never advances it. Retained channel measurements and metadata may
+still be exported after a failure; gate channel/connection alerts on recent
+successful collection. A zero-channel read is rejected rather than labelled
+healthy. When no usable channel data can be collected, report a collection
+failure even if optional status metadata is available.
+
+`docsight_downstream_snr_valid` is 1 when the channel has a usable SNR measurement
+and 0 otherwise. The Sagemcom driver treats zero, negative, non-finite, missing
+and malformed SNR as unavailable. This is a conservative validity policy, not a
+claim that a zero firmware value means a physical 0 dB signal. The channel and
+codeword counters remain visible, and analysis reports `snr warning (unavailable)`.
+Unlocked rows remain excluded from the existing active-channel contract; this
+release does not expose a separate channel-lock metric.
+
+Start with a 60-second polling interval. Alert separately on exporter availability, failed or stale collection, confirmed DOCSIS offline status and decreasing modem uptime.

--- a/tests/collectors/test_base.py
+++ b/tests/collectors/test_base.py
@@ -161,3 +161,26 @@ class TestModemDriverBase:
         assert d._user == "admin"
         assert d._password == "secret"
 
+
+
+def test_poll_freshness_survives_failure_skip_and_recovery():
+    c = ConcreteCollector(60)
+    assert c.get_status()['last_success'] == 0
+    assert c.get_status()['poll_success'] is False
+    with patch('app.collectors.base.time.time', return_value=1000):
+        c.record_success()
+    with patch('app.collectors.base.time.time', return_value=2000):
+        c.record_failure()
+        assert c.get_status()['last_success'] == 1000
+        assert c.get_status()['last_poll'] == 2000
+        assert c.get_status()['poll_success'] is False
+        assert not c.should_poll()
+    with patch('app.collectors.base.time.time', return_value=3000):
+        c.record_skip()
+        assert c.get_status()['last_success'] == 1000
+        assert c.get_status()['poll_success'] is False
+        c.record_success()
+        assert c.get_status()['last_success'] == 3000
+        assert c.get_status()['poll_success'] is True
+        c.record_skip()
+        assert c.get_status()['poll_success'] is True

--- a/tests/drivers/surfboard/test_resilience.py
+++ b/tests/drivers/surfboard/test_resilience.py
@@ -249,6 +249,7 @@ class TestLegacyTLSFallback:
             raise req.ConnectionError("connection refused")
 
         with patch.object(driver, "_do_login", side_effect=mock_do_login), \
+             patch.object(driver, "_html_login", side_effect=RuntimeError("HTML unavailable")), \
              patch("app.drivers.surfboard.time"):
             with pytest.raises(
                 RuntimeError,
@@ -363,6 +364,7 @@ class TestLegacyTLSFallback:
             raise req.ConnectionError("Connection reset by peer")
 
         with patch.object(driver, "_hnap_post", side_effect=mock_hnap_post), \
+             patch.object(driver, "_html_login", side_effect=RuntimeError("HTML unavailable")), \
              patch("app.drivers.surfboard.time"):
             with pytest.raises(
                 RuntimeError,

--- a/tests/test_cm3500.py
+++ b/tests/test_cm3500.py
@@ -1,6 +1,7 @@
 """Tests for Arris CM3500B modem driver."""
 
 import pytest
+import requests
 from unittest.mock import patch, MagicMock
 from app.drivers.cm3500 import CM3500Driver
 
@@ -262,7 +263,8 @@ class TestDeviceInfo:
 
     def test_connection_info_fallback_empty(self, mock_status):
         """Returns empty dict when config_params_cgi is not reachable."""
-        assert mock_status.get_connection_info() == {}
+        with patch.object(mock_status._session, "get", side_effect=requests.ConnectionError("unreachable")):
+            assert mock_status.get_connection_info() == {}
 
 
 # -- Table section finding --

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -188,3 +188,24 @@ class TestMetricsEndpoint:
         resp = protected_metrics_client.get("/metrics", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
         assert resp.content_type == "text/plain; version=0.0.4; charset=utf-8"
+
+
+def test_failed_poll_keeps_last_success_and_exposes_failure(metrics_client_with_data):
+    from unittest.mock import patch
+    from app.collectors.base import Collector
+
+    class ModemCollector(Collector):
+        name = 'modem'
+
+    collector = ModemCollector(60)
+    current_runtime().modem_collector = collector
+    with patch('app.collectors.base.time.time', return_value=1000):
+        collector.record_success()
+    with patch('app.collectors.base.time.time', return_value=2000):
+        collector.record_failure()
+    current_runtime().update_state(error='timeout')
+    response = metrics_client_with_data.get('/metrics')
+    assert response.status_code == 200
+    assert b'docsight_last_poll_timestamp_seconds 1000.0' in response.data
+    assert b'docsight_modem_poll_success 0' in response.data
+    assert b'docsight_downstream_power_dbmv' in response.data

--- a/tests/test_sagemcom_driver.py
+++ b/tests/test_sagemcom_driver.py
@@ -683,3 +683,56 @@ def test_rejects_unusable_channel_response(driver, fault):
     driver._session.post = _mock_post([response])
     with pytest.raises(RuntimeError, match='Sagemcom'):
         driver._fetch_docsis_data()
+
+
+def _metadata_response(uptime, status):
+    response = _device_info_response()
+    for index, (path, value) in enumerate([
+        ('Device/DeviceInfo/UpTime', uptime),
+        ('Device/Docsis/CableModem/Status', status),
+    ], start=2):
+        response['reply']['actions'].append({
+            'id': index, 'error': {'description': 'XMO_NO_ERR'},
+            'callbacks': [{'result': {'description': 'XMO_NO_ERR'},
+                           'xpath': path, 'parameters': {'value': value}}],
+        })
+    return response
+
+
+@pytest.mark.parametrize('uptime,expected', [(170015, 170015), ('170015', 170015), (0, 0),
+                                            (-1, None), (True, None), ('bad', None), (1.5, None)])
+def test_uptime_normalization(driver, uptime, expected):
+    driver._session.post = _mock_post([_metadata_response(uptime, 'OPERATIONAL')])
+    assert driver.get_device_info().get('uptime_seconds') == expected
+
+
+@pytest.mark.parametrize('status,expected', [('OPERATIONAL', 'online'), ('ONLINE', 'online'),
+    ('FORWARDING_DISABLED', 'offline'), ('UNRECOGNIZED', None), (None, None), ([], None)])
+def test_docsis_status_normalization(driver, status, expected):
+    driver._session.post = _mock_post([_metadata_response(170015, status)])
+    assert driver.get_device_info().get('docsis_status') == expected
+
+
+def test_metadata_reboot_and_missing_values_are_not_cached(driver):
+    driver._session.post = _mock_post([
+        _metadata_response(170015, 'OPERATIONAL'), _metadata_response(2, 'FORWARDING_DISABLED'),
+        _device_info_response(),
+    ])
+    assert driver.get_device_info()['uptime_seconds'] == 170015
+    info = driver.get_device_info()
+    assert info['uptime_seconds'] == 2
+    assert info['docsis_status'] == 'offline'
+    info = driver.get_device_info()
+    assert 'uptime_seconds' not in info
+    assert 'docsis_status' not in info
+    assert info['model'] == 'FAST3896_WIFIHUBC4'
+
+
+def test_failed_optional_action_preserves_other_metadata(driver):
+    response = _metadata_response(170015, 'OPERATIONAL')
+    response['reply']['actions'][2]['error']['description'] = 'XMO_UNKNOWN_PATH_ERR'
+    driver._session.post = _mock_post([response])
+    info = driver.get_device_info()
+    assert 'uptime_seconds' not in info
+    assert info['docsis_status'] == 'online'
+    assert info['model'] == 'FAST3896_WIFIHUBC4'

--- a/tests/test_sagemcom_driver.py
+++ b/tests/test_sagemcom_driver.py
@@ -661,3 +661,25 @@ class TestRegistration:
         from app.drivers import driver_registry
         d = driver_registry.load_driver("sagemcom", "http://192.168.100.1", "admin", "pass")
         assert isinstance(d, SagemcomDriver)
+
+
+@pytest.mark.parametrize('fault', ['action', 'callback', 'missing', 'malformed', 'empty', 'unlocked'])
+def test_rejects_unusable_channel_response(driver, fault):
+    row = {'ChannelID': 1, 'LockStatus': True, 'SNR': 40, 'Modulation': 'Qam256'}
+    response = _docsis_response([row], [])
+    action = response['reply']['actions'][0]
+    if fault == 'action':
+        action['error']['description'] = 'XMO_UNKNOWN_PATH_ERR'
+    elif fault == 'callback':
+        action['callbacks'][0]['result']['description'] = 'XMO_UNKNOWN_PATH_ERR'
+    elif fault == 'missing':
+        response['reply']['actions'].pop()
+    elif fault == 'malformed':
+        action['callbacks'][0]['parameters']['value'] = 'invalid'
+    elif fault == 'empty':
+        action['callbacks'][0]['parameters']['value'] = []
+    else:
+        row['LockStatus'] = False
+    driver._session.post = _mock_post([response])
+    with pytest.raises(RuntimeError, match='Sagemcom'):
+        driver._fetch_docsis_data()

--- a/tests/test_sagemcom_driver.py
+++ b/tests/test_sagemcom_driver.py
@@ -736,3 +736,27 @@ def test_failed_optional_action_preserves_other_metadata(driver):
     assert 'uptime_seconds' not in info
     assert info['docsis_status'] == 'online'
     assert info['model'] == 'FAST3896_WIFIHUBC4'
+
+
+@pytest.mark.parametrize('snr,valid', [(0, False), (None, False), ('bad', False),
+                                      (float('nan'), False), (True, False), (40, True), ('40', True)])
+@pytest.mark.parametrize('bandwidth', [8000000, 96000000])
+def test_snr_validity_keeps_channel_and_counters(driver, snr, valid, bandwidth):
+    from app.analyzer import analyze
+    from app.prometheus import format_metrics
+
+    ds30, ds31 = driver._parse_downstream([{
+        'ChannelID': 21, 'LockStatus': True, 'Frequency': 562000000,
+        'PowerLevel': 2.3, 'SNR': snr, 'Modulation': 'Qam256', 'BandWidth': bandwidth,
+        'CorrectableCodewords': 123, 'UncorrectableCodewords': 4,
+    }])
+    analysis = analyze({'channelDs': {'docsis30': ds30, 'docsis31': ds31}, 'channelUs': {}})
+    channel = analysis['ds_channels'][0]
+    assert channel['correctable_errors'] == 123
+    assert channel['uncorrectable_errors'] == 4
+    assert (channel['snr'] is not None) == valid
+    if not valid:
+        assert channel['health'] != 'good'
+        assert 'unavailable' in channel['health_detail']
+    output = format_metrics(analysis, {}, {}, 1000)
+    assert f'docsight_downstream_snr_valid{{channel_id="21",frequency="562"}} {int(valid)}' in output


### PR DESCRIPTION
## Description

Failed modem polls refreshed the timestamp documented as the last successful poll, while the Sagemcom driver omitted uptime and DOCSIS status and hid invalid SNR readings. This change makes failed collection distinguishable from fresh data and exposes the missing Sagemcom device metrics.

## User-Facing Impact

- Last-success timestamps advance only after successful collection; `docsight_modem_poll_success` reports the latest poll outcome.
- Sagemcom exports uptime and known DOCSIS online/offline states. Missing or unknown device metadata stays unavailable.
- Incomplete channel responses fail collection instead of producing an apparently healthy snapshot. Unavailable SNR produces a warning and `docsight_downstream_snr_valid=0` while preserving channel counters.
- Documents the metrics and installs available runtime OS updates during image builds.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update
- [ ] New modem driver
- [ ] Performance improvement

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/itsDNNS/docsight/blob/main/CONTRIBUTING.md)
- [ ] I have opened an issue **before** starting work on this PR
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] Python suite excluding browser E2E and JavaScript suite pass (results below)
- [x] I have added tests for new functionality
- [x] I have tested both success and failure paths
- [x] I have updated the documentation
- [x] Translation validation passes; no new translation keys
- [x] I have documented API/metrics impact
- [ ] Screenshots/video (not applicable)

## Testing

**Test Environment:**
- Modem: Sagemcom FAST3896, DNA firmware `FAST3896_DNA_sw23.83.19.25g`
- Deployment: Docker on Linux for live integration verification

**Test Steps:**
1. Run regression tests for successful/failed/skipped polls, incomplete modem replies, uptime/status parsing, and unavailable SNR.
2. Collect three live modem polls through the collector and HTTP metrics endpoint: uptime advanced `175132 → 175195 → 175259` seconds, DOCSIS online and poll success stayed `1`, and last-success timestamps advanced with collection.
3. Validate the complete non-E2E Python suite, JavaScript suite, translations, and whitespace on public head `7438ad5b`.

**Verification Commands:**
```bash
python -m pytest tests/ -q --tb=short --ignore=tests/e2e -rs
npm test
python scripts/i18n_check.py --validate
git diff --check f32b0843..HEAD
```

**Results:**
```text
Python: 4264 passed, 2 skipped
JavaScript: 95 passed
Translations: all 92 language files in sync
Whitespace: passed
```

The Python skips require a local BNetzA PDF fixture and Windows, respectively. Browser E2E was not run on this public head. Live verification used a local integration image with identical modem/collector/metrics implementation. Offline transitions and uptime resets are covered synthetically; no live modem disconnect or reboot was induced.

## Additional Notes

Opening as a draft because this work did not have the prior issue/discussion requested by the contribution guidelines. Feedback on scope and approach is welcome before marking ready for review.

Three existing transport-failure tests now mock their network fallback paths so the regression suite cannot contact a live modem during those tests.
