### PR TITLE
Simplify BQM quick-day chart loading

### DIFF
--- a/app/modules/bqm/static/main.js
+++ b/app/modules/bqm/static/main.js
@@ -197,6 +197,10 @@ function loadBqmChart(date) {
 }
 
 function loadBqmRangeChart(start, end) {
+    if (start === end) {
+        loadBqmChart(start);
+        return;
+    }
     setBqmViewMode('chart');
     hideBqmLiveBadge();
     var toggle = document.getElementById('bqm-view-toggle');
@@ -208,7 +212,7 @@ function loadBqmRangeChart(start, end) {
                 showBqmNoData(T.bqm_csv_dates_only || 'This range only has PNG fallback data.');
                 return;
             }
-            BQMChart.render('bqm-chart-container', data, { dateAxis: start !== end });
+            BQMChart.render('bqm-chart-container', data, { dateAxis: true });
             showBqmCard();
         })
         .catch(function() {
@@ -253,8 +257,8 @@ function initBqmCalendar() {
     });
 }
 
-function setBqmQuickRange(days) {
-    var endDate = todayStr();
+function setBqmQuickRange(days, endDate) {
+    endDate = endDate || todayStr();
     var end = new Date(endDate + 'T12:00:00');
     var start = new Date(end);
     start.setDate(start.getDate() - (days - 1));
@@ -297,14 +301,7 @@ if (bqmYesterdayBtn) bqmYesterdayBtn.addEventListener('click', function() {
         selectBqmQuickDate(yd);
         return;
     }
-    _bqmRangeStart = yd;
-    _bqmRangeEnd = yd;
-    bqmDate = yd;
-    _bqmCalYear = d.getFullYear();
-    _bqmCalMonth = d.getMonth();
-    updateBqmRangeLabel();
-    renderBqmCalendar(_bqmCalYear, _bqmCalMonth);
-    loadBqmRangeChart(yd, yd);
+    setBqmQuickRange(1, yd);
 });
 if (bqm7dBtn) bqm7dBtn.addEventListener('click', function() { setBqmQuickRange(7); });
 if (bqm30dBtn) bqm30dBtn.addEventListener('click', function() { setBqmQuickRange(30); });

--- a/tests/e2e/shards.json
+++ b/tests/e2e/shards.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "expected_total": 581,
+  "expected_total": 585,
   "baseline_cpu_seconds": 1534.372,
   "shards": [
     {
       "id": 1,
-      "collected_cases": 88,
+      "collected_cases": 92,
       "files": [
         "test_connection_monitor.py",
         "test_event_log_redesign.py",

--- a/tests/e2e/test_module_views.py
+++ b/tests/e2e/test_module_views.py
@@ -132,16 +132,27 @@ def test_prefixed_module_hash_navigation_and_script_urls(page, prefixed_module_s
 
 
 @pytest.mark.parametrize("theme,width", [("light", 1280), ("dark", 1280), ("light", 390), ("dark", 390)])
-def test_bqm_quick_selection_and_sparse_range_axes(page, live_server, theme, width):
+@pytest.mark.parametrize("has_png", [False, True], ids=["csv-only", "csv-and-png"])
+def test_bqm_quick_selection_and_sparse_range_axes(page, live_server, theme, width, has_png):
     """Real controls and uPlot callbacks retain the selected view with sparse CSV data."""
     from datetime import datetime, timezone
+    from io import BytesIO
 
+    from PIL import Image
+
+    errors = []
+    page.on("pageerror", lambda error: errors.append(str(error)))
     page.clock.install(time=datetime(2026, 6, 15, 12, tzinfo=timezone.utc))
     page.set_viewport_size({"width": width, "height": 844})
     dates = ["2026-06-15", "2026-06-14", "2026-06-12"]
     page.route("**/api/bqm/data/dates", lambda route: route.fulfill(json={
-        "csv_dates": dates, "png_dates": [],
+        "csv_dates": dates, "png_dates": dates if has_png else [],
     }))
+    png = BytesIO()
+    Image.new("RGB", (64, 32), "blue").save(png, format="PNG")
+    page.route("**/api/bqm/image/2026-*", lambda route: route.fulfill(
+        content_type="image/png", body=png.getvalue(),
+    ))
     # Both multi-day selections deliberately contain only a single day's samples.
     payload = {"points": 2, "data": {
         "timestamps": ["2026-06-15T12:00:00", "2026-06-15T12:05:00"],
@@ -183,9 +194,29 @@ def test_bqm_quick_selection_and_sparse_range_axes(page, live_server, theme, wid
 
     selection("today")
     for name in ("today", "yesterday", "7d", "30d"):
+        if name == "yesterday":
+            page.evaluate("startBqmLiveRefresh()")
         click_chart(f"#bqm-{name}-btn")
         selection(name)
         axis(name in ("7d", "30d"))
+        if name in ("today", "yesterday"):
+            date = dates[0] if name == "today" else dates[1]
+            assert page.evaluate("[_bqmRangeStart, _bqmRangeEnd]") == [date, date]
+            assert page.evaluate("_bqmLiveTimer === null")
+            if has_png:
+                expect(page.locator("#bqm-view-toggle")).to_be_visible()
+                page.locator("#bqm-toggle-png").click()
+                image = page.locator("#bqm-image")
+                expect(image).to_be_visible()
+                expect(image).to_have_attribute("src", "/api/bqm/image/" + date)
+                page.wait_for_function("() => document.getElementById('bqm-image').naturalWidth === 64")
+                assert page.evaluate("!charts['bqm-chart-container']")
+                click_chart("#bqm-toggle-uplot")
+                axis(False)
+            else:
+                expect(page.locator("#bqm-view-toggle")).not_to_be_visible()
+        else:
+            expect(page.locator("#bqm-view-toggle")).not_to_be_visible()
     page.locator("#bqm-month-prev").click()
     selection("30d")
     page.locator("#bqm-month-next").click()
@@ -198,3 +229,4 @@ def test_bqm_quick_selection_and_sparse_range_axes(page, live_server, theme, wid
     click_chart("#bqm-yesterday-btn")
     selection("yesterday")
     axis(False)
+    assert errors == []

--- a/tests/js/bqm.test.js
+++ b/tests/js/bqm.test.js
@@ -15,16 +15,22 @@ function setup() {
     }
     for (const id of ['today', 'yesterday', '7d', '30d']) element('bqm-' + id + '-btn');
     element('bqm-calendar-grid'); element('bqm-month-label');
+    element('bqm-view-toggle'); element('bqm-range-label');
+    const requests = [];
+    class FixedDate extends Date {
+        constructor(...args) { super(...(args.length ? args : ['2026-01-02T12:00:00'])); }
+    }
     const c = vm.createContext({document: {getElementById: id => elements[id], createElement: () => element('cell')},
+        Date: FixedDate,
         T: {}, todayStr: () => '2026-01-02', pad: n => String(n).padStart(2, '0'),
         formatDateDE: s => s, clearTimeout() {}, docsightUrl: s => s,
-        fetch: async () => ({json: async () => ({points: 1, data: {}})}),
+        fetch: async url => { requests.push(url); return {json: async () => ({points: 1, data: {}})}; },
         BQMChart: {render(...args) { c.rendered = args; }}});
     c.window = c;
     run(c, 'app/modules/bqm/static/main.js');
     c._bqmCsvDates = new Set(['2026-01-02', '2026-01-01', '2025-12-30']);
     c._bqmAvailableDates = c._bqmCsvDates;
-    return {c, elements};
+    return {c, elements, requests};
 }
 function selected(elements, expected) {
     for (const name of ['today', 'yesterday', '7d', '30d']) {
@@ -57,6 +63,44 @@ test('loaders pass selected date mode even for sparse responses', async () => {
     await new Promise(resolve => setImmediate(resolve));
     assert.equal(c.rendered[2].dateAxis, false);
 });
+for (const [name, date] of [['today', '2026-01-02'], ['yesterday', '2026-01-01']]) {
+    test(name + ' shows both formats, stops live refresh and retains the image deletion range', async () => {
+        const {c, elements, requests} = setup();
+        const clearedTimers = [];
+        c.clearTimeout = timer => clearedTimers.push(timer);
+        c._bqmPngDates = new Set([date]);
+        c._bqmLiveTimer = 42;
+        c._bqmRangeStart = '2025-12-04';
+        c._bqmRangeEnd = '2026-01-02';
+        c.bqmMonthNav(-1);
+
+        elements['bqm-' + name + '-btn'].click();
+        await new Promise(resolve => setImmediate(resolve));
+
+        assert.equal(c._bqmLiveTimer, null);
+        assert.equal(elements['bqm-view-toggle'].style.display, 'flex');
+        assert.deepEqual(requests, ['/api/bqm/data/' + date]);
+        assert.equal(c.bqmDate, date);
+        assert.equal(c._bqmRangeStart, date);
+        assert.equal(c._bqmRangeEnd, date);
+        assert.deepEqual(clearedTimers, [42]);
+        assert.equal(elements['bqm-range-label'].textContent, date + ' \u2013 ' + date + ' (1)');
+        assert.equal(elements['bqm-month-label'].textContent, 'January 2026');
+        assert.equal(c.rendered[2].dateAxis, false);
+        selected(elements, name);
+
+        let deletion;
+        c.docsightConfirm = async () => true;
+        c.showToast = () => {};
+        c.fetch = async (url, opts) => {
+            if (opts && opts.method === 'DELETE') deletion = {url, body: JSON.parse(opts.body)};
+            return {json: async () => ({deleted: 1})};
+        };
+        c.deleteBqmImages();
+        await new Promise(resolve => setImmediate(resolve));
+        assert.deepEqual(deletion, {url: '/api/bqm/images', body: {start: date, end: date}});
+    });
+}
 test('BQM axis uses dates for sparse ranges and retains time in tooltip labels', () => {
     let rendered;
     const c = vm.createContext({window: {}, document: {getElementById: id => ({id})}, T: {},


### PR DESCRIPTION
Today and Yesterday used the range renderer even for a single day, which hid the PNG toggle when CSV and PNG evidence both existed. Yesterday also duplicated the quick-range state updates and missed stopping live refresh.

Reuse the quick-range updater for Yesterday and the day renderer for single-day ranges. This deletes the duplicated selection updates while preserving range labels and image-deletion scope. CSV-only days, PNG fallback, multi-day and sparse-range axes, calendar selection, and chart data semantics remain intact.

Validated with regression tests failing before the change and passing afterward, 114 JavaScript tests, 4,227 portable Python tests, and 12 Chromium checks covering both themes, desktop/mobile layouts, CSV/PNG switching, module navigation, and the mobile quality gate. JavaScript syntax, translation validation, shard validation, and diff checks pass. The unfiltered Python run encountered 18 Linux-marked checks that require Linux headers or newer Bash on this macOS host; the portable selection passes.
