### PR TITLE
Simplify Incident Journal storage queries

### DIFF
--- a/app/modules/journal/storage.py
+++ b/app/modules/journal/storage.py
@@ -74,6 +74,11 @@ class JournalStorage:
           0 -> only unassigned (WHERE incident_id IS NULL)
           N -> only entries for incident N
         """
+        return self._query_entries(limit=limit, offset=offset, search=search, incident_id=incident_id)
+
+    def _query_entries(self, *, limit=-1, offset=0, search=None, incident_id=None,
+                       date_from=None, date_to=None):
+        """Select entries for lists and exports; SQLite LIMIT -1 means no limit."""
         query = (
             "SELECT i.id, i.date, i.title, i.description, i.icon, i.incident_id, i.created_at, i.updated_at, "
             "(SELECT COUNT(*) FROM journal_attachments WHERE entry_id = i.id) AS attachment_count "
@@ -81,6 +86,12 @@ class JournalStorage:
         )
         conditions = []
         params = []
+        if date_from:
+            conditions.append("i.date >= ?")
+            params.append(date_from)
+        if date_to:
+            conditions.append("i.date <= ?")
+            params.append(date_to)
         if search:
             conditions.append("(i.title LIKE ? OR i.description LIKE ? OR i.date LIKE ?)")
             like = "%" + search + "%"
@@ -196,31 +207,9 @@ class JournalStorage:
             date_to: Optional end date (YYYY-MM-DD), inclusive.
             incident_id: None=all, 0=unassigned, N=specific incident.
         """
-        query = (
-            "SELECT i.id, i.date, i.title, i.description, i.icon, i.incident_id, i.created_at, i.updated_at, "
-            "(SELECT COUNT(*) FROM journal_attachments WHERE entry_id = i.id) AS attachment_count "
-            "FROM journal_entries i"
+        return self._query_entries(
+            date_from=date_from, date_to=date_to, incident_id=incident_id,
         )
-        conditions = []
-        params = []
-        if date_from:
-            conditions.append("i.date >= ?")
-            params.append(date_from)
-        if date_to:
-            conditions.append("i.date <= ?")
-            params.append(date_to)
-        if incident_id is not None:
-            if incident_id == 0:
-                conditions.append("i.incident_id IS NULL")
-            else:
-                conditions.append("i.incident_id = ?")
-                params.append(incident_id)
-        if conditions:
-            query += " WHERE " + " AND ".join(conditions)
-        query += " ORDER BY i.date DESC, i.created_at DESC"
-        with self._read() as conn:
-            rows = conn.execute(query, params).fetchall()
-        return [dict(r) for r in rows]
 
     # ── Incident Containers ──
 
@@ -301,15 +290,7 @@ class JournalStorage:
 
     def unassign_entries(self, entry_ids):
         """Remove incident assignment from journal entries. Returns count."""
-        if not entry_ids:
-            return 0
-        placeholders = ",".join("?" for _ in entry_ids)
-        with self._write() as conn:
-            rowcount = conn.execute(
-                "UPDATE journal_entries SET incident_id = NULL WHERE id IN (%s)" % placeholders,
-                list(entry_ids),
-            ).rowcount
-        return rowcount
+        return self.assign_entries_to_incident(entry_ids, None)
 
     def assign_entries_by_date_range(self, incident_id, start_date, end_date):
         """Assign all journal entries in a date range to an incident. Returns count."""

--- a/tests/test_journal_storage.py
+++ b/tests/test_journal_storage.py
@@ -1,0 +1,115 @@
+"""Journal selection and assignment contracts against real SQLite storage."""
+
+import pytest
+
+from app.modules.journal.storage import JournalStorage
+from app.storage.sqlite import write_transaction
+
+
+@pytest.fixture
+def journal(tmp_path):
+    storage = JournalStorage(str(tmp_path / "journal.db"))
+    incident = storage.save_incident("Intermittent outages")
+    other = storage.save_incident("Other incident")
+    rows = [
+        ("2026-01-01", "Old note", "", incident),
+        ("2026-01-02", "Support call", "Ticket 123", incident),
+        ("2026-01-02", "Router restarted", "Support suggested this", incident),
+        ("2026-01-03", "Unassigned note", "Support follow-up", None),
+        ("2026-01-04", "Other note", "Support follow-up", other),
+    ]
+    for index, (date, title, description, incident_id) in enumerate(rows, 1):
+        entry_id = storage.save_entry(date, title, description, incident_id=incident_id)
+        # Deliberately distinct creation times establish the same-date ordering.
+        with write_transaction(storage.db_path) as conn:
+            conn.execute(
+                "UPDATE journal_entries SET created_at=? WHERE id=?",
+                (f"2026-01-05T00:00:0{index}Z", entry_id),
+            )
+    storage.save_attachment(2, "support.txt", "text/plain", b"Ticket evidence")
+    storage.save_attachment(2, "reply.txt", "text/plain", b"Support reply")
+    return storage
+
+
+@pytest.mark.parametrize("incident_id, expected", [
+    (None, [5, 4, 3, 2, 1]), (0, [4]), (1, [3, 2, 1]), (2, [5]), (999, []),
+])
+def test_list_and_export_selection(journal, incident_id, expected):
+    entries = journal.get_entries(incident_id=incident_id)
+    assert [entry["id"] for entry in entries] == expected
+    assert journal.get_entries_for_export(incident_id=incident_id) == entries
+    for entry in entries:
+        assert set(entry) == {
+            "id", "date", "title", "description", "icon", "incident_id",
+            "created_at", "updated_at", "attachment_count",
+        }
+        assert entry["attachment_count"] == (2 if entry["id"] == 2 else 0)
+
+
+@pytest.mark.parametrize("search, expected", [
+    ("SUPPORT", [3, 2]), ("2026-01-01", [1]), ("Ticket", [2]),
+    ("%' OR 1=1 --", []), ("missing", []),
+])
+def test_search_combines_with_incident_filter(journal, search, expected):
+    assert [entry["id"] for entry in journal.get_entries(search=search, incident_id=1)] == expected
+
+
+def test_pagination_follows_search_and_assignment_filters(journal):
+    entries = journal.get_entries(1, 1, "Support", 1)
+    assert [entry["id"] for entry in entries] == [2]
+    assert journal.get_entries(limit=0) == []
+    assert journal.get_entries(offset=5) == []
+
+
+@pytest.mark.parametrize("date_from, date_to, incident_id, expected", [
+    ("2026-01-02", "2026-01-03", None, [4, 3, 2]),
+    ("2026-01-02", "2026-01-03", 1, [3, 2]),
+    ("2026-01-02", "2026-01-03", 0, [4]),
+    ("2026-01-02", "2026-01-02", 1, [3, 2]),
+    (None, "2026-01-02", None, [3, 2, 1]),
+    ("2026-01-03", None, None, [5, 4]),
+    ("", "", 1, [3, 2, 1]),
+    ("2026-01-03", "2026-01-01", None, []),
+])
+def test_export_date_bounds_are_inclusive(journal, date_from, date_to, incident_id, expected):
+    entries = journal.get_entries_for_export(date_from, date_to, incident_id)
+    assert [entry["id"] for entry in entries] == expected
+
+
+def test_export_has_no_list_limit(journal):
+    for index in range(101):
+        journal.save_entry("2026-02-01", f"Note {index}", "", incident_id=1)
+    assert len(journal.get_entries(incident_id=1)) == 100
+    assert len(journal.get_active_entries()) == 100
+    assert len(journal.get_entries_for_export(incident_id=1)) == 104
+    assert len(journal.get_entries_for_export("2026-02-01", "2026-02-01", 1)) == 101
+
+
+def test_assignment_changes_preserve_entries_and_attachments_on_reopen(journal):
+    before = journal.get_entry(2)
+    attachment = journal.get_attachment(1)
+    assert journal.assign_entries_to_incident([], 2) == 0
+    assert journal.assign_entries_to_incident([2, 2, 999], 2) == 1
+    assert journal.get_incident(1)["entry_count"] == 2
+    assert journal.get_incident(2)["entry_count"] == 2
+    assert journal.unassign_entries([]) == 0
+    assert journal.unassign_entries([2, 2, 999]) == 1
+    assert journal.unassign_entries([2]) == 1
+
+    reopened = JournalStorage(journal.db_path)
+    assert reopened.get_entry(2) == {**before, "incident_id": None}
+    assert reopened.get_attachment(1) == attachment
+    assert [entry["id"] for entry in reopened.get_entries(incident_id=0)] == [4, 2]
+    assert reopened.get_incident(2)["entry_count"] == 1
+    assert reopened.get_entry(3)["incident_id"] == 1
+
+
+def test_deleting_incident_preserves_evidence(journal):
+    before = journal.get_entry(2)
+    attachment = journal.get_attachment(1)
+    assert journal.delete_incident(1)
+    assert not journal.delete_incident(1)
+    assert journal.get_entry(2) == {**before, "incident_id": None}
+    assert journal.get_attachment(1) == attachment
+    assert journal.get_entry(5)["incident_id"] == 2
+    assert len(journal.get_entries_for_export()) == 5


### PR DESCRIPTION
Journal lists and exports maintained duplicate SQL for selecting entries, counting attachments, filtering incidents, and ordering results. Share that query and reuse the assignment update when clearing an incident assignment.

Existing storage methods, pagination, unlimited exports, date bounds, attachment data, and incident deletion behavior are preserved. No schema, API, or frontend changes are required.

Validation:
- 22 new SQLite contract tests pass against both the previous and updated implementations.
- Affected backend suites: 252 passed.
- Full backend suite: 4,258 passed, 2 skipped, 18 failed on macOS. The same 18 failures reproduce with the previous implementation: two Linux-specific C helper builds and 16 Windows release checks that require Bash `mapfile`.
- JavaScript suite: 114 passed.
- Journal modal and responsive Chromium tests: 7 passed.
- Real Chromium workflow passed for entry creation/editing, attachments, incident filtering, search/sort, timeline/PDF, CSV/JSON/Markdown export, bulk assignment, reload persistence, and reviewed import.
- Python syntax, workflow YAML, and final diff checks passed.
